### PR TITLE
fix: hierarchy clicks switch visible terminal (#83)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.25.1"
+version = "0.25.2"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.25.1"
+version = "0.25.2"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -3593,6 +3593,55 @@ Workers record learnings during task completion. Your curation responsibilities:
 5. **Spawn next worker** - When a task completes, spawn the next worker if needed
 6. **Review & integrate** - Review worker output and coordinate integration
 
+## Worktree Awareness (READ THIS FIRST)
+
+⚠️ **You are running in your OWN worktree**, separate from where the workers are working. This means:
+
+- `git status` / `git diff` in your CWD **will NOT show worker changes** — your worktree only sees your own commits.
+- `ls`, Read, Glob in your CWD will show the repo as it existed when your worktree was created, NOT the workers' live edits.
+- **Never assume "no diff = no work done."** Workers commit into `hive/{session_id}/worker-N` branches inside their own worktree paths.
+
+### How to actually see worker progress
+
+Always target the worker's worktree path or branch explicitly. For every worker `N`:
+
+```bash
+WT=.hive-manager/worktrees/{session_id}/worker-N
+BR=hive/{session_id}/worker-N
+
+# Has the worker committed anything yet?
+git -C "$WT" log --oneline "$BR" ^<feature-branch>
+
+# What's changed (committed)?
+git -C "$WT" diff --stat <feature-branch>...$BR
+git -C "$WT" diff <feature-branch>...$BR -- <path>
+
+# What's in-flight (staged + unstaged + untracked)?
+git -C "$WT" status --short
+git -C "$WT" diff            # unstaged
+git -C "$WT" diff --cached   # staged
+
+# Read a file as the worker currently has it on disk:
+cat "$WT/<relative/path>"
+# Or as committed on their branch:
+git -C "$WT" show "$BR:<relative/path>"
+```
+
+If a worker's task file says COMPLETED but `git log` on their branch is empty, check `git status` in their worktree — they may have forgotten to commit. Prompt them to commit rather than assuming failure.
+
+### Monitoring cadence
+
+When polling for worker progress, iterate over every worker worktree and run the commands above — do NOT rely on your own CWD's `git status`. A quick sweep:
+
+```bash
+for WT in .hive-manager/worktrees/{session_id}/worker-*; do
+  BR="hive/{session_id}/$(basename "$WT")"
+  echo "=== $BR ==="
+  git -C "$WT" log --oneline "$BR" ^<feature-branch> 2>/dev/null | head -5
+  git -C "$WT" status --short
+done
+```
+
 ## Worktree Integration Protocol
 
 Workers run in isolated git worktrees. Each worker has its own worktree + branch created by the backend at `.hive-manager/worktrees/{session_id}/worker-N` on branch `hive/{session_id}/worker-N`. Integrate them back into the feature branch as follows:

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/cell/CellCard.svelte
+++ b/src/lib/components/cell/CellCard.svelte
@@ -107,6 +107,8 @@
         overflow: hidden;
         display: flex;
         flex-direction: column;
+        min-height: 0;
+        max-height: 100%;
     }
 
     .cell-card:hover {
@@ -195,6 +197,9 @@
         display: flex;
         flex-direction: column;
         gap: 16px;
+        overflow-y: auto;
+        min-height: 0;
+        flex: 1 1 auto;
     }
 
     .objective {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -51,6 +51,7 @@
             const queen = $activeAgents.find(a => a.role === 'Queen' || a.id.endsWith('-queen'));
             if (queen) {
               ui.setFocusedAgent(queen.id);
+              ui.setSelectedAgent(queen.id);
             }
             isTransitioning = false;
           });
@@ -71,12 +72,15 @@
     // Auto-select first agent when agents are added and nothing is selected
     if (agents.length > 0 && !currentFocusId) {
       ui.setFocusedAgent(agents[0].id);
+      ui.setSelectedAgent(agents[0].id);
       return;
     }
 
     // Reset if focused agent no longer exists
     if (currentFocusId && !agents.find(a => a.id === currentFocusId)) {
-      ui.setFocusedAgent(agents[0]?.id ?? null);
+      const nextId = agents[0]?.id ?? null;
+      ui.setFocusedAgent(nextId);
+      ui.setSelectedAgent(nextId);
       return;
     }
 
@@ -84,6 +88,7 @@
     const waitingAgent = agents.find(a => typeof a.status === 'object' && 'WaitingForInput' in a.status);
     if (waitingAgent && currentFocusId !== waitingAgent.id) {
       ui.setFocusedAgent(waitingAgent.id);
+      ui.setSelectedAgent(waitingAgent.id);
     }
   });
 
@@ -141,8 +146,17 @@
       event.preventDefault();
       // Focus the new session button - handled by SessionSidebar
     }
-    // Navigate agents with arrow keys when tree is focused
-    if ($activeAgents.length > 0 && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
+    // Navigate agents with arrow keys — skip when user is typing in inputs, textareas,
+    // contenteditable regions, or terminal panes so we don't hijack their keystrokes.
+    const target = event.target as HTMLElement | null;
+    const inTypingContext = !!target && (
+      target.tagName === 'INPUT' ||
+      target.tagName === 'TEXTAREA' ||
+      target.tagName === 'SELECT' ||
+      target.isContentEditable ||
+      !!target.closest('.xterm, .terminal, [data-terminal], [contenteditable="true"]')
+    );
+    if (!inTypingContext && $activeAgents.length > 0 && (event.key === 'ArrowUp' || event.key === 'ArrowDown')) {
       const currentIndex = $activeAgents.findIndex(a => a.id === focusedAgentId);
       if (currentIndex !== -1) {
         event.preventDefault();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -121,6 +121,7 @@
 
   function handleAgentSelect(e: CustomEvent<string>) {
     ui.setFocusedAgent(e.detail);
+    ui.setSelectedAgent(e.detail);
   }
 
   // Keyboard shortcuts
@@ -149,6 +150,7 @@
           ? Math.max(0, currentIndex - 1)
           : Math.min($activeAgents.length - 1, currentIndex + 1);
         ui.setFocusedAgent($activeAgents[nextIndex].id);
+        ui.setSelectedAgent($activeAgents[nextIndex].id);
       }
     }
   }


### PR DESCRIPTION
## Summary
- Hierarchy clicks and arrow-key nav now set both `selectedAgentId` and `focusedAgentId` so `SessionOverview`'s `terminalAgentId = selectedAgentId || focusedAgentId` actually swaps the visible terminal.
- Regression from the Lattice cell-events merge: once any cell was clicked, `selectedAgentId` shadowed `focusedAgentId` and the hierarchy stopped driving terminal visibility.

Fixes #83.

## Test plan
- [ ] Open a session with multiple agents, click a cell → that terminal is visible.
- [ ] Click a different agent in the Hierarchy sidebar → visible terminal swaps.
- [ ] Arrow-up / arrow-down over the hierarchy → visible terminal swaps.
- [ ] Cell-grid active-cell behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Selection and keyboard navigation now keep both focused and selected agent in sync; arrow keys won’t change focus when typing in inputs/terminals.

* **Style**
  * Improved card layout constraints and scrolling so expanded content sizes and scrolls without overflow.

* **Documentation**
  * Added guidance clarifying separate worktrees and how to inspect worker progress and branches.

* **Chores**
  * App version bumped to 0.25.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->