### PR TITLE
feat(lattice): fix empty UI panels + missing worktrees (#73-#76)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.23.1"
+version = "0.24.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/cli/registry.rs
+++ b/src-tauri/src/cli/registry.rs
@@ -226,6 +226,8 @@ mod tests {
             model: Some("sonnet".to_string()),
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         };
@@ -245,6 +247,8 @@ mod tests {
             model: None,
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         };
@@ -262,6 +266,8 @@ mod tests {
             model: None,
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         };
@@ -279,6 +285,8 @@ mod tests {
             model: Some("glm-4.7".to_string()),
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         };
@@ -298,6 +306,8 @@ mod tests {
             model: None,
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         };

--- a/src-tauri/src/commands/coordination_commands.rs
+++ b/src-tauri/src/commands/coordination_commands.rs
@@ -152,8 +152,19 @@ pub async fn add_worker_to_session(
 
     // Add worker through session controller
     let mut config = request.config;
-    config.name = request.name.or(config.name);
-    config.description = request.description.or(config.description);
+    let normalize_opt_str = |value: Option<String>| {
+        value.and_then(|v| {
+            let trimmed = v.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        })
+    };
+    config.name = normalize_opt_str(request.name).or_else(|| normalize_opt_str(config.name));
+    config.description =
+        normalize_opt_str(request.description).or_else(|| normalize_opt_str(config.description));
 
     let agent_info = controller
         .add_worker(

--- a/src-tauri/src/commands/coordination_commands.rs
+++ b/src-tauri/src/commands/coordination_commands.rs
@@ -32,6 +32,8 @@ pub struct AddWorkerRequest {
     pub session_id: String,
     pub config: AgentConfig,
     pub role: WorkerRole,
+    pub name: Option<String>,
+    pub description: Option<String>,
     pub parent_id: Option<String>,
 }
 
@@ -149,10 +151,14 @@ pub async fn add_worker_to_session(
     let controller = session_state.0.write();
 
     // Add worker through session controller
+    let mut config = request.config;
+    config.name = request.name.or(config.name);
+    config.description = request.description.or(config.description);
+
     let agent_info = controller
         .add_worker(
             &request.session_id,
-            request.config,
+            config,
             request.role.clone(),
             request.parent_id,
         )

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -165,6 +165,8 @@ pub async fn launch_solo(
         model,
         flags: flags.unwrap_or_default(),
         label: None,
+        name: None,
+        description: None,
         role: None,
         initial_prompt: None,
     };

--- a/src-tauri/src/domain/event.rs
+++ b/src-tauri/src/domain/event.rs
@@ -20,6 +20,7 @@ pub enum EventType {
     SessionStatusChanged,
     CellCreated,
     CellStatusChanged,
+    ConversationMessage,
     WorkspaceCreated,
     AgentLaunched,
     AgentCompleted,

--- a/src-tauri/src/domain/status.rs
+++ b/src-tauri/src/domain/status.rs
@@ -94,6 +94,7 @@ mod tests {
         assert_enum_round_trip(EventType::SessionStatusChanged, "\"session_status_changed\"");
         assert_enum_round_trip(EventType::CellCreated, "\"cell_created\"");
         assert_enum_round_trip(EventType::CellStatusChanged, "\"cell_status_changed\"");
+        assert_enum_round_trip(EventType::ConversationMessage, "\"conversation_message\"");
         assert_enum_round_trip(EventType::WorkspaceCreated, "\"workspace_created\"");
         assert_enum_round_trip(EventType::AgentLaunched, "\"agent_launched\"");
         assert_enum_round_trip(EventType::AgentCompleted, "\"agent_completed\"");

--- a/src-tauri/src/http/handlers/artifacts.rs
+++ b/src-tauri/src/http/handlers/artifacts.rs
@@ -188,6 +188,11 @@ pub async fn post_artifact(
         .save_artifact(&session_id, &cell_id, &req.artifact)
         .map_err(|err| ApiError::internal(err.to_string()))?;
 
+    state
+        .session_controller
+        .read()
+        .emit_artifact_updated_for_cell(&session_id, &cell_id, None);
+
     Ok((
         StatusCode::CREATED,
         Json(serde_json::json!({

--- a/src-tauri/src/http/handlers/conversations.rs
+++ b/src-tauri/src/http/handlers/conversations.rs
@@ -74,11 +74,16 @@ pub async fn append_conversation(
     validate_agent_id(&from)?;
     let content = sanitize_text(&req.content, MAX_MESSAGE_CONTENT_LEN, "content")?;
 
-    state
+    let message = state
         .storage
         .append_conversation_message(&session_id, &agent_id, &from, &content)
         .await
         .map_err(|e| ApiError::internal(format!("Failed to append conversation message: {}", e)))?;
+
+    state
+        .emit_conversation_message(&session_id, &agent_id, &message)
+        .await
+        .map_err(ApiError::internal)?;
 
     Ok((
         StatusCode::CREATED,

--- a/src-tauri/src/http/handlers/conversations.rs
+++ b/src-tauri/src/http/handlers/conversations.rs
@@ -80,10 +80,17 @@ pub async fn append_conversation(
         .await
         .map_err(|e| ApiError::internal(format!("Failed to append conversation message: {}", e)))?;
 
-    state
+    if let Err(error) = state
         .emit_conversation_message(&session_id, &agent_id, &message)
         .await
-        .map_err(ApiError::internal)?;
+    {
+        tracing::warn!(
+            "Failed to emit conversation message for session {} agent {}: {}",
+            session_id,
+            agent_id,
+            error
+        );
+    }
 
     Ok((
         StatusCode::CREATED,

--- a/src-tauri/src/http/handlers/evaluator.rs
+++ b/src-tauri/src/http/handlers/evaluator.rs
@@ -116,6 +116,8 @@ pub async fn add_evaluator(
         model: req.model,
         flags: vec![],
         label: req.label.clone().or_else(|| Some("Evaluator".to_string())),
+        name: None,
+        description: None,
         role: None,
         initial_prompt: req.initial_task,
     };
@@ -203,6 +205,8 @@ pub async fn add_qa_worker(
             .label
             .clone()
             .or_else(|| Some(qa_specialization_label(&req.specialization).to_string())),
+        name: None,
+        description: None,
         role: None,
         initial_prompt: req.initial_task,
     };

--- a/src-tauri/src/http/handlers/events.rs
+++ b/src-tauri/src/http/handlers/events.rs
@@ -9,6 +9,7 @@ use futures::stream::StreamExt;
 use std::convert::Infallible;
 use std::sync::Arc;
 use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::wrappers::errors::BroadcastStreamRecvError;
 
 use crate::domain::event::Event as DomainEvent;
 use crate::http::error::ApiError;
@@ -74,9 +75,13 @@ pub async fn stream_events(
                             .data(json)))
                     }
                     Ok(_) => None, // Filtered out (different session)
-                    Err(e) => {
-                        tracing::warn!("SSE client lagged, events may have been dropped: {e:?}");
-                        None
+                    Err(BroadcastStreamRecvError::Lagged(n)) => {
+                        // Emit synthetic SSE frame for lagged clients
+                        // CONTRACT: frontend expects event name 'lagged' and JSON {"dropped": N}
+                        tracing::warn!("SSE client lagged, dropped {} events", n);
+                        Some(Ok(Event::default()
+                            .event("lagged")
+                            .data(format!(r#"{{"dropped":{}}}"#, n))))
                     }
                 }
             }

--- a/src-tauri/src/http/handlers/planners.rs
+++ b/src-tauri/src/http/handlers/planners.rs
@@ -78,6 +78,8 @@ pub async fn add_planner(
         model,
         flags: vec![],
         label: req.label.clone().or_else(|| Some(format!("{} Planner", req.domain))),
+        name: None,
+        description: None,
         role: None,
         initial_prompt: None,
     };
@@ -91,6 +93,8 @@ pub async fn add_planner(
                 model: None,
                 flags: vec![],
                 label: w.label.clone(),
+                name: None,
+                description: None,
                 role: Some(crate::pty::WorkerRole {
                     role_type: w.role_type.clone(),
                     label: w.label.clone().unwrap_or_else(|| w.role_type.clone()),
@@ -109,6 +113,8 @@ pub async fn add_planner(
                 model: None,
                 flags: vec![],
                 label: Some(format!("Worker {}", i + 1)),
+                name: None,
+                description: None,
                 role: Some(crate::pty::WorkerRole {
                     role_type: "general".to_string(),
                     label: format!("Worker {}", i + 1),

--- a/src-tauri/src/http/handlers/resolver.rs
+++ b/src-tauri/src/http/handlers/resolver.rs
@@ -87,7 +87,7 @@ pub async fn launch_resolver(
         state.storage.base_dir().clone(),
     )
     .map_err(|err| ApiError::internal(format!("Failed to initialize resolver storage: {}", err)))?;
-    let resolver = Resolver::new(resolver_storage);
+    let resolver = Resolver::new_with_event_bus(resolver_storage, Arc::clone(&state.event_bus));
 
     // Wait for candidates if timeout specified
     if let Some(timeout_secs) = body.timeout_secs {

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -223,6 +223,8 @@ pub async fn create_session(
                 model: req.default_model.clone(),
                 flags: vec![],
                 label: Some("Queen".to_string()),
+                name: None,
+                description: None,
                 role: None,
                 initial_prompt: None,
             };
@@ -233,6 +235,8 @@ pub async fn create_session(
                 model: req.default_model,
                 flags: vec![],
                 label: None,
+                name: None,
+                description: None,
                 role: None,
                 initial_prompt: None,
             };
@@ -301,6 +305,8 @@ pub async fn create_session(
                     model: req.judge_model.or(req.default_model.clone()),
                     flags: vec![],
                     label: Some("Fusion Judge".to_string()),
+                    name: None,
+                    description: None,
                     role: None,
                     initial_prompt: None,
                 },
@@ -454,6 +460,8 @@ pub async fn launch_swarm(
         model: None,
         flags: vec![],
         label: None,
+        name: None,
+        description: None,
         role: None,
         initial_prompt: None,
     };
@@ -502,6 +510,8 @@ pub async fn launch_solo(
         model: req.model,
         flags: req.flags.unwrap_or_default(),
         label: None,
+        name: None,
+        description: None,
         role: None,
         initial_prompt: None,
     };
@@ -577,6 +587,8 @@ pub async fn launch_fusion(
         model: req.judge_model.or(req.default_model.clone()),
         flags: vec![],
         label: Some("Fusion Judge".to_string()),
+        name: None,
+        description: None,
         role: None,
         initial_prompt: None,
     };

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -41,6 +41,7 @@ pub struct AddWorkerRequest {
     #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub name: Option<String>,
     /// One-line task summary used for deterministic labels
+    #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub description: Option<String>,
     /// CLI to use: claude, gemini, cursor, droid, qwen, etc. Defaults to "claude"
     pub cli: Option<String>,

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -13,6 +13,23 @@ use crate::http::state::AppState;
 use crate::pty::{AgentConfig, AgentRole, WorkerRole};
 use super::{validate_session_id, validate_cli};
 
+fn deserialize_optional_trimmed_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
+}
+
 /// Request to add a worker to a session
 #[derive(Debug, Clone, Deserialize)]
 pub struct AddWorkerRequest {
@@ -21,6 +38,7 @@ pub struct AddWorkerRequest {
     /// Optional custom label for the worker
     pub label: Option<String>,
     /// Stable worker name
+    #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub name: Option<String>,
     /// One-line task summary used for deterministic labels
     pub description: Option<String>,

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -20,6 +20,10 @@ pub struct AddWorkerRequest {
     pub role_type: String,
     /// Optional custom label for the worker
     pub label: Option<String>,
+    /// Stable worker name
+    pub name: Option<String>,
+    /// One-line task summary used for deterministic labels
+    pub description: Option<String>,
     /// CLI to use: claude, gemini, cursor, droid, qwen, etc. Defaults to "claude"
     pub cli: Option<String>,
     /// Model to use (optional)
@@ -79,6 +83,8 @@ pub async fn add_worker(
         model: req.model,
         flags: vec![],
         label: Some(role_label.clone()),
+        name: req.name,
+        description: req.description,
         role: Some(role.clone()),
         initial_prompt: req.initial_task.clone(),
     };

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -1,7 +1,11 @@
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use parking_lot::RwLock as PLRwLock;
+use tauri::{AppHandle, Emitter};
+
+use crate::domain::event::{Event, EventType, Severity};
 use crate::storage::{AppConfig, SessionStorage};
+use crate::storage::ConversationMessage;
 use crate::pty::PtyManager;
 use crate::session::SessionController;
 use crate::coordination::InjectionManager;
@@ -15,6 +19,7 @@ pub struct AppState {
     pub injection_manager: Arc<PLRwLock<InjectionManager>>,
     pub storage: Arc<SessionStorage>,
     pub event_bus: Arc<EventBus>,
+    pub app_handle: Option<AppHandle>,
 }
 
 impl AppState {
@@ -25,6 +30,7 @@ impl AppState {
         injection_manager: Arc<PLRwLock<InjectionManager>>,
         storage: Arc<SessionStorage>,
         event_bus: Arc<EventBus>,
+        app_handle: Option<AppHandle>,
     ) -> Self {
         Self {
             config,
@@ -33,6 +39,42 @@ impl AppState {
             injection_manager,
             storage,
             event_bus,
+            app_handle,
         }
+    }
+
+    pub async fn emit_conversation_message(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        message: &ConversationMessage,
+    ) -> Result<(), String> {
+        if let Some(app_handle) = self.app_handle.as_ref() {
+            app_handle
+                .emit("conversation-message", serde_json::json!({
+                    "agent_id": agent_id,
+                    "timestamp": message.timestamp,
+                    "from": message.from,
+                    "content": message.content,
+                }))
+                .map_err(|error| format!("Failed to emit Tauri conversation message: {error}"))?;
+        }
+
+        self.event_bus
+            .publish(Event {
+                id: uuid::Uuid::new_v4().to_string(),
+                session_id: session_id.to_string(),
+                cell_id: None,
+                agent_id: Some(agent_id.to_string()),
+                event_type: EventType::ConversationMessage,
+                timestamp: message.timestamp,
+                payload: serde_json::json!({
+                    "timestamp": message.timestamp,
+                    "from": message.from,
+                    "content": message.content,
+                }),
+                severity: Severity::Info,
+            })
+            .await
     }
 }

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -52,6 +52,7 @@ impl AppState {
         if let Some(app_handle) = self.app_handle.as_ref() {
             app_handle
                 .emit("conversation-message", serde_json::json!({
+                    "session_id": session_id,
                     "agent_id": agent_id,
                     "timestamp": message.timestamp,
                     "from": message.from,

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -2106,6 +2106,28 @@ fn test_add_worker_request_blank_name_deserializes_to_none() {
 }
 
 #[test]
+fn test_add_worker_request_blank_description_deserializes_to_none() {
+    for raw_description in ["", "   "] {
+        let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
+            serde_json::json!({
+                "role_type": "frontend",
+                "cli": "codex",
+                "name": "Worker 2 (Frontend)",
+                "description": raw_description,
+                "initial_task": "Handle SSE lagged events"
+            }),
+        )
+        .unwrap();
+
+        assert!(
+            request.description.is_none(),
+            "expected blank description {:?} to deserialize as None",
+            raw_description
+        );
+    }
+}
+
+#[test]
 fn test_persisted_agent_config_round_trips_name_and_description_fields() {
     let config = crate::storage::PersistedAgentConfig {
         cli: "codex".to_string(),

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -27,7 +27,6 @@ async fn setup_test_app() -> axum::Router {
         SessionStorage::new().unwrap(),
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
-
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -35,6 +34,7 @@ async fn setup_test_app() -> axum::Router {
         injection_manager,
         storage,
         event_bus,
+        None,
     ));
 
     create_router(state)
@@ -52,7 +52,6 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
         SessionStorage::new().unwrap(),
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
-
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -60,6 +59,7 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
         injection_manager,
         storage,
         event_bus,
+        None,
     ));
 
     (create_router(state), session_controller)
@@ -2061,6 +2061,53 @@ async fn test_add_worker_explicit_cli_overrides_session_default() {
     );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[test]
+fn test_add_worker_request_accepts_name_and_description_fields() {
+    let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
+        serde_json::json!({
+            "role_type": "frontend",
+            "cli": "codex",
+            "name": "Worker 2 (Frontend)",
+            "description": "SSE resync + chat/timeline event handling",
+            "initial_task": "Handle SSE lagged events"
+        }),
+    )
+    .unwrap();
+
+    assert_eq!(request.name.as_deref(), Some("Worker 2 (Frontend)"));
+    assert_eq!(
+        request.description.as_deref(),
+        Some("SSE resync + chat/timeline event handling")
+    );
+}
+
+#[test]
+fn test_persisted_agent_config_round_trips_name_and_description_fields() {
+    let config = crate::storage::PersistedAgentConfig {
+        cli: "codex".to_string(),
+        model: Some("gpt-5.4".to_string()),
+        flags: vec![],
+        label: Some("Worker 2 (Frontend) — SSE resync + chat/timeline event handling".to_string()),
+        name: Some("Worker 2 (Frontend)".to_string()),
+        description: Some("SSE resync + chat/timeline event handling".to_string()),
+        role_type: Some("frontend".to_string()),
+        initial_prompt: Some("Handle SSE lagged events".to_string()),
+    };
+
+    let encoded = serde_json::to_string(&config).unwrap();
+    let decoded: crate::storage::PersistedAgentConfig = serde_json::from_str(&encoded).unwrap();
+
+    assert_eq!(decoded.name.as_deref(), Some("Worker 2 (Frontend)"));
+    assert_eq!(
+        decoded.description.as_deref(),
+        Some("SSE resync + chat/timeline event handling")
+    );
+    assert_eq!(
+        decoded.label.as_deref(),
+        Some("Worker 2 (Frontend) — SSE resync + chat/timeline event handling")
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -2084,6 +2084,28 @@ fn test_add_worker_request_accepts_name_and_description_fields() {
 }
 
 #[test]
+fn test_add_worker_request_blank_name_deserializes_to_none() {
+    for raw_name in ["", "   "] {
+        let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
+            serde_json::json!({
+                "role_type": "frontend",
+                "cli": "codex",
+                "name": raw_name,
+                "description": "SSE resync + chat/timeline event handling",
+                "initial_task": "Handle SSE lagged events"
+            }),
+        )
+        .unwrap();
+
+        assert!(
+            request.name.is_none(),
+            "expected blank name {:?} to deserialize as None",
+            raw_name
+        );
+    }
+}
+
+#[test]
 fn test_persisted_agent_config_round_trips_name_and_description_fields() {
     let config = crate::storage::PersistedAgentConfig {
         cli: "codex".to_string(),
@@ -2108,6 +2130,35 @@ fn test_persisted_agent_config_round_trips_name_and_description_fields() {
         decoded.label.as_deref(),
         Some("Worker 2 (Frontend) — SSE resync + chat/timeline event handling")
     );
+}
+
+#[test]
+fn test_persisted_agent_config_blank_name_round_trip_uses_indexed_default_behavior() {
+    for raw_name in ["", "   "] {
+        let config = crate::storage::PersistedAgentConfig {
+            cli: "codex".to_string(),
+            model: Some("gpt-5.4".to_string()),
+            flags: vec![],
+            label: Some("Worker 2 (Frontend) — SSE resync + chat/timeline event handling".to_string()),
+            name: Some(raw_name.to_string()),
+            description: Some("SSE resync + chat/timeline event handling".to_string()),
+            role_type: Some("frontend".to_string()),
+            initial_prompt: Some("Handle SSE lagged events".to_string()),
+        };
+
+        let encoded = serde_json::to_string(&config).unwrap();
+        let decoded: crate::storage::PersistedAgentConfig = serde_json::from_str(&encoded).unwrap();
+
+        assert!(
+            decoded.name.is_none(),
+            "expected blank persisted name {:?} to deserialize as None",
+            raw_name
+        );
+        assert_eq!(
+            decoded.description.as_deref(),
+            Some("SSE resync + chat/timeline event handling")
+        );
+    }
 }
 
 #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -191,8 +191,10 @@ pub fn run() {
                             | EventType::AgentCompleted
                             | EventType::AgentWaitingInput
                             | EventType::AgentFailed
+                            | EventType::ArtifactUpdated
                             | EventType::CellCreated
                             | EventType::CellStatusChanged
+                            | EventType::WorkspaceCreated
                     ) {
                         continue;
                     }
@@ -212,8 +214,10 @@ pub fn run() {
                                         | EventType::AgentCompleted
                                         | EventType::AgentWaitingInput
                                         | EventType::AgentFailed
+                                        | EventType::ArtifactUpdated
                                         | EventType::CellCreated
                                         | EventType::CellStatusChanged
+                                        | EventType::WorkspaceCreated
                                 ) {
                                     pending_sessions.insert(event.session_id);
                                 }
@@ -249,6 +253,7 @@ pub fn run() {
             let http_config = shared_config.clone();
             let http_session_controller = session_controller.clone();
             let http_event_bus = event_bus.clone();
+            let http_app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 let (enabled, port) = {
                     let cfg = http_config.read().await;
@@ -264,6 +269,7 @@ pub fn run() {
                         injection_manager.clone(),
                         storage.clone(),
                         http_event_bus,
+                        Some(http_app_handle),
                     ));
                     if let Err(e) = http::serve(state, port).await {
                         tracing::error!("HTTP server error: {}", e);

--- a/src-tauri/src/orchestrator/resolver.rs
+++ b/src-tauri/src/orchestrator/resolver.rs
@@ -1,10 +1,13 @@
 use std::time::{Duration, Instant};
+use std::sync::Arc;
 
 use thiserror::Error;
 
 use crate::{
     artifacts::{collector::ArtifactCollector, resolver_input::{assemble_resolver_input, ResolverInput}},
     domain::ResolverOutput,
+    events::{EventBus, EventEmitter},
+    session::cell_status::RESOLVER_CELL_ID,
     storage::{SessionStorage, StorageError},
     templates::{PromptContext, TemplateEngine},
 };
@@ -28,10 +31,22 @@ pub struct Resolver {
     #[allow(dead_code)]
     artifacts_collector: ArtifactCollector,
     template_engine: TemplateEngine,
+    event_emitter: Option<EventEmitter>,
 }
 
 impl Resolver {
     pub fn new(storage: SessionStorage) -> Self {
+        Self::new_with_optional_emitter(storage, None)
+    }
+
+    pub fn new_with_event_bus(storage: SessionStorage, event_bus: Arc<EventBus>) -> Self {
+        Self::new_with_optional_emitter(storage, Some(EventEmitter::new(event_bus)))
+    }
+
+    fn new_with_optional_emitter(
+        storage: SessionStorage,
+        event_emitter: Option<EventEmitter>,
+    ) -> Self {
         let templates_dir = storage.templates_dir();
         let artifacts_collector = ArtifactCollector::new(SessionStorage::new_with_base(
             storage.base_dir().clone(),
@@ -42,6 +57,7 @@ impl Resolver {
             storage,
             artifacts_collector,
             template_engine: TemplateEngine::new(templates_dir),
+            event_emitter,
         }
     }
 
@@ -118,6 +134,24 @@ impl Resolver {
         output: &ResolverOutput,
     ) -> Result<(), ResolverError> {
         self.storage.save_resolver_output(session_id, output)?;
+        if let Some(emitter) = self.event_emitter.clone() {
+            let session_id = session_id.to_string();
+            let selected_candidate = output.selected_candidate.clone();
+            let rationale = output.rationale.clone();
+            tokio::spawn(async move {
+                if let Err(error) = emitter
+                    .emit_resolver_selected_candidate(
+                        &session_id,
+                        RESOLVER_CELL_ID,
+                        &selected_candidate,
+                        &rationale,
+                    )
+                    .await
+                {
+                    tracing::debug!("Failed to emit resolver selected candidate event: {}", error);
+                }
+            });
+        }
         Ok(())
     }
 

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -61,6 +61,10 @@ pub struct AgentConfig {
     #[serde(default)]
     pub flags: Vec<String>,       // Additional CLI flags
     pub label: Option<String>,    // Display name
+    #[serde(default)]
+    pub name: Option<String>,     // Stable agent name
+    #[serde(default)]
+    pub description: Option<String>, // One-line task summary
     pub role: Option<WorkerRole>, // Worker role assignment
     pub initial_prompt: Option<String>, // Prompt to inject on spawn
 }
@@ -76,6 +80,8 @@ impl Default for AgentConfig {
             model: None,
             flags: vec![],
             label: None,
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         }

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -157,6 +157,9 @@ fn agent_in_cell_with_variant_cache(
             // Variant cells contain only Fusion agents matching that variant
             fusion_agent_matches_cell(cell_id, agent, variant_cell_cache)
         }
+        SessionType::Fusion { variants } if variants.is_empty() => {
+            cell_id == PRIMARY_CELL_ID
+        }
         SessionType::Fusion { .. } => {
             // PRIMARY_CELL_ID is not used in Fusion sessions
             false
@@ -327,6 +330,21 @@ mod tests {
         let session = test_session(SessionState::Running, vec![AgentStatus::Running]);
 
         assert!(!agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
+    }
+
+    #[test]
+    fn empty_variant_fusion_uses_primary_cell() {
+        let session = Session {
+            session_type: SessionType::Fusion { variants: vec![] },
+            ..test_session(SessionState::Running, vec![AgentStatus::Running])
+        };
+
+        assert_eq!(
+            session_cell_ids(&session),
+            vec![PRIMARY_CELL_ID.to_string()]
+        );
+        assert!(agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
+        assert_eq!(aggregate_cell_status(&session, PRIMARY_CELL_ID), CellStatus::Running);
     }
 
     #[test]

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -150,12 +150,21 @@ fn agent_in_cell_with_variant_cache(
 ) -> bool {
     match &session.session_type {
         SessionType::Fusion { .. } if cell_id == RESOLVER_CELL_ID => {
+            // Resolver cell contains all NON-Fusion agents (judge, planner, evaluator, QA)
             !matches!(&agent.role, AgentRole::Fusion { .. })
         }
         SessionType::Fusion { .. } if cell_id != PRIMARY_CELL_ID => {
+            // Variant cells contain only Fusion agents matching that variant
             fusion_agent_matches_cell(cell_id, agent, variant_cell_cache)
         }
-        _ => true,
+        SessionType::Fusion { .. } => {
+            // PRIMARY_CELL_ID is not used in Fusion sessions
+            false
+        }
+        _ => {
+            // Non-Fusion sessions: all agents go to primary cell
+            cell_id == PRIMARY_CELL_ID
+        }
     }
 }
 
@@ -299,5 +308,90 @@ mod tests {
         let session = test_session(SessionState::Running, vec![]);
 
         assert_eq!(aggregate_cell_status(&session, RESOLVER_CELL_ID), CellStatus::Queued);
+    }
+
+    #[test]
+    fn non_fusion_primary_cell_contains_all_agents() {
+        // Non-Fusion sessions: all agents go to primary cell
+        let session = Session {
+            session_type: SessionType::Hive { worker_count: 1 },
+            ..test_session(SessionState::Running, vec![AgentStatus::Running])
+        };
+
+        assert!(agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
+    }
+
+    #[test]
+    fn fusion_primary_cell_contains_no_agents() {
+        // Fusion sessions do NOT use primary cell
+        let session = test_session(SessionState::Running, vec![AgentStatus::Running]);
+
+        assert!(!agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
+    }
+
+    #[test]
+    fn fusion_variant_cell_only_matches_fusion_agents() {
+        // Fusion variant cells contain only Fusion agents matching that variant
+        let fusion_agent = AgentInfo {
+            id: "fusion-agent".to_string(),
+            role: AgentRole::Fusion {
+                variant: "Alpha".to_string(),
+            },
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+        };
+        let judge_agent = AgentInfo {
+            id: "judge-agent".to_string(),
+            role: AgentRole::Judge {
+                session_id: "session-1".to_string(),
+            },
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+        };
+
+        let session = Session {
+            agents: vec![fusion_agent.clone(), judge_agent.clone()],
+            ..test_session(SessionState::Running, vec![])
+        };
+
+        // Fusion agent matches variant:alpha
+        assert!(agent_in_cell(&session, "variant:alpha", &fusion_agent));
+        // Judge agent does NOT match variant:alpha
+        assert!(!agent_in_cell(&session, "variant:alpha", &judge_agent));
+    }
+
+    #[test]
+    fn fusion_resolver_cell_contains_non_fusion_agents() {
+        // Resolver cell contains non-Fusion agents (judge, planner, evaluator, QA)
+        let fusion_agent = AgentInfo {
+            id: "fusion-agent".to_string(),
+            role: AgentRole::Fusion {
+                variant: "Alpha".to_string(),
+            },
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+        };
+        let judge_agent = AgentInfo {
+            id: "judge-agent".to_string(),
+            role: AgentRole::Judge {
+                session_id: "session-1".to_string(),
+            },
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+        };
+
+        let session = Session {
+            agents: vec![fusion_agent.clone(), judge_agent.clone()],
+            ..test_session(SessionState::Running, vec![])
+        };
+
+        // Fusion agent does NOT go to resolver
+        assert!(!agent_in_cell(&session, RESOLVER_CELL_ID, &fusion_agent));
+        // Judge agent goes to resolver
+        assert!(agent_in_cell(&session, RESOLVER_CELL_ID, &judge_agent));
     }
 }

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -15,11 +15,12 @@ use crate::events::{EventBus, EventEmitter};
 use crate::pty::{AgentRole, AgentStatus, AgentConfig, PtyManager, WorkerRole};
 use crate::storage::{SessionStorage, StorageError};
 use crate::session::cell_status::{
-    derive_cell_status_name, derive_cell_status_name_for_state, session_cell_ids, variant_to_cell_id,
+    agent_in_cell, derive_cell_status_name, derive_cell_status_name_for_state, session_cell_ids, variant_to_cell_id,
     PRIMARY_CELL_ID, RESOLVER_CELL_ID,
 };
 use crate::templates::{PromptContext, TemplateEngine};
 use crate::watcher::TaskFileWatcher;
+use crate::workspace::git::{cleanup_session_worktrees, create_session_worktree};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SessionType {
@@ -568,6 +569,8 @@ impl SessionController {
                 model: if cmd == "claude" { Some("opus-4-6".to_string()) } else { None },
                 flags: base_args.iter().map(|s| s.to_string()).collect(),
                 label: None,
+                name: None,
+                description: None,
                 role: None,
                 initial_prompt: None,
             };
@@ -608,6 +611,8 @@ impl SessionController {
                     model: if cmd == "claude" { Some("opus-4-6".to_string()) } else { None },
                     flags: worker_args.iter().map(|s| s.to_string()).collect(),
                     label: None,
+                    name: None,
+                    description: None,
                     role: None,
                     initial_prompt: None,
                 };
@@ -841,6 +846,91 @@ impl SessionController {
         });
     }
 
+    fn emit_agent_completed(&self, session: &Session, agent: &AgentInfo) {
+        let Some(emitter) = self.event_emitter.clone() else {
+            return;
+        };
+        let session_id = session.id.clone();
+        let cell_id = agent_cell_id(session, agent);
+        let agent_id = agent.id.clone();
+        tokio::spawn(async move {
+            if let Err(error) = emitter
+                .emit_agent_completed(&session_id, &cell_id, &agent_id)
+                .await
+            {
+                tracing::debug!("Failed to emit agent completed event: {}", error);
+            }
+        });
+    }
+
+    fn emit_workspace_created(
+        &self,
+        session_id: &str,
+        cell_id: &str,
+        branch: &str,
+        worktree_path: Option<&str>,
+    ) {
+        let Some(emitter) = self.event_emitter.clone() else {
+            return;
+        };
+        let session_id = session_id.to_string();
+        let cell_id = cell_id.to_string();
+        let branch = branch.to_string();
+        let worktree_path = worktree_path.map(str::to_string);
+        tokio::spawn(async move {
+            if let Err(error) = emitter
+                .emit_workspace_created(&session_id, &cell_id, &branch, worktree_path.as_deref())
+                .await
+            {
+                tracing::debug!("Failed to emit workspace created event: {}", error);
+            }
+        });
+    }
+
+    pub fn emit_artifact_updated_for_cell(
+        &self,
+        session_id: &str,
+        cell_id: &str,
+        agent_id: Option<&str>,
+    ) {
+        let Some(storage) = self.storage.as_ref() else {
+            return;
+        };
+        let Some(emitter) = self.event_emitter.clone() else {
+            return;
+        };
+
+        let resolved_agent_id = agent_id
+            .map(str::to_string)
+            .or_else(|| {
+                self.get_session(session_id).and_then(|session| {
+                    session
+                        .agents
+                        .iter()
+                        .find(|agent| agent_in_cell(&session, cell_id, agent))
+                        .map(|agent| agent.id.clone())
+                })
+            })
+            .unwrap_or_else(|| cell_id.to_string());
+        let artifact_path = storage
+            .session_dir(session_id)
+            .join("artifacts")
+            .join(format!("{}.json", cell_id))
+            .to_string_lossy()
+            .to_string();
+        let session_id = session_id.to_string();
+        let cell_id = cell_id.to_string();
+
+        tokio::spawn(async move {
+            if let Err(error) = emitter
+                .emit_artifact_updated(&session_id, &cell_id, &resolved_agent_id, &artifact_path)
+                .await
+            {
+                tracing::debug!("Failed to emit artifact updated event: {}", error);
+            }
+        });
+    }
+
     fn emit_agent_batch_launched(&self, session: &Session, agents: &[AgentInfo]) {
         let mut emitted_cells = HashMap::<String, bool>::new();
         for agent in agents {
@@ -990,12 +1080,15 @@ impl SessionController {
     }
 
     pub fn close_session(&self, id: &str) -> Result<(), String> {
-        let agent_ids: Vec<String> = {
+        let (agent_ids, cleanup_session): (Vec<String>, Session) = {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_mut(id) {
                 let changes = self.set_session_state_with_events(session, SessionState::Closing);
                 self.emit_cell_status_changes(id, changes);
-                session.agents.iter().map(|a| a.id.clone()).collect()
+                (
+                    session.agents.iter().map(|a| a.id.clone()).collect(),
+                    session.clone(),
+                )
             } else {
                 return Err(format!("Session not found: {}", id));
             }
@@ -1022,22 +1115,35 @@ impl SessionController {
             heartbeats.remove(id);
         }
 
-        let closed_changes = {
+        if let Err(err) = cleanup_session_worktrees(&cleanup_session) {
+            tracing::warn!("Session {} cleanup had issues: {}", id, err);
+        }
+
+        let closed_state = {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_mut(id) {
+                let completed_agents = session
+                    .agents
+                    .iter()
+                    .filter(|agent| agent.status != AgentStatus::Completed)
+                    .cloned()
+                    .collect::<Vec<_>>();
                 for agent in &mut session.agents {
                     agent.status = AgentStatus::Completed;
                 }
                 let changes = self.set_session_state_with_events(session, SessionState::Closed);
                 session.auth_strategy = AuthStrategy::None;
-                Some(changes)
+                Some((session.clone(), completed_agents, changes))
             } else {
                 None
             }
         };
 
         self.update_session_storage(id);
-        if let Some(changes) = closed_changes {
+        if let Some((session, completed_agents, changes)) = closed_state {
+            for agent in &completed_agents {
+                self.emit_agent_completed(&session, agent);
+            }
             self.emit_cell_status_changes(id, changes);
         }
         self.emit_session_update(id);
@@ -1051,16 +1157,89 @@ impl SessionController {
         let pty_manager = self.pty_manager.read();
         pty_manager.kill(agent_id).map_err(|e| e.to_string())?;
 
-        {
+        let completed_agent = {
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_mut(session_id) {
-                if let Some(agent) = session.agents.iter_mut().find(|a| a.id == agent_id) {
-                    agent.status = AgentStatus::Completed;
+                if let Some(index) = session.agents.iter().position(|agent| agent.id == agent_id) {
+                    session.agents[index].status = AgentStatus::Completed;
+                    Some((session.clone(), session.agents[index].clone()))
+                } else {
+                    None
                 }
+            } else {
+                None
             }
+        };
+        self.update_session_storage(session_id);
+        if let Some((session, agent)) = completed_agent {
+            self.emit_agent_completed(&session, &agent);
         }
 
         Ok(())
+    }
+
+    fn truncate_agent_label(value: String, max_chars: usize) -> String {
+        let mut chars = value.chars();
+        let truncated: String = chars.by_ref().take(max_chars).collect();
+        if chars.next().is_some() {
+            format!("{}...", truncated.trim_end())
+        } else {
+            value
+        }
+    }
+
+    fn summarize_prompt_line(prompt: Option<&str>) -> Option<String> {
+        prompt
+            .and_then(|value| value.lines().find(|line| !line.trim().is_empty()))
+            .map(|line| line.split_whitespace().collect::<Vec<_>>().join(" "))
+            .filter(|line| !line.is_empty())
+    }
+
+    fn derive_worker_name(
+        worker_index: u8,
+        role: &WorkerRole,
+        explicit_name: Option<&str>,
+    ) -> String {
+        explicit_name
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .unwrap_or_else(|| format!("Worker {} ({})", worker_index, role.label))
+    }
+
+    fn derive_worker_description(
+        role: &WorkerRole,
+        explicit_description: Option<&str>,
+        prompt: Option<&str>,
+    ) -> String {
+        explicit_description
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+            .or_else(|| Self::summarize_prompt_line(prompt))
+            .unwrap_or_else(|| format!("{} tasks", role.label))
+    }
+
+    fn derive_worker_label(name: &str, description: &str) -> String {
+        Self::truncate_agent_label(format!("{} — {}", name, description), 80)
+    }
+
+    fn apply_worker_identity(
+        worker_index: u8,
+        role: &WorkerRole,
+        mut config: AgentConfig,
+    ) -> AgentConfig {
+        let name = Self::derive_worker_name(worker_index, role, config.name.as_deref());
+        let description = Self::derive_worker_description(
+            role,
+            config.description.as_deref(),
+            config.initial_prompt.as_deref(),
+        );
+        config.name = Some(name.clone());
+        config.description = Some(description.clone());
+        config.label = Some(Self::derive_worker_label(&name, &description));
+        config.role = Some(role.clone());
+        config
     }
 
     /// Build command and args from AgentConfig
@@ -2886,7 +3065,7 @@ Tool documentation is in `.hive-manager/{session_id}/tools/`. Read these files f
 ```bash
 curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
   -H "Content-Type: application/json" \
-  -d '{{"role_type": "backend", "cli": "{cli}"}}'
+  -d '{{"role_type": "backend", "cli": "{cli}", "name": "Worker 1 (Backend)", "description": "Implement backend changes"}}'
 ```
 
 ### Task Assignment
@@ -3352,7 +3531,7 @@ Read `.hive-manager/{session_id}/tools/spawn-worker.md` for detailed documentati
 # Spawn a worker
 curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
   -H "Content-Type: application/json" \
-  -d '{{"role_type": "ROLE", "cli": "{cli}", "initial_task": "TASK", "parent_id": "{session_id}-planner-{index}"}}'
+  -d '{{"role_type": "ROLE", "cli": "{cli}", "name": "Worker N (Role)", "description": "TASK", "initial_task": "TASK", "parent_id": "{session_id}-planner-{index}"}}'
 ```
 
 ## SEQUENTIAL SPAWNING PROTOCOL (CRITICAL)
@@ -3717,6 +3896,8 @@ Content-Type: application/json
 {{
   "role_type": "backend",
   "cli": "{default_cli}",
+  "name": "Worker 2 (Frontend)",
+  "description": "One-line task summary",
   "initial_task": "Optional task description"
 }}
 ```
@@ -3727,7 +3908,9 @@ Content-Type: application/json
 |-----------|------|----------|-------------|
 | role_type | string | Yes | Worker role: backend, frontend, coherence, simplify, reviewer, resolver, tester, code-quality |
 | cli | string | No | CLI to use: {default_cli} (default), gemini, codex, opencode, cursor, droid, qwen |
-| label | string | No | Custom label for the worker |
+| name | string | No | Stable worker name; defaults to `Worker N (Role)` |
+| description | string | No | One-line task summary used for deterministic labels |
+| label | string | No | Legacy label field; kept as a fallback input |
 | initial_task | string | No | Initial task/prompt for the worker |
 | parent_id | string | No | Parent agent ID (defaults to Queen) |
 
@@ -3742,12 +3925,12 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
 # Spawn a frontend worker with an initial task
 curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
   -H "Content-Type: application/json" \
-  -d '{{"role_type": "frontend", "cli": "{default_cli}", "initial_task": "Implement the login form UI"}}'
+  -d '{{"role_type": "frontend", "cli": "{default_cli}", "name": "Worker 2 (Frontend)", "description": "Implement the login form UI", "initial_task": "Implement the login form UI"}}'
 
 # Spawn a reviewer worker
 curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
   -H "Content-Type: application/json" \
-  -d '{{"role_type": "reviewer", "cli": "{default_cli}"}}'
+  -d '{{"role_type": "reviewer", "cli": "{default_cli}", "name": "Worker 3 (Reviewer)", "description": "Review the current implementation"}}'
 ```
 
 ## Response
@@ -4292,12 +4475,23 @@ Last updated: {timestamp}
         flags: Vec<String>,
     ) -> Result<Session, String> {
         let session_id = Uuid::new_v4().to_string();
-        let cwd = project_path.to_str().unwrap_or(".");
+        let (_, solo_cwd) = create_session_worktree(
+            &session_id,
+            "worker-1",
+            &format!("solo/{}/worker-1", session_id),
+            "HEAD",
+            &project_path,
+        )?;
+        let solo_name = "Solo Worker".to_string();
+        let solo_description = Self::summarize_prompt_line(task_description.as_deref())
+            .unwrap_or_else(|| "Solo session".to_string());
         let solo_config = AgentConfig {
             cli: cli.clone(),
             model: model.clone(),
             flags,
-            label: None,
+            label: Some(Self::derive_worker_label(&solo_name, &solo_description)),
+            name: Some(solo_name),
+            description: Some(solo_description),
             role: None,
             initial_prompt: task_description.clone(),
         };
@@ -4312,7 +4506,7 @@ Last updated: {timestamp}
                     AgentRole::Worker { index: 1, parent: None },
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(cwd),
+                    Some(&solo_cwd),
                     120,
                     30,
                 )
@@ -4383,7 +4577,6 @@ Last updated: {timestamp}
         let session_id = Uuid::new_v4().to_string();
         let mut agents = Vec::new();
         let project_path = PathBuf::from(&config.project_path);
-        let cwd = config.project_path.as_str();
 
         // If with_planning is true, spawn Master Planner first
         if config.with_planning {
@@ -4401,6 +4594,13 @@ Last updated: {timestamp}
             // Create Queen agent
             let queen_id = format!("{}-queen", session_id);
             let (cmd, mut args) = Self::build_command(&config.queen_config);
+            let (_, queen_cwd) = create_session_worktree(
+                &session_id,
+                "queen",
+                &format!("hive/{}/queen", session_id),
+                "HEAD",
+                &project_path,
+            )?;
 
             // Check if plan.md exists (from previous planning phase)
             let plan_path = project_path.join(".hive-manager").join(&session_id).join("plan.md");
@@ -4415,7 +4615,7 @@ Last updated: {timestamp}
             // Write tool documentation files
             Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli)?;
 
-            tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, cwd);
+            tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, queen_cwd);
 
             pty_manager
                 .create_session(
@@ -4423,7 +4623,7 @@ Last updated: {timestamp}
                     AgentRole::Queen,
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(cwd),
+                    Some(&queen_cwd),
                     120,
                     30,
                 )
@@ -4441,19 +4641,31 @@ Last updated: {timestamp}
             for (i, worker_config) in config.workers.iter().enumerate() {
                 let index = (i + 1) as u8;
                 let worker_id = format!("{}-worker-{}", session_id, index);
-                let (cmd, mut args) = Self::build_command(worker_config);
+                let worker_role = worker_config.role.clone().unwrap_or_else(|| {
+                    WorkerRole::new("general", "Worker", &worker_config.cli)
+                });
+                let worker_config =
+                    Self::apply_worker_identity(index, &worker_role, worker_config.clone());
+                let (cmd, mut args) = Self::build_command(&worker_config);
+                let (_, worker_cwd) = create_session_worktree(
+                    &session_id,
+                    &format!("worker-{}", index),
+                    &format!("hive/{}/worker-{}", session_id, index),
+                    "HEAD",
+                    &project_path,
+                )?;
 
                 // Write task file for this worker (STANDBY or with initial task)
                 Self::write_task_file(&project_path, &session_id, index, worker_config.initial_prompt.as_deref())?;
 
                 // Write worker prompt to file and pass to CLI
-                let worker_prompt = Self::build_worker_prompt(index, worker_config, &queen_id, &session_id);
+                let worker_prompt = Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
                 let filename = format!("worker-{}-prompt.md", index);
                 let prompt_file = Self::write_prompt_file(&project_path, &session_id, &filename, &worker_prompt)?;
                 let prompt_path = prompt_file.to_string_lossy().to_string();
                 Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
-                tracing::info!("Launching Worker {} agent (v2): {} {:?} in {:?}", index, cmd, args, cwd);
+                tracing::info!("Launching Worker {} agent (v2): {} {:?} in {:?}", index, cmd, args, worker_cwd);
 
                 pty_manager
                     .create_session(
@@ -4461,7 +4673,7 @@ Last updated: {timestamp}
                         AgentRole::Worker { index, parent: Some(queen_id.clone()) },
                         &cmd,
                         &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                        Some(cwd),
+                        Some(&worker_cwd),
                         120,
                         30,
                     )
@@ -4639,6 +4851,12 @@ Last updated: {timestamp}
                     &base_branch,
                 ],
             )?;
+            self.emit_workspace_created(
+                &session_id,
+                &variant_to_cell_id(&variant.name),
+                &variant.branch,
+                Some(&variant.worktree_path),
+            );
 
             Self::write_fusion_variant_task_file(
                 &project_path,
@@ -4659,6 +4877,8 @@ Last updated: {timestamp}
                 model: source_variant.model.clone().or(config.default_model.clone()),
                 flags: source_variant.flags.clone(),
                 label: Some(format!("Fusion {}", variant.name)),
+                name: None,
+                description: None,
                 role: None,
                 initial_prompt: Some(config.task_description.clone()),
             };
@@ -5087,6 +5307,12 @@ Last updated: {timestamp}
                     &base_branch,
                 ],
             )?;
+            self.emit_workspace_created(
+                session_id,
+                &variant_to_cell_id(&variant.name),
+                &variant.branch,
+                Some(&variant.worktree_path),
+            );
 
             Self::write_fusion_variant_task_file(
                 &session.project_path,
@@ -5107,6 +5333,8 @@ Last updated: {timestamp}
                 model: source_variant.model.clone().or(config.default_model.clone()),
                 flags: source_variant.flags.clone(),
                 label: Some(format!("Fusion {}", variant.name)),
+                name: None,
+                description: None,
                 role: None,
                 initial_prompt: Some(config.task_description.clone()),
             };
@@ -5467,6 +5695,8 @@ Last updated: {timestamp}
                     model: session.default_model.clone(),
                     flags: vec![],
                     label: Some("Evaluator".to_string()),
+                    name: None,
+                    description: None,
                     role: None,
                     initial_prompt: None,
                 }
@@ -5697,15 +5927,23 @@ Last updated: {timestamp}
             }
         }
 
-        {
+        let completed_agent = {
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
-                if let Some(agent) = s.agents.iter_mut().find(|a| a.id == variant.agent_id) {
-                    agent.status = AgentStatus::Completed;
+                if let Some(index) = s.agents.iter().position(|agent| agent.id == variant.agent_id) {
+                    s.agents[index].status = AgentStatus::Completed;
+                    Some((s.clone(), s.agents[index].clone()))
+                } else {
+                    None
                 }
+            } else {
+                None
             }
-        }
+        };
         self.update_session_storage(session_id);
+        if let Some((session, agent)) = completed_agent {
+            self.emit_agent_completed(&session, &agent);
+        }
 
         let already_judging = {
             let sessions = self.sessions.read();
@@ -5943,22 +6181,11 @@ Last updated: {timestamp}
             &["commit", "-m", &format!("Merge fusion winner: {}", winner.name)],
         )?;
 
-        let mut cleanup_errors = Vec::new();
         for variant in &metadata.variants {
-            if let Err(err) = Self::run_git_in_dir(
-                &session.project_path,
-                &["worktree", "remove", &variant.worktree_path, "--force"],
-            ) {
-                cleanup_errors.push(format!("{}: {}", variant.worktree_path, err));
-            }
-
             let pty_manager = self.pty_manager.read();
             if let Err(err) = pty_manager.kill(&variant.agent_id) {
                 tracing::warn!("Failed to stop variant agent {}: {}", variant.agent_id, err);
             }
-        }
-        if let Err(err) = Self::run_git_in_dir(&session.project_path, &["worktree", "prune"]) {
-            cleanup_errors.push(format!("worktree prune: {}", err));
         }
 
         {
@@ -5967,31 +6194,42 @@ Last updated: {timestamp}
             let _ = pty_manager.kill(&judge_id);
         }
 
-        let completed_changes = {
+        let cleanup_result = cleanup_session_worktrees(&session);
+
+        let completed_state = {
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
+                let completed_agents = s
+                    .agents
+                    .iter()
+                    .filter(|agent| agent.status != AgentStatus::Completed)
+                    .cloned()
+                    .collect::<Vec<_>>();
                 for agent in &mut s.agents {
                     agent.status = AgentStatus::Completed;
                 }
                 let changes = self.set_session_state_with_events(s, SessionState::Completed);
                 s.auth_strategy = AuthStrategy::None;
-                Some(changes)
+                Some((s.clone(), completed_agents, changes))
             } else {
                 None
             }
         };
         self.emit_session_update(session_id);
         self.update_session_storage(session_id);
-        if let Some(changes) = completed_changes {
+        if let Some((session, completed_agents, changes)) = completed_state {
+            for agent in &completed_agents {
+                self.emit_agent_completed(&session, agent);
+            }
             self.emit_cell_status_changes(session_id, changes);
         }
 
-        if cleanup_errors.is_empty() {
+        if cleanup_result.is_ok() {
             Ok(())
         } else {
             Err(format!(
                 "Winner merged, but worktree cleanup had issues: {}",
-                cleanup_errors.join(" | ")
+                cleanup_result.unwrap_err()
             ))
         }
     }
@@ -6007,11 +6245,26 @@ Last updated: {timestamp}
             .map_err(|e| SessionError::TerminationError(format!("Failed to kill worker {}: {}", worker_id, e)))?;
 
         // Update agent status
-        let mut sessions = self.sessions.write();
-        if let Some(session) = sessions.get_mut(session_id) {
-            if let Some(agent) = session.agents.iter_mut().find(|a| a.id == worker_agent_id) {
-                agent.status = AgentStatus::Completed;
+        let completed_agent = {
+            let mut sessions = self.sessions.write();
+            if let Some(session) = sessions.get_mut(session_id) {
+                if let Some(index) = session
+                    .agents
+                    .iter()
+                    .position(|agent| agent.id == worker_agent_id)
+                {
+                    session.agents[index].status = AgentStatus::Completed;
+                    Some((session.clone(), session.agents[index].clone()))
+                } else {
+                    None
+                }
+            } else {
+                None
             }
+        };
+        self.update_session_storage(session_id);
+        if let Some((session, agent)) = completed_agent {
+            self.emit_agent_completed(&session, &agent);
         }
 
         Ok(())
@@ -6246,6 +6499,8 @@ Last updated: {timestamp}
                     model: pa.config.model.clone(),
                     flags: pa.config.flags.clone(),
                     label: pa.config.label.clone(),
+                    name: pa.config.name.clone(),
+                    description: pa.config.description.clone(),
                     role: pa.config.role_type.as_ref().map(|rt: &String| WorkerRole {
                         role_type: rt.clone(),
                         label: pa.config.label.clone().unwrap_or_default(),
@@ -6547,6 +6802,8 @@ Last updated: {timestamp}
             model: None,
             flags: vec![],
             label: Some("Evaluator".to_string()),
+            name: None,
+            description: None,
             role: None,
             initial_prompt: None,
         });
@@ -6599,15 +6856,15 @@ Last updated: {timestamp}
         // Generate worker ID
         let worker_id = format!("{}-worker-{}", session_id, worker_index);
 
-        // Build command
-        let (cmd, mut args) = Self::build_command(&config);
-
-        // Get project path
-        let cwd = session.project_path.to_str().unwrap_or(".");
-
-        // Create a temporary config with role for prompt generation
-        let mut config_with_role = config.clone();
-        config_with_role.role = Some(role.clone());
+        let config_with_role = Self::apply_worker_identity(worker_index, &role, config);
+        let (cmd, mut args) = Self::build_command(&config_with_role);
+        let (_, worker_cwd) = create_session_worktree(
+            session_id,
+            &format!("worker-{}", worker_index),
+            &format!("hive/{}/worker-{}", session_id, worker_index),
+            "HEAD",
+            &session.project_path,
+        )?;
 
         // Write task file for this worker (STANDBY or with initial task)
         Self::write_task_file(&session.project_path, session_id, worker_index, config_with_role.initial_prompt.as_deref())?;
@@ -6639,7 +6896,7 @@ Last updated: {timestamp}
                     worker_role.clone(),
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(cwd),
+                    Some(&worker_cwd),
                     120,
                     30,
                 )
@@ -6647,8 +6904,7 @@ Last updated: {timestamp}
         }
 
         // Create agent info with role
-        let mut agent_config = config;
-        agent_config.role = Some(role);
+        let agent_config = config_with_role;
 
         let agent_info = AgentInfo {
             id: worker_id.clone(),
@@ -7068,6 +7324,8 @@ Last updated: {timestamp}
                     model: a.config.model.clone(),
                     flags: a.config.flags.clone(),
                     label: a.config.label.clone(),
+                    name: a.config.name.clone(),
+                    description: a.config.description.clone(),
                     role_type: a.config.role.as_ref().map(|r| r.role_type.clone()),
                     initial_prompt: a.config.initial_prompt.clone(),
                 },

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::Arc;
@@ -63,6 +63,8 @@ impl From<String> for SessionError {
 
 const DEFAULT_MAX_QA_ITERATIONS: u8 = 3;
 const DEFAULT_QA_TIMEOUT_SECS: u64 = 300;
+const MAX_PRIMARY_CELL_BRANCHES: usize = 4;
+const MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN: usize = 4_096;
 
 /// Authentication strategy for QA workers accessing the session
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -863,15 +865,7 @@ impl SessionController {
                 changed_files.push(f);
             }
         }
-        let branch = if existing.branch.trim().is_empty() {
-            incoming.branch
-        } else if incoming.branch.trim().is_empty() {
-            existing.branch
-        } else if existing.branch == incoming.branch {
-            existing.branch
-        } else {
-            format!("{} | {}", existing.branch, incoming.branch)
-        };
+        let branch = Self::merge_primary_cell_branch_labels([existing.branch.clone(), incoming.branch.clone()]);
         let summary = match (existing.summary, incoming.summary) {
             (Some(a), Some(b)) if a != b => Some(format!("{} · {}", a, b)),
             (Some(a), _) => Some(a),
@@ -879,10 +873,8 @@ impl SessionController {
             _ => None,
         };
         let test_results = incoming.test_results.or(existing.test_results);
-        let diff_summary = match (existing.diff_summary, incoming.diff_summary) {
-            (Some(a), Some(b)) => Some(format!("{}\n---\n{}", a, b)),
-            (a, b) => a.or(b),
-        };
+        let diff_summary =
+            Self::merge_primary_cell_diff_summaries(existing.diff_summary, incoming.diff_summary);
         let mut unresolved_issues = existing.unresolved_issues;
         unresolved_issues.extend(incoming.unresolved_issues);
         let confidence = match (existing.confidence, incoming.confidence) {
@@ -905,6 +897,67 @@ impl SessionController {
             confidence,
             recommended_next_step,
         }
+    }
+
+    fn merge_primary_cell_branch_labels(branches: [String; 2]) -> String {
+        let unique = branches
+            .into_iter()
+            .filter_map(|branch| {
+                let trimmed = branch.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                }
+            })
+            .fold(Vec::new(), |mut acc, branch| {
+                if !acc.contains(&branch) {
+                    acc.push(branch);
+                }
+                acc
+            });
+
+        match unique.len() {
+            0 => String::new(),
+            1 => unique.into_iter().next().unwrap_or_default(),
+            len if len > MAX_PRIMARY_CELL_BRANCHES => {
+                let mut limited = unique.into_iter().take(MAX_PRIMARY_CELL_BRANCHES).collect::<Vec<_>>();
+                limited.push(format!("+{} more", len - MAX_PRIMARY_CELL_BRANCHES));
+                limited.join(" | ")
+            }
+            _ => unique.join(" | "),
+        }
+    }
+
+    fn merge_primary_cell_diff_summaries(
+        existing: Option<String>,
+        incoming: Option<String>,
+    ) -> Option<String> {
+        let mut unique = Vec::new();
+        for summary in [existing, incoming].into_iter().flatten() {
+            let trimmed = summary.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !unique.iter().any(|value: &String| value == trimmed) {
+                unique.push(trimmed.to_string());
+            }
+        }
+
+        if unique.is_empty() {
+            return None;
+        }
+
+        let merged = unique.join("\n---\n");
+        if merged.chars().count() <= MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN {
+            return Some(merged);
+        }
+
+        let truncated = merged
+            .chars()
+            .take(MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN.saturating_sub(16))
+            .collect::<String>();
+        Some(format!("{truncated}\n...[truncated]"))
     }
 
     fn agent_git_worktree_path_for_artifacts(session: &Session, agent: &AgentInfo) -> Option<PathBuf> {
@@ -963,22 +1016,31 @@ impl SessionController {
         };
         let cell_id = agent_cell_id(session, agent);
         let session_id = session.id.as_str();
-        let bundle = if cell_id == PRIMARY_CELL_ID {
-            match storage.load_artifact(session_id, &cell_id) {
-                Ok(Some(existing)) => Self::merge_primary_cell_artifact_bundles(existing, bundle),
-                _ => bundle,
+        if cell_id == PRIMARY_CELL_ID {
+            let incoming_bundle = bundle;
+            if let Err(err) = storage.atomic_update_artifact(session_id, &cell_id, move |existing| {
+                existing.map_or(incoming_bundle.clone(), |existing_bundle| {
+                    Self::merge_primary_cell_artifact_bundles(existing_bundle, incoming_bundle)
+                })
+            }) {
+                tracing::warn!(
+                    "Failed to persist artifacts for session {} cell {}: {}",
+                    session_id,
+                    cell_id,
+                    err
+                );
+                return;
             }
         } else {
-            bundle
-        };
-        if let Err(err) = storage.save_artifact(session_id, &cell_id, &bundle) {
-            tracing::warn!(
-                "Failed to persist artifacts for session {} cell {}: {}",
-                session_id,
-                cell_id,
-                err
-            );
-            return;
+            if let Err(err) = storage.save_artifact(session_id, &cell_id, &bundle) {
+                tracing::warn!(
+                    "Failed to persist artifacts for session {} cell {}: {}",
+                    session_id,
+                    cell_id,
+                    err
+                );
+                return;
+            }
         }
         self.emit_artifact_updated_for_cell(session_id, &cell_id, Some(agent.id.as_str()));
     }
@@ -1195,15 +1257,6 @@ impl SessionController {
 
             self.emit_cell_status_changes(session_id, changes);
             self.emit_session_update(session_id);
-            if let Some(session) = self.get_session(session_id) {
-                if let Err(err) = cleanup_session_worktrees(&session) {
-                    tracing::warn!(
-                        "Session {} worktree cleanup after mark_session_completed: {}",
-                        session_id,
-                        err
-                    );
-                }
-            }
             return Ok(());
         }
 
@@ -1222,15 +1275,6 @@ impl SessionController {
         storage
             .save_session(&persisted)
             .map_err(|e| format!("Failed to persist session completion: {}", e))?;
-
-        let session_shell = Self::session_shell_from_persisted_for_worktree_cleanup(&persisted);
-        if let Err(err) = cleanup_session_worktrees(&session_shell) {
-            tracing::warn!(
-                "Session {} worktree cleanup after persisted mark_session_completed: {}",
-                session_id,
-                err
-            );
-        }
 
         Ok(())
     }
@@ -1307,6 +1351,42 @@ impl SessionController {
             tracing::warn!("Session {} closed with PTY kill errors: {}", id, kill_errors.join(" | "));
         }
         Ok(())
+    }
+
+    fn rollback_launch_allocations(
+        &self,
+        project_path: &PathBuf,
+        session_id: &str,
+        created_cells: &[String],
+        spawned_agent_ids: &[String],
+    ) {
+        let mut seen_agent_ids = HashSet::new();
+        {
+            let pty_manager = self.pty_manager.read();
+            for agent_id in spawned_agent_ids.iter().rev() {
+                if !seen_agent_ids.insert(agent_id.clone()) {
+                    continue;
+                }
+                if let Err(err) = pty_manager.kill(agent_id) {
+                    tracing::warn!("Launch rollback failed to kill agent {}: {}", agent_id, err);
+                }
+            }
+        }
+
+        let mut seen_cells = HashSet::new();
+        for cell_id in created_cells.iter().rev() {
+            if !seen_cells.insert(cell_id.clone()) {
+                continue;
+            }
+            if let Err(err) = remove_session_worktree_cell(project_path, session_id, cell_id) {
+                tracing::warn!(
+                    "Launch rollback failed to remove worktree for session {} cell {}: {}",
+                    session_id,
+                    cell_id,
+                    err
+                );
+            }
+        }
     }
 
     pub fn stop_agent(&self, session_id: &str, agent_id: &str) -> Result<(), String> {
@@ -4727,7 +4807,7 @@ Last updated: {timestamp}
             .or_else(|| config.queen_config.initial_prompt.clone());
 
         self.launch_solo_internal(
-            project_path,
+            project_path.clone(),
             task_description,
             config.name.clone(),
             config.color.clone(),
@@ -4741,6 +4821,8 @@ Last updated: {timestamp}
         let session_id = Uuid::new_v4().to_string();
         let mut agents = Vec::new();
         let project_path = PathBuf::from(&config.project_path);
+        let mut created_cells = Vec::new();
+        let mut spawned_agent_ids = Vec::new();
 
         // If with_planning is true, spawn Master Planner first
         if config.with_planning {
@@ -4763,6 +4845,7 @@ Last updated: {timestamp}
             "HEAD",
             &project_path,
         )?;
+        created_cells.push("queen".to_string());
         self.emit_workspace_created(
             &session_id,
             PRIMARY_CELL_ID,
@@ -4776,12 +4859,21 @@ Last updated: {timestamp}
 
         // Write Queen prompt to file and pass to CLI
         let master_prompt = Self::build_queen_master_prompt(&config.queen_config.cli, &session_id, &config.workers, config.prompt.as_deref(), has_plan);
-        let prompt_file = Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt)?;
+        let prompt_file = match Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt) {
+            Ok(prompt_file) => prompt_file,
+            Err(err) => {
+                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                return Err(err);
+            }
+        };
         let prompt_path = prompt_file.to_string_lossy().to_string();
         Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
         // Write tool documentation files
-        Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli)?;
+        if let Err(err) = Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli) {
+            self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+            return Err(err);
+        }
 
         tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, queen_cwd);
 
@@ -4796,10 +4888,11 @@ Last updated: {timestamp}
                 120,
                 30,
             ) {
-                let _ = remove_session_worktree_cell(&project_path, &session_id, "queen");
+                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
                 return Err(format!("Failed to spawn Queen: {}", e));
             }
         }
+        spawned_agent_ids.push(queen_id.clone());
 
         agents.push(AgentInfo {
             id: queen_id.clone(),
@@ -4820,13 +4913,21 @@ Last updated: {timestamp}
                 Self::apply_worker_identity(index, &worker_role, worker_config.clone());
             let (cmd, mut args) = Self::build_command(&worker_config);
             let worker_branch = format!("hive/{}/worker-{}", session_id, index);
-            let (_, worker_cwd) = create_session_worktree(
+            let worker_cell_id = format!("worker-{}", index);
+            let (_, worker_cwd) = match create_session_worktree(
                 &session_id,
-                &format!("worker-{}", index),
+                &worker_cell_id,
                 &worker_branch,
                 "HEAD",
                 &project_path,
-            )?;
+            ) {
+                Ok(result) => result,
+                Err(err) => {
+                    self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                    return Err(err);
+                }
+            };
+            created_cells.push(worker_cell_id.clone());
             self.emit_workspace_created(
                 &session_id,
                 PRIMARY_CELL_ID,
@@ -4835,12 +4936,23 @@ Last updated: {timestamp}
             );
 
             // Write task file for this worker (STANDBY or with initial task)
-            Self::write_task_file(&project_path, &session_id, index, worker_config.initial_prompt.as_deref())?;
+            if let Err(err) =
+                Self::write_task_file(&project_path, &session_id, index, worker_config.initial_prompt.as_deref())
+            {
+                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                return Err(err);
+            }
 
             // Write worker prompt to file and pass to CLI
             let worker_prompt = Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
             let filename = format!("worker-{}-prompt.md", index);
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, &filename, &worker_prompt)?;
+            let prompt_file = match Self::write_prompt_file(&project_path, &session_id, &filename, &worker_prompt) {
+                Ok(prompt_file) => prompt_file,
+                Err(err) => {
+                    self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                    return Err(err);
+                }
+            };
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
@@ -4857,14 +4969,11 @@ Last updated: {timestamp}
                     120,
                     30,
                 ) {
-                    let _ = remove_session_worktree_cell(
-                        &project_path,
-                        &session_id,
-                        &format!("worker-{index}"),
-                    );
+                    self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
                     return Err(format!("Failed to spawn Worker {}: {}", index, e));
                 }
             }
+            spawned_agent_ids.push(worker_id.clone());
 
             agents.push(AgentInfo {
                 id: worker_id,
@@ -4880,7 +4989,7 @@ Last updated: {timestamp}
             name: config.name.clone(),
             color: config.color.clone(),
             session_type: SessionType::Hive { worker_count: config.workers.len() as u8 },
-            project_path,
+            project_path: project_path.clone(),
             state: SessionState::Running,
             created_at: Utc::now(),
             agents,
@@ -4913,7 +5022,23 @@ Last updated: {timestamp}
             config.evaluator_config.clone(),
             config.qa_workers.as_deref(),
             config.smoke_test,
-        )?;
+        )
+        .map_err(|err| {
+            {
+                let mut watchers = self.task_watchers.lock();
+                let _ = watchers.remove(&session.id);
+            }
+            {
+                let mut heartbeats = self.agent_heartbeats.write();
+                heartbeats.remove(&session.id);
+            }
+            {
+                let mut sessions = self.sessions.write();
+                sessions.remove(&session.id);
+            }
+            self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+            err
+        })?;
 
         Ok(session)
     }
@@ -6728,42 +6853,6 @@ Last updated: {timestamp}
             qa_timeout_secs: persisted.qa_timeout_secs,
             auth_strategy,
         })
-    }
-
-    /// Minimal `Session` for `cleanup_session_worktrees` when no in-memory session exists.
-    fn session_shell_from_persisted_for_worktree_cleanup(
-        persisted: &crate::storage::PersistedSession,
-    ) -> Session {
-        let session_type = match &persisted.session_type {
-            crate::storage::SessionTypeInfo::Hive { worker_count } => SessionType::Hive {
-                worker_count: *worker_count,
-            },
-            crate::storage::SessionTypeInfo::Swarm { planner_count } => SessionType::Swarm {
-                planner_count: *planner_count,
-            },
-            crate::storage::SessionTypeInfo::Fusion { variants } => SessionType::Fusion {
-                variants: variants.clone(),
-            },
-            crate::storage::SessionTypeInfo::Solo { cli, model } => SessionType::Solo {
-                cli: cli.clone(),
-                model: model.clone(),
-            },
-        };
-        Session {
-            id: persisted.id.clone(),
-            name: persisted.name.clone(),
-            color: persisted.color.clone(),
-            session_type,
-            project_path: PathBuf::from(&persisted.project_path),
-            state: SessionState::Completed,
-            created_at: persisted.created_at,
-            agents: vec![],
-            default_cli: persisted.default_cli.clone(),
-            default_model: persisted.default_model.clone(),
-            max_qa_iterations: persisted.max_qa_iterations,
-            qa_timeout_secs: persisted.qa_timeout_secs,
-            auth_strategy: AuthStrategy::None,
-        }
     }
 
     /// Continue a Swarm session after planning phase

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -20,7 +20,11 @@ use crate::session::cell_status::{
 };
 use crate::templates::{PromptContext, TemplateEngine};
 use crate::watcher::TaskFileWatcher;
-use crate::workspace::git::{cleanup_session_worktrees, create_session_worktree};
+use crate::artifacts::collector::ArtifactCollector;
+use crate::domain::ArtifactBundle;
+use crate::workspace::git::{
+    cleanup_session_worktrees, create_session_worktree, remove_session_worktree_cell,
+};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SessionType {
@@ -846,7 +850,141 @@ impl SessionController {
         });
     }
 
+    fn merge_primary_cell_artifact_bundles(existing: ArtifactBundle, incoming: ArtifactBundle) -> ArtifactBundle {
+        let mut commits = existing.commits.clone();
+        for c in incoming.commits {
+            if !commits.iter().any(|x| x == &c) {
+                commits.push(c);
+            }
+        }
+        let mut changed_files = existing.changed_files.clone();
+        for f in incoming.changed_files {
+            if !changed_files.iter().any(|x| x == &f) {
+                changed_files.push(f);
+            }
+        }
+        let branch = if existing.branch.trim().is_empty() {
+            incoming.branch
+        } else if incoming.branch.trim().is_empty() {
+            existing.branch
+        } else if existing.branch == incoming.branch {
+            existing.branch
+        } else {
+            format!("{} | {}", existing.branch, incoming.branch)
+        };
+        let summary = match (existing.summary, incoming.summary) {
+            (Some(a), Some(b)) if a != b => Some(format!("{} · {}", a, b)),
+            (Some(a), _) => Some(a),
+            (_, Some(b)) => Some(b),
+            _ => None,
+        };
+        let test_results = incoming.test_results.or(existing.test_results);
+        let diff_summary = match (existing.diff_summary, incoming.diff_summary) {
+            (Some(a), Some(b)) => Some(format!("{}\n---\n{}", a, b)),
+            (a, b) => a.or(b),
+        };
+        let mut unresolved_issues = existing.unresolved_issues;
+        unresolved_issues.extend(incoming.unresolved_issues);
+        let confidence = match (existing.confidence, incoming.confidence) {
+            (Some(a), Some(b)) => Some(a.max(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            _ => None,
+        };
+        let recommended_next_step = incoming
+            .recommended_next_step
+            .or(existing.recommended_next_step);
+        ArtifactBundle {
+            summary,
+            changed_files,
+            commits,
+            branch,
+            test_results,
+            diff_summary,
+            unresolved_issues,
+            confidence,
+            recommended_next_step,
+        }
+    }
+
+    fn agent_git_worktree_path_for_artifacts(session: &Session, agent: &AgentInfo) -> Option<PathBuf> {
+        match &agent.role {
+            AgentRole::Fusion { variant } => {
+                Self::read_fusion_metadata(&session.project_path, &session.id)
+                    .ok()
+                    .and_then(|meta| {
+                        meta.variants
+                            .iter()
+                            .find(|v| &v.name == variant || v.agent_id == agent.id)
+                            .map(|v| PathBuf::from(&v.worktree_path))
+                    })
+            }
+            AgentRole::Queen => Some(
+                session
+                    .project_path
+                    .join(".hive-manager")
+                    .join("worktrees")
+                    .join(&session.id)
+                    .join("queen"),
+            ),
+            AgentRole::Worker { index, .. } => Some(
+                session
+                    .project_path
+                    .join(".hive-manager")
+                    .join("worktrees")
+                    .join(&session.id)
+                    .join(format!("worker-{index}")),
+            ),
+            _ => None,
+        }
+    }
+
+    fn harvest_completion_artifacts(&self, session: &Session, agent: &AgentInfo) {
+        let Some(storage) = self.storage.as_ref() else {
+            return;
+        };
+        let Some(wt) = Self::agent_git_worktree_path_for_artifacts(session, agent) else {
+            return;
+        };
+        if !wt.exists() {
+            return;
+        }
+        let bundle = match ArtifactCollector::collect_from_worktree(&wt) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::warn!(
+                    "Artifact harvest failed for agent {} in {}: {}",
+                    agent.id,
+                    wt.display(),
+                    err
+                );
+                return;
+            }
+        };
+        let cell_id = agent_cell_id(session, agent);
+        let session_id = session.id.as_str();
+        let bundle = if cell_id == PRIMARY_CELL_ID {
+            match storage.load_artifact(session_id, &cell_id) {
+                Ok(Some(existing)) => Self::merge_primary_cell_artifact_bundles(existing, bundle),
+                _ => bundle,
+            }
+        } else {
+            bundle
+        };
+        if let Err(err) = storage.save_artifact(session_id, &cell_id, &bundle) {
+            tracing::warn!(
+                "Failed to persist artifacts for session {} cell {}: {}",
+                session_id,
+                cell_id,
+                err
+            );
+            return;
+        }
+        self.emit_artifact_updated_for_cell(session_id, &cell_id, Some(agent.id.as_str()));
+    }
+
     fn emit_agent_completed(&self, session: &Session, agent: &AgentInfo) {
+        self.harvest_completion_artifacts(session, agent);
         let Some(emitter) = self.event_emitter.clone() else {
             return;
         };
@@ -1057,6 +1195,15 @@ impl SessionController {
 
             self.emit_cell_status_changes(session_id, changes);
             self.emit_session_update(session_id);
+            if let Some(session) = self.get_session(session_id) {
+                if let Err(err) = cleanup_session_worktrees(&session) {
+                    tracing::warn!(
+                        "Session {} worktree cleanup after mark_session_completed: {}",
+                        session_id,
+                        err
+                    );
+                }
+            }
             return Ok(());
         }
 
@@ -1075,6 +1222,15 @@ impl SessionController {
         storage
             .save_session(&persisted)
             .map_err(|e| format!("Failed to persist session completion: {}", e))?;
+
+        let session_shell = Self::session_shell_from_persisted_for_worktree_cleanup(&persisted);
+        if let Err(err) = cleanup_session_worktrees(&session_shell) {
+            tracing::warn!(
+                "Session {} worktree cleanup after persisted mark_session_completed: {}",
+                session_id,
+                err
+            );
+        }
 
         Ok(())
     }
@@ -4475,13 +4631,20 @@ Last updated: {timestamp}
         flags: Vec<String>,
     ) -> Result<Session, String> {
         let session_id = Uuid::new_v4().to_string();
+        let solo_branch = format!("solo/{}/worker-1", session_id);
         let (_, solo_cwd) = create_session_worktree(
             &session_id,
             "worker-1",
-            &format!("solo/{}/worker-1", session_id),
+            &solo_branch,
             "HEAD",
             &project_path,
         )?;
+        self.emit_workspace_created(
+            &session_id,
+            PRIMARY_CELL_ID,
+            &solo_branch,
+            Some(&solo_cwd),
+        );
         let solo_name = "Solo Worker".to_string();
         let solo_description = Self::summarize_prompt_line(task_description.as_deref())
             .unwrap_or_else(|| "Solo session".to_string());
@@ -4500,28 +4663,29 @@ Last updated: {timestamp}
 
         {
             let pty_manager = self.pty_manager.read();
-            pty_manager
-                .create_session(
-                    solo_id.clone(),
-                    AgentRole::Worker { index: 1, parent: None },
-                    &cmd,
-                    &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(&solo_cwd),
-                    120,
-                    30,
-                )
-                .map_err(|e| format!("Failed to spawn solo agent: {}", e))?;
+            if let Err(e) = pty_manager.create_session(
+                solo_id.clone(),
+                AgentRole::Worker { index: 1, parent: None },
+                &cmd,
+                &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                Some(&solo_cwd),
+                120,
+                30,
+            ) {
+                let _ = remove_session_worktree_cell(&project_path, &session_id, "worker-1");
+                return Err(format!("Failed to spawn solo agent: {}", e));
+            }
         }
 
         let session = Session {
             id: session_id.clone(),
             name,
             color,
+            project_path: project_path.clone(),
             session_type: SessionType::Solo {
                 cli: cli.clone(),
                 model: model.clone(),
             },
-            project_path,
             state: SessionState::Running,
             created_at: Utc::now(),
             agents: vec![AgentInfo {
@@ -4588,105 +4752,127 @@ Last updated: {timestamp}
             return self.launch_solo(config);
         }
 
+        // Create Queen agent
+        let queen_id = format!("{}-queen", session_id);
+        let (cmd, mut args) = Self::build_command(&config.queen_config);
+        let queen_branch = format!("hive/{}/queen", session_id);
+        let (_, queen_cwd) = create_session_worktree(
+            &session_id,
+            "queen",
+            &queen_branch,
+            "HEAD",
+            &project_path,
+        )?;
+        self.emit_workspace_created(
+            &session_id,
+            PRIMARY_CELL_ID,
+            &queen_branch,
+            Some(&queen_cwd),
+        );
+
+        // Check if plan.md exists (from previous planning phase)
+        let plan_path = project_path.join(".hive-manager").join(&session_id).join("plan.md");
+        let has_plan = plan_path.exists();
+
+        // Write Queen prompt to file and pass to CLI
+        let master_prompt = Self::build_queen_master_prompt(&config.queen_config.cli, &session_id, &config.workers, config.prompt.as_deref(), has_plan);
+        let prompt_file = Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt)?;
+        let prompt_path = prompt_file.to_string_lossy().to_string();
+        Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
+
+        // Write tool documentation files
+        Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli)?;
+
+        tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, queen_cwd);
+
         {
             let pty_manager = self.pty_manager.read();
+            if let Err(e) = pty_manager.create_session(
+                queen_id.clone(),
+                AgentRole::Queen,
+                &cmd,
+                &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                Some(&queen_cwd),
+                120,
+                30,
+            ) {
+                let _ = remove_session_worktree_cell(&project_path, &session_id, "queen");
+                return Err(format!("Failed to spawn Queen: {}", e));
+            }
+        }
 
-            // Create Queen agent
-            let queen_id = format!("{}-queen", session_id);
-            let (cmd, mut args) = Self::build_command(&config.queen_config);
-            let (_, queen_cwd) = create_session_worktree(
+        agents.push(AgentInfo {
+            id: queen_id.clone(),
+            role: AgentRole::Queen,
+            status: AgentStatus::Running,
+            config: config.queen_config.clone(),
+            parent_id: None,
+        });
+
+        // Create Worker agents
+        for (i, worker_config) in config.workers.iter().enumerate() {
+            let index = (i + 1) as u8;
+            let worker_id = format!("{}-worker-{}", session_id, index);
+            let worker_role = worker_config.role.clone().unwrap_or_else(|| {
+                WorkerRole::new("general", "Worker", &worker_config.cli)
+            });
+            let worker_config =
+                Self::apply_worker_identity(index, &worker_role, worker_config.clone());
+            let (cmd, mut args) = Self::build_command(&worker_config);
+            let worker_branch = format!("hive/{}/worker-{}", session_id, index);
+            let (_, worker_cwd) = create_session_worktree(
                 &session_id,
-                "queen",
-                &format!("hive/{}/queen", session_id),
+                &format!("worker-{}", index),
+                &worker_branch,
                 "HEAD",
                 &project_path,
             )?;
+            self.emit_workspace_created(
+                &session_id,
+                PRIMARY_CELL_ID,
+                &worker_branch,
+                Some(&worker_cwd),
+            );
 
-            // Check if plan.md exists (from previous planning phase)
-            let plan_path = project_path.join(".hive-manager").join(&session_id).join("plan.md");
-            let has_plan = plan_path.exists();
+            // Write task file for this worker (STANDBY or with initial task)
+            Self::write_task_file(&project_path, &session_id, index, worker_config.initial_prompt.as_deref())?;
 
-            // Write Queen prompt to file and pass to CLI
-            let master_prompt = Self::build_queen_master_prompt(&config.queen_config.cli, &session_id, &config.workers, config.prompt.as_deref(), has_plan);
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt)?;
+            // Write worker prompt to file and pass to CLI
+            let worker_prompt = Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
+            let filename = format!("worker-{}-prompt.md", index);
+            let prompt_file = Self::write_prompt_file(&project_path, &session_id, &filename, &worker_prompt)?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
-            // Write tool documentation files
-            Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli)?;
+            tracing::info!("Launching Worker {} agent (v2): {} {:?} in {:?}", index, cmd, args, worker_cwd);
 
-            tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, queen_cwd);
-
-            pty_manager
-                .create_session(
-                    queen_id.clone(),
-                    AgentRole::Queen,
+            {
+                let pty_manager = self.pty_manager.read();
+                if let Err(e) = pty_manager.create_session(
+                    worker_id.clone(),
+                    AgentRole::Worker { index, parent: Some(queen_id.clone()) },
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(&queen_cwd),
+                    Some(&worker_cwd),
                     120,
                     30,
-                )
-                .map_err(|e| format!("Failed to spawn Queen: {}", e))?;
+                ) {
+                    let _ = remove_session_worktree_cell(
+                        &project_path,
+                        &session_id,
+                        &format!("worker-{index}"),
+                    );
+                    return Err(format!("Failed to spawn Worker {}: {}", index, e));
+                }
+            }
 
             agents.push(AgentInfo {
-                id: queen_id.clone(),
-                role: AgentRole::Queen,
+                id: worker_id,
+                role: AgentRole::Worker { index, parent: Some(queen_id.clone()) },
                 status: AgentStatus::Running,
-                config: config.queen_config.clone(),
-                parent_id: None,
+                config: worker_config.clone(),
+                parent_id: Some(queen_id.clone()),
             });
-
-            // Create Worker agents
-            for (i, worker_config) in config.workers.iter().enumerate() {
-                let index = (i + 1) as u8;
-                let worker_id = format!("{}-worker-{}", session_id, index);
-                let worker_role = worker_config.role.clone().unwrap_or_else(|| {
-                    WorkerRole::new("general", "Worker", &worker_config.cli)
-                });
-                let worker_config =
-                    Self::apply_worker_identity(index, &worker_role, worker_config.clone());
-                let (cmd, mut args) = Self::build_command(&worker_config);
-                let (_, worker_cwd) = create_session_worktree(
-                    &session_id,
-                    &format!("worker-{}", index),
-                    &format!("hive/{}/worker-{}", session_id, index),
-                    "HEAD",
-                    &project_path,
-                )?;
-
-                // Write task file for this worker (STANDBY or with initial task)
-                Self::write_task_file(&project_path, &session_id, index, worker_config.initial_prompt.as_deref())?;
-
-                // Write worker prompt to file and pass to CLI
-                let worker_prompt = Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
-                let filename = format!("worker-{}-prompt.md", index);
-                let prompt_file = Self::write_prompt_file(&project_path, &session_id, &filename, &worker_prompt)?;
-                let prompt_path = prompt_file.to_string_lossy().to_string();
-                Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
-
-                tracing::info!("Launching Worker {} agent (v2): {} {:?} in {:?}", index, cmd, args, worker_cwd);
-
-                pty_manager
-                    .create_session(
-                        worker_id.clone(),
-                        AgentRole::Worker { index, parent: Some(queen_id.clone()) },
-                        &cmd,
-                        &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                        Some(&worker_cwd),
-                        120,
-                        30,
-                    )
-                    .map_err(|e| format!("Failed to spawn Worker {}: {}", index, e))?;
-
-                agents.push(AgentInfo {
-                    id: worker_id,
-                    role: AgentRole::Worker { index, parent: Some(queen_id.clone()) },
-                    status: AgentStatus::Running,
-                    config: worker_config.clone(),
-                    parent_id: Some(queen_id.clone()),
-                });
-            }
         }
 
         let session = Session {
@@ -6542,6 +6728,42 @@ Last updated: {timestamp}
             qa_timeout_secs: persisted.qa_timeout_secs,
             auth_strategy,
         })
+    }
+
+    /// Minimal `Session` for `cleanup_session_worktrees` when no in-memory session exists.
+    fn session_shell_from_persisted_for_worktree_cleanup(
+        persisted: &crate::storage::PersistedSession,
+    ) -> Session {
+        let session_type = match &persisted.session_type {
+            crate::storage::SessionTypeInfo::Hive { worker_count } => SessionType::Hive {
+                worker_count: *worker_count,
+            },
+            crate::storage::SessionTypeInfo::Swarm { planner_count } => SessionType::Swarm {
+                planner_count: *planner_count,
+            },
+            crate::storage::SessionTypeInfo::Fusion { variants } => SessionType::Fusion {
+                variants: variants.clone(),
+            },
+            crate::storage::SessionTypeInfo::Solo { cli, model } => SessionType::Solo {
+                cli: cli.clone(),
+                model: model.clone(),
+            },
+        };
+        Session {
+            id: persisted.id.clone(),
+            name: persisted.name.clone(),
+            color: persisted.color.clone(),
+            session_type,
+            project_path: PathBuf::from(&persisted.project_path),
+            state: SessionState::Completed,
+            created_at: persisted.created_at,
+            agents: vec![],
+            default_cli: persisted.default_cli.clone(),
+            default_model: persisted.default_model.clone(),
+            max_qa_iterations: persisted.max_qa_iterations,
+            qa_timeout_secs: persisted.qa_timeout_secs,
+            auth_strategy: AuthStrategy::None,
+        }
     }
 
     /// Continue a Swarm session after planning phase

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -7080,13 +7080,20 @@ Last updated: {timestamp}
 
         let config_with_role = Self::apply_worker_identity(worker_index, &role, config);
         let (cmd, mut args) = Self::build_command(&config_with_role);
+        let worker_branch = format!("hive/{}/worker-{}", session_id, worker_index);
         let (_, worker_cwd) = create_session_worktree(
             session_id,
             &format!("worker-{}", worker_index),
-            &format!("hive/{}/worker-{}", session_id, worker_index),
+            &worker_branch,
             "HEAD",
             &session.project_path,
         )?;
+        self.emit_workspace_created(
+            session_id,
+            PRIMARY_CELL_ID,
+            &worker_branch,
+            Some(&worker_cwd),
+        );
 
         // Write task file for this worker (STANDBY or with initial task)
         Self::write_task_file(&session.project_path, session_id, worker_index, config_with_role.initial_prompt.as_deref())?;
@@ -7112,17 +7119,22 @@ Last updated: {timestamp}
         // Spawn PTY
         {
             let pty_manager = self.pty_manager.read();
-            pty_manager
-                .create_session(
-                    worker_id.clone(),
-                    worker_role.clone(),
-                    &cmd,
-                    &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
-                    Some(&worker_cwd),
-                    120,
-                    30,
-                )
-                .map_err(|e| format!("Failed to spawn Worker {}: {}", worker_index, e))?;
+            if let Err(e) = pty_manager.create_session(
+                worker_id.clone(),
+                worker_role.clone(),
+                &cmd,
+                &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                Some(&worker_cwd),
+                120,
+                30,
+            ) {
+                let _ = remove_session_worktree_cell(
+                    &session.project_path,
+                    session_id,
+                    &format!("worker-{worker_index}"),
+                );
+                return Err(format!("Failed to spawn Worker {}: {}", worker_index, e));
+            }
         }
 
         // Create agent info with role

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -12,6 +12,7 @@ use thiserror::Error;
 
 use crate::coordination::CoordinationMessage;
 use crate::domain::{ArtifactBundle, ResolverOutput};
+use crate::session::cell_status::PRIMARY_CELL_ID;
 use crate::templates::SessionTemplate;
 
 /// Generate a deterministic ID for legacy learnings that lack one.
@@ -897,7 +898,14 @@ impl SessionStorage {
     ) -> Result<(), StorageError> {
         let artifact_dir = self.artifact_dir(session_id);
         fs::create_dir_all(&artifact_dir)?;
-        self.atomic_write_json(&self.artifact_file_path(session_id, cell_id), artifact)
+
+        if cell_id == PRIMARY_CELL_ID {
+            let lock = self.artifact_lock(session_id, cell_id);
+            let _guard = lock.lock();
+            self.atomic_write_json(&self.artifact_file_path(session_id, cell_id), artifact)
+        } else {
+            self.atomic_write_json(&self.artifact_file_path(session_id, cell_id), artifact)
+        }
     }
 
     pub fn load_artifact(
@@ -1135,6 +1143,9 @@ pub struct RoleDefaults {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{mpsc, Arc};
+    use std::thread;
+    use std::time::Duration;
     use tempfile::TempDir;
 
     fn create_test_storage() -> (SessionStorage, TempDir) {
@@ -1373,5 +1384,58 @@ invalid json line
         assert_eq!(learnings[0].id, "valid-1");
         assert_eq!(learnings[1].id, "valid-2");
         assert_eq!(learnings[2].id, "valid-3");
+    }
+
+    #[test]
+    fn test_primary_cell_save_artifact_waits_for_existing_lock() {
+        let (storage, _temp_dir) = create_test_storage();
+        let storage = Arc::new(storage);
+        let session_id = "test-session-primary-artifact-lock";
+
+        storage.create_session_dir(session_id).unwrap();
+
+        let artifact = ArtifactBundle {
+            summary: Some("summary".to_string()),
+            changed_files: vec!["src/main.rs".to_string()],
+            commits: vec!["abc123".to_string()],
+            branch: "feature/primary-lock".to_string(),
+            test_results: None,
+            diff_summary: None,
+            unresolved_issues: vec![],
+            confidence: Some(0.9),
+            recommended_next_step: None,
+        };
+
+        let lock = storage.artifact_lock(session_id, PRIMARY_CELL_ID);
+        let guard = lock.lock();
+
+        let (done_tx, done_rx) = mpsc::channel();
+        let storage_clone = Arc::clone(&storage);
+        let artifact_clone = artifact.clone();
+
+        let save_thread = thread::spawn(move || {
+            storage_clone
+                .save_artifact(session_id, PRIMARY_CELL_ID, &artifact_clone)
+                .unwrap();
+            done_tx.send(()).unwrap();
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "save_artifact should wait while the primary cell lock is held"
+        );
+
+        drop(guard);
+
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("save_artifact should complete after the primary cell lock is released");
+        save_thread.join().unwrap();
+
+        let saved = storage
+            .load_artifact(session_id, PRIMARY_CELL_ID)
+            .unwrap()
+            .expect("artifact should be persisted");
+        assert_eq!(saved.branch, artifact.branch);
     }
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -3,8 +3,10 @@ use std::fs;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -37,6 +39,23 @@ fn stable_learning_id(learning: &Learning) -> String {
         learning.files_touched.join(","),
     );
     Uuid::new_v5(&Uuid::NAMESPACE_DNS, content.as_bytes()).to_string()
+}
+
+fn deserialize_optional_trimmed_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = Option::<String>::deserialize(deserializer)?;
+    Ok(value.and_then(|raw| {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -145,6 +164,7 @@ pub struct PersistedAgentConfig {
     pub model: Option<String>,
     pub flags: Vec<String>,
     pub label: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub name: Option<String>,
     pub description: Option<String>,
     pub role_type: Option<String>,
@@ -154,6 +174,7 @@ pub struct PersistedAgentConfig {
 /// Manages session storage in %APPDATA%/hive-manager
 pub struct SessionStorage {
     base_dir: PathBuf,
+    artifact_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
 }
 
 impl SessionStorage {
@@ -176,7 +197,10 @@ impl SessionStorage {
             fs::write(&config_path, serde_json::to_string_pretty(&default_config)?)?;
         }
 
-        Ok(Self { base_dir })
+        Ok(Self {
+            base_dir,
+            artifact_locks: Mutex::new(HashMap::new()),
+        })
     }
 
     /// Get the app data directory path
@@ -626,6 +650,15 @@ impl SessionStorage {
         self.artifact_dir(session_id).join(format!("{}.json", cell_id))
     }
 
+    fn artifact_lock(&self, session_id: &str, cell_id: &str) -> Arc<Mutex<()>> {
+        let key = format!("{session_id}:{cell_id}");
+        let mut locks = self.artifact_locks.lock();
+        locks
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
     fn resolver_output_path(&self, session_id: &str) -> PathBuf {
         self.session_dir(session_id).join("resolver_output.json")
     }
@@ -874,6 +907,28 @@ impl SessionStorage {
     ) -> Result<Option<ArtifactBundle>, StorageError> {
         let path = self.artifact_file_path(session_id, cell_id);
         self.read_optional_json(&path)
+    }
+
+    pub fn atomic_update_artifact<F>(
+        &self,
+        session_id: &str,
+        cell_id: &str,
+        update: F,
+    ) -> Result<ArtifactBundle, StorageError>
+    where
+        F: FnOnce(Option<ArtifactBundle>) -> ArtifactBundle,
+    {
+        let artifact_dir = self.artifact_dir(session_id);
+        fs::create_dir_all(&artifact_dir)?;
+
+        let lock = self.artifact_lock(session_id, cell_id);
+        let _guard = lock.lock();
+
+        let path = self.artifact_file_path(session_id, cell_id);
+        let current = self.read_optional_json(&path)?;
+        let updated = update(current);
+        self.atomic_write_json(&path, &updated)?;
+        Ok(updated)
     }
 
     pub fn save_resolver_output(

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -145,6 +145,8 @@ pub struct PersistedAgentConfig {
     pub model: Option<String>,
     pub flags: Vec<String>,
     pub label: Option<String>,
+    pub name: Option<String>,
+    pub description: Option<String>,
     pub role_type: Option<String>,
     pub initial_prompt: Option<String>,
 }
@@ -559,15 +561,20 @@ impl SessionStorage {
         agent_id: &str,
         from: &str,
         content: &str,
-    ) -> Result<(), StorageError> {
+    ) -> Result<ConversationMessage, StorageError> {
         let conversations_dir = self.session_dir(session_id).join("conversations");
         fs::create_dir_all(&conversations_dir)?;
         let path = self.conversation_file_path(session_id, agent_id);
+        let message = ConversationMessage {
+            timestamp: Utc::now(),
+            from: from.to_string(),
+            content: content.to_string(),
+        };
         let entry = format!(
             "---\n[{}] from @{}\n{}\n\n",
-            Utc::now().to_rfc3339(),
-            from,
-            content
+            message.timestamp.to_rfc3339(),
+            message.from,
+            message.content
         );
 
         tokio::task::spawn_blocking(move || -> Result<(), StorageError> {
@@ -576,7 +583,9 @@ impl SessionStorage {
             Ok(())
         })
         .await
-        .map_err(|e| StorageError::InvalidPath(format!("Join error in append conversation: {}", e)))?
+        .map_err(|e| StorageError::InvalidPath(format!("Join error in append conversation: {}", e)))??;
+
+        Ok(message)
     }
 
     /// Read conversation messages with optional since filter.

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -654,7 +654,7 @@ Branch: {{branch}}
 {{task}}
 
 ## Rules
-- Work ONLY within your worktree directory
+- Work ONLY within the provided working directory
 - Commit all changes to your branch
 - Do NOT interact with other variants
 - When complete, update your task file status to COMPLETED

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -117,6 +117,32 @@ pub fn create_session_worktree(
     Ok((worktree_path, worktree_str))
 }
 
+/// Remove a single session worktree under `.hive-manager/worktrees/{session}/{cell_id}`.
+/// Used when PTY spawn fails after `create_session_worktree` so branches/worktrees are not left behind.
+pub fn remove_session_worktree_cell(
+    project_path: &Path,
+    session_id: &str,
+    cell_id: &str,
+) -> Result<(), String> {
+    let worktree_path = project_path
+        .join(".hive-manager")
+        .join("worktrees")
+        .join(session_id)
+        .join(cell_id);
+    if !worktree_path.exists() {
+        return Ok(());
+    }
+
+    let manager = WorktreeManager::new(project_path);
+    if let Err(err) = manager.remove_worktree(&worktree_path, true) {
+        if !is_missing_worktree_error(&err.message) {
+            return Err(err.message);
+        }
+    }
+    let _ = manager.prune_worktrees();
+    Ok(())
+}
+
 pub fn cleanup_session_worktrees(session: &Session) -> Result<(), String> {
     let manager = WorktreeManager::new(&session.project_path);
     let worktrees = manager

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -3,7 +3,7 @@
 //! Provides branch naming conventions and dirty state detection
 //! for cell-based worktree operations.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[cfg(windows)]
@@ -13,6 +13,8 @@ use std::os::windows::process::CommandExt;
 const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 use crate::domain::{CellType, SessionMode};
+use crate::runtime::WorktreeManager;
+use crate::session::{Session, SessionType};
 
 /// Generate a branch name for a cell based on session mode and cell type.
 ///
@@ -88,6 +90,78 @@ pub fn branch_exists(worktree_path: &Path, branch_name: &str) -> Result<bool, St
     }
 }
 
+pub fn create_session_worktree(
+    session_id: &str,
+    cell_id: &str,
+    branch: &str,
+    base_branch: &str,
+    project_path: &Path,
+) -> Result<(PathBuf, String), String> {
+    let worktree_path = project_path
+        .join(".hive-manager")
+        .join("worktrees")
+        .join(session_id)
+        .join(cell_id);
+
+    if let Some(parent) = worktree_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create worktree parent dir: {}", e))?;
+    }
+
+    let worktree_str = worktree_path.to_string_lossy().to_string();
+    run_git(
+        project_path,
+        &["worktree", "add", &worktree_str, "-b", branch, base_branch],
+    )?;
+
+    Ok((worktree_path, worktree_str))
+}
+
+pub fn cleanup_session_worktrees(session: &Session) -> Result<(), String> {
+    let manager = WorktreeManager::new(&session.project_path);
+    let worktrees = manager
+        .list_worktrees()
+        .map_err(|e| format!("worktree list: {}", e.message))?;
+
+    let session_prefixes = match &session.session_type {
+        SessionType::Fusion { .. } => vec![session.project_path.join(".hive-fusion").join(&session.id)],
+        _ => vec![session
+            .project_path
+            .join(".hive-manager")
+            .join("worktrees")
+            .join(&session.id)],
+    };
+
+    let mut cleanup_errors = Vec::new();
+    for worktree in worktrees {
+        if !session_prefixes.iter().any(|prefix| worktree.path.starts_with(prefix)) {
+            continue;
+        }
+
+        if let Err(err) = manager.remove_worktree(&worktree.path, true) {
+            if is_missing_worktree_error(&err.message) {
+                tracing::debug!(
+                    "Ignoring missing worktree during cleanup: {} ({})",
+                    worktree.path.display(),
+                    err.message
+                );
+            } else {
+                cleanup_errors.push(format!("{}: {}", worktree.path.display(), err.message));
+            }
+        }
+    }
+
+    if let Err(err) = manager.prune_worktrees() {
+        cleanup_errors.push(format!("worktree prune: {}", err.message));
+    }
+
+    if cleanup_errors.is_empty() {
+        Ok(())
+    } else {
+        Err(cleanup_errors.join(" | "))
+    }
+}
+
 /// Run a git command in the specified directory.
 fn run_git(cwd: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("git");
@@ -115,6 +189,15 @@ fn run_git(cwd: &Path, args: &[&str]) -> Result<String, String> {
     }
 
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+fn is_missing_worktree_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("is not a working tree")
+        || lower.contains("is not a git repository")
+        || lower.contains("could not remove reference")
+        || lower.contains("no such file or directory")
+        || lower.contains("cannot find the path specified")
 }
 
 #[cfg(test)]

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -108,11 +108,20 @@ pub fn create_session_worktree(
             .map_err(|e| format!("Failed to create worktree parent dir: {}", e))?;
     }
 
+    let manager = WorktreeManager::new(project_path);
+    manager
+        .prune_worktrees()
+        .map_err(|err| format!("worktree prune: {}", err.message))?;
+
     let worktree_str = worktree_path.to_string_lossy().to_string();
-    run_git(
-        project_path,
-        &["worktree", "add", &worktree_str, "-b", branch, base_branch],
-    )?;
+    if branch_exists(project_path, branch)? {
+        run_git(project_path, &["worktree", "add", &worktree_str, branch])?;
+    } else {
+        run_git(
+            project_path,
+            &["worktree", "add", &worktree_str, "-b", branch, base_branch],
+        )?;
+    }
 
     Ok((worktree_path, worktree_str))
 }
@@ -129,11 +138,12 @@ pub fn remove_session_worktree_cell(
         .join("worktrees")
         .join(session_id)
         .join(cell_id);
+    let manager = WorktreeManager::new(project_path);
+    let _ = manager.prune_worktrees();
     if !worktree_path.exists() {
         return Ok(());
     }
 
-    let manager = WorktreeManager::new(project_path);
     if let Err(err) = manager.remove_worktree(&worktree_path, true) {
         if !is_missing_worktree_error(&err.message) {
             return Err(err.message);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.23.1",
+  "version": "0.24.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -31,6 +31,8 @@
   let selectedRoleType = 'backend';
   let customRoleName = '';
   let selectedCli = 'claude';
+  let workerName = '';
+  let workerDescription = '';
   let initialTask = '';
   let selectedParent: string | null = null;
   let loading = false;
@@ -71,6 +73,9 @@
       return;
     }
 
+    const trimmedName = workerName.trim() || `Worker (${roleLabel})`;
+    const trimmedDescription = workerDescription.trim() || initialTask.trim() || `${roleLabel} tasks`;
+
     const role: WorkerRole = {
       role_type: roleType,
       label: roleLabel,
@@ -80,9 +85,13 @@
 
     const request: AddWorkerRequest = {
       session_id: $activeSession.id,
+      name: trimmedName,
+      description: trimmedDescription,
       config: {
         cli: selectedCli,
         flags: [],
+        name: trimmedName,
+        description: trimmedDescription,
         role,
         initial_prompt: initialTask || undefined,
       },
@@ -200,6 +209,28 @@
             </select>
           </div>
         {/if}
+
+        <div class="form-section">
+          <label class="section-label" for="name-input">Worker Name</label>
+          <input
+            id="name-input"
+            type="text"
+            placeholder="Worker 2 (Frontend)"
+            bind:value={workerName}
+            class="custom-role-input"
+          />
+        </div>
+
+        <div class="form-section">
+          <label class="section-label" for="description-input">Description</label>
+          <input
+            id="description-input"
+            type="text"
+            placeholder="One-line task summary"
+            bind:value={workerDescription}
+            class="custom-role-input"
+          />
+        </div>
 
         <div class="form-section">
           <label class="section-label" for="task-input">Initial Task (optional)</label>

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -74,7 +74,7 @@
     }
 
     const explicitName = workerName.trim();
-    const trimmedDescription = workerDescription.trim() || initialTask.trim() || `${roleLabel} tasks`;
+    const trimmedDescription = workerDescription.trim() || `${roleLabel} tasks`;
 
     const role: WorkerRole = {
       role_type: roleType,

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -73,7 +73,7 @@
       return;
     }
 
-    const trimmedName = workerName.trim() || `Worker (${roleLabel})`;
+    const explicitName = workerName.trim();
     const trimmedDescription = workerDescription.trim() || initialTask.trim() || `${roleLabel} tasks`;
 
     const role: WorkerRole = {
@@ -85,12 +85,12 @@
 
     const request: AddWorkerRequest = {
       session_id: $activeSession.id,
-      name: trimmedName,
+      ...(explicitName ? { name: explicitName } : {}),
       description: trimmedDescription,
       config: {
         cli: selectedCli,
         flags: [],
-        name: trimmedName,
+        ...(explicitName ? { name: explicitName } : {}),
         description: trimmedDescription,
         role,
         initial_prompt: initialTask || undefined,

--- a/src/lib/components/TerminalGrid.svelte
+++ b/src/lib/components/TerminalGrid.svelte
@@ -51,13 +51,14 @@
 >
   {#each agents as agent (agent.id)}
     {@const status = serdeEnumVariantName(agent.status)}
+    {@const roleLabel = getRoleLabel(agent)}
     <div 
       class="terminal-item" 
       class:focused={agent.id === focusedAgentId}
       onclick={() => onSelect(agent.id)}
     >
       <div class="terminal-header" style:border-top-color={$activeSession?.color || 'transparent'} style:border-top-width={$activeSession?.color ? '3px' : '0'}>
-        <span class="role-label">{getRoleLabel(agent)}</span>
+        <span class="role-label" title={roleLabel}>{roleLabel}</span>
         <div class="terminal-meta">
           <span class="cli-badge">{agent.config?.cli || 'unknown'}</span>
           <span class="status-indicator" 
@@ -121,6 +122,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    gap: 8px;
     padding: 6px 10px;
     background: var(--bg-surface);
     border-bottom: 1px solid var(--border-structural);
@@ -128,6 +130,11 @@
   }
 
   .role-label {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
     font-size: 11px;
     font-weight: 600;
     color: var(--text-primary);

--- a/src/lib/components/TerminalGrid.svelte
+++ b/src/lib/components/TerminalGrid.svelte
@@ -30,6 +30,8 @@
 
   function getRoleLabel(agent: AgentInfo) {
     if (agent.config?.label) return agent.config.label;
+    if (agent.config?.name && agent.config?.description) return `${agent.config.name} — ${agent.config.description}`;
+    if (agent.config?.name) return agent.config.name;
     if (serdeEnumVariantName(agent.role) === 'Queen') return 'Queen';
     if (typeof agent.role === 'object' && agent.role !== null) {
       if ('Judge' in agent.role) return 'Judge';

--- a/src/lib/components/TreeItem.svelte
+++ b/src/lib/components/TreeItem.svelte
@@ -98,7 +98,10 @@
   $: children = childrenMap.get(agent.id) || [];
   $: hasChildren = children.length > 0;
   $: isSelected = selectedId === agent.id;
-  $: displayLabel = agent.config?.label || getRoleName(agent.role);
+  $: displayLabel = agent.config?.label
+    || (agent.config?.name && agent.config?.description ? `${agent.config.name} — ${agent.config.description}` : null)
+    || agent.config?.name
+    || getRoleName(agent.role);
   $: RoleIcon = getRoleIcon(agent.role);
   $: StatusIcon = getStatusIcon(agent.status);
 </script>

--- a/src/lib/components/session/SessionOverview.svelte
+++ b/src/lib/components/session/SessionOverview.svelte
@@ -4,6 +4,7 @@
     import { cells } from '../../stores/cells';
     import { agents } from '../../stores/agents';
     import { events } from '../../stores/events';
+    import { conversationStore } from '../../stores/conversations';
     import { activeSession, activeAgents, type AgentInfo } from '../../stores/sessions';
     import SessionHeader from './SessionHeader.svelte';
     import CellGrid from '../cell/CellGrid.svelte';
@@ -77,6 +78,8 @@
         await cells.fetchCells(sid);
         const cellIds = Object.keys($cells.cells);
         await Promise.all(cellIds.map(cid => agents.fetchAgents(sid, cid)));
+        // Also poll for messages in the selected conversation
+        await conversationStore.pollMessages();
     }
 
     $effect(() => {
@@ -84,6 +87,8 @@
             connectedSessionId = sessionId;
             fetchCellsAndAgents(sessionId);
             cells.setExternalRefreshHandler(() => {
+                // Immediate refresh on external signal (e.g. Tauri event)
+                void fetchCellsAndAgents(sessionId);
                 schedulePoll();
             });
             schedulePoll();
@@ -91,6 +96,7 @@
             events.connect(sessionId);
         } else if (sessionId) {
             cells.setExternalRefreshHandler(() => {
+                void fetchCellsAndAgents(sessionId);
                 schedulePoll();
             });
         }

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -82,6 +82,7 @@ function mergeConversationMessages(
 }
 
 function createConversationStore() {
+  let activeConversationRequest = 0;
   const { subscribe, update } = writable<ConversationState>({
     messages: [],
     loading: false,
@@ -116,19 +117,28 @@ function createConversationStore() {
     subscribe,
 
     selectAgent(agentId: string | null) {
-      update((state) => ({ ...state, selectedAgent: agentId, messages: [] }));
+      activeConversationRequest += 1;
+      update((state) => ({
+        ...state,
+        selectedAgent: agentId,
+        messages: [],
+        loading: false,
+      }));
     },
 
     setSessionId(sessionId: string | null) {
+      activeConversationRequest += 1;
       update((state) => ({
         ...state,
         sessionId,
         messages: [],
         selectedAgent: null,
+        loading: false,
       }));
     },
 
     async loadConversation(sessionId: string, agentId: string, since?: string) {
+      const requestToken = ++activeConversationRequest;
       update((state) => ({ ...state, loading: true, error: null }));
       try {
         let url = apiUrl(`/api/sessions/${sessionId}/conversations/${agentId}`);
@@ -139,6 +149,14 @@ function createConversationStore() {
         const messages: ConversationMessage[] = data.messages ?? [];
         
         update((state) => {
+          if (requestToken !== activeConversationRequest) {
+            return state;
+          }
+
+          if (state.sessionId !== sessionId || state.selectedAgent !== agentId) {
+            return { ...state, loading: false };
+          }
+
           const newMessages = since
             ? mergeConversationMessages(state.messages, messages)
             : dedupeConversationMessages(messages);
@@ -152,7 +170,13 @@ function createConversationStore() {
           };
         });
       } catch (err) {
-        update((state) => ({ ...state, loading: false, error: String(err) }));
+        update((state) => {
+          if (requestToken !== activeConversationRequest) {
+            return state;
+          }
+
+          return { ...state, loading: false, error: String(err) };
+        });
       }
     },
 
@@ -167,7 +191,7 @@ function createConversationStore() {
           }
         );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        // No need to reload - Tauri event will push it (and poll will catch up if missed)
+        await this.pollMessages();
       } catch (err) {
         update((state) => ({ ...state, error: String(err) }));
       }

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -124,6 +124,7 @@ function createConversationStore() {
         selectedAgent: agentId,
         messages: [],
         loading: false,
+        error: null,
       }));
     },
 
@@ -135,6 +136,7 @@ function createConversationStore() {
         messages: [],
         selectedAgent: null,
         loading: false,
+        error: null,
       }));
     },
 

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -3,10 +3,12 @@ import { listen } from '@tauri-apps/api/event';
 import { apiUrl } from '$lib/config';
 
 export interface ConversationMessage {
+  id?: string;
   timestamp: string;
   from: string;
   content: string;
   agent_id?: string;
+  session_id?: string;
 }
 
 export interface HeartbeatInfo {
@@ -33,6 +35,52 @@ function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+function hashContent(value: string): string {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash * 31 + value.charCodeAt(i)) >>> 0;
+  }
+
+  return hash.toString(16);
+}
+
+function conversationMessageKey(message: ConversationMessage): string {
+  if (message.id) {
+    return message.id;
+  }
+
+  return [
+    message.timestamp,
+    message.from,
+    message.agent_id ?? '',
+    hashContent(message.content),
+  ].join('|');
+}
+
+function dedupeConversationMessages(messages: ConversationMessage[]): ConversationMessage[] {
+  const seen = new Set<string>();
+  const deduped: ConversationMessage[] = [];
+
+  for (const message of messages) {
+    const key = conversationMessageKey(message);
+    if (seen.has(key)) {
+      continue;
+    }
+
+    seen.add(key);
+    deduped.push(message);
+  }
+
+  return deduped;
+}
+
+function mergeConversationMessages(
+  existing: ConversationMessage[],
+  incoming: ConversationMessage[],
+): ConversationMessage[] {
+  return dedupeConversationMessages([...existing, ...incoming]);
+}
+
 function createConversationStore() {
   const { subscribe, update } = writable<ConversationState>({
     messages: [],
@@ -45,13 +93,21 @@ function createConversationStore() {
   // Listen for real-time conversation messages from Tauri
   listen<ConversationMessage>('conversation-message', (event) => {
     update((state) => {
-      // CONTRACT: only push if it belongs to selected agent (or no agent_id in payload, but we fixed that)
-      if (event.payload.agent_id && state.selectedAgent !== event.payload.agent_id) {
+      if (!state.sessionId || !state.selectedAgent) {
         return state;
       }
+
+      if (event.payload.session_id !== state.sessionId) {
+        return state;
+      }
+
+      if (event.payload.agent_id !== state.selectedAgent) {
+        return state;
+      }
+
       return {
         ...state,
-        messages: [...state.messages, event.payload],
+        messages: mergeConversationMessages(state.messages, [event.payload]),
       };
     });
   });
@@ -83,17 +139,17 @@ function createConversationStore() {
         const messages: ConversationMessage[] = data.messages ?? [];
         
         update((state) => {
-           // If we are appending (using 'since'), don't overwrite
-           const newMessages = since 
-             ? [...state.messages, ...messages] 
-             : messages;
-           return {
-             ...state,
-             messages: newMessages,
-             loading: false,
-             sessionId,
-             selectedAgent: agentId,
-           };
+          const newMessages = since
+            ? mergeConversationMessages(state.messages, messages)
+            : dedupeConversationMessages(messages);
+
+          return {
+            ...state,
+            messages: newMessages,
+            loading: false,
+            sessionId,
+            selectedAgent: agentId,
+          };
         });
       } catch (err) {
         update((state) => ({ ...state, loading: false, error: String(err) }));

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -6,6 +6,7 @@ export interface ConversationMessage {
   timestamp: string;
   from: string;
   content: string;
+  agent_id?: string;
 }
 
 export interface HeartbeatInfo {
@@ -43,10 +44,16 @@ function createConversationStore() {
 
   // Listen for real-time conversation messages from Tauri
   listen<ConversationMessage>('conversation-message', (event) => {
-    update((state) => ({
-      ...state,
-      messages: [...state.messages, event.payload],
-    }));
+    update((state) => {
+      // CONTRACT: only push if it belongs to selected agent (or no agent_id in payload, but we fixed that)
+      if (event.payload.agent_id && state.selectedAgent !== event.payload.agent_id) {
+        return state;
+      }
+      return {
+        ...state,
+        messages: [...state.messages, event.payload],
+      };
+    });
   });
 
   return {
@@ -74,13 +81,20 @@ function createConversationStore() {
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
         const data = await resp.json();
         const messages: ConversationMessage[] = data.messages ?? [];
-        update((state) => ({
-          ...state,
-          messages,
-          loading: false,
-          sessionId,
-          selectedAgent: agentId,
-        }));
+        
+        update((state) => {
+           // If we are appending (using 'since'), don't overwrite
+           const newMessages = since 
+             ? [...state.messages, ...messages] 
+             : messages;
+           return {
+             ...state,
+             messages: newMessages,
+             loading: false,
+             sessionId,
+             selectedAgent: agentId,
+           };
+        });
       } catch (err) {
         update((state) => ({ ...state, loading: false, error: String(err) }));
       }
@@ -97,14 +111,21 @@ function createConversationStore() {
           }
         );
         if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        // Reload to get the appended message
-        const state = getState();
-        if (state.sessionId && state.selectedAgent) {
-          await this.loadConversation(state.sessionId, state.selectedAgent);
-        }
+        // No need to reload - Tauri event will push it (and poll will catch up if missed)
       } catch (err) {
         update((state) => ({ ...state, error: String(err) }));
       }
+    },
+
+    // CONTRACT: Fallback poll in case Tauri event is lost
+    async pollMessages() {
+      const state = getState();
+      if (!state.sessionId || !state.selectedAgent) return;
+      
+      const lastMsg = state.messages[state.messages.length - 1];
+      const since = lastMsg?.timestamp;
+      
+      await this.loadConversation(state.sessionId, state.selectedAgent, since);
     },
 
     clearError() {

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -44,11 +44,7 @@ function hashContent(value: string): string {
   return hash.toString(16);
 }
 
-function conversationMessageKey(message: ConversationMessage): string {
-  if (message.id) {
-    return message.id;
-  }
-
+function conversationMessageSignature(message: ConversationMessage): string {
   return [
     message.timestamp,
     message.from,
@@ -58,16 +54,21 @@ function conversationMessageKey(message: ConversationMessage): string {
 }
 
 function dedupeConversationMessages(messages: ConversationMessage[]): ConversationMessage[] {
-  const seen = new Set<string>();
+  const seenIds = new Set<string>();
+  const seenSignatures = new Set<string>();
   const deduped: ConversationMessage[] = [];
 
   for (const message of messages) {
-    const key = conversationMessageKey(message);
-    if (seen.has(key)) {
+    const signature = conversationMessageSignature(message);
+    const id = message.id;
+    if ((id && seenIds.has(id)) || seenSignatures.has(signature)) {
       continue;
     }
 
-    seen.add(key);
+    if (id) {
+      seenIds.add(id);
+    }
+    seenSignatures.add(signature);
     deduped.push(message);
   }
 

--- a/src/lib/stores/coordination.ts
+++ b/src/lib/stores/coordination.ts
@@ -38,11 +38,15 @@ export interface QueenInjectRequest {
 
 export interface AddWorkerRequest {
   session_id: string;
+  name?: string;
+  description?: string;
   config: {
     cli: string;
     model?: string;
     flags: string[];
     label?: string;
+    name?: string;
+    description?: string;
     role?: WorkerRole;
     initial_prompt?: string;
   };

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -23,8 +23,22 @@ interface EventsState {
     error: string | null;
 }
 
+function sortEventsNewestFirst(events: SessionEvent[]): SessionEvent[] {
+    return [...events].sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+}
+
+function mergeEventsById(existing: SessionEvent[], incoming: SessionEvent[]): SessionEvent[] {
+    const merged = new Map<string, SessionEvent>();
+
+    for (const event of [...existing, ...incoming]) {
+        merged.set(event.id, event);
+    }
+
+    return sortEventsNewestFirst(Array.from(merged.values())).slice(0, 1000);
+}
+
 function createEventsStore() {
-    const { subscribe, set, update } = writable<EventsState>({
+    const { subscribe, update } = writable<EventsState>({
         events: [],
         loading: false,
         error: null,
@@ -43,7 +57,7 @@ function createEventsStore() {
             const event: SessionEvent = JSON.parse(raw.data);
             update(state => ({
                 ...state,
-                events: [event, ...state.events].slice(0, 1000),
+                events: mergeEventsById(state.events, [event]),
             }));
         } catch (err) {
             console.error('Failed to parse event:', err);
@@ -68,7 +82,7 @@ function createEventsStore() {
 
             update(state => ({
                 ...state,
-                events: [syntheticEvent, ...state.events].slice(0, 1000),
+                events: mergeEventsById(state.events, [syntheticEvent]),
             }));
 
             // CONTRACT: resync after lag
@@ -156,10 +170,11 @@ function createEventsStore() {
                 const response = await fetch(apiUrl(`/api/sessions/${sessionId}/events`));
                 if (!response.ok) throw new Error(`Failed to fetch events: ${response.statusText}`);
                 const events: SessionEvent[] = await response.json();
+                const normalizedEvents = sortEventsNewestFirst(events);
                 
                 update(state => ({
                     ...state,
-                    events: [...events].reverse(), // Show newest first
+                    events: mergeEventsById(state.events, normalizedEvents),
                     loading: false
                 }));
             } catch (err) {

--- a/src/lib/stores/events.ts
+++ b/src/lib/stores/events.ts
@@ -7,6 +7,7 @@ const EVENT_TYPES = [
     'session_status_changed',
     'cell_created',
     'cell_status_changed',
+    'conversation_message',
     'workspace_created',
     'agent_launched',
     'agent_completed',
@@ -49,6 +50,34 @@ function createEventsStore() {
         }
     }
 
+    function handleLagged(raw: MessageEvent<string>, source: EventSource, sessionId: string, store: any) {
+        if (eventSource !== source) {
+            return;
+        }
+
+        try {
+            const data = JSON.parse(raw.data);
+            const syntheticEvent: SessionEvent = {
+                id: `lagged-${Date.now()}`,
+                session_id: sessionId,
+                event_type: 'lagged',
+                timestamp: new Date().toISOString(),
+                payload: data,
+                severity: 'warning'
+            };
+
+            update(state => ({
+                ...state,
+                events: [syntheticEvent, ...state.events].slice(0, 1000),
+            }));
+
+            // CONTRACT: resync after lag
+            store.fetchEvents(sessionId);
+        } catch (err) {
+            console.error('Failed to handle lagged event:', err);
+        }
+    }
+
     return {
         subscribe,
 
@@ -80,6 +109,10 @@ function createEventsStore() {
                     consecutiveErrors = 0;
                     prependEvent(event as MessageEvent<string>, source);
                 });
+            });
+
+            source.addEventListener('lagged', (event) => {
+                handleLagged(event as MessageEvent<string>, source, sessionId, this);
             });
 
             source.onerror = async (err) => {

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -31,6 +31,8 @@ export interface AgentConfig {
   model?: string;
   flags: string[];
   label?: string;
+  name?: string;
+  description?: string;
   role?: WorkerRole;
   initial_prompt?: string;
 }

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -111,13 +111,15 @@ export type EventType =
     | 'session_status_changed'
     | 'cell_created'
     | 'cell_status_changed'
+    | 'conversation_message'
     | 'workspace_created'
     | 'agent_launched'
     | 'agent_completed'
     | 'agent_waiting_input'
     | 'agent_failed'
     | 'artifact_updated'
-    | 'resolver_selected_candidate';
+    | 'resolver_selected_candidate'
+    | 'lagged';
 
 export type Severity = 'info' | 'warning' | 'error';
 


### PR DESCRIPTION
## Summary
- Fixes #73 Active Cells panel agent filter (cell membership rules aligned across build_fusion_cell / build_resolver_cell / list_agents_in_cell)
- Fixes #74 Queen/Solo worktree auto-creation via extracted workspace/git.rs helper + idempotent cleanup
- Fixes #75 Observability/Artifacts populated by wiring emit_artifact_updated + artifacts collector into completion paths
- Fixes #76 Chat/Timeline populated via conversation-message event + synthetic SSE lagged frame for resync
- Adds Task 4b: spawn API split into explicit name + description fields as source of truth for terminal titles and UI labels
- Bumps v0.23.1 -> 0.24.0

## Test plan
- [ ] cargo check --tests passes
- [ ] Start a Queen session — worktree auto-created under ~/.hive-manager/<id>/worktrees
- [ ] Active Cells panel shows agents (non-Fusion + Fusion sessions)
- [ ] Artifacts tab populates as workers complete
- [ ] Chat panel receives conversation-message events
- [ ] Timeline handles SSE lagged frame and resyncs via GET /events
- [ ] Session close cleans up worktrees
- [ ] Spawn dialog submits with/without name field; indexed default used when empty

Closes #73
Closes #74
Closes #75
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workers can include optional name and one-line description.
  * Conversation messages are delivered in real time (events) and exposed via a polling fallback; UI receives and displays new messages.

* **Improvements**
  * UI shows name/description fallbacks in agent lists and headers.
  * Event stream now emits explicit "lagged" notifications and better resynchronization.
  * More robust artifact harvesting and workspace/worktree lifecycle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->