### PR TITLE
feat: Kanban dashboard (#77) + QA quiescence completion (#78)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-manager",
-  "version": "0.23.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-manager",
-      "version": "0.23.0",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.24.0"
+version = "0.25.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/http/handlers/artifacts.rs
+++ b/src-tauri/src/http/handlers/artifacts.rs
@@ -113,6 +113,9 @@ fn session_from_persisted(persisted: PersistedSession) -> Session {
         project_path: persisted.project_path.into(),
         state: session_state_from_persisted(&persisted.state),
         created_at: persisted.created_at,
+        last_activity_at: persisted
+            .last_activity_at
+            .unwrap_or(persisted.created_at),
         agents: vec![],
         default_cli: persisted.default_cli,
         default_model: persisted.default_model,

--- a/src-tauri/src/http/handlers/evaluator.rs
+++ b/src-tauri/src/http/handlers/evaluator.rs
@@ -327,7 +327,7 @@ pub async fn force_pass(
     Ok(Json(json!({
         "session_id": session_id,
         "action": "force-pass",
-        "new_state": "Running"
+        "new_state": "QaPassed"
     })))
 }
 

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -771,3 +771,27 @@ pub async fn close_session(
         "message": format!("Session {} closed", id)
     })))
 }
+
+/// POST /api/sessions/{id}/complete - Mark a session as completed
+pub async fn complete_session(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    validate_session_id(&id)?;
+
+    state
+        .session_controller
+        .read()
+        .mark_session_completed(&id)
+        .map_err(|e| {
+            if e.starts_with("Session not found") {
+                ApiError::not_found(e)
+            } else {
+                ApiError::internal(e)
+            }
+        })?;
+
+    Ok(Json(serde_json::json!({
+        "message": format!("Session {} marked completed", id)
+    })))
+}

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -352,19 +352,58 @@ pub async fn launch_session(
 pub async fn list_sessions(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SessionListResponse>, ApiError> {
-    let summaries = state.storage.list_sessions()
+    let persisted = state.storage.list_sessions()
         .map_err(|e| ApiError::internal(e.to_string()))?;
-    
-    let sessions = summaries.into_iter().map(|s| SessionInfo {
-        id: s.id,
-        name: s.name,
-        color: s.color,
-        session_type: s.session_type,
-        status: s.state,
-        project_path: s.project_path,
-        created_at: s.created_at.to_rfc3339(),
-        last_activity_at: s.last_activity_at.to_rfc3339(),
-    }).collect();
+
+    let active_sessions = state.session_controller.read().list_sessions();
+    let mut sessions = persisted
+        .into_iter()
+        .map(|s| {
+            (
+                s.id.clone(),
+                SessionInfo {
+                    id: s.id,
+                    name: s.name,
+                    color: s.color,
+                    session_type: s.session_type,
+                    status: s.state,
+                    project_path: s.project_path,
+                    created_at: s.created_at.to_rfc3339(),
+                    last_activity_at: s.last_activity_at.to_rfc3339(),
+                },
+            )
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    for session in active_sessions {
+        sessions.insert(
+            session.id.clone(),
+            SessionInfo {
+                id: session.id.clone(),
+                name: session.name.clone(),
+                color: session.color.clone(),
+                session_type: match &session.session_type {
+                    crate::session::SessionType::Hive { worker_count } => {
+                        format!("Hive ({})", worker_count)
+                    }
+                    crate::session::SessionType::Swarm { planner_count } => {
+                        format!("Swarm ({})", planner_count)
+                    }
+                    crate::session::SessionType::Fusion { variants } => {
+                        format!("Fusion ({})", variants.len())
+                    }
+                    crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
+                },
+                status: format!("{:?}", session.state),
+                project_path: session.project_path.to_string_lossy().to_string(),
+                created_at: session.created_at.to_rfc3339(),
+                last_activity_at: session.last_activity_at.to_rfc3339(),
+            },
+        );
+    }
+
+    let mut sessions = sessions.into_values().collect::<Vec<_>>();
+    sessions.sort_by(|a, b| b.created_at.cmp(&a.created_at));
 
     Ok(Json(SessionListResponse { sessions }))
 }
@@ -794,6 +833,8 @@ pub async fn complete_session(
         .map_err(|e| {
             if e.starts_with("Session not found") {
                 ApiError::not_found(e)
+            } else if e.starts_with("Session completion blocked:") {
+                ApiError::new(StatusCode::CONFLICT, e)
             } else {
                 ApiError::internal(e)
             }

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -79,6 +79,7 @@ pub struct SessionInfo {
     pub status: String,
     pub project_path: String,
     pub created_at: String,
+    pub last_activity_at: String,
 }
 
 #[derive(Serialize)]
@@ -362,6 +363,7 @@ pub async fn list_sessions(
         status: s.state,
         project_path: s.project_path,
         created_at: s.created_at.to_rfc3339(),
+        last_activity_at: s.last_activity_at.to_rfc3339(),
     }).collect();
 
     Ok(Json(SessionListResponse { sessions }))
@@ -389,6 +391,7 @@ pub async fn get_session(
             status: format!("{:?}", session.state),
             project_path: session.project_path.to_string_lossy().to_string(),
             created_at: session.created_at.to_rfc3339(),
+            last_activity_at: session.last_activity_at.to_rfc3339(),
         }));
     }
 
@@ -409,6 +412,10 @@ pub async fn get_session(
         status: persisted.state,
         project_path: persisted.project_path,
         created_at: persisted.created_at.to_rfc3339(),
+        last_activity_at: persisted
+            .last_activity_at
+            .unwrap_or(persisted.created_at)
+            .to_rfc3339(),
     }))
 }
 
@@ -654,6 +661,7 @@ pub async fn update_session(
         status: format!("{:?}", session.state),
         project_path: session.project_path.to_string_lossy().to_string(),
         created_at: session.created_at.to_rfc3339(),
+        last_activity_at: session.last_activity_at.to_rfc3339(),
     }))
 }
 

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -40,6 +40,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/sessions/{id}/resolver/launch", post(resolver::launch_resolver))
         .route("/api/sessions/{id}/stop", post(sessions::stop_session))
         .route("/api/sessions/{id}/close", post(sessions::close_session))
+        .route("/api/sessions/{id}/complete", post(sessions::complete_session))
         // Worker routes
         .route("/api/sessions/{id}/workers", get(workers::list_workers))
         .route("/api/sessions/{id}/workers", post(workers::add_worker))

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -124,6 +124,33 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
     }
 }
 
+fn make_test_session_for_completion(
+    id: &str,
+    project_path: &str,
+    state: SessionState,
+    last_activity_at: chrono::DateTime<chrono::Utc>,
+    with_evaluator: bool,
+) -> Session {
+    let mut session = make_test_session(id, project_path);
+    session.state = state;
+    session.last_activity_at = last_activity_at;
+    session.created_at = last_activity_at - chrono::Duration::minutes(1);
+    if with_evaluator {
+        session.agents.push(AgentInfo {
+            id: format!("{id}-evaluator"),
+            role: AgentRole::Evaluator,
+            status: AgentStatus::Completed,
+            config: AgentConfig::default(),
+            parent_id: None,
+        });
+    } else {
+        session.session_type = SessionType::Fusion {
+            variants: vec!["variant-a".to_string()],
+        };
+    }
+    session
+}
+
 #[tokio::test]
 async fn test_health_check() {
     let app = setup_test_app().await;
@@ -3651,6 +3678,194 @@ async fn test_get_active_sessions_includes_heartbeat_after_post() {
     assert!(agents[0].get("last_activity").unwrap().as_str().is_some());
     assert_eq!(agents[0].get("status").unwrap().as_str().unwrap(), "working");
     assert_eq!(agents[0].get("summary").unwrap().as_str().unwrap(), "2/3 done");
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_list_sessions_reflects_fresh_heartbeat_activity_and_persists_it() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let storage = SessionStorage::new().unwrap();
+    let session_id = format!("session-list-hb-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let _ = std::fs::remove_dir_all(storage.session_dir(&session_id));
+
+    let before = chrono::Utc::now() - chrono::Duration::minutes(20);
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
+    {
+        let sessions = controller.write();
+        let session = sessions
+            .get_session(&session_id)
+            .expect("session inserted");
+        let mut updated = session.clone();
+        updated.last_activity_at = before;
+        updated.created_at = before - chrono::Duration::minutes(1);
+        sessions.insert_test_session(updated);
+    }
+
+    let heartbeat_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/heartbeat", session_id))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    r#"{"agent_id":"worker-1","status":"working","summary":"fresh activity"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(heartbeat_response.status(), StatusCode::OK);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let listed = response_json
+        .get("sessions")
+        .and_then(|sessions| sessions.as_array())
+        .and_then(|sessions| {
+            sessions
+                .iter()
+                .find(|session| session.get("id").and_then(|id| id.as_str()) == Some(session_id.as_str()))
+        })
+        .expect("session should be listed");
+
+    let listed_last_activity = listed
+        .get("last_activity_at")
+        .and_then(|value| value.as_str())
+        .expect("last_activity_at");
+    let listed_last_activity = chrono::DateTime::parse_from_rfc3339(listed_last_activity)
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    assert!(listed_last_activity > before);
+
+    let persisted = storage.load_session(&session_id).unwrap();
+    assert_eq!(persisted.last_activity_at, Some(listed_last_activity));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+    let _ = std::fs::remove_dir_all(storage.session_dir(&session_id));
+}
+
+#[tokio::test]
+async fn test_complete_session_returns_conflict_when_not_quiescent() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-complete-blocked");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(make_test_session_for_completion(
+        "session-complete-blocked",
+        temp_dir.to_str().unwrap(),
+        SessionState::Running,
+        chrono::Utc::now() - chrono::Duration::minutes(11),
+        true,
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-complete-blocked/complete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let error = response_json.get("error").and_then(|value| value.as_str()).unwrap();
+    assert!(error.contains("QaPassed"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_complete_session_allows_quiet_evaluator_backed_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-complete-ok");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(make_test_session_for_completion(
+        "session-complete-ok",
+        temp_dir.to_str().unwrap(),
+        SessionState::QaPassed,
+        chrono::Utc::now() - chrono::Duration::minutes(11),
+        true,
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-complete-ok/complete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let session = controller
+        .read()
+        .get_session("session-complete-ok")
+        .expect("session should remain loaded");
+    assert!(matches!(session.state, SessionState::Completed));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_complete_session_allows_quiet_fusion_session_without_evaluator() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-complete-fusion");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(make_test_session_for_completion(
+        "session-complete-fusion",
+        temp_dir.to_str().unwrap(),
+        SessionState::Running,
+        chrono::Utc::now() - chrono::Duration::minutes(11),
+        false,
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-complete-fusion/complete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let session = controller
+        .read()
+        .get_session("session-complete-fusion")
+        .expect("session should remain loaded");
+    assert!(matches!(session.state, SessionState::Completed));
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -3801,6 +3801,41 @@ async fn test_complete_session_returns_conflict_when_not_quiescent() {
 }
 
 #[tokio::test]
+async fn test_complete_session_returns_conflict_for_recent_qa_passed_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-complete-recent-pass");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(make_test_session_for_completion(
+        "session-complete-recent-pass",
+        temp_dir.to_str().unwrap(),
+        SessionState::QaPassed,
+        chrono::Utc::now() - chrono::Duration::minutes(5),
+        true,
+    ));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-complete-recent-pass/complete")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let error = response_json.get("error").and_then(|value| value.as_str()).unwrap();
+    assert!(error.contains("10 minutes"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
 async fn test_complete_session_allows_quiet_evaluator_backed_session() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = std::env::temp_dir().join("hive-test-complete-ok");

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -71,6 +71,7 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
 }
 
 fn make_test_session(id: &str, project_path: &str) -> Session {
+    let now = chrono::Utc::now();
     Session {
         id: id.to_string(),
         name: None,
@@ -78,7 +79,8 @@ fn make_test_session(id: &str, project_path: &str) -> Session {
         session_type: SessionType::Hive { worker_count: 1 },
         project_path: PathBuf::from(project_path),
         state: SessionState::Running,
-        created_at: chrono::Utc::now(),
+        created_at: now,
+        last_activity_at: now,
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
@@ -103,6 +105,7 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
             parent_id: None,
         })
         .collect();
+    let now = chrono::Utc::now();
     Session {
         id: id.to_string(),
         name: None,
@@ -110,7 +113,8 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
         session_type: SessionType::Hive { worker_count: 1 },
         project_path: PathBuf::from(project_path),
         state: SessionState::Running,
-        created_at: chrono::Utc::now(),
+        created_at: now,
+        last_activity_at: now,
         agents,
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
@@ -223,6 +227,7 @@ async fn test_patch_session_omitted_field_preserves_existing_value() {
         project_path: temp_dir.clone(),
         state: SessionState::Running,
         created_at: chrono::Utc::now(),
+        last_activity_at: chrono::Utc::now(),
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
@@ -271,6 +276,7 @@ async fn test_patch_session_null_clears_field() {
         project_path: temp_dir.clone(),
         state: SessionState::Running,
         created_at: chrono::Utc::now(),
+        last_activity_at: chrono::Utc::now(),
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
@@ -418,6 +424,7 @@ async fn test_patch_session_updates_persisted_session_not_loaded_in_memory() {
         session_type: SessionTypeInfo::Hive { worker_count: 1 },
         project_path: std::env::temp_dir().join("hive-test-persisted-update").to_string_lossy().to_string(),
         created_at: chrono::Utc::now(),
+        last_activity_at: None,
         agents: vec![],
         state: "Completed".to_string(),
         default_cli: "claude".to_string(),
@@ -2345,6 +2352,7 @@ fn test_persisted_session_serializes_default_cli() {
         session_type: SessionTypeInfo::Hive { worker_count: 2 },
         project_path: "/tmp/test".to_string(),
         created_at: chrono::Utc::now(),
+        last_activity_at: None,
         agents: vec![],
         state: "Running".to_string(),
         default_cli: "gemini".to_string(),
@@ -3071,6 +3079,7 @@ async fn test_list_artifacts_uses_persisted_session_fallback() {
             session_type: SessionTypeInfo::Hive { worker_count: 1 },
             project_path: temp_dir.path().to_string_lossy().to_string(),
             created_at: chrono::Utc::now(),
+            last_activity_at: None,
             agents: vec![],
             state: "Completed".to_string(),
             default_cli: "claude".to_string(),
@@ -3736,6 +3745,7 @@ async fn test_stream_events_rejects_path_traversal_session_id() {
 // ── Resolver launch endpoint tests ──────────────────────────────────────
 
 fn make_fusion_session(id: &str, project_path: &str) -> Session {
+    let now = chrono::Utc::now();
     Session {
         id: id.to_string(),
         name: None,
@@ -3743,7 +3753,8 @@ fn make_fusion_session(id: &str, project_path: &str) -> Session {
         session_type: SessionType::Fusion { variants: vec!["variant-a".to_string(), "variant-b".to_string()] },
         project_path: PathBuf::from(project_path),
         state: SessionState::Running,
-        created_at: chrono::Utc::now(),
+        created_at: now,
+        last_activity_at: now,
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -10,11 +10,16 @@ use crate::http::routes::create_router;
 use crate::http::state::AppState;
 use crate::storage::{SessionStorage, PersistedSession, SessionTypeInfo};
 use crate::pty::PtyManager;
-use crate::session::{Session, SessionController, SessionState, SessionType, AgentInfo, AuthStrategy};
+use crate::session::{Session, SessionController, SessionState, SessionType, AgentInfo, AuthStrategy, DEFAULT_MAX_QA_ITERATIONS};
 use crate::pty::{AgentRole, AgentStatus, AgentConfig};
 use crate::coordination::InjectionManager;
 use crate::events::EventBus;
 use parking_lot::RwLock;
+
+/// Helper to get the default max_qa_iterations for test fixtures
+fn test_default_max_qa_iterations() -> u8 {
+    DEFAULT_MAX_QA_ITERATIONS
+}
 
 async fn setup_test_app() -> axum::Router {
     let storage = Arc::new(SessionStorage::new().unwrap());
@@ -77,7 +82,7 @@ fn make_test_session(id: &str, project_path: &str) -> Session {
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
     }
@@ -109,7 +114,7 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
         agents,
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
     }
@@ -221,7 +226,7 @@ async fn test_patch_session_omitted_field_preserves_existing_value() {
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
     });
@@ -269,7 +274,7 @@ async fn test_patch_session_null_clears_field() {
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
     });
@@ -417,7 +422,7 @@ async fn test_patch_session_updates_persisted_session_not_loaded_in_memory() {
         state: "Completed".to_string(),
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: String::new(),
     };
@@ -2344,7 +2349,7 @@ fn test_persisted_session_serializes_default_cli() {
         state: "Running".to_string(),
         default_cli: "gemini".to_string(),
         default_model: Some("gemini-2.5-pro".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: String::new(),
     };
@@ -2383,7 +2388,7 @@ fn test_persisted_session_legacy_json_defaults_to_claude() {
     );
     assert_eq!(session.name, None);
     assert_eq!(session.color, None);
-    assert_eq!(session.max_qa_iterations, 3);
+    assert_eq!(session.max_qa_iterations, DEFAULT_MAX_QA_ITERATIONS);
     assert_eq!(session.qa_timeout_secs, 300);
 }
 
@@ -3070,7 +3075,7 @@ async fn test_list_artifacts_uses_persisted_session_fallback() {
             state: "Completed".to_string(),
             default_cli: "claude".to_string(),
             default_model: Some("opus-4-6".to_string()),
-            max_qa_iterations: 3,
+            max_qa_iterations: test_default_max_qa_iterations(),
             qa_timeout_secs: 300,
             auth_strategy: String::new(),
         })
@@ -3742,7 +3747,7 @@ fn make_fusion_session(id: &str, project_path: &str) -> Session {
         agents: vec![],
         default_cli: "claude".to_string(),
         default_model: Some("opus-4-6".to_string()),
-        max_qa_iterations: 3,
+        max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
     }

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -225,6 +225,7 @@ mod tests {
     use crate::session::AuthStrategy;
 
     use super::*;
+    use super::super::controller::DEFAULT_MAX_QA_ITERATIONS;
 
     fn test_session(state: SessionState, agent_statuses: Vec<AgentStatus>) -> Session {
         Session {
@@ -252,7 +253,7 @@ mod tests {
                 .collect(),
             default_cli: "claude".to_string(),
             default_model: None,
-            max_qa_iterations: 3,
+            max_qa_iterations: DEFAULT_MAX_QA_ITERATIONS,
             qa_timeout_secs: 300,
             auth_strategy: AuthStrategy::None,
         }

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -43,7 +43,7 @@ pub(crate) fn agent_in_cell(session: &Session, cell_id: &str, agent: &AgentInfo)
 
 pub(crate) fn session_state_to_cell_status(state: &SessionState) -> CellStatus {
     match state {
-        SessionState::Planning | SessionState::PlanReady => CellStatus::Queued,
+        SessionState::Planning | SessionState::PlanReady => CellStatus::Preparing,
         SessionState::Starting
         | SessionState::SpawningWorker(_)
         | SessionState::SpawningPlanner(_)
@@ -57,8 +57,10 @@ pub(crate) fn session_state_to_cell_status(state: &SessionState) -> CellStatus {
         | SessionState::MergingWinner
         | SessionState::QaInProgress { .. }
         | SessionState::Running => CellStatus::Running,
-        SessionState::AwaitingVerdictSelection | SessionState::Paused => CellStatus::WaitingInput,
-        SessionState::QaPassed | SessionState::Completed | SessionState::Closed => CellStatus::Completed,
+        SessionState::AwaitingVerdictSelection | SessionState::Paused | SessionState::QaPassed => {
+            CellStatus::WaitingInput
+        }
+        SessionState::Completed | SessionState::Closed => CellStatus::Completed,
         SessionState::QaFailed { .. } | SessionState::QaMaxRetriesExceeded | SessionState::Failed(_) => {
             CellStatus::Failed
         }
@@ -287,6 +289,22 @@ mod tests {
         let session = test_session(SessionState::Completed, vec![AgentStatus::Running]);
 
         assert_eq!(aggregate_cell_status(&session, "variant:alpha"), CellStatus::Completed);
+    }
+
+    #[test]
+    fn planning_and_qa_passed_states_keep_pre_completion_distinctions() {
+        assert_eq!(
+            session_state_to_cell_status(&SessionState::Planning),
+            CellStatus::Preparing
+        );
+        assert_eq!(
+            session_state_to_cell_status(&SessionState::PlanReady),
+            CellStatus::Preparing
+        );
+        assert_eq!(
+            session_state_to_cell_status(&SessionState::QaPassed),
+            CellStatus::WaitingInput
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -228,6 +228,7 @@ mod tests {
     use super::super::controller::DEFAULT_MAX_QA_ITERATIONS;
 
     fn test_session(state: SessionState, agent_statuses: Vec<AgentStatus>) -> Session {
+        let now = Utc::now();
         Session {
             id: "session-1".to_string(),
             name: None,
@@ -237,7 +238,8 @@ mod tests {
             },
             project_path: PathBuf::from("."),
             state,
-            created_at: Utc::now(),
+            created_at: now,
+            last_activity_at: now,
             agents: agent_statuses
                 .into_iter()
                 .enumerate()

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -26,6 +26,13 @@ use crate::workspace::git::{
     cleanup_session_worktrees, create_session_worktree, remove_session_worktree_cell,
 };
 
+/// Example `coordination.log` lines for Queen quality-reconciliation (quiescence-based; no iteration cap).
+const QUEEN_QUALITY_RECONCILIATION_LOG_LINES: &str = r#"[TIMESTAMP] QUEEN: Entering reconciliation loop for latest push
+[TIMESTAMP] QUEEN: Collected N evaluator findings, M external comments since latest push
+[TIMESTAMP] QUEEN: Spawned Reconciler — awaiting unified fix list
+[TIMESTAMP] QUEEN: Reconciliation complete — N fixes assigned
+[TIMESTAMP] QUEEN: Quality loop complete - session marked completed"#;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SessionType {
     Hive { worker_count: u8 },
@@ -335,6 +342,8 @@ pub struct Session {
     pub project_path: PathBuf,
     pub state: SessionState,
     pub created_at: DateTime<Utc>,
+    /// Latest meaningful activity (state persistence, heartbeats, etc.) for dashboards.
+    pub last_activity_at: DateTime<Utc>,
     pub agents: Vec<AgentInfo>,
     pub default_cli: String,
     pub default_model: Option<String>,
@@ -650,6 +659,7 @@ impl SessionController {
             project_path,
             state: SessionState::Running,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: cmd.to_string(),
             default_model: if cmd == "claude" { Some("opus-4-6".to_string()) } else { None },
@@ -686,22 +696,25 @@ impl SessionController {
         name: Option<Option<String>>,
         color: Option<Option<String>>,
     ) -> Result<Session, String> {
-        let updated = {
+        let had_in_memory = {
             let mut sessions = self.sessions.write();
-            sessions.get_mut(session_id).map(|session| {
-                if let Some(name) = name.clone() {
-                    session.name = name;
-                }
-                if let Some(color) = color.clone() {
-                    session.color = color;
-                }
-                session.clone()
-            })
+            sessions
+                .get_mut(session_id)
+                .map(|session| {
+                    if let Some(name) = name.clone() {
+                        session.name = name;
+                    }
+                    if let Some(color) = color.clone() {
+                        session.color = color;
+                    }
+                })
+                .is_some()
         };
 
-        let updated = if let Some(updated) = updated {
+        let updated = if had_in_memory {
             self.update_session_storage_checked(session_id)?;
-            updated
+            self.get_session(session_id)
+                .ok_or_else(|| format!("Session not found: {}", session_id))?
         } else {
             let storage = self
                 .storage
@@ -717,6 +730,7 @@ impl SessionController {
             if let Some(color) = color {
                 persisted.color = color;
             }
+            persisted.last_activity_at = Some(Utc::now());
 
             storage
                 .save_session(&persisted)
@@ -742,7 +756,21 @@ impl SessionController {
 
     pub fn list_sessions(&self) -> Vec<Session> {
         let sessions = self.sessions.read();
-        sessions.values().cloned().collect()
+        let heartbeats = self.agent_heartbeats.read();
+        sessions
+            .values()
+            .cloned()
+            .map(|mut session| {
+                if let Some(map) = heartbeats.get(&session.id) {
+                    if let Some(max_hb) = map.values().map(|h| h.last_activity).max() {
+                        if max_hb > session.last_activity_at {
+                            session.last_activity_at = max_hb;
+                        }
+                    }
+                }
+                session
+            })
+            .collect()
     }
 
     // --- Heartbeat / Stall Detection ---
@@ -770,6 +798,14 @@ impl SessionController {
             );
             prev
         };
+        {
+            let mut sessions = self.sessions.write();
+            if let Some(session) = sessions.get_mut(session_id) {
+                if now > session.last_activity_at {
+                    session.last_activity_at = now;
+                }
+            }
+        }
         let status_changed = prev_status.as_ref().map(|s| s != status).unwrap_or(true);
         if status_changed {
             if let Some(ref app_handle) = self.app_handle {
@@ -3530,16 +3566,15 @@ c. Wait for workers to complete
 d. Review changes, commit, and push
 
 ### Step 5: Repeat or Complete
-1. If NEW comments arrive after the push: repeat from Step 2 (maximum 3 iterations)
-2. If NO new comments found: exit quality loop and mark session complete
+The loop is **quiescence-based** (no fixed iteration cap):
+
+1. Commit and push fixes, then use the new push as the review baseline. If NEW unresolved PR comments appear after that push, return to Step 2 and repeat until quiescent.
+2. Only exit when ALL are true at the same time: internal `QA_VERDICT: PASS` has been received (when an Evaluator runs), the latest push has been live for at least 10 minutes, and `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since that push.
+3. When all conditions are met, mark the session complete (`POST .../complete`).
 
 Log each iteration to `.hive-manager/{session_id}/coordination.log`:
 ```
-[TIMESTAMP] QUEEN: Entering reconciliation loop (iteration N/3)
-[TIMESTAMP] QUEEN: Collected N evaluator findings, M external comments
-[TIMESTAMP] QUEEN: Spawned Reconciler — awaiting unified fix list
-[TIMESTAMP] QUEEN: Reconciliation complete — N fixes assigned
-[TIMESTAMP] QUEEN: Quality loop complete — session done
+{queen_quality_log}
 ```
 
 After your orchestration objective is complete, transition to `idle` heartbeat status and continue checking your conversation file on heartbeat cadence.
@@ -3554,6 +3589,7 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
             plan_section = plan_section,
             worker_list = worker_list,
             qa_milestone_handoff = qa_milestone_handoff,
+            queen_quality_log = QUEEN_QUALITY_RECONCILIATION_LOG_LINES,
             task = user_prompt.unwrap_or("Read the plan and begin coordinating workers.")
         )
     }
@@ -4065,11 +4101,7 @@ After all planners complete, integration is done, and changes are pushed to the 
 
 Log each iteration to `.hive-manager/{session_id}/coordination.log`:
 ```
-[TIMESTAMP] QUEEN: Entering reconciliation loop for latest push
-[TIMESTAMP] QUEEN: Collected N evaluator findings, M external comments since latest push
-[TIMESTAMP] QUEEN: Spawned Reconciler — awaiting unified fix list
-[TIMESTAMP] QUEEN: Reconciliation complete — N fixes assigned
-[TIMESTAMP] QUEEN: Quality loop complete - session marked completed
+{queen_quality_log}
 ```
 
 ## Your Task
@@ -4081,6 +4113,7 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
             planner_info = planner_info,
             planner_count = planner_count,
             qa_milestone_handoff = qa_milestone_handoff,
+            queen_quality_log = QUEEN_QUALITY_RECONCILIATION_LOG_LINES,
             task = user_prompt.unwrap_or("Awaiting instructions from the operator.")
         )
     }
@@ -4769,6 +4802,7 @@ Last updated: {timestamp}
             },
             state: SessionState::Running,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents: vec![AgentInfo {
                 id: solo_id,
                 role: AgentRole::Worker { index: 1, parent: None },
@@ -4994,6 +5028,7 @@ Last updated: {timestamp}
             project_path: project_path.clone(),
             state: SessionState::Running,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
@@ -5114,6 +5149,7 @@ Last updated: {timestamp}
             project_path: project_path.clone(),
             state: SessionState::Starting,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents: Vec::new(),
             default_cli: default_cli.clone(),
             default_model: config.default_model.clone(),
@@ -5370,6 +5406,7 @@ Last updated: {timestamp}
             project_path,
             state: SessionState::Planning,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
@@ -5462,6 +5499,7 @@ Last updated: {timestamp}
             project_path: project_path.clone(),
             state: SessionState::Planning,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: if config.default_cli.trim().is_empty() { "claude".to_string() } else { config.default_cli.trim().to_string() },
             default_model: config.default_model.clone(),
@@ -5825,6 +5863,7 @@ Last updated: {timestamp}
             project_path,
             state: SessionState::Planning,
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
@@ -6857,6 +6896,9 @@ Last updated: {timestamp}
             project_path: PathBuf::from(&persisted.project_path),
             state,
             created_at: persisted.created_at,
+            last_activity_at: persisted
+                .last_activity_at
+                .unwrap_or(persisted.created_at),
             agents,
             default_cli: persisted.default_cli.clone(),
             default_model: persisted.default_model.clone(),
@@ -7075,6 +7117,7 @@ Last updated: {timestamp}
             project_path,
             state: SessionState::Running,  // Queen will spawn planners sequentially
             created_at: Utc::now(),
+            last_activity_at: Utc::now(),
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
@@ -7682,6 +7725,7 @@ Last updated: {timestamp}
             session_type,
             project_path: session.project_path.to_string_lossy().to_string(),
             created_at: session.created_at,
+            last_activity_at: Some(session.last_activity_at),
             agents,
             state: state_str,
             default_cli: session.default_cli.clone(),
@@ -7785,13 +7829,18 @@ Last updated: {timestamp}
     fn update_session_storage_checked(&self, session_id: &str) -> Result<(), String> {
         if let Some(ref storage) = self.storage {
             let session = {
-                let sessions = self.sessions.read();
-                sessions.get(session_id).cloned()
+                let mut sessions = self.sessions.write();
+                let Some(session) = sessions.get_mut(session_id) else {
+                    return Ok(());
+                };
+                let now = Utc::now();
+                if now > session.last_activity_at {
+                    session.last_activity_at = now;
+                }
+                session.clone()
             };
 
-            if let Some(session) = session {
-                Self::persist_session_snapshot(storage, &session, session_id)?;
-            }
+            Self::persist_session_snapshot(storage, &session, session_id)?;
         }
 
         Ok(())

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -61,7 +61,7 @@ impl From<String> for SessionError {
     }
 }
 
-const DEFAULT_MAX_QA_ITERATIONS: u8 = 20;
+pub const DEFAULT_MAX_QA_ITERATIONS: u8 = 20;
 const DEFAULT_QA_TIMEOUT_SECS: u64 = 300;
 const MAX_PRIMARY_CELL_BRANCHES: usize = 4;
 const MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN: usize = 4_096;

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -189,6 +189,7 @@ impl SessionState {
                 | SessionState::WaitingForPlanner(_)
                 | SessionState::SpawningEvaluator
                 | SessionState::QaInProgress { .. }
+                | SessionState::QaPassed
                 | SessionState::QaFailed { .. }
         )
     }
@@ -773,6 +774,65 @@ impl SessionController {
             .collect()
     }
 
+    fn session_requires_internal_evaluator(session: &Session) -> bool {
+        session.agents.iter().any(|agent| {
+            matches!(
+                agent.role,
+                AgentRole::Evaluator | AgentRole::QaWorker { .. }
+            )
+        })
+    }
+
+    fn state_allows_completion(session: &Session) -> bool {
+        if Self::session_requires_internal_evaluator(session) {
+            matches!(session.state, SessionState::QaPassed)
+        } else {
+            matches!(session.state, SessionState::Running | SessionState::QaPassed)
+        }
+    }
+
+    pub fn can_complete_session(&self, session_id: &str) -> Result<(), String> {
+        let session = if let Some(session) = self.get_session(session_id) {
+            session
+        } else {
+            let storage = self
+                .storage
+                .as_ref()
+                .ok_or_else(|| format!("Session not found: {}", session_id))?;
+            let persisted = storage
+                .load_session(session_id)
+                .map_err(|_| format!("Session not found: {}", session_id))?;
+            self.session_from_persisted(&persisted)?
+        };
+
+        if !Self::state_allows_completion(&session) {
+            let requirement = if Self::session_requires_internal_evaluator(&session) {
+                "session must remain in QaPassed after internal QA passes"
+            } else {
+                "session must be in a quiescent Running/QaPassed state"
+            };
+            return Err(format!(
+                "Session completion blocked: {} (current state: {:?})",
+                requirement, session.state
+            ));
+        }
+
+        let quiet_for = Utc::now() - session.last_activity_at;
+        if quiet_for < chrono::Duration::minutes(10) {
+            let remaining = (chrono::Duration::minutes(10) - quiet_for)
+                .num_seconds()
+                .max(0);
+            return Err(format!(
+                "Session completion blocked: session must remain quiescent for at least 10 minutes after the last activity ({}s remaining)",
+                remaining
+            ));
+        }
+
+        // External reviewer comments are not tracked server-side yet, so the completion gate enforces
+        // the internal quiescence conditions we can prove here: evaluator-aware state + 10-minute quiet period.
+        Ok(())
+    }
+
     // --- Heartbeat / Stall Detection ---
 
     /// Update heartbeat for an agent. Emits Tauri event if status changed.
@@ -798,13 +858,18 @@ impl SessionController {
             );
             prev
         };
-        {
+        let session_snapshot = {
             let mut sessions = self.sessions.write();
-            if let Some(session) = sessions.get_mut(session_id) {
+            sessions.get_mut(session_id).map(|session| {
                 if now > session.last_activity_at {
                     session.last_activity_at = now;
                 }
-            }
+                session.clone()
+            })
+        };
+
+        if let (Some(storage), Some(session)) = (self.storage.as_ref(), session_snapshot.as_ref()) {
+            Self::persist_session_snapshot(storage, session, session_id)?;
         }
         let status_changed = prev_status.as_ref().map(|s| s != status).unwrap_or(true);
         if status_changed {
@@ -1280,6 +1345,8 @@ impl SessionController {
     }
 
     pub fn mark_session_completed(&self, session_id: &str) -> Result<(), String> {
+        self.can_complete_session(session_id)?;
+
         let previous_state = {
             let mut sessions = self.sessions.write();
             sessions.get_mut(session_id).map(|session| {
@@ -2365,7 +2432,7 @@ After the Judge winner is selected and merge is complete:
 2. Track the latest push timestamp and the PR review baseline from that push forward
 3. WAIT 10 minutes (`sleep 600`) so the latest push has been live long enough for external review
 4. Collect ALL findings since the latest push:
-   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS`
+   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS` only when an Evaluator is attached
    b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments`
    c. Your own code integrity concerns
 5. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
@@ -3569,7 +3636,7 @@ d. Review changes, commit, and push
 The loop is **quiescence-based** (no fixed iteration cap):
 
 1. Commit and push fixes, then use the new push as the review baseline. If NEW unresolved PR comments appear after that push, return to Step 2 and repeat until quiescent.
-2. Only exit when ALL are true at the same time: internal `QA_VERDICT: PASS` has been received (when an Evaluator runs), the latest push has been live for at least 10 minutes, and `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since that push.
+2. Only exit when ALL are true at the same time: internal `QA_VERDICT: PASS` has been received if an Evaluator runs, the latest push has been live for at least 10 minutes, and `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since that push.
 3. When all conditions are met, mark the session complete (`POST .../complete`).
 
 Log each iteration to `.hive-manager/{session_id}/coordination.log`:
@@ -4079,7 +4146,7 @@ After all planners complete, integration is done, and changes are pushed to the 
 2. Track the latest push timestamp and treat it as the baseline for new review activity
 3. WAIT 10 minutes (`sleep 600`) so the latest push has been live long enough for reviewers
 4. Collect ALL findings since the latest push:
-   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS`
+   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS` only when an Evaluator is attached
    b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments`
    c. Your own code integrity concerns
 5. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
@@ -6104,19 +6171,7 @@ Last updated: {timestamp}
                     self.emit_cell_status_changes(session_id, changes);
                 }
 
-                let running_changes = {
-                    let mut sessions = self.sessions.write();
-                    sessions
-                        .get_mut(session_id)
-                        .map(|session| self.set_session_state_with_events(session, SessionState::Running))
-                };
-                self.emit_session_update(session_id);
-                self.update_session_storage(session_id);
-                if let Some(changes) = running_changes {
-                    self.emit_cell_status_changes(session_id, changes);
-                }
-
-                Ok(SessionState::Running)
+                Ok(SessionState::QaPassed)
             }
             "FAIL" | "QA_VERDICT: FAIL" => {
                 let (next_state, changes) = {
@@ -6207,13 +6262,14 @@ Last updated: {timestamp}
             if is_qa {
                 tracing::warn!("QA timeout fired for session {} after {}s — auto-passing", sid, timeout_secs);
 
-                // Transition directly to Running (skip transient QaPassed to avoid race)
+                // A timeout auto-pass should leave the session in QaPassed so the server can enforce
+                // the same quiescence gate as an explicit evaluator PASS.
                 let transition = {
                     let mut sessions = sessions.write();
                     if let Some(session) = sessions.get_mut(&sid) {
                         let previous_state = session.state.clone();
-                        let changes = cell_status_changes_for_transition(session, &SessionState::Running);
-                        session.state = SessionState::Running;
+                        let changes = cell_status_changes_for_transition(session, &SessionState::QaPassed);
+                        session.state = SessionState::QaPassed;
                         Some((previous_state, changes, session.clone()))
                     } else {
                         None
@@ -8088,8 +8144,15 @@ fn include_in_worker_roster(role: &AgentRole) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{parse_persisted_session_state, serialize_session_state, AgentConfig, AuthStrategy, SessionController, SessionState};
+    use super::{
+        parse_persisted_session_state, serialize_session_state, AgentConfig, AgentInfo,
+        AuthStrategy, Session, SessionController, SessionState, SessionType,
+    };
+    use crate::pty::{AgentRole, AgentStatus, PtyManager};
+    use chrono::{Duration, Utc};
+    use parking_lot::RwLock;
     use std::path::PathBuf;
+    use std::sync::Arc;
 
     #[test]
     fn session_state_variants_exist() {
@@ -8200,6 +8263,104 @@ mod tests {
         assert!(prompt.contains("This session uses CLI: codex, Model: gpt-5.4."));
         assert!(prompt.contains(r#""specialization": "api", "cli": "codex", "model": "gpt-5.4""#));
         assert!(!prompt.contains(r#""cli": "claude""#));
+    }
+
+    fn test_controller() -> SessionController {
+        SessionController::new(Arc::new(RwLock::new(PtyManager::new())))
+    }
+
+    fn test_completion_session(
+        id: &str,
+        state: SessionState,
+        last_activity_at: chrono::DateTime<Utc>,
+        with_evaluator: bool,
+    ) -> Session {
+        let mut agents = Vec::new();
+        if with_evaluator {
+            agents.push(AgentInfo {
+                id: format!("{id}-evaluator"),
+                role: AgentRole::Evaluator,
+                status: AgentStatus::Completed,
+                config: AgentConfig::default(),
+                parent_id: None,
+            });
+        }
+
+        Session {
+            id: id.to_string(),
+            name: None,
+            color: None,
+            session_type: if with_evaluator {
+                SessionType::Hive { worker_count: 1 }
+            } else {
+                SessionType::Fusion {
+                    variants: vec!["alpha".to_string()],
+                }
+            },
+            project_path: PathBuf::from("."),
+            state,
+            created_at: last_activity_at - Duration::minutes(1),
+            last_activity_at,
+            agents,
+            default_cli: "claude".to_string(),
+            default_model: None,
+            max_qa_iterations: 3,
+            qa_timeout_secs: 300,
+            auth_strategy: AuthStrategy::default(),
+        }
+    }
+
+    #[test]
+    fn can_complete_session_allows_quiet_evaluator_backed_session() {
+        let controller = test_controller();
+        controller.insert_test_session(test_completion_session(
+            "evaluator-ok",
+            SessionState::QaPassed,
+            Utc::now() - Duration::minutes(11),
+            true,
+        ));
+
+        assert!(controller.can_complete_session("evaluator-ok").is_ok());
+    }
+
+    #[test]
+    fn can_complete_session_rejects_non_quiet_or_missing_qa_pass() {
+        let controller = test_controller();
+        controller.insert_test_session(test_completion_session(
+            "evaluator-blocked",
+            SessionState::Running,
+            Utc::now() - Duration::minutes(11),
+            true,
+        ));
+        controller.insert_test_session(test_completion_session(
+            "fusion-recent",
+            SessionState::Running,
+            Utc::now() - Duration::minutes(2),
+            false,
+        ));
+
+        let blocked = controller
+            .can_complete_session("evaluator-blocked")
+            .expect_err("evaluator-backed session should require QaPassed");
+        assert!(blocked.contains("QaPassed"));
+
+        let recent = controller
+            .can_complete_session("fusion-recent")
+            .expect_err("fusion session should still require quiet period");
+        assert!(recent.contains("10 minutes"));
+    }
+
+    #[test]
+    fn can_complete_session_allows_quiet_fusion_session_without_evaluator() {
+        let controller = test_controller();
+        controller.insert_test_session(test_completion_session(
+            "fusion-ok",
+            SessionState::Running,
+            Utc::now() - Duration::minutes(11),
+            false,
+        ));
+
+        assert!(controller.can_complete_session("fusion-ok").is_ok());
     }
 }
 

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -137,6 +137,14 @@ fn default_qa_timeout_secs() -> u64 {
     DEFAULT_QA_TIMEOUT_SECS
 }
 
+fn default_session_qa_settings() -> (u8, u64, AuthStrategy) {
+    (
+        default_max_qa_iterations(),
+        default_qa_timeout_secs(),
+        AuthStrategy::dev_bypass(),
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum SessionState {
     Planning,
@@ -633,6 +641,7 @@ impl SessionController {
             }
         }
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name,
@@ -644,9 +653,9 @@ impl SessionController {
             agents,
             default_cli: cmd.to_string(),
             default_model: if cmd == "claude" { Some("opus-4-6".to_string()) } else { None },
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -2371,6 +2380,51 @@ Read tool docs in `.hive-manager/{session_id}/tools/` for:
         )
     }
 
+    fn build_qa_milestone_handoff(session_id: &str, completion_scope: &str) -> String {
+        format!(
+r#"## QA Milestone Handoff (CRITICAL — Evaluator waits for this)
+
+When ALL {completion_scope} have completed, you MUST signal the Evaluator:
+
+1. **Write the milestone-ready file** (this is what the Evaluator polls for):
+   ```bash
+   mkdir -p .hive-manager/{session_id}/peer
+   cat > .hive-manager/{session_id}/peer/milestone-ready.md << 'MILESTONE_EOF'
+   # Milestone Ready
+
+   ## Status: MILESTONE_READY
+   ## Milestone: [name or "smoke-test"]
+   ## Contract: .hive-manager/{session_id}/contracts/milestone-1.md
+   ## Scope: [brief description of what was implemented]
+   ## Risks: [known risks or "none"]
+   MILESTONE_EOF
+   ```
+
+2. **Also notify the Evaluator via conversation** (backup signal):
+   ```bash
+   curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/queen/append" \
+     -H "Content-Type: application/json" \
+     -d '{{"from":"queen","content":"MILESTONE_READY: All workers completed. Please begin QA evaluation."}}'
+   ```
+
+3. For smoke tests: write a simple contract for the Evaluator to grade against:
+   ```bash
+   mkdir -p .hive-manager/{session_id}/contracts
+   cat > .hive-manager/{session_id}/contracts/milestone-1.md << 'CONTRACT_EOF'
+   # Smoke Test Contract
+
+   ## Criteria
+   1. All workers spawned and ran successfully
+   2. Heartbeat API exercised by all workers
+   3. Conversation API exercised (queen inbox + shared channel)
+   4. All task files transitioned to COMPLETED status
+   CONTRACT_EOF
+   ```"#,
+            session_id = session_id,
+            completion_scope = completion_scope,
+        )
+    }
+
     /// Build the Master Planner's prompt for initial planning phase
     fn build_master_planner_prompt(session_id: &str, user_prompt: &str, workers: &[AgentConfig]) -> String {
         // Build worker info section
@@ -3253,6 +3307,7 @@ git push -u origin feat/add-authentication
 
 Do NOT assign worker tasks until the branch exists!
 "#;
+        let qa_milestone_handoff = Self::build_qa_milestone_handoff(session_id, "workers");
 
         format!(
             r#"# Queen Agent - Hive Manager Session
@@ -3415,44 +3470,7 @@ Workers record learnings during task completion. Your curation responsibilities:
 - Before creating a PR
 - When learnings count exceeds 10
 
-## QA Milestone Handoff (CRITICAL — Evaluator waits for this)
-
-When ALL workers have completed their tasks, you MUST signal the Evaluator:
-
-1. **Write the milestone-ready file** (this is what the Evaluator polls for):
-   ```bash
-   mkdir -p .hive-manager/{session_id}/peer
-   cat > .hive-manager/{session_id}/peer/milestone-ready.md << 'MILESTONE_EOF'
-   # Milestone Ready
-
-   ## Status: MILESTONE_READY
-   ## Milestone: [name or "smoke-test"]
-   ## Contract: .hive-manager/{session_id}/contracts/milestone-1.md
-   ## Scope: [brief description of what was implemented]
-   ## Risks: [known risks or "none"]
-   MILESTONE_EOF
-   ```
-
-2. **Also notify the Evaluator via conversation** (backup signal):
-   ```bash
-   curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/queen/append" \
-     -H "Content-Type: application/json" \
-     -d '{{"from":"queen","content":"MILESTONE_READY: All workers completed. Please begin QA evaluation."}}'
-   ```
-
-3. For smoke tests: write a simple contract for the Evaluator to grade against:
-   ```bash
-   mkdir -p .hive-manager/{session_id}/contracts
-   cat > .hive-manager/{session_id}/contracts/milestone-1.md << 'CONTRACT_EOF'
-   # Smoke Test Contract
-
-   ## Criteria
-   1. All workers spawned and ran successfully
-   2. Heartbeat API exercised by all workers
-   3. Conversation API exercised (queen inbox + shared channel)
-   4. All task files transitioned to COMPLETED status
-   CONTRACT_EOF
-   ```
+{qa_milestone_handoff}
 
 ## Coordination Protocol
 
@@ -3535,6 +3553,7 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
             cli = cli,
             plan_section = plan_section,
             worker_list = worker_list,
+            qa_milestone_handoff = qa_milestone_handoff,
             task = user_prompt.unwrap_or("Read the plan and begin coordinating workers.")
         )
     }
@@ -3863,6 +3882,7 @@ If you find yourself about to edit code, STOP. Assign work to a Planner instead.
         } else {
             ""
         };
+        let qa_milestone_handoff = Self::build_qa_milestone_handoff(session_id, "workers/planners");
 
         format!(
 r#"# Queen Agent - Swarm Session
@@ -3969,44 +3989,7 @@ Workers and planners record learnings during task completion. Your curation resp
 - Before creating a PR
 - When learnings count exceeds 10
 
-## QA Milestone Handoff (CRITICAL — Evaluator waits for this)
-
-When ALL workers/planners have completed, you MUST signal the Evaluator:
-
-1. **Write the milestone-ready file** (this is what the Evaluator polls for):
-   ```bash
-   mkdir -p .hive-manager/{session_id}/peer
-   cat > .hive-manager/{session_id}/peer/milestone-ready.md << 'MILESTONE_EOF'
-   # Milestone Ready
-
-   ## Status: MILESTONE_READY
-   ## Milestone: [name or "smoke-test"]
-   ## Contract: .hive-manager/{session_id}/contracts/milestone-1.md
-   ## Scope: [brief description of what was implemented]
-   ## Risks: [known risks or "none"]
-   MILESTONE_EOF
-   ```
-
-2. **Also notify the Evaluator via conversation** (backup signal):
-   ```bash
-   curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/queen/append" \
-     -H "Content-Type: application/json" \
-     -d '{{"from":"queen","content":"MILESTONE_READY: All workers completed. Please begin QA evaluation."}}'
-   ```
-
-3. For smoke tests: write a simple contract for the Evaluator to grade against:
-   ```bash
-   mkdir -p .hive-manager/{session_id}/contracts
-   cat > .hive-manager/{session_id}/contracts/milestone-1.md << 'CONTRACT_EOF'
-   # Smoke Test Contract
-
-   ## Criteria
-   1. All workers spawned and ran successfully
-   2. Heartbeat API exercised by all workers
-   3. Conversation API exercised (queen inbox + shared channel)
-   4. All task files transitioned to COMPLETED status
-   CONTRACT_EOF
-   ```
+{qa_milestone_handoff}
 
 ## SEQUENTIAL SPAWNING PROTOCOL WITH COMMITS (CRITICAL)
 
@@ -4097,6 +4080,7 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
             cli = cli,
             planner_info = planner_info,
             planner_count = planner_count,
+            qa_milestone_handoff = qa_milestone_handoff,
             task = user_prompt.unwrap_or("Awaiting instructions from the operator.")
         )
     }
@@ -4773,6 +4757,7 @@ Last updated: {timestamp}
             }
         }
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name,
@@ -4793,9 +4778,9 @@ Last updated: {timestamp}
             }],
             default_cli: cli,
             default_model: model,
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -5000,6 +4985,7 @@ Last updated: {timestamp}
             });
         }
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -5011,9 +4997,9 @@ Last updated: {timestamp}
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -5117,6 +5103,7 @@ Last updated: {timestamp}
             });
         }
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -5130,9 +5117,9 @@ Last updated: {timestamp}
             agents: Vec::new(),
             default_cli: default_cli.clone(),
             default_model: config.default_model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -5374,6 +5361,7 @@ Last updated: {timestamp}
         std::fs::write(&pending_config_path, config_json)
             .map_err(|e| format!("Failed to write pending config: {}", e))?;
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -5385,9 +5373,9 @@ Last updated: {timestamp}
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -5465,6 +5453,7 @@ Last updated: {timestamp}
             .map_err(|e| format!("Failed to write pending config: {}", e))?;
 
         let variant_names: Vec<String> = config.variants.iter().map(|v| v.name.clone()).collect();
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -5476,9 +5465,9 @@ Last updated: {timestamp}
             agents,
             default_cli: if config.default_cli.trim().is_empty() { "claude".to_string() } else { config.default_cli.trim().to_string() },
             default_model: config.default_model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -5827,6 +5816,7 @@ Last updated: {timestamp}
         std::fs::write(&pending_config_path, config_json)
             .map_err(|e| format!("Failed to write pending config: {}", e))?;
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -5838,9 +5828,9 @@ Last updated: {timestamp}
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {
@@ -7076,6 +7066,7 @@ Last updated: {timestamp}
         std::fs::write(&swarm_config_path, planners_json)
             .map_err(|e| format!("Failed to write planner config: {}", e))?;
 
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
         let session = Session {
             id: session_id.clone(),
             name: config.name.clone(),
@@ -7087,9 +7078,9 @@ Last updated: {timestamp}
             agents,
             default_cli: config.queen_config.cli.clone(),
             default_model: config.queen_config.model.clone(),
-            max_qa_iterations: default_max_qa_iterations(),
-            qa_timeout_secs: default_qa_timeout_secs(),
-            auth_strategy: AuthStrategy::dev_bypass(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
         };
 
         {

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -2444,7 +2444,7 @@ After the Judge winner is selected and merge is complete:
 6. Read the reconciled fix list, spawn code-quality workers for the unified fixes
 7. Commit and push, then restart this loop using the new push as the baseline
 8. Only finish when ALL of these are true at the same time:
-   a. Internal `QA_VERDICT: PASS` has been received
+   a. If an Evaluator is attached, internal `QA_VERDICT: PASS` has been received
    b. The latest push has been live for at least 10 minutes
    c. `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since the latest push
 9. When all three conditions are met, mark the session complete:
@@ -4158,7 +4158,7 @@ After all planners complete, integration is done, and changes are pushed to the 
 6. Read the reconciled fix list, spawn code-quality workers for the unified fixes
 7. Commit and push, then restart this loop using the new push as the baseline
 8. Only finish when ALL of these are true at the same time:
-   a. Internal `QA_VERDICT: PASS` has been received
+   a. If an Evaluator is attached, internal `QA_VERDICT: PASS` has been received
    b. The latest push has been live for at least 10 minutes
    c. `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since the latest push
 9. When all three conditions are met, mark the session complete:
@@ -8348,6 +8348,22 @@ mod tests {
             .can_complete_session("fusion-recent")
             .expect_err("fusion session should still require quiet period");
         assert!(recent.contains("10 minutes"));
+    }
+
+    #[test]
+    fn can_complete_session_rejects_recent_qa_passed_session() {
+        let controller = test_controller();
+        controller.insert_test_session(test_completion_session(
+            "evaluator-recent-pass",
+            SessionState::QaPassed,
+            Utc::now() - Duration::minutes(5),
+            true,
+        ));
+
+        let blocked = controller
+            .can_complete_session("evaluator-recent-pass")
+            .expect_err("QaPassed session should still satisfy quiet period");
+        assert!(blocked.contains("10 minutes"));
     }
 
     #[test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -61,7 +61,7 @@ impl From<String> for SessionError {
     }
 }
 
-const DEFAULT_MAX_QA_ITERATIONS: u8 = 3;
+const DEFAULT_MAX_QA_ITERATIONS: u8 = 20;
 const DEFAULT_QA_TIMEOUT_SECS: u64 = 300;
 const MAX_PRIMARY_CELL_BRANCHES: usize = 4;
 const MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN: usize = 4_096;
@@ -2317,21 +2317,28 @@ After spawning the Judge, monitor the evaluation directory:
 After the Judge winner is selected and merge is complete:
 
 1. Push the PR branch — this triggers CodeRabbit and Gemini reviewers
-2. WAIT 10 minutes (`sleep 600`) for external reviewers to post comments
-3. Collect ALL findings:
-   a. Evaluator QA verdicts (from queen conversation)
-   b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments --jq '.[].body'`
+2. Track the latest push timestamp and the PR review baseline from that push forward
+3. WAIT 10 minutes (`sleep 600`) so the latest push has been live long enough for external review
+4. Collect ALL findings since the latest push:
+   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS`
+   b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments`
    c. Your own code integrity concerns
-4. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
+5. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
    ```bash
    curl -s -X POST "http://localhost:18800/api/sessions/{{{{session_id}}}}/workers" \
      -H "Content-Type: application/json" \
      -d '{{"role_type":"reconciler","cli":"codex","initial_task":"RECONCILE findings into unified fix list. Write to .hive-manager/{{{{session_id}}}}/reconciliation.md"}}'
    ```
-5. Read the reconciled fix list, spawn code-quality workers for the unified fixes
-6. Commit and push
-7. If NEW comments arrive: repeat from step 2 (maximum 3 iterations)
-8. If NO new comments: exit quality loop and mark session complete
+6. Read the reconciled fix list, spawn code-quality workers for the unified fixes
+7. Commit and push, then restart this loop using the new push as the baseline
+8. Only finish when ALL of these are true at the same time:
+   a. Internal `QA_VERDICT: PASS` has been received
+   b. The latest push has been live for at least 10 minutes
+   c. `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since the latest push
+9. When all three conditions are met, mark the session complete:
+   ```bash
+   curl -s -X POST "http://localhost:18800/api/sessions/{{{{session_id}}}}/complete"
+   ```
 
 ## Status Reporting
 
@@ -2340,9 +2347,11 @@ Write status updates to `.hive-manager/{session_id}/coordination.log`:
 [TIMESTAMP] QUEEN: Variant N (name) - COMPLETED/IN_PROGRESS/FAILED
 [TIMESTAMP] QUEEN: All variants complete - spawning Judge
 [TIMESTAMP] QUEEN: Judge evaluation complete
-[TIMESTAMP] QUEEN: Entering quality loop (iteration N/3)
-[TIMESTAMP] QUEEN: Found/No new PR comments
-[TIMESTAMP] QUEEN: Quality loop complete — session done
+[TIMESTAMP] QUEEN: Entering quality loop for latest push
+[TIMESTAMP] QUEEN: QA PASS received / waiting on QA PASS
+[TIMESTAMP] QUEEN: Latest push has / has not aged 10 minutes
+[TIMESTAMP] QUEEN: Found / no new unresolved PR comments since latest push
+[TIMESTAMP] QUEEN: Quality loop complete - session marked completed
 ```
 
 ## Learning Tools
@@ -4048,29 +4057,36 @@ git commit -m "feat(DOMAIN): Brief description of what this domain accomplished"
 After all planners complete, integration is done, and changes are pushed to the PR branch:
 
 1. Push triggers CodeRabbit and Gemini reviewers automatically
-2. WAIT 10 minutes (`sleep 600`) for external reviewers to post comments
-3. Collect ALL findings:
-   a. Evaluator QA verdicts (from queen conversation)
-   b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments --jq '.[].body'`
+2. Track the latest push timestamp and treat it as the baseline for new review activity
+3. WAIT 10 minutes (`sleep 600`) so the latest push has been live long enough for reviewers
+4. Collect ALL findings since the latest push:
+   a. Evaluator QA verdicts (from queen conversation) — require an internal `QA_VERDICT: PASS`
+   b. CodeRabbit + Gemini PR comments: `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments`
    c. Your own code integrity concerns
-4. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
+5. If findings exist, spawn a **Reconciler** worker to triage and deduplicate:
    ```bash
    curl -s -X POST "http://localhost:18800/api/sessions/{{{{session_id}}}}/workers" \
      -H "Content-Type: application/json" \
      -d '{{"role_type":"reconciler","cli":"codex","initial_task":"RECONCILE findings into unified fix list. Write to .hive-manager/{{{{session_id}}}}/reconciliation.md"}}'
    ```
-5. Read the reconciled fix list, spawn code-quality workers for the unified fixes
-6. Commit and push
-7. If NEW comments arrive: repeat from step 2 (maximum 3 iterations)
-8. If NO new comments: exit quality loop and mark session complete
+6. Read the reconciled fix list, spawn code-quality workers for the unified fixes
+7. Commit and push, then restart this loop using the new push as the baseline
+8. Only finish when ALL of these are true at the same time:
+   a. Internal `QA_VERDICT: PASS` has been received
+   b. The latest push has been live for at least 10 minutes
+   c. `gh api repos/{{{{owner}}}}/{{{{repo}}}}/pulls/{{{{pr_number}}}}/comments` returns no NEW unresolved comments since the latest push
+9. When all three conditions are met, mark the session complete:
+   ```bash
+   curl -s -X POST "http://localhost:18800/api/sessions/{{{{session_id}}}}/complete"
+   ```
 
 Log each iteration to `.hive-manager/{session_id}/coordination.log`:
 ```
-[TIMESTAMP] QUEEN: Entering reconciliation loop (iteration N/3)
-[TIMESTAMP] QUEEN: Collected N evaluator findings, M external comments
+[TIMESTAMP] QUEEN: Entering reconciliation loop for latest push
+[TIMESTAMP] QUEEN: Collected N evaluator findings, M external comments since latest push
 [TIMESTAMP] QUEEN: Spawned Reconciler — awaiting unified fix list
 [TIMESTAMP] QUEEN: Reconciliation complete — N fixes assigned
-[TIMESTAMP] QUEEN: Quality loop complete — session done
+[TIMESTAMP] QUEEN: Quality loop complete - session marked completed
 ```
 
 ## Your Task
@@ -6083,6 +6099,11 @@ Last updated: {timestamp}
                     let next_iteration = next_qa_failure_iteration(&session.state);
 
                     if next_iteration > session.max_qa_iterations {
+                        tracing::warn!(
+                            "Session {} exhausted the QA safety ceiling at {} failed verdicts",
+                            session_id,
+                            session.max_qa_iterations
+                        );
                         let changes =
                             self.set_session_state_with_events(session, SessionState::QaMaxRetriesExceeded);
                         session.auth_strategy = AuthStrategy::None;

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -5,4 +5,5 @@ mod controller;
 pub use controller::{
     Session, SessionController, HiveLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig,
     FusionVariantConfig, FusionVariantStatus, SessionType, AgentInfo, SessionState, AuthStrategy,
+    DEFAULT_MAX_QA_ITERATIONS,
 };

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 use crate::coordination::CoordinationMessage;
 use crate::domain::{ArtifactBundle, ResolverOutput};
 use crate::session::cell_status::PRIMARY_CELL_ID;
+use crate::session::DEFAULT_MAX_QA_ITERATIONS;
 use crate::templates::SessionTemplate;
 
 /// Generate a deterministic ID for legacy learnings that lack one.
@@ -136,7 +137,7 @@ fn default_cli() -> String {
 }
 
 fn default_max_qa_iterations() -> u8 {
-    20
+    DEFAULT_MAX_QA_ITERATIONS
 }
 
 fn default_qa_timeout_secs() -> u64 {

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -103,6 +103,8 @@ pub struct SessionSummary {
     pub session_type: String,
     pub project_path: String,
     pub created_at: DateTime<Utc>,
+    /// Best-known recent activity for dashboards (falls back to `created_at` when unset in storage).
+    pub last_activity_at: DateTime<Utc>,
     pub agent_count: usize,
     pub state: String,
 }
@@ -118,6 +120,8 @@ pub struct PersistedSession {
     pub session_type: SessionTypeInfo,
     pub project_path: String,
     pub created_at: DateTime<Utc>,
+    #[serde(default)]
+    pub last_activity_at: Option<DateTime<Utc>>,
     pub agents: Vec<PersistedAgentInfo>,
     pub state: String,
     #[serde(default = "default_cli")]
@@ -342,6 +346,9 @@ impl SessionStorage {
                         session_type,
                         project_path: session.project_path,
                         created_at: session.created_at,
+                        last_activity_at: session
+                            .last_activity_at
+                            .unwrap_or(session.created_at),
                         agent_count: session.agents.len(),
                         state: session.state,
                     });

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -136,7 +136,7 @@ fn default_cli() -> String {
 }
 
 fn default_max_qa_iterations() -> u8 {
-    3
+    20
 }
 
 fn default_qa_timeout_secs() -> u64 {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -51,6 +51,7 @@
     session_type: string;
     project_path: string;
     created_at: string;
+    last_activity_at?: string;
     agent_count: number;
     state: string;
   }
@@ -359,7 +360,7 @@
                         {#if 'Solo' in session.session_type || ('Hive' in session.session_type && session.session_type.Hive.worker_count === 1 && session.agents.length === 1)}
                           <span class="type-tag solo">Solo</span>
                         {/if}
-                        {formatTimestamp(session.created_at)}
+                        {formatTimestamp(session.last_activity_at ?? session.created_at)}
                       </span>
                     {/if}
                   </div>
@@ -407,7 +408,7 @@
                     {#if session.session_type.startsWith('Solo') || (session.session_type === 'Hive (1)' && session.agent_count === 1)}
                       <span class="type-tag solo">Solo</span>
                     {/if}
-                    {formatTimestamp(session.created_at)}
+                    {formatTimestamp(session.last_activity_at ?? session.created_at)}
                   </span>
                 </div>
                 <button class="load-button" onclick={() => handleResumeSession(session.id)} title="Load Session" aria-label="Load session" type="button">

--- a/src/lib/components/cell/CellCard.svelte
+++ b/src/lib/components/cell/CellCard.svelte
@@ -3,7 +3,8 @@
     import WorkspaceBadge from './WorkspaceBadge.svelte';
     import AgentList from '../agent/AgentList.svelte';
     import { ui } from '../../stores/ui';
-    import { Hourglass, Wrench, Rocket, Lightning, NotePencil, CheckCircle, Question, XCircle, Skull, Users } from 'phosphor-svelte';
+    import { Question, Users } from 'phosphor-svelte';
+    import { statusIconFor, statusIconWeight } from './statusIcon';
 
     export let cell: Cell;
 
@@ -27,17 +28,6 @@
         toggleSelection();
     }
 
-    const statusIcons: Record<string, any> = {
-        'queued': Hourglass,
-        'preparing': Wrench,
-        'launching': Rocket,
-        'running': Lightning,
-        'summarizing': NotePencil,
-        'completed': CheckCircle,
-        'waiting_input': Question,
-        'failed': XCircle,
-        'killed': Skull
-    };
 </script>
 
 <div 
@@ -54,9 +44,9 @@
     <div class="header">
         <div class="status-icon" title={cell.status} aria-hidden="true">
             <svelte:component 
-                this={statusIcons[cell.status] || Question} 
+                this={statusIconFor(cell.status) || Question} 
                 size={isCollapsed ? 14 : 18}
-                weight={cell.status === 'completed' || cell.status === 'failed' ? 'fill' : 'light'}
+                weight={statusIconWeight(cell.status)}
             />
         </div>
         <div class="name-box">

--- a/src/lib/components/cell/statusIcon.ts
+++ b/src/lib/components/cell/statusIcon.ts
@@ -1,0 +1,32 @@
+import {
+  CheckCircle,
+  Hourglass,
+  Lightning,
+  NotePencil,
+  Question,
+  Rocket,
+  Skull,
+  Wrench,
+  XCircle,
+} from 'phosphor-svelte';
+import type { CellStatus } from '$lib/types/domain';
+
+const statusIcons: Partial<Record<CellStatus, any>> = {
+  queued: Hourglass,
+  preparing: Wrench,
+  launching: Rocket,
+  running: Lightning,
+  summarizing: NotePencil,
+  completed: CheckCircle,
+  waiting_input: Question,
+  failed: XCircle,
+  killed: Skull,
+};
+
+export function statusIconFor(status: string): any {
+  return statusIcons[status as CellStatus] ?? Question;
+}
+
+export function statusIconWeight(status: string): 'fill' | 'light' {
+  return status === 'completed' || status === 'failed' ? 'fill' : 'light';
+}

--- a/src/lib/components/dashboard/KanbanBoard.svelte
+++ b/src/lib/components/dashboard/KanbanBoard.svelte
@@ -68,6 +68,7 @@
     {#each PRIMARY_COLUMNS as col (col.status)}
       <KanbanColumn
         label={col.label}
+        status={col.status}
         accent={col.accent}
         sessions={groups.get(col.status) ?? []}
       />
@@ -92,11 +93,13 @@
       <div class="columns">
         <KanbanColumn
           label="Failed"
+          status="failed"
           accent="var(--status-error)"
           sessions={groups.get('failed') ?? []}
         />
         <KanbanColumn
           label="Killed"
+          status="killed"
           accent="var(--status-blocked)"
           sessions={groups.get('killed') ?? []}
         />

--- a/src/lib/components/dashboard/KanbanBoard.svelte
+++ b/src/lib/components/dashboard/KanbanBoard.svelte
@@ -14,7 +14,7 @@
     switch (key) {
       case 'Planning':
       case 'PlanReady':
-        return 'preparing';
+        return 'queued';
       case 'Starting':
         return 'launching';
       case 'Running':
@@ -22,7 +22,7 @@
       case 'QaInProgress':
         return 'running';
       case 'QaPassed':
-        return 'summarizing';
+        return 'completed';
       case 'Paused':
       case 'QaFailed':
         return 'waiting_input';

--- a/src/lib/components/dashboard/KanbanBoard.svelte
+++ b/src/lib/components/dashboard/KanbanBoard.svelte
@@ -1,41 +1,7 @@
 <script lang="ts">
-  import { CaretDown, CaretRight } from 'phosphor-svelte';
-  import { sessions as sessionsStore, type Session, type SessionState } from '$lib/stores/sessions';
+  import { sessions as sessionsStore, sessionStateToCellStatus, type Session } from '$lib/stores/sessions';
   import type { CellStatus } from '$lib/types/domain';
   import KanbanColumn from './KanbanColumn.svelte';
-
-  function stateKey(state: SessionState): string {
-    if (typeof state === 'string') return state;
-    return Object.keys(state)[0] ?? 'Unknown';
-  }
-
-  function sessionToCellStatus(session: Session): CellStatus {
-    const key = stateKey(session.state);
-    switch (key) {
-      case 'Planning':
-      case 'PlanReady':
-        return 'queued';
-      case 'Starting':
-        return 'launching';
-      case 'Running':
-      case 'SpawningEvaluator':
-      case 'QaInProgress':
-        return 'running';
-      case 'QaPassed':
-        return 'completed';
-      case 'Paused':
-      case 'QaFailed':
-        return 'waiting_input';
-      case 'QaMaxRetriesExceeded':
-      case 'Failed':
-        return 'failed';
-      case 'Completed':
-      case 'Closed':
-        return 'completed';
-      default:
-        return 'queued';
-    }
-  }
 
   const PRIMARY_COLUMNS: { status: CellStatus; label: string; accent: string }[] = [
     { status: 'queued', label: 'Queued', accent: 'var(--status-queued)' },
@@ -45,22 +11,20 @@
     { status: 'waiting_input', label: 'Waiting Input', accent: 'var(--status-warning)' },
     { status: 'summarizing', label: 'Summarizing', accent: 'var(--accent-chrome)' },
     { status: 'completed', label: 'Completed', accent: 'var(--status-success)' },
+    { status: 'failed', label: 'Failed', accent: 'var(--status-error)' },
+    { status: 'killed', label: 'Killed', accent: 'var(--status-blocked)' },
   ];
-
-  let collapsedFailed = $state(true);
 
   let groups = $derived.by(() => {
     const map = new Map<CellStatus, Session[]>();
     for (const s of $sessionsStore.sessions) {
-      const k = sessionToCellStatus(s);
+      const k = sessionStateToCellStatus(s.state);
       const arr = map.get(k) ?? [];
       arr.push(s);
       map.set(k, arr);
     }
     return map;
   });
-
-  let failedKilled = $derived([...(groups.get('failed') ?? []), ...(groups.get('killed') ?? [])]);
 </script>
 
 <div class="board">
@@ -74,38 +38,6 @@
       />
     {/each}
   </div>
-
-  <section class="failed-section" class:collapsed={collapsedFailed}>
-    <button
-      class="failed-header"
-      aria-expanded={!collapsedFailed}
-      onclick={() => (collapsedFailed = !collapsedFailed)}
-    >
-      {#if collapsedFailed}
-        <CaretRight size={14} weight="bold" />
-      {:else}
-        <CaretDown size={14} weight="bold" />
-      {/if}
-      <span>Failed / Killed</span>
-      <span class="count">{failedKilled.length}</span>
-    </button>
-    {#if !collapsedFailed}
-      <div class="columns">
-        <KanbanColumn
-          label="Failed"
-          status="failed"
-          accent="var(--status-error)"
-          sessions={groups.get('failed') ?? []}
-        />
-        <KanbanColumn
-          label="Killed"
-          status="killed"
-          accent="var(--status-blocked)"
-          sessions={groups.get('killed') ?? []}
-        />
-      </div>
-    {/if}
-  </section>
 </div>
 
 <style>
@@ -123,30 +55,5 @@
     padding-bottom: var(--space-2);
     flex: 1;
     min-height: 0;
-  }
-  .failed-section {
-    border-top: 1px solid var(--color-border);
-    padding-top: var(--space-3);
-  }
-  .failed-header {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--text-primary);
-    font-family: var(--font-display);
-    font-size: var(--text-small);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    padding: var(--space-2) 0;
-  }
-  .failed-header:hover {
-    color: var(--status-error);
-  }
-  .count {
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
   }
 </style>

--- a/src/lib/components/dashboard/KanbanBoard.svelte
+++ b/src/lib/components/dashboard/KanbanBoard.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+  import { CaretDown, CaretRight } from 'phosphor-svelte';
+  import { sessions as sessionsStore, type Session, type SessionState } from '$lib/stores/sessions';
+  import type { CellStatus } from '$lib/types/domain';
+  import KanbanColumn from './KanbanColumn.svelte';
+
+  function stateKey(state: SessionState): string {
+    if (typeof state === 'string') return state;
+    return Object.keys(state)[0] ?? 'Unknown';
+  }
+
+  function sessionToCellStatus(session: Session): CellStatus {
+    const key = stateKey(session.state);
+    switch (key) {
+      case 'Planning':
+      case 'PlanReady':
+        return 'preparing';
+      case 'Starting':
+        return 'launching';
+      case 'Running':
+      case 'SpawningEvaluator':
+      case 'QaInProgress':
+        return 'running';
+      case 'QaPassed':
+        return 'summarizing';
+      case 'Paused':
+      case 'QaFailed':
+        return 'waiting_input';
+      case 'QaMaxRetriesExceeded':
+      case 'Failed':
+        return 'failed';
+      case 'Completed':
+      case 'Closed':
+        return 'completed';
+      default:
+        return 'queued';
+    }
+  }
+
+  const PRIMARY_COLUMNS: { status: CellStatus; label: string; accent: string }[] = [
+    { status: 'queued', label: 'Queued', accent: 'var(--status-queued)' },
+    { status: 'preparing', label: 'Preparing', accent: 'var(--accent-chrome)' },
+    { status: 'launching', label: 'Launching', accent: 'var(--accent-amber)' },
+    { status: 'running', label: 'Running', accent: 'var(--status-running)' },
+    { status: 'waiting_input', label: 'Waiting Input', accent: 'var(--status-warning)' },
+    { status: 'summarizing', label: 'Summarizing', accent: 'var(--accent-chrome)' },
+    { status: 'completed', label: 'Completed', accent: 'var(--status-success)' },
+  ];
+
+  let collapsedFailed = $state(true);
+
+  let groups = $derived.by(() => {
+    const map = new Map<CellStatus, Session[]>();
+    for (const s of $sessionsStore.sessions) {
+      const k = sessionToCellStatus(s);
+      const arr = map.get(k) ?? [];
+      arr.push(s);
+      map.set(k, arr);
+    }
+    return map;
+  });
+
+  let failedKilled = $derived([...(groups.get('failed') ?? []), ...(groups.get('killed') ?? [])]);
+</script>
+
+<div class="board">
+  <div class="columns">
+    {#each PRIMARY_COLUMNS as col (col.status)}
+      <KanbanColumn
+        label={col.label}
+        accent={col.accent}
+        sessions={groups.get(col.status) ?? []}
+      />
+    {/each}
+  </div>
+
+  <section class="failed-section" class:collapsed={collapsedFailed}>
+    <button
+      class="failed-header"
+      aria-expanded={!collapsedFailed}
+      onclick={() => (collapsedFailed = !collapsedFailed)}
+    >
+      {#if collapsedFailed}
+        <CaretRight size={14} weight="bold" />
+      {:else}
+        <CaretDown size={14} weight="bold" />
+      {/if}
+      <span>Failed / Killed</span>
+      <span class="count">{failedKilled.length}</span>
+    </button>
+    {#if !collapsedFailed}
+      <div class="columns">
+        <KanbanColumn
+          label="Failed"
+          accent="var(--status-error)"
+          sessions={groups.get('failed') ?? []}
+        />
+        <KanbanColumn
+          label="Killed"
+          accent="var(--status-blocked)"
+          sessions={groups.get('killed') ?? []}
+        />
+      </div>
+    {/if}
+  </section>
+</div>
+
+<style>
+  .board {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-4);
+    height: 100%;
+    min-height: 0;
+  }
+  .columns {
+    display: flex;
+    gap: var(--space-3);
+    overflow-x: auto;
+    padding-bottom: var(--space-2);
+    flex: 1;
+    min-height: 0;
+  }
+  .failed-section {
+    border-top: 1px solid var(--color-border);
+    padding-top: var(--space-3);
+  }
+  .failed-header {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    font-size: var(--text-small);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: var(--space-2) 0;
+  }
+  .failed-header:hover {
+    color: var(--status-error);
+  }
+  .count {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+</style>

--- a/src/lib/components/dashboard/KanbanCard.svelte
+++ b/src/lib/components/dashboard/KanbanCard.svelte
@@ -2,13 +2,17 @@
   import { Eye, Users } from 'phosphor-svelte';
   import { goto } from '$app/navigation';
   import { sessions, type Session } from '$lib/stores/sessions';
+  import type { CellStatus } from '$lib/types/domain';
+  import { statusIconFor, statusIconWeight } from '$lib/components/cell/statusIcon';
 
   interface Props {
     session: Session;
+    status: CellStatus;
   }
-  let { session }: Props = $props();
+  let { session, status }: Props = $props();
 
   let agentCount = $derived(session.agents?.length ?? 0);
+  let StatusIcon = $derived(statusIconFor(status));
 
   let lastActivity = $derived(session.created_at);
 
@@ -36,7 +40,12 @@
 
 <article class="card" aria-label={title}>
   <header class="card-head">
-    <h3 class="title" title={title}>{title}</h3>
+    <div class="title-wrap">
+      <div class="status-icon" title={status} aria-hidden="true">
+        <StatusIcon size={14} weight={statusIconWeight(status)} />
+      </div>
+      <h3 class="title" title={title}>{title}</h3>
+    </div>
     <button class="eye" aria-label="Open session" title="Open session" onclick={openSession}>
       <Eye size={16} weight="light" />
     </button>
@@ -72,6 +81,24 @@
     justify-content: space-between;
     gap: var(--space-2);
   }
+  .title-wrap {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-width: 0;
+    flex: 1;
+  }
+  .status-icon {
+    width: 24px;
+    height: 24px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-sm);
+    background: rgba(0, 0, 0, 0.2);
+    color: var(--text-secondary);
+    flex: 0 0 auto;
+  }
   .title {
     margin: 0;
     font-family: var(--font-display);
@@ -82,6 +109,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     min-width: 0;
+    flex: 1;
   }
   .eye {
     background: none;

--- a/src/lib/components/dashboard/KanbanCard.svelte
+++ b/src/lib/components/dashboard/KanbanCard.svelte
@@ -21,7 +21,8 @@
     const d = new Date(lastActivity);
     if (Number.isNaN(d.getTime())) return '—';
     const diffMs = Date.now() - d.getTime();
-    const sec = Math.floor(diffMs / 1000);
+    const sec = Math.max(0, Math.floor(diffMs / 1000));
+    if (sec === 0) return 'just now';
     if (sec < 60) return `${sec}s ago`;
     const min = Math.floor(sec / 60);
     if (min < 60) return `${min}m ago`;

--- a/src/lib/components/dashboard/KanbanCard.svelte
+++ b/src/lib/components/dashboard/KanbanCard.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import { Eye, Users } from 'phosphor-svelte';
+  import { goto } from '$app/navigation';
+  import { sessions, type Session } from '$lib/stores/sessions';
+
+  interface Props {
+    session: Session;
+  }
+  let { session }: Props = $props();
+
+  let agentCount = $derived(session.agents?.length ?? 0);
+
+  let lastActivity = $derived(session.created_at);
+
+  let lastActivityLabel = $derived.by(() => {
+    if (!lastActivity) return '—';
+    const d = new Date(lastActivity);
+    if (Number.isNaN(d.getTime())) return '—';
+    const diffMs = Date.now() - d.getTime();
+    const sec = Math.floor(diffMs / 1000);
+    if (sec < 60) return `${sec}s ago`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m ago`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `${hr}h ago`;
+    return d.toLocaleDateString();
+  });
+
+  let title = $derived(session.name ?? session.id.slice(0, 8));
+
+  function openSession() {
+    sessions.setActiveSession(session.id);
+    void goto('/');
+  }
+</script>
+
+<article class="card" aria-label={title}>
+  <header class="card-head">
+    <h3 class="title" title={title}>{title}</h3>
+    <button class="eye" aria-label="Open session" title="Open session" onclick={openSession}>
+      <Eye size={16} weight="light" />
+    </button>
+  </header>
+  <div class="meta">
+    <span class="meta-item" title="Agents">
+      <Users size={12} weight="light" />
+      {agentCount}
+    </span>
+    <span class="meta-item" title={lastActivity ?? ''}>
+      {lastActivityLabel}
+    </span>
+  </div>
+</article>
+
+<style>
+  .card {
+    background: var(--bg-elevated);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    padding: var(--space-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    transition: border-color var(--transition-fast);
+  }
+  .card:hover {
+    border-color: var(--accent-cyan);
+  }
+  .card-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+  }
+  .title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    font-weight: 600;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+  }
+  .eye {
+    background: none;
+    border: none;
+    color: var(--text-secondary);
+    cursor: pointer;
+    padding: var(--space-1);
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--radius-sm);
+  }
+  .eye:hover {
+    color: var(--accent-cyan);
+    background: rgba(0, 229, 255, 0.08);
+  }
+  .meta {
+    display: flex;
+    gap: var(--space-3);
+    font-size: var(--text-small);
+    color: var(--text-secondary);
+  }
+  .meta-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+  }
+</style>

--- a/src/lib/components/dashboard/KanbanCard.svelte
+++ b/src/lib/components/dashboard/KanbanCard.svelte
@@ -14,7 +14,7 @@
   let agentCount = $derived(session.agents?.length ?? 0);
   let StatusIcon = $derived(statusIconFor(status));
 
-  let lastActivity = $derived(session.created_at);
+  let lastActivity = $derived(session.last_activity_at ?? session.created_at);
 
   let lastActivityLabel = $derived.by(() => {
     if (!lastActivity) return '—';

--- a/src/lib/components/dashboard/KanbanColumn.svelte
+++ b/src/lib/components/dashboard/KanbanColumn.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+  import type { Session } from '$lib/stores/sessions';
+  import KanbanCard from './KanbanCard.svelte';
+
+  interface Props {
+    label: string;
+    sessions: Session[];
+    accent?: string;
+  }
+  let { label, sessions: items, accent = 'var(--text-secondary)' }: Props = $props();
+</script>
+
+<section class="column" style="--col-accent: {accent};" aria-label={label}>
+  <header class="col-head">
+    <span class="dot" aria-hidden="true"></span>
+    <span class="label">{label}</span>
+    <span class="count">{items.length}</span>
+  </header>
+  <div class="col-body">
+    {#each items as s (s.id)}
+      <KanbanCard session={s} />
+    {/each}
+    {#if items.length === 0}
+      <div class="empty">—</div>
+    {/if}
+  </div>
+</section>
+
+<style>
+  .column {
+    display: flex;
+    flex-direction: column;
+    min-width: 220px;
+    width: 220px;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    max-height: 100%;
+  }
+  .col-head {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    border-bottom: 1px solid var(--color-border);
+    font-family: var(--font-display);
+    font-size: var(--text-small);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-primary);
+  }
+  .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--col-accent);
+    box-shadow: 0 0 8px var(--col-accent);
+  }
+  .label {
+    flex: 1;
+  }
+  .count {
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+  .col-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: var(--space-3);
+    overflow-y: auto;
+    flex: 1;
+  }
+  .empty {
+    color: var(--text-disabled);
+    font-size: var(--text-small);
+    text-align: center;
+    padding: var(--space-3) 0;
+  }
+</style>

--- a/src/lib/components/dashboard/KanbanColumn.svelte
+++ b/src/lib/components/dashboard/KanbanColumn.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import type { Session } from '$lib/stores/sessions';
+  import type { CellStatus } from '$lib/types/domain';
   import KanbanCard from './KanbanCard.svelte';
 
   interface Props {
     label: string;
     sessions: Session[];
+    status?: CellStatus;
     accent?: string;
   }
-  let { label, sessions: items, accent = 'var(--text-secondary)' }: Props = $props();
+  let { label, sessions: items, status = 'queued', accent = 'var(--text-secondary)' }: Props = $props();
 </script>
 
 <section class="column" style="--col-accent: {accent};" aria-label={label}>
@@ -18,7 +20,7 @@
   </header>
   <div class="col-body">
     {#each items as s (s.id)}
-      <KanbanCard session={s} />
+      <KanbanCard session={s} status={status} />
     {/each}
     {#if items.length === 0}
       <div class="empty">—</div>

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -1,6 +1,7 @@
 import { writable, derived } from 'svelte/store';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
+import type { CellStatus } from '$lib/types/domain';
 
 export type AgentRole =
   | 'MasterPlanner'
@@ -139,6 +140,46 @@ export function serdeEnumVariantName(value: unknown): string | undefined {
     if (keys.length === 1) return keys[0];
   }
   return undefined;
+}
+
+export function sessionStateToCellStatus(state: SessionState | unknown): CellStatus {
+  const key = serdeEnumVariantName(state) ?? 'Unknown';
+
+  switch (key) {
+    case 'Planning':
+    case 'PlanReady':
+      return 'queued';
+    case 'Starting':
+    case 'SpawningWorker':
+    case 'SpawningPlanner':
+    case 'SpawningFusionVariant':
+    case 'SpawningJudge':
+    case 'SpawningEvaluator':
+      return 'launching';
+    case 'WaitingForWorker':
+    case 'WaitingForPlanner':
+    case 'WaitingForFusionVariants':
+    case 'Judging':
+    case 'MergingWinner':
+    case 'QaInProgress':
+    case 'Running':
+      return 'running';
+    case 'AwaitingVerdictSelection':
+    case 'Paused':
+      return 'waiting_input';
+    case 'QaPassed':
+    case 'Completed':
+    case 'Closed':
+      return 'completed';
+    case 'QaFailed':
+    case 'QaMaxRetriesExceeded':
+    case 'Failed':
+      return 'failed';
+    case 'Closing':
+      return 'summarizing';
+    default:
+      return 'queued';
+  }
 }
 
 export interface Session {

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -153,6 +153,8 @@ export interface Session {
   project_path: string;
   state: SessionState;
   created_at: string;
+  /** RFC3339; omitted on older persisted sessions — UI falls back to `created_at`. */
+  last_activity_at?: string;
   agents: AgentInfo[];
 }
 

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -148,7 +148,7 @@ export function sessionStateToCellStatus(state: SessionState | unknown): CellSta
   switch (key) {
     case 'Planning':
     case 'PlanReady':
-      return 'queued';
+      return 'preparing';
     case 'Starting':
     case 'SpawningWorker':
     case 'SpawningPlanner':
@@ -166,8 +166,8 @@ export function sessionStateToCellStatus(state: SessionState | unknown): CellSta
       return 'running';
     case 'AwaitingVerdictSelection':
     case 'Paused':
-      return 'waiting_input';
     case 'QaPassed':
+      return 'waiting_input';
     case 'Completed':
     case 'Closed':
       return 'completed';

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -6,11 +6,11 @@
 </script>
 
 <nav class="top-nav" aria-label="Primary">
-  <a href="/" class="nav-link" class:active={$page.url.pathname === '/'} title="Session view">
+  <a href="/" class="nav-link" class:active={$page.url.pathname === '/'} aria-current={$page.url.pathname === '/' ? 'page' : undefined} title="Session view">
     <House size={14} weight="light" />
     <span>Session</span>
   </a>
-  <a href="/dashboard" class="nav-link" class:active={$page.url.pathname === '/dashboard'} title="Dashboard">
+  <a href="/dashboard" class="nav-link" class:active={$page.url.pathname === '/dashboard'} aria-current={$page.url.pathname === '/dashboard' ? 'page' : undefined} title="Dashboard">
     <Kanban size={14} weight="light" />
     <span>Dashboard</span>
   </a>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,55 @@
-<script>
+<script lang="ts">
   import '../lib/styles/lattice-tokens.css';
   import '../lib/styles/lattice-base.css';
+  import { page } from '$app/stores';
+  import { Kanban, House } from 'phosphor-svelte';
 </script>
 
+<nav class="top-nav" aria-label="Primary">
+  <a href="/" class="nav-link" class:active={$page.url.pathname === '/'} title="Session view">
+    <House size={14} weight="light" />
+    <span>Session</span>
+  </a>
+  <a href="/dashboard" class="nav-link" class:active={$page.url.pathname === '/dashboard'} title="Dashboard">
+    <Kanban size={14} weight="light" />
+    <span>Dashboard</span>
+  </a>
+</nav>
+
 <slot />
+
+<style>
+  .top-nav {
+    position: fixed;
+    top: 8px;
+    right: 12px;
+    z-index: 1000;
+    display: flex;
+    gap: 6px;
+    background: var(--bg-elevated, rgba(21, 24, 32, 0.9));
+    border: 1px solid var(--color-border, #222631);
+    border-radius: var(--radius-sm, 2px);
+    padding: 4px;
+    backdrop-filter: blur(6px);
+  }
+  .nav-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    font-size: 12px;
+    text-decoration: none;
+    color: var(--text-secondary, #8B949E);
+    border-radius: var(--radius-sm, 2px);
+    font-family: var(--font-display, sans-serif);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+  .nav-link:hover {
+    color: var(--accent-cyan, #00E5FF);
+  }
+  .nav-link.active {
+    color: var(--accent-cyan, #00E5FF);
+    background: rgba(0, 229, 255, 0.1);
+  }
+</style>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { House } from 'phosphor-svelte';
+  import KanbanBoard from '$lib/components/dashboard/KanbanBoard.svelte';
+  import { sessions } from '$lib/stores/sessions';
+
+  onMount(() => {
+    sessions.loadSessions();
+  });
+</script>
+
+<div class="dashboard">
+  <header class="page-head">
+    <div>
+      <h1>Dashboard</h1>
+      <p class="subtitle">All sessions grouped by status</p>
+    </div>
+    <a href="/" class="home-link" title="Back to session view">
+      <House size={16} weight="light" />
+      Session View
+    </a>
+  </header>
+  <div class="board-wrap">
+    <KanbanBoard />
+  </div>
+</div>
+
+<style>
+  .dashboard {
+    display: flex;
+    flex-direction: column;
+    width: 100vw;
+    height: 100vh;
+    background: var(--color-bg);
+    color: var(--color-text);
+    padding: var(--space-5);
+    gap: var(--space-4);
+    font-family: var(--font-body);
+    overflow: hidden;
+  }
+  .page-head {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: var(--space-3);
+  }
+  h1 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--text-h1);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+  }
+  .subtitle {
+    margin: var(--space-1) 0 0 0;
+    color: var(--text-secondary);
+    font-size: var(--text-small);
+  }
+  .home-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    color: var(--text-secondary);
+    text-decoration: none;
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    font-size: var(--text-small);
+  }
+  .home-link:hover {
+    color: var(--accent-cyan);
+    border-color: var(--accent-cyan);
+  }
+  .board-wrap {
+    flex: 1;
+    min-height: 0;
+  }
+  :global(body) {
+    margin: 0;
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- Adds read-only `/dashboard` Kanban route grouping sessions by `CellStatus` (closes #77).
- Lifts hardcoded 3-iteration QA cap to a 20-safety ceiling and gates session completion on quiescence (internal QA PASS + 10min post-push + no new reviewer comments) (closes #78).
- Adds `POST /api/sessions/{id}/complete` endpoint for Queen to mark session completed.
- Extracts shared `statusIcon.ts` mapping used by both `CellCard` and `KanbanCard`.
- Adds `last_activity_at` to session summary, surfaced by dashboard cards.

## Task breakdown
- **Task 1** (backend/codex): QA cap lift + completion endpoint + Queen prompt quiescence block.
- **Task 2** (frontend/claude): `/dashboard` route + KanbanBoard/Column/Card components + nav link.
- **Task 3** (coherence/droid): tests + duplicate-constant sync.
- **Task 4** (simplify/codex): consolidate QA helpers + shared status-icon mapping.
- **Task 5** (reviewer/codex): cross-cutting review → 1 HIGH + 2 MEDIUM findings.
- **Task 6** (resolver/cursor): fixed stale 3-iteration text, added last_activity_at, aligned frontend status bucketing with backend.

## Test plan
- [ ] `cargo check --tests` passes (Windows DLL issue prevents local `cargo test`; CI is source of truth).
- [ ] `npm run check` passes with no new warnings.
- [ ] `/dashboard` route renders all CellStatus columns in correct order.
- [ ] KanbanCard Eye icon navigates to session view without breaking single-session store gating.
- [ ] `POST /api/sessions/{id}/complete` transitions session to Completed only after quiescence conditions met.
- [ ] Queen prompt no longer references "maximum 3 iterations" or "iteration N/3".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard with Kanban-style session board and cards
  * New "complete session" API endpoint

* **Improvements**
  * Session last-activity timestamps shown across the UI and used for ordering
  * Unified status icons and weights for clearer cell/status visuals
  * QA handling: larger QA iteration limit, quiescence-based completion gating, and adjusted QA state transitions

* **Tests**
  * Added end-to-end and unit tests covering activity/heartbeat, listing, and completion behaviors

* **Chore**
  * App version bumped to 0.25.0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->