### PR TITLE
fix(ui): guard xterm writes and bound scrollback to prevent blank-pane crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1641,7 +1641,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "axum",
  "chrono",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.26.0"
+version = "0.26.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -23,6 +23,7 @@
   let terminalContainer: HTMLDivElement;
   let term: XTerm | null = null;
   let fitAddon: FitAddon | null = null;
+  let webglAddon: WebglAddon | null = null;
   let unlistenOutput: UnlistenFn | null = null;
   let unlistenStatus: UnlistenFn | null = null;
   let unlistenDragDrop: UnlistenFn | null = null;
@@ -323,6 +324,7 @@
       lineHeight: 1.2,
       cursorBlink: true,
       cursorStyle: 'block',
+      scrollback: 10000,
       allowProposedApi: true,
     });
 
@@ -347,11 +349,14 @@
       }
     }, true);
 
-    // Try to load WebGL addon for better performance
+    // Try to load WebGL addon for better performance. Retain the reference so
+    // a write-time rendering failure (see pty-output listener) can dispose it
+    // and fall back to the default DOM renderer without losing the terminal.
     try {
-      const webglAddon = new WebglAddon();
+      webglAddon = new WebglAddon();
       term.loadAddon(webglAddon);
     } catch (e) {
+      webglAddon = null;
       console.warn('WebGL addon not supported, using canvas renderer');
     }
 
@@ -438,12 +443,29 @@
       await sendToPty(data);
     });
 
-    // Listen for PTY output
+    // Listen for PTY output.
+    // Guard term.write: @xterm/addon-webgl@0.19.0 can throw on long-running
+    // buffers, leaving the renderer in a corrupted state that blanks the pane
+    // to only xterm's fallback glyph. On failure, dispose the WebGL addon
+    // once and retry; subsequent writes use the default DOM renderer.
     unlistenOutput = await listen<{ id: string; data: number[] }>('pty-output', (event) => {
       if (event.payload.id === agentId && term) {
         const decoder = new TextDecoder();
         const text = decoder.decode(new Uint8Array(event.payload.data));
-        term.write(text);
+        try {
+          term.write(text);
+        } catch (e) {
+          if (webglAddon) {
+            console.error('xterm write failed, disposing WebGL addon and falling back to DOM renderer:', e);
+            try { webglAddon.dispose(); } catch { /* ignore */ }
+            webglAddon = null;
+            try { term.write(text); } catch (e2) {
+              console.error('xterm write failed after WebGL fallback:', e2);
+            }
+          } else {
+            console.error('xterm write failed:', e);
+          }
+        }
       }
     });
 

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -108,6 +108,33 @@
   // internal paste listener also fires onData → double send.
   let suppressPaste = false;
 
+  // Single shared decoder with stream mode so multi-byte UTF-8 sequences
+  // split across 4KB PTY chunks don't decode to replacement characters.
+  const ptyDecoder = new TextDecoder('utf-8');
+
+  // Centralised guard for term.write(). @xterm/addon-webgl@0.19.0 can throw
+  // from write() on long-running buffers, corrupting the renderer so the pane
+  // collapses to only xterm's fallback glyph. On first failure, dispose the
+  // WebGL addon and retry once; subsequent writes use the default DOM renderer.
+  // All write paths (PTY listener, exported write()) must route through here.
+  function writeSafely(data: string) {
+    if (!term) return;
+    try {
+      term.write(data);
+    } catch (e) {
+      if (webglAddon) {
+        console.error('xterm write failed, disposing WebGL addon and falling back to DOM renderer:', e);
+        try { webglAddon.dispose(); } catch { /* ignore */ }
+        webglAddon = null;
+        try { term.write(data); } catch (e2) {
+          console.error('xterm write failed after WebGL fallback:', e2);
+        }
+      } else {
+        console.error('xterm write failed:', e);
+      }
+    }
+  }
+
   async function sendToPty(data: string) {
     try {
       await invoke('write_to_pty', { id: agentId, data });
@@ -443,29 +470,13 @@
       await sendToPty(data);
     });
 
-    // Listen for PTY output.
-    // Guard term.write: @xterm/addon-webgl@0.19.0 can throw on long-running
-    // buffers, leaving the renderer in a corrupted state that blanks the pane
-    // to only xterm's fallback glyph. On failure, dispose the WebGL addon
-    // once and retry; subsequent writes use the default DOM renderer.
+    // Listen for PTY output. Uses writeSafely() so a WebGL renderer failure
+    // doesn't blank the pane. Uses a shared streaming decoder so multi-byte
+    // UTF-8 sequences split across chunks decode correctly.
     unlistenOutput = await listen<{ id: string; data: number[] }>('pty-output', (event) => {
       if (event.payload.id === agentId && term) {
-        const decoder = new TextDecoder();
-        const text = decoder.decode(new Uint8Array(event.payload.data));
-        try {
-          term.write(text);
-        } catch (e) {
-          if (webglAddon) {
-            console.error('xterm write failed, disposing WebGL addon and falling back to DOM renderer:', e);
-            try { webglAddon.dispose(); } catch { /* ignore */ }
-            webglAddon = null;
-            try { term.write(text); } catch (e2) {
-              console.error('xterm write failed after WebGL fallback:', e2);
-            }
-          } else {
-            console.error('xterm write failed:', e);
-          }
-        }
+        const text = ptyDecoder.decode(new Uint8Array(event.payload.data), { stream: true });
+        writeSafely(text);
       }
     });
 
@@ -535,7 +546,7 @@
   }
 
   export function write(data: string) {
-    term?.write(data);
+    writeSafely(data);
   }
 </script>
 


### PR DESCRIPTION
## Summary

- Guards `term.write()` in the `pty-output` listener so a WebGL rendering failure no longer blanks the pane
- On the first write failure, disposes the WebGL addon and retries once — subsequent writes fall back to xterm's default DOM renderer for the life of that terminal
- Hoists the `webglAddon` reference to component scope so it is disposable
- Bounds `scrollback: 10000` to cap buffer growth (acceptance criterion #1)

Fixes #99.

## Why

`@xterm/addon-webgl@0.19.0` can throw from `term.write()` on long-running buffers. The previous listener had no try/catch, so the exception corrupted the renderer and the pane collapsed to only xterm's fallback `☹` glyph while the backend PTY kept running. The fix is scoped to the primary crash site called out in the issue; the backend PTY chunking suggestion and the `@xterm/addon-webgl` upgrade are deliberately out of scope to keep the change minimal.

## Test plan

- [ ] Run a hive with Queen + Evaluator + workers for 30+ minutes and confirm no pane blanks out
- [ ] Flood output (e.g. `yes | head -c 5M`) into a worker terminal; pane continues rendering
- [ ] If a write ever fails, console shows `xterm write failed, disposing WebGL addon…` and the terminal keeps rendering via the DOM renderer
- [ ] No standalone `☹` glyph-only state reproducible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased terminal scrollback to 10,000 lines for improved session retention.

* **Bug Fixes**
  * More robust rendering: terminal now gracefully falls back from WebGL to DOM and retries output to prevent lost text.
  * Fixed character corruption by improving handling of multi-byte UTF‑8 across streamed input.

* **Chores**
  * App version updated to 0.26.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->