### PR TITLE
feat: Session-scoped learnings API for multi-codebase support

### DIFF
--- a/src-tauri/src/http/handlers/learnings.rs
+++ b/src-tauri/src/http/handlers/learnings.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{State},
+    extract::{Path, State},
     http::StatusCode,
     Json,
 };
@@ -35,10 +35,24 @@ fn resolve_project_path(state: &AppState) -> Result<PathBuf, ApiError> {
 
     let first_path = sessions[0].project_path.clone();
     if sessions.iter().any(|s| s.project_path != first_path) {
-        return Err(ApiError::bad_request("Multiple active sessions with different project paths"));
+        return Err(ApiError::bad_request(
+            "Multiple active sessions with different project paths. \
+             Use session-scoped endpoints instead: \
+             GET/POST /api/sessions/{session_id}/learnings, \
+             GET /api/sessions/{session_id}/project-dna"
+        ));
     }
 
     Ok(first_path)
+}
+
+/// Resolve project_path from a session ID (O(1) HashMap lookup)
+fn resolve_session_project_path(state: &AppState, session_id: &str) -> Result<PathBuf, ApiError> {
+    let controller = state.session_controller.read();
+    let session = controller
+        .get_session(session_id)
+        .ok_or_else(|| ApiError::not_found(format!("Session {} not found", session_id)))?;
+    Ok(session.project_path.clone())
 }
 
 /// POST /api/learnings - Submit a learning
@@ -138,6 +152,117 @@ pub async fn get_project_dna(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<Value>, ApiError> {
     let project_path = resolve_project_path(&state)?;
+
+    let content = state
+        .storage
+        .read_project_dna(&project_path)
+        .map_err(|e| ApiError::internal(format!("Failed to read project DNA: {}", e)))?;
+
+    Ok(Json(json!({
+        "content": content
+    })))
+}
+
+/// POST /api/sessions/{id}/learnings - Submit a learning (session-scoped)
+pub async fn submit_learning_for_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Json(req): Json<SubmitLearningRequest>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    if req.session.trim().is_empty() {
+        return Err(ApiError::bad_request("Session cannot be empty"));
+    }
+
+    if req.task.trim().is_empty() {
+        return Err(ApiError::bad_request("Task cannot be empty"));
+    }
+
+    if req.insight.trim().is_empty() {
+        return Err(ApiError::bad_request("Insight cannot be empty"));
+    }
+
+    match req.outcome.as_str() {
+        "success" | "partial" | "failed" => {}
+        _ => {
+            return Err(ApiError::bad_request(
+                "Outcome must be one of: success, partial, failed",
+            ));
+        }
+    }
+
+    for file_path in &req.files_touched {
+        if file_path.contains("..") || file_path.starts_with('/') || file_path.contains('\\') {
+            return Err(ApiError::bad_request(format!(
+                "Invalid file path: {}",
+                file_path
+            )));
+        }
+    }
+
+    let project_path = resolve_session_project_path(&state, &session_id)?;
+
+    let learning = Learning {
+        date: chrono::Utc::now().format("%Y-%m-%d").to_string(),
+        session: req.session,
+        task: req.task,
+        outcome: req.outcome,
+        keywords: req.keywords,
+        insight: req.insight,
+        files_touched: req.files_touched,
+    };
+
+    state
+        .storage
+        .append_learning(&project_path, &learning)
+        .map_err(|e| ApiError::internal(format!("Failed to save learning: {}", e)))?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(json!({
+            "message": "Learning submitted successfully",
+        })),
+    ))
+}
+
+/// GET /api/sessions/{id}/learnings - List learnings for a session (session-scoped)
+pub async fn list_learnings_for_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let project_path = resolve_session_project_path(&state, &session_id)?;
+
+    let learnings = state
+        .storage
+        .read_learnings(&project_path)
+        .map_err(|e| ApiError::internal(format!("Failed to read learnings: {}", e)))?;
+
+    let learnings_json: Vec<Value> = learnings
+        .iter()
+        .map(|learning| {
+            json!({
+                "date": learning.date,
+                "session": learning.session,
+                "task": learning.task,
+                "outcome": learning.outcome,
+                "keywords": learning.keywords,
+                "insight": learning.insight,
+                "files_touched": learning.files_touched,
+            })
+        })
+        .collect();
+
+    Ok(Json(json!({
+        "learnings": learnings_json,
+        "count": learnings_json.len()
+    })))
+}
+
+/// GET /api/sessions/{id}/project-dna - Get project DNA for a session (session-scoped)
+pub async fn get_project_dna_for_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    let project_path = resolve_session_project_path(&state, &session_id)?;
 
     let content = state
         .storage

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -26,10 +26,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // Planner routes (Swarm mode)
         .route("/api/sessions/{id}/planners", get(planners::list_planners))
         .route("/api/sessions/{id}/planners", post(planners::add_planner))
-        // Learning routes
+        // Learning routes (legacy - work when single project active)
         .route("/api/learnings", get(learnings::list_learnings))
         .route("/api/learnings", post(learnings::submit_learning))
         .route("/api/project-dna", get(learnings::get_project_dna))
+        // Session-scoped learning routes (preferred - work with multiple projects)
+        .route("/api/sessions/{id}/learnings", get(learnings::list_learnings_for_session))
+        .route("/api/sessions/{id}/learnings", post(learnings::submit_learning_for_session))
+        .route("/api/sessions/{id}/project-dna", get(learnings::get_project_dna_for_session))
         // Injection routes
         .route("/api/sessions/{id}/inject", post(inject::operator_inject))
         .route("/api/sessions/{id}/inject/queen", post(inject::queen_inject))

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -2,13 +2,14 @@ use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use std::path::PathBuf;
 use std::sync::Arc;
 use tower::ServiceExt;
 use crate::http::routes::create_router;
 use crate::http::state::AppState;
 use crate::storage::SessionStorage;
 use crate::pty::PtyManager;
-use crate::session::SessionController;
+use crate::session::{Session, SessionController, SessionState, SessionType};
 use crate::coordination::InjectionManager;
 use parking_lot::RwLock;
 
@@ -31,6 +32,39 @@ async fn setup_test_app() -> axum::Router {
     ));
 
     create_router(state)
+}
+
+/// Setup test app and return both the router and session controller for inserting test sessions
+async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionController>>) {
+    let storage = Arc::new(SessionStorage::new().unwrap());
+    let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new().unwrap(),
+    )));
+
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller.clone(),
+        injection_manager,
+        storage,
+    ));
+
+    (create_router(state), session_controller)
+}
+
+fn make_test_session(id: &str, project_path: &str) -> Session {
+    Session {
+        id: id.to_string(),
+        session_type: SessionType::Hive { worker_count: 1 },
+        project_path: PathBuf::from(project_path),
+        state: SessionState::Running,
+        created_at: chrono::Utc::now(),
+        agents: vec![],
+    }
 }
 
 #[tokio::test]
@@ -77,4 +111,301 @@ async fn test_get_nonexistent_session() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// --- Session-scoped learnings endpoint tests ---
+
+#[tokio::test]
+async fn test_session_scoped_list_learnings_returns_404_for_nonexistent_session() {
+    let app = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/nonexistent-id/learnings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_session_scoped_project_dna_returns_404_for_nonexistent_session() {
+    let app = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/nonexistent-id/project-dna")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_session_scoped_list_learnings_for_valid_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    // Insert a test session with a temp dir as project path
+    let temp_dir = std::env::temp_dir().join("hive-test-session-a");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-a", temp_dir.to_str().unwrap())
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/session-a/learnings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Cleanup
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_session_scoped_project_dna_for_valid_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-session-dna");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-dna", temp_dir.to_str().unwrap())
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/session-dna/project-dna")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_legacy_learnings_works_with_single_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-single-session");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-single", temp_dir.to_str().unwrap())
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/learnings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Old endpoint should work when only one project is active
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_legacy_learnings_returns_error_with_multiple_projects() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir_a = std::env::temp_dir().join("hive-test-multi-a");
+    let temp_dir_b = std::env::temp_dir().join("hive-test-multi-b");
+    let _ = std::fs::create_dir_all(&temp_dir_a);
+    let _ = std::fs::create_dir_all(&temp_dir_b);
+
+    // Insert two sessions with different project paths
+    controller.read().insert_test_session(
+        make_test_session("session-multi-a", temp_dir_a.to_str().unwrap())
+    );
+    controller.read().insert_test_session(
+        make_test_session("session-multi-b", temp_dir_b.to_str().unwrap())
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/learnings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Old endpoint should return 400 with helpful error when multiple projects active
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let _ = std::fs::remove_dir_all(&temp_dir_a);
+    let _ = std::fs::remove_dir_all(&temp_dir_b);
+}
+
+#[tokio::test]
+async fn test_session_scoped_learnings_work_with_multiple_projects() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir_a = std::env::temp_dir().join("hive-test-scoped-a");
+    let temp_dir_b = std::env::temp_dir().join("hive-test-scoped-b");
+    let _ = std::fs::create_dir_all(&temp_dir_a);
+    let _ = std::fs::create_dir_all(&temp_dir_b);
+
+    controller.read().insert_test_session(
+        make_test_session("scoped-a", temp_dir_a.to_str().unwrap())
+    );
+    controller.read().insert_test_session(
+        make_test_session("scoped-b", temp_dir_b.to_str().unwrap())
+    );
+
+    // Session-scoped endpoint should work even with multiple projects
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/scoped-a/learnings")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = std::fs::remove_dir_all(&temp_dir_a);
+    let _ = std::fs::remove_dir_all(&temp_dir_b);
+}
+
+#[tokio::test]
+async fn test_session_scoped_submit_learning_validates_input() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-submit-validation");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-submit", temp_dir.to_str().unwrap())
+    );
+
+    // Submit with empty insight should fail
+    let body = serde_json::json!({
+        "session": "session-submit",
+        "task": "test task",
+        "outcome": "success",
+        "keywords": [],
+        "insight": "",
+        "files_touched": []
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-submit/learnings")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_session_scoped_submit_learning_rejects_path_traversal() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-path-traversal");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-traversal", temp_dir.to_str().unwrap())
+    );
+
+    // Submit with path traversal in files_touched should fail
+    let body = serde_json::json!({
+        "session": "session-traversal",
+        "task": "test task",
+        "outcome": "success",
+        "keywords": ["test"],
+        "insight": "A valid insight",
+        "files_touched": ["../../etc/passwd"]
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-traversal/learnings")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_session_scoped_submit_learning_success() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-submit-success");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(
+        make_test_session("session-ok", temp_dir.to_str().unwrap())
+    );
+
+    let body = serde_json::json!({
+        "session": "session-ok",
+        "task": "implement feature X",
+        "outcome": "success",
+        "keywords": ["feature", "api"],
+        "insight": "Using session-scoped endpoints prevents multi-project conflicts",
+        "files_touched": ["src/handlers/learnings.rs"]
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-ok/learnings")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -352,6 +352,13 @@ impl SessionController {
         sessions.values().cloned().collect()
     }
 
+    /// Insert a session directly (for testing purposes only)
+    #[cfg(test)]
+    pub fn insert_test_session(&self, session: Session) {
+        let mut sessions = self.sessions.write();
+        sessions.insert(session.id.clone(), session);
+    }
+
     pub fn stop_session(&self, id: &str) -> Result<(), String> {
         let session = {
             let sessions = self.sessions.read();
@@ -1301,12 +1308,12 @@ Workers record learnings during task completion. Your curation responsibilities:
 
 1. **Review learnings periodically**:
    ```bash
-   curl "http://localhost:18800/api/learnings"
+   curl "http://localhost:18800/api/sessions/{session_id}/learnings"
    ```
 
 2. **Review current project DNA**:
    ```bash
-   curl "http://localhost:18800/api/project-dna"
+   curl "http://localhost:18800/api/sessions/{session_id}/project-dna"
    ```
 
 3. **Curate useful learnings** into `.ai-docs/project-dna.md` (manual edit):
@@ -1326,7 +1333,7 @@ Workers record learnings during task completion. Your curation responsibilities:
 ```
 
 ### Curation Process
-1. Review raw learnings via `GET /api/learnings`
+1. Review raw learnings via `GET /api/sessions/{session_id}/learnings`
 2. Synthesize insights into `.ai-docs/project-dna.md` sections:
    - **Patterns That Work** - Successful approaches
    - **Patterns That Failed** - What to avoid
@@ -1433,7 +1440,7 @@ Your task assignments are in: `{task_file}`
 Before marking your task COMPLETED, submit what you learned:
 
 ```bash
-curl -X POST "http://localhost:18800/api/learnings" \
+curl -X POST "http://localhost:18800/api/sessions/{session_id}/learnings" \
   -H "Content-Type: application/json" \
   -d '{{
     "session": "{session_id}",

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,3 +4,6 @@ pub use controller::{
     Session, SessionController, HiveLaunchConfig, SwarmLaunchConfig,
     SessionType, AgentInfo,
 };
+
+#[cfg(test)]
+pub use controller::SessionState;

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -186,12 +186,12 @@ Workers record learnings during task completion. Your curation responsibilities:
 
 1. **Review learnings periodically**:
    ```bash
-   curl "http://localhost:18800/api/learnings"
+   curl "http://localhost:18800/api/sessions/{{session_id}}/learnings"
    ```
 
 2. **Review current project DNA**:
    ```bash
-   curl "http://localhost:18800/api/project-dna"
+   curl "http://localhost:18800/api/sessions/{{session_id}}/project-dna"
    ```
 
 3. **Curate useful learnings** into `.ai-docs/project-dna.md` (manual edit):
@@ -210,7 +210,7 @@ Workers record learnings during task completion. Your curation responsibilities:
 ```
 
 ### Curation Process
-1. Review learnings via `GET /api/learnings`
+1. Review learnings via `GET /api/sessions/{{session_id}}/learnings`
 2. Synthesize insights into `.ai-docs/project-dna.md`
 3. After 50+ learnings, archive to `.ai-docs/archive/`
 
@@ -254,12 +254,12 @@ Workers record learnings during task completion. Your curation responsibilities:
 
 1. **Review learnings periodically**:
    ```bash
-   curl "http://localhost:18800/api/learnings"
+   curl "http://localhost:18800/api/sessions/{{session_id}}/learnings"
    ```
 
 2. **Review current project DNA**:
    ```bash
-   curl "http://localhost:18800/api/project-dna"
+   curl "http://localhost:18800/api/sessions/{{session_id}}/project-dna"
    ```
 
 3. **Curate useful learnings** into `.ai-docs/project-dna.md` (manual edit):
@@ -278,7 +278,7 @@ Workers record learnings during task completion. Your curation responsibilities:
 ```
 
 ### Curation Process
-1. Review learnings via `GET /api/learnings`
+1. Review learnings via `GET /api/sessions/{{session_id}}/learnings`
 2. Synthesize insights into `.ai-docs/project-dna.md`
 3. After 50+ learnings, archive to `.ai-docs/archive/`
 
@@ -377,6 +377,9 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
 
         // Also support planners_list for swarm
         rendered = rendered.replace("{{planners_list}}", &workers_list);
+
+        // Replace session_id placeholder
+        rendered = rendered.replace("{{session_id}}", &context.session_id);
 
         // Replace task placeholder
         if let Some(ref task) = context.task {


### PR DESCRIPTION
## Summary

Resolves #17

- Adds RESTful session-scoped endpoints (`/api/sessions/{id}/learnings`, `/api/sessions/{id}/project-dna`) following existing patterns like `/api/sessions/{id}/workers`
- Fixes the ambient context anti-pattern in `resolve_project_path()` that blocked multi-codebase workflows with "Multiple active sessions with different project paths"
- Updates all agent prompt curl commands (Queen + Worker) to use session-scoped URLs
- Legacy endpoints preserved with backward compatibility (single project works, multiple projects returns helpful migration error)

## Changes

### Core (3 files)
- **`learnings.rs`** — New `resolve_session_project_path()` helper (O(1) lookup) + 3 session-scoped handlers
- **`routes.rs`** — 3 new routes: `GET/POST /api/sessions/{id}/learnings`, `GET /api/sessions/{id}/project-dna`
- **`templates/mod.rs`** — Updated queen-hive/queen-swarm curl commands + added `{{session_id}}` replacement in `render_queen_prompt()`

### Prompt Templates (1 file)
- **`controller.rs`** — Updated 4 hardcoded curl URLs in Queen/Worker prompts to session-scoped equivalents

### Tests (1 file)
- **`tests.rs`** — 10 new integration tests: 404 validation, multi-project isolation, backward compat, input validation, path traversal rejection, successful submission

### Supporting (1 file)
- **`session/mod.rs`** — Re-export `SessionState` (cfg(test)) + `insert_test_session()` helper

## Test plan

- [x] `cargo check` passes with zero warnings
- [x] `cargo test --no-run` compiles cleanly
- [ ] Session-scoped GET learnings returns 200 for valid session
- [ ] Session-scoped GET learnings returns 404 for invalid session
- [ ] Session-scoped POST learnings creates learning in correct project directory
- [ ] Legacy GET /api/learnings works with single active session
- [ ] Legacy GET /api/learnings returns 400 with helpful error when multiple projects active
- [ ] Path traversal in files_touched is rejected
- [ ] Manual: Run two Hive sessions on different projects simultaneously

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session-scoped learning endpoints now available for submitting and retrieving insights tied to specific projects and sessions, providing better support for managing learnings across multiple projects.
  * New endpoint to retrieve project DNA for individual sessions.
  * Legacy learning endpoints remain functional for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->