### PR TITLE
fix: chat API base + sidebar icon toggle + worktree chip (closes #80)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ nul
 
 # Local planning docs (not shipped)
 PLANNING DOCS/
+dist-local/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.25.0"
+version = "0.25.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/http/handlers/artifacts.rs
+++ b/src-tauri/src/http/handlers/artifacts.rs
@@ -122,6 +122,8 @@ fn session_from_persisted(persisted: PersistedSession) -> Session {
         max_qa_iterations: persisted.max_qa_iterations,
         qa_timeout_secs: persisted.qa_timeout_secs,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: persisted.worktree_path,
+        worktree_branch: persisted.worktree_branch,
     }
 }
 

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -87,6 +87,8 @@ fn make_test_session(id: &str, project_path: &str) -> Session {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
     }
 }
 
@@ -121,6 +123,8 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
     }
 }
 
@@ -261,6 +265,8 @@ async fn test_patch_session_omitted_field_preserves_existing_value() {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
     });
 
     let body = serde_json::json!({
@@ -310,6 +316,8 @@ async fn test_patch_session_null_clears_field() {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
     });
 
     let body = serde_json::json!({
@@ -459,6 +467,8 @@ async fn test_patch_session_updates_persisted_session_not_loaded_in_memory() {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: String::new(),
+        worktree_path: None,
+        worktree_branch: None,
     };
     storage.save_session(&persisted).unwrap();
 
@@ -2387,6 +2397,8 @@ fn test_persisted_session_serializes_default_cli() {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: String::new(),
+        worktree_path: None,
+        worktree_branch: None,
     };
 
     let json = serde_json::to_string(&session).unwrap();
@@ -3114,6 +3126,8 @@ async fn test_list_artifacts_uses_persisted_session_fallback() {
             max_qa_iterations: test_default_max_qa_iterations(),
             qa_timeout_secs: 300,
             auth_strategy: String::new(),
+            worktree_path: None,
+            worktree_branch: None,
         })
         .unwrap();
     storage
@@ -4011,6 +4025,8 @@ fn make_fusion_session(id: &str, project_path: &str) -> Session {
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
         auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
     }
 }
 

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -260,6 +260,8 @@ mod tests {
             max_qa_iterations: DEFAULT_MAX_QA_ITERATIONS,
             qa_timeout_secs: 300,
             auth_strategy: AuthStrategy::None,
+            worktree_path: None,
+            worktree_branch: None,
         }
     }
 

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -352,6 +352,11 @@ pub struct Session {
     pub qa_timeout_secs: u64,
     #[serde(default)]
     pub auth_strategy: AuthStrategy,
+    /// Primary git worktree path for this session (e.g. Queen or first Fusion variant), for UI.
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub worktree_branch: Option<String>,
 }
 
 #[derive(Clone, Serialize)]
@@ -667,6 +672,8 @@ impl SessionController {
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
         };
 
         {
@@ -4882,6 +4889,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: Some(solo_cwd.clone()),
+            worktree_branch: Some(solo_branch.clone()),
         };
 
         {
@@ -5102,6 +5111,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: Some(queen_cwd.clone()),
+            worktree_branch: Some(queen_branch.clone()),
         };
 
         {
@@ -5223,6 +5234,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: variants.first().map(|v| v.worktree_path.clone()),
+            worktree_branch: variants.first().map(|v| v.branch.clone()),
         };
 
         {
@@ -5480,6 +5493,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
         };
 
         {
@@ -5573,6 +5588,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
         };
 
         {
@@ -5835,6 +5852,10 @@ Last updated: {timestamp}
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
                 s.agents.extend(new_agents.clone());
+                if let Some(v) = variants.first() {
+                    s.worktree_path = Some(v.worktree_path.clone());
+                    s.worktree_branch = Some(v.branch.clone());
+                }
                 self.emit_agent_batch_launched(s, &new_agents);
                 let changes =
                     self.set_session_state_with_events(s, SessionState::WaitingForFusionVariants);
@@ -5937,6 +5958,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
         };
 
         {
@@ -6961,6 +6984,8 @@ Last updated: {timestamp}
             max_qa_iterations: persisted.max_qa_iterations,
             qa_timeout_secs: persisted.qa_timeout_secs,
             auth_strategy,
+            worktree_path: persisted.worktree_path.clone(),
+            worktree_branch: persisted.worktree_branch.clone(),
         })
     }
 
@@ -7180,6 +7205,8 @@ Last updated: {timestamp}
             max_qa_iterations,
             qa_timeout_secs,
             auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
         };
 
         {
@@ -7353,6 +7380,10 @@ Last updated: {timestamp}
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_mut(session_id) {
                 session.agents.push(agent_info.clone());
+                if session.worktree_path.is_none() {
+                    session.worktree_path = Some(worker_cwd.clone());
+                    session.worktree_branch = Some(worker_branch.clone());
+                }
                 self.emit_agent_launched(session, &agent_info);
             }
         }
@@ -7789,6 +7820,8 @@ Last updated: {timestamp}
             max_qa_iterations: session.max_qa_iterations,
             qa_timeout_secs: session.qa_timeout_secs,
             auth_strategy: auth_strategy.persist_value(),
+            worktree_path: session.worktree_path.clone(),
+            worktree_branch: session.worktree_branch.clone(),
         }
     }
 
@@ -8307,6 +8340,8 @@ mod tests {
             max_qa_iterations: 3,
             qa_timeout_secs: 300,
             auth_strategy: AuthStrategy::default(),
+            worktree_path: None,
+            worktree_branch: None,
         }
     }
 

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -3610,7 +3610,7 @@ Workers run in isolated git worktrees. Each worker has its own worktree + branch
 
 5. **CLEANUP** after successful integration: `git worktree remove <path>` and `git branch -D hive/{session_id}/worker-N`. (Backend also cleans on session completion — safe to leave if unsure.)
 
-6. **CONFLICTS**: resolve in the main checkout, re-run `cargo check --tests` to confirm integrity, then commit the resolution.
+6. **CONFLICTS**: resolve in the main checkout, re-run the repository's relevant verification commands (from the plan, project DNA, and touched package/tooling) to confirm integrity, then commit the resolution.
 
 7. **Commit & push** - You handle final commits (workers don't push)
 8. **Signal Evaluator** - Once all tasks are done, write milestone-ready (see above)

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1452,6 +1452,8 @@ impl SessionController {
                 }
                 let changes = self.set_session_state_with_events(session, SessionState::Closed);
                 session.auth_strategy = AuthStrategy::None;
+                session.worktree_path = None;
+                session.worktree_branch = None;
                 Some((session.clone(), completed_agents, changes))
             } else {
                 None
@@ -6672,6 +6674,8 @@ Last updated: {timestamp}
                 }
                 let changes = self.set_session_state_with_events(s, SessionState::Completed);
                 s.auth_strategy = AuthStrategy::None;
+                s.worktree_path = None;
+                s.worktree_branch = None;
                 Some((s.clone(), completed_agents, changes))
             } else {
                 None

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -3590,6 +3590,28 @@ Workers record learnings during task completion. Your curation responsibilities:
 4. **Monitor progress** - Watch for workers to mark tasks COMPLETED
 5. **Spawn next worker** - When a task completes, spawn the next worker if needed
 6. **Review & integrate** - Review worker output and coordinate integration
+
+## Worktree Integration Protocol
+
+Workers run in isolated git worktrees. Each worker has its own worktree + branch created by the backend at `.hive-manager/worktrees/{session_id}/worker-N` on branch `hive/{session_id}/worker-N`. Integrate them back into the feature branch as follows:
+
+1. **LOCATE** each worker's worktree at `.hive-manager/worktrees/{session_id}/worker-N` on branch `hive/{session_id}/worker-N`. Inspect changes via:
+   - `git -C <worktree> log <branch> ^<feature-branch>`
+   - `git -C <worktree> diff <feature-branch>...<branch>`
+
+2. **CHOOSE** integration method per worker:
+   - **Preferred — cherry-pick** (from the main checkout): `git cherry-pick hive/{session_id}/worker-N` — preserves worker commit, clean history.
+   - **Squash merge**: `git merge --squash <branch> && git commit -m '...'` — use when the worker made noisy WIP commits.
+   - **Diff-apply**: `git -C <worktree> diff HEAD | git apply` then Queen commits — use when the worker did not commit at all.
+
+3. **ORDER integration** to minimize conflicts. Integrate disjoint-file tasks first. For tasks that touch overlapping files, integrate one, then rebase the next worker branch onto the updated tip before picking.
+
+4. **COMMIT CADENCE**: one separate commit per worker on the feature branch; push after each commit to give external reviewers (CodeRabbit/Gemini) incremental surface.
+
+5. **CLEANUP** after successful integration: `git worktree remove <path>` and `git branch -D hive/{session_id}/worker-N`. (Backend also cleans on session completion — safe to leave if unsure.)
+
+6. **CONFLICTS**: resolve in the main checkout, re-run `cargo check --tests` to confirm integrity, then commit the resolution.
+
 7. **Commit & push** - You handle final commits (workers don't push)
 8. **Signal Evaluator** - Once all tasks are done, write milestone-ready (see above)
 

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -3600,9 +3600,9 @@ Workers run in isolated git worktrees. Each worker has its own worktree + branch
    - `git -C <worktree> diff <feature-branch>...<branch>`
 
 2. **CHOOSE** integration method per worker:
-   - **Preferred — cherry-pick** (from the main checkout): `git cherry-pick hive/{session_id}/worker-N` — preserves worker commit, clean history.
+   - **Preferred — cherry-pick the full branch range**: `git rev-list --reverse <feature-branch>..<branch> | xargs -n1 git cherry-pick` — preserves the worker's full commit history.
    - **Squash merge**: `git merge --squash <branch> && git commit -m '...'` — use when the worker made noisy WIP commits.
-   - **Diff-apply**: `git -C <worktree> diff HEAD | git apply` then Queen commits — use when the worker did not commit at all.
+   - **Patch apply**: only use this when the worker has no commits and has staged/tracked all files first; otherwise newly created untracked files will be missed.
 
 3. **ORDER integration** to minimize conflicts. Integrate disjoint-file tasks first. For tasks that touch overlapping files, integrate one, then rebase the next worker branch onto the updated tip before picking.
 
@@ -7402,10 +7402,8 @@ Last updated: {timestamp}
             let mut sessions = self.sessions.write();
             if let Some(session) = sessions.get_mut(session_id) {
                 session.agents.push(agent_info.clone());
-                if session.worktree_path.is_none() {
-                    session.worktree_path = Some(worker_cwd.clone());
-                    session.worktree_branch = Some(worker_branch.clone());
-                }
+                // Don't promote ephemeral worker worktrees to session-level metadata.
+                // Only persist long-lived primary worktrees here.
                 self.emit_agent_launched(session, &agent_info);
             }
         }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -134,6 +134,10 @@ pub struct PersistedSession {
     pub qa_timeout_secs: u64,
     #[serde(default)]
     pub auth_strategy: String,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub worktree_branch: Option<String>,
 }
 
 fn default_cli() -> String {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { CaretDown, CaretRight, Check, ClipboardText, PencilSimple } from 'phosphor-svelte';
+  import { CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
+  import { page } from '$app/stores';
   import { sessions, activeSession, serdeEnumVariantName, type Session, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig } from '$lib/stores/sessions';
   import { invoke } from '@tauri-apps/api/core';
   import { onMount } from 'svelte';
@@ -260,14 +261,41 @@
 </script>
 
 <aside class="sidebar" class:collapsed={sidebarCollapsed}>
-  <button class="sidebar-header" onclick={() => sidebarCollapsed = !sidebarCollapsed} title={sidebarCollapsed ? "Expand Sessions" : "Collapse Sessions"}>
-    <span class="sidebar-icon">
-      <ClipboardText size={18} weight="light" />
-    </span>
-    {#if !sidebarCollapsed}
-      <h2>Sessions</h2>
-    {/if}
-  </button>
+  <div class="sidebar-header" class:collapsed={sidebarCollapsed}>
+    <nav class="view-toggle" class:collapsed={sidebarCollapsed} aria-label="View switcher">
+      <a
+        href="/"
+        class="view-link"
+        class:active={$page.url.pathname === '/'}
+        aria-current={$page.url.pathname === '/' ? 'page' : undefined}
+        title="Sessions"
+      >
+        <House size={18} weight="light" />
+      </a>
+      <a
+        href="/dashboard"
+        class="view-link"
+        class:active={$page.url.pathname === '/dashboard'}
+        aria-current={$page.url.pathname === '/dashboard' ? 'page' : undefined}
+        title="Dashboard"
+      >
+        <Kanban size={18} weight="light" />
+      </a>
+    </nav>
+    <button
+      type="button"
+      class="collapse-chevron"
+      onclick={() => sidebarCollapsed = !sidebarCollapsed}
+      title={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+      aria-label={sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
+    >
+      {#if sidebarCollapsed}
+        <CaretRight size={14} weight="light" />
+      {:else}
+        <CaretLeft size={14} weight="light" />
+      {/if}
+    </button>
+  </div>
 
   {#if !sidebarCollapsed}
   <div class="sidebar-content">
@@ -478,38 +506,70 @@
   .sidebar-header {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 16px;
+    gap: 8px;
+    padding: 8px;
     border-bottom: 1px solid var(--border-structural);
-    background: none;
-    border-left: none;
-    border-right: none;
-    border-top: none;
-    cursor: pointer;
     width: 100%;
-    text-align: left;
   }
 
-  .sidebar-header:hover {
-    background: var(--bg-elevated);
+  .sidebar-header.collapsed {
+    flex-direction: column;
+    gap: 6px;
   }
 
-  .sidebar-icon {
+  .view-toggle {
     display: flex;
+    flex-direction: row;
+    gap: 4px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .view-toggle.collapsed {
+    flex-direction: column;
+    flex: none;
+  }
+
+  .view-link {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    border-radius: var(--radius-sm, 2px);
+    color: var(--text-muted);
+    text-decoration: none;
+    border: 1px solid transparent;
+    transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+  }
+
+  .view-link:hover {
     color: var(--accent-cyan);
   }
 
-  .sidebar-header h2 {
-    margin: 0;
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-primary);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    white-space: nowrap;
+  .view-link.active {
+    color: var(--accent-cyan);
+    background: var(--bg-elevated);
+    border-color: var(--border-structural);
+  }
+
+  .collapse-chevron {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: none;
+    border: none;
+    color: var(--text-muted);
+    cursor: pointer;
+    border-radius: var(--radius-sm, 2px);
+    flex-shrink: 0;
+  }
+
+  .collapse-chevron:hover {
+    background: var(--bg-elevated);
+    color: var(--accent-cyan);
   }
 
   .sidebar-content {

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -263,24 +263,21 @@
 <aside class="sidebar" class:collapsed={sidebarCollapsed}>
   <div class="sidebar-header" class:collapsed={sidebarCollapsed}>
     <nav class="view-toggle" class:collapsed={sidebarCollapsed} aria-label="View switcher">
-      <a
-        href="/"
-        class="view-link"
-        class:active={$page.url.pathname === '/'}
-        aria-current={$page.url.pathname === '/' ? 'page' : undefined}
-        title="Sessions"
-      >
-        <House size={18} weight="light" />
-      </a>
-      <a
-        href="/dashboard"
-        class="view-link"
-        class:active={$page.url.pathname === '/dashboard'}
-        aria-current={$page.url.pathname === '/dashboard' ? 'page' : undefined}
-        title="Dashboard"
-      >
-        <Kanban size={18} weight="light" />
-      </a>
+      {#each [
+        { path: '/', icon: House, label: 'Sessions' },
+        { path: '/dashboard', icon: Kanban, label: 'Dashboard' }
+      ] as { path, icon: Icon, label } (path)}
+        <a
+          href={path}
+          class="view-link"
+          class:active={$page.url.pathname === path}
+          aria-label={label}
+          aria-current={$page.url.pathname === path ? 'page' : undefined}
+          title={label}
+        >
+          <Icon size={18} weight="light" />
+        </a>
+      {/each}
     </nav>
     <button
       type="button"

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -10,7 +10,7 @@
         const p = path.trim();
         if (p.length <= maxLen) return p;
         const head = Math.floor(maxLen / 2) - 1;
-        const tail = maxLen - head - 3;
+        const tail = maxLen - head - 1;
         return `${p.slice(0, Math.max(head, 1))}…${p.slice(-Math.max(tail, 1))}`;
     }
 

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -1,9 +1,24 @@
 <script lang="ts">
+    import { GitBranch } from 'phosphor-svelte';
     import { activeSession, serdeEnumVariantName } from '../../stores/sessions';
 
     $: session = $activeSession;
     $: mode = session ? serdeEnumVariantName(session.session_type)?.toLowerCase() ?? 'session' : 'session';
     $: status = session ? serdeEnumVariantName(session.state)?.toLowerCase() ?? 'unknown' : 'unknown';
+
+    function truncatePath(path: string, maxLen = 44): string {
+        const p = path.trim();
+        if (p.length <= maxLen) return p;
+        const head = Math.floor(maxLen / 2) - 1;
+        const tail = maxLen - head - 3;
+        return `${p.slice(0, Math.max(head, 1))}…${p.slice(-Math.max(tail, 1))}`;
+    }
+
+    $: wtPath = session?.worktree_path?.trim() ?? '';
+    $: wtBranch = session?.worktree_branch?.trim() ?? '';
+    $: worktreeTooltip = [wtBranch && `Branch: ${wtBranch}`, wtPath && `Path: ${wtPath}`].filter(Boolean).join('\n');
+    $: worktreeChipLabel = wtBranch || (wtPath ? truncatePath(wtPath) : '');
+    $: showWorktreeChip = Boolean(wtBranch || wtPath);
 </script>
 
 <div class="session-header">
@@ -13,6 +28,12 @@
                 <span class="mode-badge {mode}">{mode}</span>
                 <h1 class="session-name">{session.name || session.id}</h1>
                 <span class="status-badge {status}">{status.replaceAll('_', ' ')}</span>
+                {#if showWorktreeChip}
+                    <span class="worktree-chip" title={worktreeTooltip}>
+                        <GitBranch size={14} weight="light" aria-hidden="true" />
+                        <span class="worktree-label">{worktreeChipLabel}</span>
+                    </span>
+                {/if}
             </div>
             <p class="objective">Session ID: {session.id}</p>
         </div>
@@ -91,6 +112,32 @@
     }
 
     .status-badge.running { color: var(--status-running); border-color: var(--status-running); background: color-mix(in srgb, var(--status-running) 5%, transparent); }
+
+    .worktree-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        max-width: min(240px, 38vw);
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border-structural);
+        background: var(--bg-elevated);
+        color: var(--text-muted);
+        font-size: 11px;
+        font-family: var(--font-mono);
+        white-space: nowrap;
+    }
+
+    .worktree-chip :global(svg) {
+        flex-shrink: 0;
+        color: var(--accent-cyan);
+    }
+
+    .worktree-label {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+    }
 
     .objective {
         margin: 0;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -2,14 +2,7 @@ const DEFAULT_API_BASE = 'http://localhost:18800';
 
 function resolveApiBase(): string {
   const envBase = import.meta.env.VITE_API_BASE;
-  if (typeof envBase === 'string' && envBase.length > 0) {
-    return envBase;
-  }
-
-  if (typeof window !== 'undefined' && /^https?:/.test(window.location.origin)) {
-    return window.location.origin;
-  }
-
+  if (typeof envBase === 'string' && envBase.length > 0) return envBase;
   return DEFAULT_API_BASE;
 }
 

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -197,6 +197,9 @@ export interface Session {
   /** RFC3339; omitted on older persisted sessions — UI falls back to `created_at`. */
   last_activity_at?: string;
   agents: AgentInfo[];
+  /** Git worktree path for the session primary workspace (Tauri Session), when set. */
+  worktree_path?: string | null;
+  worktree_branch?: string | null;
 }
 
 interface SessionsState {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,55 +1,6 @@
 <script lang="ts">
   import '../lib/styles/lattice-tokens.css';
   import '../lib/styles/lattice-base.css';
-  import { page } from '$app/stores';
-  import { Kanban, House } from 'phosphor-svelte';
 </script>
 
-<nav class="top-nav" aria-label="Primary">
-  <a href="/" class="nav-link" class:active={$page.url.pathname === '/'} aria-current={$page.url.pathname === '/' ? 'page' : undefined} title="Session view">
-    <House size={14} weight="light" />
-    <span>Session</span>
-  </a>
-  <a href="/dashboard" class="nav-link" class:active={$page.url.pathname === '/dashboard'} aria-current={$page.url.pathname === '/dashboard' ? 'page' : undefined} title="Dashboard">
-    <Kanban size={14} weight="light" />
-    <span>Dashboard</span>
-  </a>
-</nav>
-
 <slot />
-
-<style>
-  .top-nav {
-    position: fixed;
-    top: 8px;
-    right: 12px;
-    z-index: 1000;
-    display: flex;
-    gap: 6px;
-    background: var(--bg-elevated, rgba(21, 24, 32, 0.9));
-    border: 1px solid var(--color-border, #222631);
-    border-radius: var(--radius-sm, 2px);
-    padding: 4px;
-    backdrop-filter: blur(6px);
-  }
-  .nav-link {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    padding: 4px 10px;
-    font-size: 12px;
-    text-decoration: none;
-    color: var(--text-secondary, #8B949E);
-    border-radius: var(--radius-sm, 2px);
-    font-family: var(--font-display, sans-serif);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-  }
-  .nav-link:hover {
-    color: var(--accent-cyan, #00E5FF);
-  }
-  .nav-link.active {
-    color: var(--accent-cyan, #00E5FF);
-    background: rgba(0, 229, 255, 0.1);
-  }
-</style>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -6,6 +6,13 @@
 
   onMount(() => {
     sessions.loadSessions();
+    const intervalId = window.setInterval(() => {
+      sessions.loadSessions();
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
   });
 </script>
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -5,10 +5,19 @@
   import { sessions } from '$lib/stores/sessions';
 
   onMount(() => {
-    sessions.loadSessions();
-    const intervalId = window.setInterval(() => {
-      sessions.loadSessions();
-    }, 5000);
+    let pollInFlight = false;
+    const poll = async () => {
+      if (pollInFlight) return;
+      pollInFlight = true;
+      try {
+        await sessions.loadSessions();
+      } finally {
+        pollInFlight = false;
+      }
+    };
+
+    poll();
+    const intervalId = window.setInterval(poll, 5000);
 
     return () => {
       window.clearInterval(intervalId);


### PR DESCRIPTION
## Summary
- Fix #80 — `resolveApiBase()` no longer falls back to `window.location.origin`; always returns `VITE_API_BASE` env override or `http://localhost:18800`, so Chat/Queen/Worker/Shared tabs stop hitting the Tauri asset server.
- Replace the fixed `+layout.svelte` top-nav (which overlayed `RightDrawer`) with an icon-only Sessions/Dashboard toggle in `SessionSidebar` using phosphor `House` / `Kanban`, lattice tokens, `aria-label` + `aria-current`.
- Add a worktree-branch chip to the top session bar via `SessionHeader.svelte`; plumb `worktree_path` / `worktree_branch` through `PersistedSession` → `Session` with `#[serde(default)]` for backwards compat.
- Codify a Worktree Integration Protocol in the Queen prompt template (`controller.rs`).

## Test plan
- [ ] Launch packaged Tauri app: expand `RightDrawer`, cycle Chat/Queen/Worker/Shared — no JSON parse errors; requests hit `localhost:18800/api/...`
- [ ] `npm run dev`: same flow, same result
- [ ] Verify Sessions/Dashboard sidebar toggle in both collapsed (52px) and expanded (220px) states; keyboard-navigable
- [ ] Confirm worktree chip appears on session bar for sessions that have a worktree; hidden otherwise
- [ ] `cargo check --tests` passes (already verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now capture and persist worktree path and branch metadata.

* **UI Improvements**
  * Sidebar gains a route-based view switcher and a dedicated collapse control.
  * Session header displays worktree info as a compact chip.
  * Top navigation removed for a simplified layout.

* **Bug Fixes / Reliability**
  * Dashboard now auto-refreshes the session list every 5 seconds with proper cleanup.

* **Tests**
  * Session test fixtures updated to include new worktree fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->