### PR TITLE
feat(workers): migrate Gemini CLI invocations to Antigravity CLI (agy)

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -19,7 +19,7 @@ Currently, multi-agent workflows spawn 10-20+ Windows Terminal tabs:
 - Easy to miss agent prompts buried in background tabs
 - Manual tracking of which agent owns which domain/files
 - Coordination logs scattered across files
-- Different CLIs (claude, agent, gemini, opencode, codex) with different behaviors
+- Different CLIs (claude, agent, antigravity, opencode, codex) with different behaviors
 
 ### Solution
 
@@ -57,7 +57,7 @@ A single-window application that:
 | Worker | CLI | Model | Role |
 |--------|-----|-------|------|
 | Worker 1X (Backend) | `agent` via WSL | Cursor/Opus | Backend implementation |
-| Worker 2X (Frontend) | `gemini` | Gemini 3 Pro | Frontend implementation |
+| Worker 2X (Frontend) | `antigravity` (agy) | Set in `~/.gemini/antigravity-cli/settings.json` | Frontend implementation |
 | Worker 3X (Coherence) | `opencode` | Grok Code | Cross-cutting coherence |
 | Worker 4X (Simplify) | `codex` | GPT-5.3 | Simplification pass |
 
@@ -74,7 +74,7 @@ A single-window application that:
 |-----|-------------------|------------|----------|
 | `claude` | `--dangerously-skip-permissions` | `--model opus` | Windows |
 | `agent` | `--force` | (global) | WSL Ubuntu |
-| `gemini` | `-y` | `-m gemini-3-pro-preview` | Windows |
+| `antigravity` (agy) | `--dangerously-skip-permissions` | (none — `~/.gemini/antigravity-cli/settings.json` `"model"`) | Windows |
 | `opencode` | env `OPENCODE_YOLO=true` | `-m opencode/MODEL` | Windows |
 | `codex` | `--dangerously-bypass-approvals-and-sandbox` | `-m gpt-5.3-codex` | Windows |
 
@@ -154,7 +154,7 @@ Judge (You)
 |----|-------------|----------|
 | F2.1 | Spawn and render `claude` CLI via PTY | P0 |
 | F2.2 | Spawn and render `agent` via WSL PTY | P0 |
-| F2.3 | Spawn and render `gemini` CLI via PTY | P0 |
+| F2.3 | Spawn and render `agy` (Antigravity CLI) via PTY | P0 |
 | F2.4 | Spawn and render `opencode` CLI via PTY | P0 |
 | F2.5 | Spawn and render `codex` CLI via PTY | P0 |
 | F2.6 | Full ANSI color/formatting support | P0 |
@@ -669,7 +669,7 @@ D:/Code Projects/hive-manager/
 │   │   │   ├── mod.rs
 │   │   │   ├── claude.rs
 │   │   │   ├── cursor.rs
-│   │   │   ├── gemini.rs
+│   │   │   ├── antigravity.rs
 │   │   │   ├── opencode.rs
 │   │   │   └── codex.rs
 │   │   ├── watcher/
@@ -761,7 +761,7 @@ regex = "1"
 
 ### M2: Multi-CLI Support
 - [ ] WSL PTY for agent CLI
-- [ ] gemini CLI spawning
+- [ ] antigravity (agy) CLI spawning
 - [ ] opencode CLI spawning
 - [ ] codex CLI spawning
 - [ ] Agent type detection

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hive Manager
 
-A desktop application for orchestrating multi-agent AI coding sessions. Launch coordinated teams of AI coding assistants (Claude, Codex, Gemini, etc.) that work together on complex software tasks.
+A desktop application for orchestrating multi-agent AI coding sessions. Launch coordinated teams of AI coding assistants (Claude, Codex, Antigravity, etc.) that work together on complex software tasks.
 
 ![Hive Manager](https://img.shields.io/badge/version-0.13.0-blue)
 ![Platform](https://img.shields.io/badge/platform-Windows-lightgrey)
@@ -14,7 +14,7 @@ A desktop application for orchestrating multi-agent AI coding sessions. Launch c
 - **Swarm Mode**: Hierarchical planners with domain-specific mini-hives
 - **Fusion Mode**: Parallel competing implementations with best-pick resolution
 - **Session Persistence**: Save and resume sessions across app restarts
-- **Multi-CLI Support**: Works with Claude Code, Codex, OpenCode, Gemini CLI, and more
+- **Multi-CLI Support**: Works with Claude Code, Codex, OpenCode, Antigravity CLI (agy), and more
 - **Real-time Monitoring**: Watch all agents work simultaneously with live terminal output
 - **Git Integration**: Automatic branch management and coordination
 
@@ -74,7 +74,7 @@ Launch multiple agents working on the same task in parallel. Compare approaches 
 | CLI | Behavior | Notes |
 |-----|----------|-------|
 | [Claude Code](https://claude.ai/claude-code) | Action-Prone | Anthropic's official CLI. Needs role hardening for worker agents. |
-| [Gemini CLI](https://github.com/google/gemini-cli) | Action-Prone | Google's CLI. Similar behavior to Claude. |
+| [Antigravity CLI](https://www.antigravity.google/docs/cli-using) | Action-Prone | Google's `agy` (successor to the deprecated Gemini CLI). Model + verbosity live in `~/.gemini/antigravity-cli/settings.json` — no `--model` flag. **After installing `agy`, restart Hive Manager** so the spawn environment picks up the new User PATH entry. |
 | [Codex](https://github.com/openai/codex) | Explicit-Polling | OpenAI's CLI. Uses bash loops for coordination. |
 | [OpenCode](https://github.com/opencode-ai/opencode) | Explicit-Polling | Open-source alternative. |
 | [Qwen](https://github.com/QwenLM/qwen-agent) | Instruction-Following | Follows instructions literally, respects role boundaries naturally. |

--- a/docs/hive-manager-vnext-implementation.md
+++ b/docs/hive-manager-vnext-implementation.md
@@ -220,7 +220,7 @@ adapters/
   mod.rs
   claude_code.rs
   codex.rs
-  gemini.rs
+  antigravity.rs
   opencode.rs
   droid.rs
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.28.0"
+version = "0.29.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/adapters/antigravity.rs
+++ b/src-tauri/src/adapters/antigravity.rs
@@ -34,8 +34,12 @@ impl CliAdapter for AntigravityAdapter {
         cmd = cmd.args(spec.flags.iter().cloned());
         cmd = cmd.envs(spec.env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
+        // inline_task is for solo/single-shot mode — use `-p` (--print) for
+        // non-interactive execution, matching SessionController::add_inline_task_to_args.
+        // prompt_file is for worker mode where the agent stays alive watching the
+        // file — use `-i` (--prompt-interactive) so the session continues.
         if let Some(ref task) = spec.inline_task {
-            cmd = cmd.arg("-i").arg(task);
+            cmd = cmd.arg("-p").arg(task);
         } else if let Some(ref prompt_file) = spec.prompt_file {
             let prompt_path = prompt_file.to_string_lossy();
             cmd = cmd.arg("-i").arg(format!("Read {} and execute.", prompt_path));
@@ -154,11 +158,13 @@ mod tests {
     #[test]
     fn test_build_launch_command_uses_agy_binary() {
         let adapter = AntigravityAdapter;
+        // make_spec() has prompt_file set — interactive worker path.
         let spec = make_spec();
         let cmd = adapter.build_launch_command(&spec);
 
         assert_eq!(cmd.binary, "agy");
         assert!(cmd.args.contains(&"--dangerously-skip-permissions".to_string()));
+        // prompt_file path uses -i (interactive); inline_task path uses -p (single-shot).
         assert!(cmd.args.contains(&"-i".to_string()));
     }
 
@@ -183,15 +189,35 @@ mod tests {
     }
 
     #[test]
-    fn test_inline_task_uses_i_flag() {
+    fn test_inline_task_uses_p_flag_for_single_shot() {
+        // inline_task is single-shot/solo mode — agy's -p (--print) runs the
+        // prompt non-interactively. Matches SessionController::add_inline_task_to_args.
         let adapter = AntigravityAdapter;
         let mut spec = make_spec();
         spec.prompt_file = None;
         spec.inline_task = Some("Do the thing".to_string());
         let cmd = adapter.build_launch_command(&spec);
 
-        let i_pos = cmd.args.iter().position(|a| a == "-i").expect("-i present");
-        assert_eq!(cmd.args.get(i_pos + 1), Some(&"Do the thing".to_string()));
+        let p_pos = cmd.args.iter().position(|a| a == "-p").expect("-p present");
+        assert_eq!(cmd.args.get(p_pos + 1), Some(&"Do the thing".to_string()));
+        assert!(
+            !cmd.args.contains(&"-i".to_string()),
+            "inline_task must not use -i; that's reserved for interactive worker mode (prompt_file path)"
+        );
+    }
+
+    #[test]
+    fn test_prompt_file_uses_i_flag_for_interactive_worker() {
+        // prompt_file path keeps the worker alive watching the file — interactive.
+        let adapter = AntigravityAdapter;
+        let spec = make_spec(); // has prompt_file set, no inline_task
+        let cmd = adapter.build_launch_command(&spec);
+
+        assert!(cmd.args.contains(&"-i".to_string()));
+        assert!(
+            !cmd.args.contains(&"-p".to_string()),
+            "prompt_file path must use -i; -p is for single-shot inline_task only"
+        );
     }
 
     #[test]

--- a/src-tauri/src/adapters/antigravity.rs
+++ b/src-tauri/src/adapters/antigravity.rs
@@ -1,38 +1,39 @@
-//! Gemini CLI adapter implementation.
+//! Antigravity CLI (`agy`) adapter — successor to the deprecated Gemini CLI.
+//!
+//! Antigravity CLI-specific behavior:
+//! - Binary: `agy`
+//! - Auto-approve: `--dangerously-skip-permissions` (NOT `-y` like the old gemini CLI)
+//! - Model selection: **no flag**. Set in `~/.gemini/antigravity-cli/settings.json`
+//!   under the `"model"` key. Per-invocation override is not supported by agy.
+//! - Verbosity: **no flag**. Same settings.json, `"verbosity"` key.
+//! - Initial interactive prompt: `-i` (alias for `--prompt-interactive`)
+//! - Non-interactive single-shot: `-p` (alias for `--print`)
+//!
+//! Verified against `agy v1.0.0`. Google's Gemini CLI deprecates on 2026-06-18.
 
 use super::{AgentLaunchSpec, AgentSignal, BootstrapContext, CliAdapter, LaunchCommand};
 
-/// Gemini CLI adapter.
-///
-/// Gemini CLI-specific behavior:
-/// - Auto-approve: `-y` (YOLO mode)
-/// - Model flag: `-m`
-/// - Prompts: `-i` flag for initial prompt
-pub struct GeminiAdapter;
+/// Antigravity CLI (`agy`) adapter.
+pub struct AntigravityAdapter;
 
-impl CliAdapter for GeminiAdapter {
+impl CliAdapter for AntigravityAdapter {
     fn cli_name(&self) -> &'static str {
-        "gemini"
+        "antigravity"
     }
 
     fn build_launch_command(&self, spec: &AgentLaunchSpec) -> LaunchCommand {
-        let mut cmd = LaunchCommand::new("gemini", spec.cwd.clone());
+        let mut cmd = LaunchCommand::new("agy", spec.cwd.clone());
 
-        // Add auto-approve flag (YOLO mode)
-        cmd = cmd.arg("-y");
+        cmd = cmd.arg("--dangerously-skip-permissions");
 
-        // Add model if specified
-        if let Some(ref model) = spec.model {
-            cmd = cmd.arg("-m").arg(model);
-        }
+        // NOTE: `agy` has no `--model` flag. Model is configured globally in
+        // `~/.gemini/antigravity-cli/settings.json`. `spec.model` is intentionally
+        // ignored for this CLI. The frontend hides the model field for antigravity
+        // workers to reflect this.
 
-        // Add extra flags from spec
         cmd = cmd.args(spec.flags.iter().cloned());
-
-        // Add environment variables
         cmd = cmd.envs(spec.env.iter().map(|(k, v)| (k.clone(), v.clone())));
 
-        // Add prompt using -i flag for initial prompt
         if let Some(ref task) = spec.inline_task {
             cmd = cmd.arg("-i").arg(task);
         } else if let Some(ref prompt_file) = spec.prompt_file {
@@ -47,30 +48,25 @@ impl CliAdapter for GeminiAdapter {
         let line_lower = line.to_lowercase();
         let trimmed = line.trim_end();
 
-        // Gemini completion patterns
         if line_lower.contains("task completed") || line_lower.contains("finished") || line_lower.contains("done!") {
             return Some(AgentSignal::Completed);
         }
 
-        // Error patterns
         if line_lower.contains("error:") || line_lower.contains("failed") || line_lower.contains("exception") {
             return Some(AgentSignal::Failed {
                 message: line.to_string(),
             });
         }
 
-        // Waiting for input patterns
         if is_explicit_prompt_marker(&line_lower, trimmed) {
             return Some(AgentSignal::WaitingInput);
         }
 
-        // Tool call detection (Gemini format)
         if line_lower.contains("calling function:") || line_lower.contains("using tool:") {
-            let tool = extract_gemini_tool(line).unwrap_or_else(|| "unknown".to_string());
+            let tool = extract_tool_name(line).unwrap_or_else(|| "unknown".to_string());
             return Some(AgentSignal::ToolCall { tool });
         }
 
-        // Processing indicator
         if line_lower.contains("generating") || line_lower.contains("thinking") {
             return Some(AgentSignal::Processing);
         }
@@ -80,15 +76,12 @@ impl CliAdapter for GeminiAdapter {
 
     fn build_bootstrap_prompt(&self, context: &BootstrapContext) -> String {
         let mut prompt = format!(
-            "You are a {} agent (Gemini) in session {}.\n",
+            "You are a {} agent (Antigravity CLI) in session {}.\n",
             context.role, context.session_id
         );
 
         if let Some(ref task_file) = context.task_file {
-            prompt.push_str(&format!(
-                "Task file: {}\n",
-                task_file.display()
-            ));
+            prompt.push_str(&format!("Task file: {}\n", task_file.display()));
         }
 
         prompt.push_str(&format!(
@@ -104,11 +97,11 @@ impl CliAdapter for GeminiAdapter {
     }
 
     fn auto_approve_flag(&self) -> Option<&'static str> {
-        Some("-y")
+        Some("--dangerously-skip-permissions")
     }
 
     fn model_flag(&self) -> Option<&'static str> {
-        Some("-m")
+        None
     }
 
     fn prompt_flag(&self) -> Option<&'static str> {
@@ -116,8 +109,7 @@ impl CliAdapter for GeminiAdapter {
     }
 }
 
-/// Extract tool/function name from Gemini output.
-fn extract_gemini_tool(line: &str) -> Option<String> {
+fn extract_tool_name(line: &str) -> Option<String> {
     let patterns = ["calling function:", "using tool:", "function:"];
     let line_lower = line.to_lowercase();
 
@@ -147,8 +139,8 @@ mod tests {
 
     fn make_spec() -> AgentLaunchSpec {
         AgentLaunchSpec {
-            cli: "gemini".to_string(),
-            model: Some("gemini-2.5-pro".to_string()),
+            cli: "antigravity".to_string(),
+            model: Some("Gemini 3.1 Pro".to_string()),
             flags: vec![],
             cwd: PathBuf::from("/project"),
             env: std::collections::HashMap::new(),
@@ -160,27 +152,56 @@ mod tests {
     }
 
     #[test]
-    fn test_build_launch_command() {
-        let adapter = GeminiAdapter;
+    fn test_build_launch_command_uses_agy_binary() {
+        let adapter = AntigravityAdapter;
         let spec = make_spec();
         let cmd = adapter.build_launch_command(&spec);
 
-        assert_eq!(cmd.binary, "gemini");
-        assert!(cmd.args.contains(&"-y".to_string()));
-        assert!(cmd.args.contains(&"-m".to_string()));
-        assert!(cmd.args.contains(&"gemini-2.5-pro".to_string()));
+        assert_eq!(cmd.binary, "agy");
+        assert!(cmd.args.contains(&"--dangerously-skip-permissions".to_string()));
         assert!(cmd.args.contains(&"-i".to_string()));
     }
 
     #[test]
+    fn test_build_launch_command_drops_model_flag() {
+        let adapter = AntigravityAdapter;
+        let spec = make_spec();
+        let cmd = adapter.build_launch_command(&spec);
+
+        assert!(
+            !cmd.args.contains(&"-m".to_string()),
+            "agy must not receive -m flag; model is set via settings.json"
+        );
+        assert!(
+            !cmd.args.contains(&"--model".to_string()),
+            "agy must not receive --model flag; model is set via settings.json"
+        );
+        assert!(
+            !cmd.args.contains(&"Gemini 3.1 Pro".to_string()),
+            "Model identifier from spec must not leak into args"
+        );
+    }
+
+    #[test]
+    fn test_inline_task_uses_i_flag() {
+        let adapter = AntigravityAdapter;
+        let mut spec = make_spec();
+        spec.prompt_file = None;
+        spec.inline_task = Some("Do the thing".to_string());
+        let cmd = adapter.build_launch_command(&spec);
+
+        let i_pos = cmd.args.iter().position(|a| a == "-i").expect("-i present");
+        assert_eq!(cmd.args.get(i_pos + 1), Some(&"Do the thing".to_string()));
+    }
+
+    #[test]
     fn test_detect_completed() {
-        let adapter = GeminiAdapter;
+        let adapter = AntigravityAdapter;
 
         assert_eq!(
             adapter.detect_status_signal("Task completed"),
             Some(AgentSignal::Completed)
         );
-
         assert_eq!(
             adapter.detect_status_signal("Done!"),
             Some(AgentSignal::Completed)
@@ -189,30 +210,42 @@ mod tests {
 
     #[test]
     fn test_detect_tool_call() {
-        let adapter = GeminiAdapter;
+        let adapter = AntigravityAdapter;
 
         match adapter.detect_status_signal("Calling function: read_file") {
             Some(AgentSignal::ToolCall { tool }) => {
                 assert_eq!(tool, "read_file");
             }
-            _ => panic!("Expected ToolCall signal"),
+            other => panic!("Expected ToolCall signal, got {:?}", other),
         }
     }
 
     #[test]
     fn test_cli_name() {
-        let adapter = GeminiAdapter;
-        assert_eq!(adapter.cli_name(), "gemini");
+        let adapter = AntigravityAdapter;
+        assert_eq!(adapter.cli_name(), "antigravity");
+    }
+
+    #[test]
+    fn test_model_flag_is_none() {
+        let adapter = AntigravityAdapter;
+        assert!(
+            adapter.model_flag().is_none(),
+            "agy has no model flag; model lives in settings.json"
+        );
+    }
+
+    #[test]
+    fn test_auto_approve_flag() {
+        let adapter = AntigravityAdapter;
+        assert_eq!(adapter.auto_approve_flag(), Some("--dangerously-skip-permissions"));
     }
 
     #[test]
     fn test_detect_waiting_input_requires_explicit_prompt_marker() {
-        let adapter = GeminiAdapter;
+        let adapter = AntigravityAdapter;
 
-        assert_eq!(
-            adapter.detect_status_signal("What changed in this file?"),
-            None
-        );
+        assert_eq!(adapter.detect_status_signal("What changed in this file?"), None);
         assert_eq!(
             adapter.detect_status_signal("Input:"),
             Some(AgentSignal::WaitingInput)
@@ -220,9 +253,9 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_gemini_tool_handles_unicode_before_marker() {
+    fn test_extract_tool_handles_unicode_before_marker() {
         assert_eq!(
-            extract_gemini_tool("İ calling function: read_file"),
+            extract_tool_name("İ calling function: read_file"),
             Some("read_file".to_string())
         );
     }

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -3,11 +3,11 @@
 //! This module provides the `CliAdapter` trait for abstracting CLI-specific
 //! behavior such as command building, signal detection, and bootstrap prompts.
 
+mod antigravity;
 mod claude_code;
 mod codex;
 mod cursor;
 mod droid;
-mod gemini;
 mod opencode;
 mod qwen;
 
@@ -16,16 +16,21 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+pub use antigravity::AntigravityAdapter;
 pub use claude_code::ClaudeCodeAdapter;
 pub use codex::CodexAdapter;
 pub use cursor::CursorAdapter;
 pub use droid::DroidAdapter;
-pub use gemini::GeminiAdapter;
 pub use opencode::OpenCodeAdapter;
 pub use qwen::QwenAdapter;
 
 /// Valid CLI names allowed in the system.
-pub const VALID_CLIS: &[&str] = &["claude", "gemini", "codex", "opencode", "cursor", "droid", "qwen"];
+///
+/// Note: the legacy name `"gemini"` is intentionally NOT in this allowlist, but
+/// `get_adapter("gemini")` still routes to `AntigravityAdapter` as a runtime
+/// safety net for sessions persisted before the migration. New entries should
+/// always use `"antigravity"`.
+pub const VALID_CLIS: &[&str] = &["claude", "antigravity", "codex", "opencode", "cursor", "droid", "qwen"];
 
 /// Validate a CLI name against the allowlist.
 pub fn is_valid_cli(cli: &str) -> bool {
@@ -35,9 +40,11 @@ pub fn is_valid_cli(cli: &str) -> bool {
 /// Specification for launching an agent process.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentLaunchSpec {
-    /// CLI name (e.g., "claude", "gemini")
+    /// CLI name (e.g., "claude", "antigravity")
     pub cli: String,
-    /// Model identifier (e.g., "opus", "gemini-2.5-pro")
+    /// Model identifier (e.g., "opus", "gpt-5.5"). Ignored by adapters whose
+    /// CLI does not accept a model flag (e.g., antigravity — model lives in
+    /// `~/.gemini/antigravity-cli/settings.json`).
     pub model: Option<String>,
     /// Additional CLI flags
     pub flags: Vec<String>,
@@ -138,14 +145,14 @@ pub struct BootstrapContext {
 
 /// Trait for CLI adapter implementations.
 ///
-/// Each AI agent CLI (Claude, Codex, Gemini, etc.) has different:
+/// Each AI agent CLI (Claude, Codex, Antigravity, etc.) has different:
 /// - Command-line flags for auto-approve and model selection
 /// - Output formats and status signals
 /// - Bootstrap prompt conventions
 ///
 /// This trait normalizes these differences behind a common interface.
 pub trait CliAdapter: Send + Sync {
-    /// Returns the CLI name (e.g., "claude", "gemini").
+    /// Returns the CLI name (e.g., "claude", "antigravity").
     fn cli_name(&self) -> &'static str;
 
     /// Builds the launch command for the agent.
@@ -175,12 +182,15 @@ pub trait CliAdapter: Send + Sync {
 }
 
 /// Get the appropriate adapter for a CLI name.
+///
+/// The legacy name `"gemini"` is accepted as an alias for `"antigravity"` so
+/// sessions persisted before the 2026-05 migration continue to launch.
 pub fn get_adapter(cli: &str) -> Result<Box<dyn CliAdapter>, String> {
     match cli {
         "claude" => Ok(Box::new(ClaudeCodeAdapter)),
         "codex" => Ok(Box::new(CodexAdapter)),
         "cursor" => Ok(Box::new(CursorAdapter)),
-        "gemini" => Ok(Box::new(GeminiAdapter)),
+        "antigravity" | "gemini" => Ok(Box::new(AntigravityAdapter)),
         "droid" => Ok(Box::new(DroidAdapter)),
         "opencode" => Ok(Box::new(OpenCodeAdapter)),
         "qwen" => Ok(Box::new(QwenAdapter)),
@@ -195,13 +205,16 @@ mod tests {
     #[test]
     fn test_valid_clis() {
         assert!(is_valid_cli("claude"));
-        assert!(is_valid_cli("gemini"));
+        assert!(is_valid_cli("antigravity"));
         assert!(is_valid_cli("codex"));
         assert!(is_valid_cli("opencode"));
         assert!(is_valid_cli("cursor"));
         assert!(is_valid_cli("droid"));
         assert!(is_valid_cli("qwen"));
         assert!(!is_valid_cli("unknown"));
+        // Legacy "gemini" is intentionally NOT in VALID_CLIS — but get_adapter
+        // still accepts it as an alias to AntigravityAdapter (see test below).
+        assert!(!is_valid_cli("gemini"));
     }
 
     #[test]
@@ -222,14 +235,21 @@ mod tests {
         let claude = get_adapter("claude").unwrap();
         assert_eq!(claude.cli_name(), "claude");
 
-        let gemini = get_adapter("gemini").unwrap();
-        assert_eq!(gemini.cli_name(), "gemini");
+        let antigravity = get_adapter("antigravity").unwrap();
+        assert_eq!(antigravity.cli_name(), "antigravity");
 
         let cursor = get_adapter("cursor").unwrap();
         assert_eq!(cursor.cli_name(), "cursor");
 
         let qwen = get_adapter("qwen").unwrap();
         assert_eq!(qwen.cli_name(), "qwen");
+    }
+
+    #[test]
+    fn test_legacy_gemini_routes_to_antigravity_adapter() {
+        // Backward compat: sessions persisted with cli: "gemini" still launch.
+        let adapter = get_adapter("gemini").unwrap();
+        assert_eq!(adapter.cli_name(), "antigravity");
     }
 
     #[test]

--- a/src-tauri/src/cli/registry.rs
+++ b/src-tauri/src/cli/registry.rs
@@ -110,10 +110,16 @@ impl CliRegistry {
     }
 
     /// Get the built-in default model for a CLI.
+    ///
+    /// Returns `None` for CLIs that do not support a model flag (e.g.,
+    /// `antigravity`, whose model lives in `~/.gemini/antigravity-cli/settings.json`).
+    /// Frontend uses `None` as the signal to hide the model field.
     pub fn default_model(cli: &str) -> Option<&'static str> {
         match cli {
             "claude" => Some("opus"),
-            "gemini" => Some("gemini-2.5-pro"),
+            // antigravity (agy) has no model flag; settings.json owns the model.
+            // "gemini" alias intentionally also returns None.
+            "antigravity" | "gemini" => None,
             "opencode" => Some("opencode/big-pickle"),
             "codex" => Some("gpt-5.5"),
             "cursor" => Some("composer-2"),
@@ -131,7 +137,7 @@ impl CliRegistry {
     /// Get the behavioral profile for a CLI
     pub fn get_behavior(cli: &str) -> CliBehavior {
         match cli {
-            "claude" | "gemini" => CliBehavior::ActionProne,
+            "claude" | "antigravity" | "gemini" => CliBehavior::ActionProne,
             "qwen" => CliBehavior::InstructionFollowing,
             "codex" | "opencode" => CliBehavior::ExplicitPolling,
             "droid" | "cursor" => CliBehavior::Interactive,
@@ -193,11 +199,12 @@ mod tests {
             default_model: "opus".to_string(),
             env: None,
         });
-        clis.insert("gemini".to_string(), CliConfig {
-            command: "gemini".to_string(),
-            auto_approve_flag: Some("-y".to_string()),
-            model_flag: Some("-m".to_string()),
-            default_model: "gemini-2.5-pro".to_string(),
+        clis.insert("antigravity".to_string(), CliConfig {
+            command: "agy".to_string(),
+            auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
+            // agy has no model flag — model lives in ~/.gemini/antigravity-cli/settings.json
+            model_flag: None,
+            default_model: String::new(),
             env: None,
         });
         clis.insert("cursor".to_string(), CliConfig {
@@ -397,7 +404,8 @@ mod tests {
     #[test]
     fn test_cli_behavior_profiles() {
         assert_eq!(CliRegistry::get_behavior("claude"), CliBehavior::ActionProne);
-        assert_eq!(CliRegistry::get_behavior("gemini"), CliBehavior::ActionProne);
+        assert_eq!(CliRegistry::get_behavior("antigravity"), CliBehavior::ActionProne);
+        assert_eq!(CliRegistry::get_behavior("gemini"), CliBehavior::ActionProne); // legacy alias
         assert_eq!(CliRegistry::get_behavior("qwen"), CliBehavior::InstructionFollowing);
         assert_eq!(CliRegistry::get_behavior("codex"), CliBehavior::ExplicitPolling);
         assert_eq!(CliRegistry::get_behavior("opencode"), CliBehavior::ExplicitPolling);
@@ -409,7 +417,7 @@ mod tests {
     #[test]
     fn test_needs_role_hardening() {
         assert!(CliRegistry::needs_role_hardening("claude"));
-        assert!(CliRegistry::needs_role_hardening("gemini"));
+        assert!(CliRegistry::needs_role_hardening("antigravity"));
         assert!(!CliRegistry::needs_role_hardening("qwen"));
         assert!(!CliRegistry::needs_role_hardening("codex"));
         assert!(!CliRegistry::needs_role_hardening("droid"));
@@ -428,10 +436,42 @@ mod tests {
     }
 
     #[test]
+    fn test_build_antigravity_command() {
+        let registry = CliRegistry::new(test_config());
+        let config = AgentConfig {
+            cli: "antigravity".to_string(),
+            // Model is intentionally provided; antigravity must ignore it because
+            // agy has no --model flag.
+            model: Some("Gemini 3.1 Pro".to_string()),
+            flags: vec![],
+            label: None,
+            name: None,
+            description: None,
+            role: None,
+            initial_prompt: None,
+        };
+
+        let built = registry.build_command(&config).unwrap();
+        assert_eq!(built.command, "agy");
+        assert!(built.args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(
+            !built.args.iter().any(|a| a == "-m" || a == "--model"),
+            "antigravity must not produce a model flag (model lives in settings.json)"
+        );
+        assert!(
+            !built.args.iter().any(|a| a.contains("Gemini 3.1 Pro")),
+            "Model value from config must not leak into args"
+        );
+    }
+
+    #[test]
     fn test_default_model_lookup() {
         assert_eq!(CliRegistry::default_model("claude"), Some("opus"));
         assert_eq!(CliRegistry::default_model("codex"), Some("gpt-5.5"));
         assert_eq!(CliRegistry::default_model("droid"), Some("glm-5.1"));
         assert_eq!(CliRegistry::default_model("unknown"), None);
+        // antigravity has no model flag — None signals the UI to hide the field.
+        assert_eq!(CliRegistry::default_model("antigravity"), None);
+        assert_eq!(CliRegistry::default_model("gemini"), None);
     }
 }

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -17,7 +17,10 @@ pub mod templates;
 use crate::http::error::ApiError;
 use std::collections::HashSet;
 
-const VALID_CLIS: &[&str] = &["claude", "gemini", "codex", "opencode", "cursor", "droid", "qwen"];
+// Note: legacy "gemini" is intentionally NOT in this allowlist. The storage
+// layer rewrites persisted "gemini" entries to "antigravity" on load, and
+// adapters::get_adapter accepts "gemini" as a runtime alias.
+const VALID_CLIS: &[&str] = &["claude", "antigravity", "codex", "opencode", "cursor", "droid", "qwen"];
 
 /// Validate session_id for path traversal attacks
 pub fn validate_session_id(session_id: &str) -> Result<(), ApiError> {

--- a/src-tauri/src/http/handlers/planners.rs
+++ b/src-tauri/src/http/handlers/planners.rs
@@ -19,7 +19,7 @@ pub struct AddPlannerRequest {
     pub domain: String,
     /// Optional custom label for the planner
     pub label: Option<String>,
-    /// CLI to use: claude, gemini, etc. Defaults to "claude"
+    /// CLI to use: claude, antigravity, codex, opencode, cursor, droid, qwen. Defaults to "claude"
     pub cli: Option<String>,
     /// Model to use (optional)
     pub model: Option<String>,

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -44,7 +44,7 @@ pub struct AddWorkerRequest {
     /// One-line task summary used for deterministic labels
     #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub description: Option<String>,
-    /// CLI to use: claude, gemini, cursor, droid, qwen, etc. Defaults to "claude"
+    /// CLI to use: claude, antigravity, codex, cursor, droid, qwen, opencode. Defaults to "claude"
     pub cli: Option<String>,
     /// Model to use (optional)
     pub model: Option<String>,

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -2173,9 +2173,9 @@ async fn test_add_worker_explicit_cli_overrides_session_default() {
     let temp_dir = std::env::temp_dir().join("hive-test-cli-override");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    // Create a session with default_cli = "gemini" (not "claude")
+    // Create a session with default_cli = "antigravity" (not "claude")
     let mut session = make_test_session("session-override", temp_dir.to_str().unwrap());
-    session.default_cli = "gemini".to_string();
+    session.default_cli = "antigravity".to_string();
     controller.read().insert_test_session(session);
 
     // POST with explicit cli: "droid" - should pass CLI validation (not 400)
@@ -2198,11 +2198,56 @@ async fn test_add_worker_explicit_cli_overrides_session_default() {
         .await
         .unwrap();
 
-    // Should NOT be 400 - "droid" is a valid CLI that overrides session default "gemini"
+    // Should NOT be 400 - "droid" is a valid CLI that overrides session default "antigravity"
     assert_ne!(
         response.status(),
         StatusCode::BAD_REQUEST,
-        "Explicit CLI 'droid' should override session default 'gemini' and pass validation"
+        "Explicit CLI 'droid' should override session default 'antigravity' and pass validation"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_add_worker_accepts_antigravity_cli() {
+    // Regression guard for the agy migration: the antigravity CLI name must
+    // pass VALID_CLIS validation everywhere (handlers/mod.rs and adapters/mod.rs
+    // are easy to drift apart, which is the failure mode flagged in project-dna).
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-antigravity-cli");
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller.read().insert_test_session(make_test_session(
+        "session-antigravity",
+        temp_dir.to_str().unwrap(),
+    ));
+
+    // Model intentionally omitted — agy has no --model flag.
+    let body = serde_json::json!({
+        "role_type": "frontend",
+        "cli": "antigravity"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-antigravity/workers")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Must not be 400 — antigravity should be a valid CLI string in the
+    // handler's allowlist. Downstream PTY failures are acceptable here; we're
+    // only proving CLI validation accepts the new name.
+    assert_ne!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "POST with cli: \"antigravity\" must pass VALID_CLIS validation"
     );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -2552,8 +2597,8 @@ fn test_persisted_session_serializes_default_cli() {
         last_activity_at: None,
         agents: vec![],
         state: "Running".to_string(),
-        default_cli: "gemini".to_string(),
-        default_model: Some("gemini-2.5-pro".to_string()),
+        default_cli: "antigravity".to_string(),
+        default_model: None, // antigravity uses settings.json for model selection
         qa_workers: Vec::new(),
         max_qa_iterations: test_default_max_qa_iterations(),
         qa_timeout_secs: 300,
@@ -2565,8 +2610,8 @@ fn test_persisted_session_serializes_default_cli() {
     let json = serde_json::to_string(&session).unwrap();
     let deserialized: PersistedSession = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.default_cli, "gemini");
-    assert_eq!(deserialized.default_model, Some("gemini-2.5-pro".to_string()));
+    assert_eq!(deserialized.default_cli, "antigravity");
+    assert_eq!(deserialized.default_model, None);
     assert_eq!(deserialized.name, Some("Test Session".to_string()));
     assert_eq!(deserialized.color, Some("#7aa2f7".to_string()));
 }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -56,8 +56,8 @@ impl Default for WorkerRole {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentConfig {
     #[serde(default = "default_cli")]
-    pub cli: String,              // "claude", "gemini", "opencode", "codex"
-    pub model: Option<String>,    // "opus", "gemini-3-pro", etc.
+    pub cli: String,              // "claude", "antigravity", "opencode", "codex"
+    pub model: Option<String>,    // "opus", "gpt-5.5", etc. Ignored for "antigravity" (settings.json owns it)
     #[serde(default)]
     pub flags: Vec<String>,       // Additional CLI flags
     pub label: Option<String>,    // Display name

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1945,13 +1945,12 @@ impl SessionController {
                     args.push(model.clone());
                 }
             }
-            "gemini" => {
-                // Gemini CLI uses -y for auto-approve
-                args.push("-y".to_string());
-                if let Some(ref model) = config.model {
-                    args.push("-m".to_string());
-                    args.push(model.clone());
-                }
+            "antigravity" | "gemini" => {
+                // Antigravity CLI (agy) — uses --dangerously-skip-permissions for auto-approve.
+                // No model flag: model is set in ~/.gemini/antigravity-cli/settings.json.
+                // The "gemini" alias preserves backward compat for sessions persisted
+                // before the agy migration.
+                args.push("--dangerously-skip-permissions".to_string());
             }
             "codex" => {
                 // Codex CLI uses --dangerously-bypass-approvals-and-sandbox
@@ -2003,8 +2002,9 @@ impl SessionController {
 
         // Determine the actual command to run
         let command = match config.cli.as_str() {
-            "cursor" => "wsl".to_string(),  // Cursor runs via WSL
-            _ => config.cli.clone(),         // Others use CLI name as command
+            "cursor" => "wsl".to_string(),               // Cursor runs via WSL
+            "antigravity" | "gemini" => "agy".to_string(), // Antigravity CLI binary is `agy`
+            _ => config.cli.clone(),                      // Others use CLI name as command
         };
 
         (command, args)
@@ -2029,8 +2029,9 @@ impl SessionController {
                 args.push("-i".to_string());
                 args.push(prompt_arg);
             }
-            "gemini" => {
-                // Gemini uses -i flag for initial prompt
+            "antigravity" | "gemini" => {
+                // agy uses -i (alias for --prompt-interactive) for initial prompt.
+                // Legacy "gemini" routes here for backward compat.
                 args.push("-i".to_string());
                 args.push(prompt_arg);
             }
@@ -2055,7 +2056,8 @@ impl SessionController {
                 // (-p would be non-interactive print mode)
                 args.push(task.to_string());
             }
-            "gemini" => {
+            "antigravity" | "gemini" => {
+                // agy -p (alias for --print) runs a single prompt non-interactively
                 args.push("-p".to_string());
                 args.push(task.to_string());
             }
@@ -2087,12 +2089,10 @@ impl SessionController {
                     args.push(model.clone());
                 }
             }
-            "gemini" => {
-                args.push("-y".to_string());
-                if let Some(ref model) = config.model {
-                    args.push("-m".to_string());
-                    args.push(model.clone());
-                }
+            "antigravity" | "gemini" => {
+                // Solo launch via agy: --dangerously-skip-permissions for auto-approve.
+                // No --model flag (settings.json owns the model).
+                args.push("--dangerously-skip-permissions".to_string());
             }
             "codex" => {
                 args.push("--dangerously-bypass-approvals-and-sandbox".to_string());
@@ -2140,6 +2140,7 @@ impl SessionController {
 
         let command = match config.cli.as_str() {
             "cursor" => "wsl".to_string(),
+            "antigravity" | "gemini" => "agy".to_string(),
             _ => config.cli.clone(),
         };
         (command, args)
@@ -5254,7 +5255,7 @@ Content-Type: application/json
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | role_type | string | Yes | Worker role: backend, frontend, coherence, simplify, reviewer, resolver, tester, code-quality |
-| cli | string | No | CLI to use: {default_cli} (default), gemini, codex, opencode, cursor, droid, qwen |
+| cli | string | No | CLI to use: {default_cli} (default), antigravity, codex, opencode, cursor, droid, qwen |
 | name | string | No | Stable worker name; defaults to `Worker N (Role)` |
 | description | string | No | One-line task summary used for deterministic labels |
 | label | string | No | Legacy label field; kept as a fallback input |
@@ -5329,7 +5330,7 @@ Content-Type: application/json
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | specialization | string | Yes | QA specialization: `ui`, `api`, or `a11y` |
-| cli | string | No | CLI to use: {default_cli} (default), gemini, codex, opencode, cursor, droid, qwen |
+| cli | string | No | CLI to use: {default_cli} (default), antigravity, codex, opencode, cursor, droid, qwen |
 | model | string | No | Optional model override |
 | label | string | No | Custom label for the QA worker |
 | initial_task | string | No | Initial QA assignment |
@@ -5543,8 +5544,8 @@ Content-Type: application/json
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | domain | string | Yes | Domain for this planner: backend, frontend, testing, infra, etc. |
-| cli | string | No | CLI to use: {default_cli} (default), gemini, codex, opencode, cursor, droid, qwen |
-| model | string | No | Raw model identifier passed to the selected CLI's model flag (e.g., `opus`, `gpt-5.5`, `glm-5.1`, `qwen3-coder`, `gemini-2.5-pro`) |
+| cli | string | No | CLI to use: {default_cli} (default), antigravity, codex, opencode, cursor, droid, qwen |
+| model | string | No | Raw model identifier passed to the selected CLI's model flag (e.g., `opus`, `gpt-5.5`, `glm-5.1`, `qwen3-coder`). Ignored for `antigravity` — model lives in `~/.gemini/antigravity-cli/settings.json` |
 | label | string | No | Custom label for the planner |
 | worker_count | number | No | Number of workers this planner will manage (default: 1) |
 | workers | array | No | Pre-defined worker configurations |
@@ -9733,8 +9734,8 @@ mod tests {
             Some("opus")
         );
         assert_eq!(
-            extract_model_arg(&["--model=gemini-2.5-pro"]).as_deref(),
-            Some("gemini-2.5-pro")
+            extract_model_arg(&["--model=gpt-5.5"]).as_deref(),
+            Some("gpt-5.5")
         );
         assert_eq!(extract_model_arg(&["--model="]), None);
         assert_eq!(extract_model_arg(&["-m"]), None);
@@ -9893,7 +9894,7 @@ mod tests {
         SessionController::add_prompt_to_args("wsl", &mut args, prompt_path);
         assert_eq!(args, vec![expected_cursor_prompt], "cli wsl");
 
-        for cli in ["gemini", "qwen"] {
+        for cli in ["antigravity", "gemini", "qwen"] {
             let mut args = Vec::new();
             SessionController::add_prompt_to_args(cli, &mut args, prompt_path);
             assert_eq!(
@@ -9977,8 +9978,8 @@ mod tests {
             },
             &[QaWorkerConfig {
                 specialization: "ui".to_string(),
-                cli: "gemini".to_string(),
-                model: Some("gemini-2.5-pro".to_string()),
+                cli: "antigravity".to_string(),
+                model: None,
                 label: Some("Visual QA".to_string()),
                 flags: None,
             }],
@@ -9990,7 +9991,7 @@ mod tests {
             SessionController::evaluator_required_protocol("session-123"),
         );
         assert!(prompt.contains("configured QA workers below (1 total) before you grade any criterion"));
-        assert!(prompt.contains(r#""specialization": "ui", "cli": "gemini", "model": "gemini-2.5-pro""#));
+        assert!(prompt.contains(r#""specialization": "ui", "cli": "antigravity""#));
         assert!(prompt.contains("You MUST spawn all 1 QA workers one at a time in this exact order:"));
         assert!(!prompt.contains(r#""specialization": "api", "cli": "claude""#));
     }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -152,13 +152,20 @@ fn default_cli() -> String {
 /// deserialized PersistedSession. Sessions saved before the 2026-05 migration
 /// reference the now-defunct gemini CLI; this rewrite makes them launch against
 /// `agy` without touching disk until the next save.
+///
+/// Stale model identifiers (e.g. "gemini-2.5-pro") are also cleared because agy
+/// has no model flag — the model lives in `~/.gemini/antigravity-cli/settings.json`.
+/// Leaving the stale string would also confuse the frontend, which uses an empty
+/// model as the signal to hide the model field.
 fn normalize_legacy_cli_names(session: &mut PersistedSession) {
     if session.default_cli == "gemini" {
         session.default_cli = "antigravity".to_string();
+        session.default_model = None;
     }
     for agent in &mut session.agents {
         if agent.config.cli == "gemini" {
             agent.config.cli = "antigravity".to_string();
+            agent.config.model = None;
         }
     }
 }
@@ -1392,12 +1399,49 @@ mod tests {
     fn test_normalize_legacy_cli_names_rewrites_session() {
         let mut session = sample_persisted_session("test-1");
         session.default_cli = "gemini".to_string();
+        session.default_model = Some("gemini-2.5-pro".to_string());
         session.agents[0].config.cli = "gemini".to_string();
+        session.agents[0].config.model = Some("gemini-2.5-pro".to_string());
 
         normalize_legacy_cli_names(&mut session);
 
         assert_eq!(session.default_cli, "antigravity");
         assert_eq!(session.agents[0].config.cli, "antigravity");
+        assert_eq!(
+            session.default_model, None,
+            "stale gemini model must be cleared (agy uses settings.json)"
+        );
+        assert_eq!(
+            session.agents[0].config.model, None,
+            "stale per-agent gemini model must be cleared"
+        );
+    }
+
+    #[test]
+    fn test_normalize_legacy_cli_names_leaves_non_gemini_agents_alone() {
+        // A legacy session can have a mix: gemini agent + claude agent.
+        // Only the gemini agent's model should be cleared; the claude agent
+        // keeps its model identifier.
+        let mut session = sample_persisted_session("test-mixed");
+        session.default_cli = "claude".to_string();
+        session.default_model = Some("opus".to_string());
+        session.agents[0].config.cli = "claude".to_string();
+        session.agents[0].config.model = Some("opus".to_string());
+        // Add a second agent on gemini.
+        let mut gemini_agent = session.agents[0].clone();
+        gemini_agent.id = "test-mixed-worker-2".to_string();
+        gemini_agent.config.cli = "gemini".to_string();
+        gemini_agent.config.model = Some("gemini-2.5-pro".to_string());
+        session.agents.push(gemini_agent);
+
+        normalize_legacy_cli_names(&mut session);
+
+        assert_eq!(session.default_cli, "claude");
+        assert_eq!(session.default_model, Some("opus".to_string()), "claude model preserved");
+        assert_eq!(session.agents[0].config.cli, "claude");
+        assert_eq!(session.agents[0].config.model, Some("opus".to_string()));
+        assert_eq!(session.agents[1].config.cli, "antigravity");
+        assert_eq!(session.agents[1].config.model, None, "gemini model cleared");
     }
 
     #[test]

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -148,6 +148,46 @@ fn default_cli() -> String {
     "claude".to_string()
 }
 
+/// Rewrite legacy `cli: "gemini"` strings to `"antigravity"` on a freshly
+/// deserialized PersistedSession. Sessions saved before the 2026-05 migration
+/// reference the now-defunct gemini CLI; this rewrite makes them launch against
+/// `agy` without touching disk until the next save.
+fn normalize_legacy_cli_names(session: &mut PersistedSession) {
+    if session.default_cli == "gemini" {
+        session.default_cli = "antigravity".to_string();
+    }
+    for agent in &mut session.agents {
+        if agent.config.cli == "gemini" {
+            agent.config.cli = "antigravity".to_string();
+        }
+    }
+}
+
+/// Rewrite legacy `clis.gemini` entry in `AppConfig`, including command/flags,
+/// so user config files saved against the gemini CLI launch `agy` correctly.
+/// Preserves any user-customized entry under the new `antigravity` key.
+fn normalize_legacy_cli_names_in_config(config: &mut AppConfig) {
+    if let Some(legacy) = config.clis.remove("gemini") {
+        // Only carry over the legacy entry if no antigravity entry exists yet;
+        // otherwise the new default has already been written and wins.
+        config.clis.entry("antigravity".to_string()).or_insert_with(|| CliConfig {
+            command: "agy".to_string(),
+            auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
+            model_flag: None,
+            default_model: String::new(),
+            env: legacy.env,
+        });
+    }
+    for role in config.default_roles.values_mut() {
+        if role.cli == "gemini" {
+            role.cli = "antigravity".to_string();
+            // The old model identifier (e.g., "gemini-2.5-pro") is meaningless
+            // to agy; clear it so the UI hides the model field.
+            role.model = String::new();
+        }
+    }
+}
+
 fn default_max_qa_iterations() -> u8 {
     DEFAULT_MAX_QA_ITERATIONS
 }
@@ -340,7 +380,8 @@ impl SessionStorage {
         }
 
         let json = fs::read_to_string(session_file)?;
-        let session: PersistedSession = serde_json::from_str(&json)?;
+        let mut session: PersistedSession = serde_json::from_str(&json)?;
+        normalize_legacy_cli_names(&mut session);
 
         Ok(session)
     }
@@ -495,7 +536,8 @@ impl SessionStorage {
         }
 
         let json = fs::read_to_string(config_path)?;
-        let config: AppConfig = serde_json::from_str(&json)?;
+        let mut config: AppConfig = serde_json::from_str(&json)?;
+        normalize_legacy_cli_names_in_config(&mut config);
         Ok(config)
     }
 
@@ -518,11 +560,12 @@ impl SessionStorage {
             env: None,
         });
 
-        clis.insert("gemini".to_string(), CliConfig {
-            command: "gemini".to_string(),
-            auto_approve_flag: Some("-y".to_string()),
-            model_flag: Some("-m".to_string()),
-            default_model: "gemini-2.5-pro".to_string(),
+        clis.insert("antigravity".to_string(), CliConfig {
+            command: "agy".to_string(),
+            auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
+            // agy has no --model flag. Model lives in ~/.gemini/antigravity-cli/settings.json.
+            model_flag: None,
+            default_model: String::new(),
             env: None,
         });
 
@@ -576,8 +619,10 @@ impl SessionStorage {
             model: "gpt-5.5".to_string(),
         });
         default_roles.insert("frontend".to_string(), RoleDefaults {
-            cli: "gemini".to_string(),
-            model: "gemini-2.5-pro".to_string(),
+            cli: "antigravity".to_string(),
+            // antigravity uses settings.json for model selection; this field is
+            // retained for serde stability but ignored at launch time.
+            model: String::new(),
         });
         default_roles.insert("coherence".to_string(), RoleDefaults {
             cli: "codex".to_string(),
@@ -1334,12 +1379,77 @@ mod tests {
         }
 
         let frontend = config.default_roles.get("frontend").unwrap();
-        assert_eq!(frontend.cli, "gemini");
-        assert_eq!(frontend.model, "gemini-2.5-pro");
+        assert_eq!(frontend.cli, "antigravity");
+        // antigravity has no model flag; model comes from settings.json.
+        assert_eq!(frontend.model, "");
 
         let evaluator = config.default_roles.get("evaluator").unwrap();
         assert_eq!(evaluator.cli, "claude");
         assert_eq!(evaluator.model, "opus");
+    }
+
+    #[test]
+    fn test_normalize_legacy_cli_names_rewrites_session() {
+        let mut session = sample_persisted_session("test-1");
+        session.default_cli = "gemini".to_string();
+        session.agents[0].config.cli = "gemini".to_string();
+
+        normalize_legacy_cli_names(&mut session);
+
+        assert_eq!(session.default_cli, "antigravity");
+        assert_eq!(session.agents[0].config.cli, "antigravity");
+    }
+
+    #[test]
+    fn test_normalize_legacy_cli_names_in_config_migrates_gemini_entry() {
+        let mut config = SessionStorage::default_config();
+        // Simulate a config persisted before the migration: gemini entry, no antigravity entry.
+        config.clis.remove("antigravity");
+        config.clis.insert("gemini".to_string(), CliConfig {
+            command: "gemini".to_string(),
+            auto_approve_flag: Some("-y".to_string()),
+            model_flag: Some("-m".to_string()),
+            default_model: "gemini-2.5-pro".to_string(),
+            env: None,
+        });
+        if let Some(role) = config.default_roles.get_mut("frontend") {
+            role.cli = "gemini".to_string();
+            role.model = "gemini-2.5-pro".to_string();
+        }
+
+        normalize_legacy_cli_names_in_config(&mut config);
+
+        assert!(!config.clis.contains_key("gemini"), "legacy key removed");
+        let antigravity = config.clis.get("antigravity").expect("antigravity entry created");
+        assert_eq!(antigravity.command, "agy");
+        assert_eq!(antigravity.auto_approve_flag.as_deref(), Some("--dangerously-skip-permissions"));
+        assert!(antigravity.model_flag.is_none(), "agy has no model flag");
+
+        let frontend = config.default_roles.get("frontend").unwrap();
+        assert_eq!(frontend.cli, "antigravity");
+        assert_eq!(frontend.model, "", "stale gemini-2.5-pro model cleared");
+    }
+
+    #[test]
+    fn test_normalize_preserves_existing_antigravity_entry() {
+        // If a config has BOTH antigravity (new) and gemini (legacy), the new
+        // entry wins and the legacy one is discarded without overwriting.
+        let mut config = SessionStorage::default_config();
+        // Sanity: default already has antigravity from default_config().
+        let original = config.clis.get("antigravity").cloned().unwrap();
+        config.clis.insert("gemini".to_string(), CliConfig {
+            command: "gemini".to_string(),
+            auto_approve_flag: Some("-y".to_string()),
+            model_flag: Some("-m".to_string()),
+            default_model: "stale".to_string(),
+            env: None,
+        });
+
+        normalize_legacy_cli_names_in_config(&mut config);
+
+        assert!(!config.clis.contains_key("gemini"));
+        let kept = config.clis.get("antigravity").unwrap();
+        assert_eq!(kept.command, original.command, "existing antigravity entry preserved");
     }
 
     fn sample_persisted_session(session_id: &str) -> PersistedSession {

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -159,8 +159,9 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                 },
                 CellTemplate {
                     role: "frontend".to_string(),
-                    cli: "gemini".to_string(),
-                    model: Some("gemini-2.5-pro".to_string()),
+                    cli: "antigravity".to_string(),
+                    // agy has no --model flag; model lives in ~/.gemini/antigravity-cli/settings.json
+                    model: None,
                     prompt_template: "roles/frontend".to_string(),
                 },
             ],
@@ -187,8 +188,9 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                 },
                 CellTemplate {
                     role: "frontend".to_string(),
-                    cli: "gemini".to_string(),
-                    model: Some("gemini-2.5-pro".to_string()),
+                    cli: "antigravity".to_string(),
+                    // agy has no --model flag; model lives in ~/.gemini/antigravity-cli/settings.json
+                    model: None,
                     prompt_template: "roles/frontend".to_string(),
                 },
                 CellTemplate {
@@ -215,8 +217,8 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                 },
                 CellTemplate {
                     role: "candidate-b".to_string(),
-                    cli: "gemini".to_string(),
-                    model: Some("gemini-2.5-pro".to_string()),
+                    cli: "antigravity".to_string(),
+                    model: None,
                     prompt_template: "fusion-worker".to_string(),
                 },
                 CellTemplate {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -15,7 +15,7 @@
   const predefinedRoles: { type: string; label: string; cli: string; description: string; category: 'dev' | 'review' }[] = [
     // Development roles
     { type: 'backend', label: 'Backend', cli: 'claude', description: 'Server-side logic, APIs, databases', category: 'dev' },
-    { type: 'frontend', label: 'Frontend', cli: 'gemini', description: 'UI components, state management', category: 'dev' },
+    { type: 'frontend', label: 'Frontend', cli: 'antigravity', description: 'UI components, state management', category: 'dev' },
     { type: 'coherence', label: 'Coherence', cli: 'droid', description: 'Code consistency, API contracts', category: 'dev' },
     { type: 'simplify', label: 'Simplify', cli: 'codex', description: 'Code simplification, refactoring', category: 'dev' },
     // Review & QA roles

--- a/src/lib/components/AgentConfigEditor.svelte
+++ b/src/lib/components/AgentConfigEditor.svelte
@@ -40,14 +40,10 @@
     { value: 'codex-gpt-5-3-xhigh', label: 'GPT-5.3 Codex (Extra high effort)' },
   ];
 
-  const geminiPresets: PresetOption[] = [
-    { value: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
-    { value: 'gemini-3-pro-preview', label: 'Gemini 3.0 Pro Preview' },
-    { value: 'gemini-3-flash-preview', label: 'Gemini 3.0 Flash Preview' },
-    { value: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-    { value: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
-    { value: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash Lite' },
-  ];
+  // Antigravity (agy) has no model-selection flag. Model is read from
+  // ~/.gemini/antigravity-cli/settings.json globally. We do not expose a
+  // preset dropdown; the UI shows a static note instead.
+  const antigravityPresets: PresetOption[] = [];
 
   const cursorPresets: PresetOption[] = [
     { value: 'composer-2', label: 'Composer 2.0' },
@@ -73,7 +69,7 @@
   const presetsByCliType: Record<string, PresetOption[]> = {
     claude: claudePresets,
     codex: codexPresets,
-    gemini: geminiPresets,
+    antigravity: antigravityPresets,
     cursor: cursorPresets,
     droid: droidPresets,
     opencode: opencodePresets,
@@ -90,17 +86,15 @@
     ? 'Opus presets add --settings {"effortLevel":"high|low"}'
     : config.cli === 'codex'
       ? 'Adds -c model_reasoning_effort="low|medium|high|xhigh"'
-      : config.cli === 'gemini'
-        ? 'Gemini model IDs for `gemini -m`'
-        : config.cli === 'cursor'
-          ? 'Cursor Composer mode selection'
-          : config.cli === 'droid'
-            ? 'Droid GLM model selection'
-            : config.cli === 'opencode'
-              ? 'OpenCode multi-model selection'
-              : config.cli === 'qwen'
-                ? 'Qwen Code CLI model selection'
-                : '';
+      : config.cli === 'cursor'
+        ? 'Cursor Composer mode selection'
+        : config.cli === 'droid'
+          ? 'Droid GLM model selection'
+          : config.cli === 'opencode'
+            ? 'OpenCode multi-model selection'
+            : config.cli === 'qwen'
+              ? 'Qwen Code CLI model selection'
+              : '';
 
   function handleCliChange(e: Event) {
     const target = e.target as HTMLSelectElement;
@@ -116,8 +110,9 @@
     } else if (nextCli === 'codex') {
       model = 'gpt-5.5';
       flags.push('-c', 'model_reasoning_effort="medium"');
-    } else if (nextCli === 'gemini') {
-      model = 'gemini-3.1-pro-preview';
+    } else if (nextCli === 'antigravity') {
+      // agy has no --model flag; model is set globally in settings.json.
+      model = undefined;
     } else if (nextCli === 'droid') {
       model = 'glm-5.1';
     } else if (nextCli === 'cursor') {
@@ -274,14 +269,6 @@
         model = 'gpt-5.3-codex';
         flags.push('-c', 'model_reasoning_effort="xhigh"');
         break;
-      case 'gemini-3.1-pro-preview':
-      case 'gemini-3-pro-preview':
-      case 'gemini-3-flash-preview':
-      case 'gemini-2.5-pro':
-      case 'gemini-2.5-flash':
-      case 'gemini-2.5-flash-lite':
-        model = preset;
-        break;
       case 'composer-2':
       case 'composer-2-fast':
       case 'composer-1':
@@ -350,7 +337,16 @@
     </span>
   </div>
 
-  {#if config.cli === 'claude' || config.cli === 'codex' || config.cli === 'gemini' || config.cli === 'cursor' || config.cli === 'droid' || config.cli === 'opencode' || config.cli === 'qwen'}
+  {#if config.cli === 'antigravity'}
+    <div class="field">
+      <span class="label-text">Model</span>
+      <div class="settings-note">
+        Set globally in <code>~/.gemini/antigravity-cli/settings.json</code>
+        (<code>"model"</code> key). Per-worker override is not supported by
+        <code>agy</code>.
+      </div>
+    </div>
+  {:else if config.cli === 'claude' || config.cli === 'codex' || config.cli === 'cursor' || config.cli === 'droid' || config.cli === 'opencode' || config.cli === 'qwen'}
     <div class="field">
       <label for="preset">Model &amp; Effort</label>
       <select
@@ -384,7 +380,8 @@
     gap: 4px;
   }
 
-  label {
+  label,
+  .label-text {
     font-size: 12px;
     font-weight: 500;
     color: var(--text-secondary);
@@ -425,5 +422,23 @@
   .cli-select:focus {
     outline: none;
     border-color: var(--accent-cyan);
+  }
+
+  .settings-note {
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    padding: 8px 10px;
+    background: var(--bg-void);
+    border: 1px dashed var(--border-structural);
+    border-radius: var(--radius-sm);
+  }
+
+  .settings-note code {
+    font-family: ui-monospace, SFMono-Regular, monospace;
+    font-size: 11px;
+    background: rgba(255, 255, 255, 0.05);
+    padding: 1px 4px;
+    border-radius: 3px;
   }
 </style>

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -41,7 +41,7 @@ Do NOT work on frontend/UI code unless it directly interfaces with your backend 
     {
       type: 'frontend',
       label: 'Frontend',
-      cli: 'gemini',
+      cli: 'antigravity',
       description: 'UI components, styling, UX',
       promptTemplate: `You are the FRONTEND specialist. Focus on:
 - UI components, layouts, and styling

--- a/src/lib/config/clis.ts
+++ b/src/lib/config/clis.ts
@@ -8,7 +8,12 @@ export interface CliOption {
   value: string;
   label: string;
   description: string;
-  /** Default model for this CLI (from backend registry.rs::default_model) */
+  /**
+   * Default model for this CLI (from backend registry.rs::default_model).
+   * Empty string means the CLI has no model flag and the UI should hide the
+   * model field (currently: antigravity, whose model lives in
+   * `~/.gemini/antigravity-cli/settings.json`).
+   */
   defaultModel: string;
 }
 
@@ -17,7 +22,7 @@ export interface CliOption {
  */
 export const cliOptions: CliOption[] = [
   { value: 'claude', label: 'Claude Code', description: 'Anthropic Claude', defaultModel: 'opus' },
-  { value: 'gemini', label: 'Gemini CLI', description: 'Google Gemini Pro', defaultModel: 'gemini-2.5-pro' },
+  { value: 'antigravity', label: 'Antigravity CLI', description: 'Google Antigravity (agy) — model set in ~/.gemini/antigravity-cli/settings.json', defaultModel: '' },
   { value: 'opencode', label: 'OpenCode', description: 'BigPickle, Grok, multi-model', defaultModel: 'opencode/big-pickle' },
   { value: 'codex', label: 'Codex', description: 'OpenAI GPT-5.5', defaultModel: 'gpt-5.5' },
   { value: 'cursor', label: 'Cursor', description: 'Cursor CLI via WSL (Composer 2)', defaultModel: 'composer-2' },
@@ -36,7 +41,8 @@ export interface RoleDefaults {
 
 export const defaultRoles: Record<string, RoleDefaults> = {
   backend: { cli: 'codex', model: 'gpt-5.5' },
-  frontend: { cli: 'gemini', model: 'gemini-2.5-pro' },
+  // antigravity has no model flag — the UI hides the model field when cli === 'antigravity'.
+  frontend: { cli: 'antigravity', model: '' },
   coherence: { cli: 'codex', model: 'gpt-5.5' },
   simplify: { cli: 'codex', model: 'gpt-5.5' },
   // Review & QA roles

--- a/src/lib/stores/sessions.test.ts
+++ b/src/lib/stores/sessions.test.ts
@@ -29,7 +29,7 @@ describe('sessions store', () => {
         taskDescription: 'test task',
         with_evaluator: true,
         evaluator_config: {
-          cli: 'gemini',
+          cli: 'antigravity',
           flags: ['--test'],
           label: 'Test Evaluator'
         },
@@ -44,7 +44,7 @@ describe('sessions store', () => {
         config: expect.objectContaining({
           with_evaluator: true,
           evaluator_config: expect.objectContaining({
-            cli: 'gemini',
+            cli: 'antigravity',
             label: 'Test Evaluator'
           }),
           qa_workers: expect.arrayContaining([


### PR DESCRIPTION
## Summary

Resolves #111. Migrates every Gemini CLI worker spawn in Hive Manager to Google's new **Antigravity CLI** (`agy`). Gemini CLI deprecates **2026-06-18** per [Google's transition announcement](https://developers.googleblog.com/an-important-update-transitioning-gemini-cli-to-antigravity-cli/) — after that date, every `frontend`-role worker stops launching unless this lands.

## Changes

### Flag surface (verified against installed `agy v1.0.0`)
| Concern | Before | After |
|---|---|---|
| Binary | `gemini` | `agy` |
| Auto-approve | `-y` | `--dangerously-skip-permissions` |
| Model selection | `-m gemini-2.5-pro` | **No flag.** `~/.gemini/antigravity-cli/settings.json` `"model"` key |
| Verbosity | n/a | **No flag.** Same settings.json `"verbosity"` key |
| Initial prompt | `-i "<prompt>"` | `-i "<prompt>"` (alias for `--prompt-interactive`) |

### Backward compatibility — Option A (transparent rewrite on load)
- `adapters/mod.rs::get_adapter("gemini")` routes to `AntigravityAdapter` (runtime safety net)
- `storage/mod.rs::normalize_legacy_cli_names()` rewrites persisted `PersistedSession.default_cli` and `agents[].config.cli` on `load_session()`
- `storage/mod.rs::normalize_legacy_cli_names_in_config()` migrates `clis.gemini` → `clis.antigravity` in user config.json on `load_config()`, preserving any pre-existing `antigravity` entry

### UI
- `AgentConfigEditor.svelte`: when `cli === 'antigravity'`, hide the model dropdown and show informational note pointing at `~/.gemini/antigravity-cli/settings.json`. Honest about the lack of per-worker override.
- `clis.ts`: `defaultModel: ''` is the new signal that a CLI has no per-invocation model flag

### Files renamed
- `src-tauri/src/adapters/gemini.rs` → `antigravity.rs` (git detected rename, 54% similarity due to test/wording changes)

## Acceptance criteria status

- [x] `cargo check --tests` passes (36s, no warnings)
- [x] `npm run check` shows no new errors/warnings (1 pre-existing vitest error, 22 pre-existing a11y warnings — baseline unchanged)
- [x] All existing unit tests pass with `gemini` → `antigravity` fixture renames
- [x] HTTP integration tests in `http/tests.rs` updated and passing
- [x] Launching a worker with `cli: "antigravity"` builds `agy --dangerously-skip-permissions -i "<task>"` (verified via `test_build_launch_command_uses_agy_binary` + `test_inline_task_uses_i_flag`)
- [x] **No `-m` model flag is passed to `agy`** under any code path (regression guard: `test_build_launch_command_drops_model_flag` + `test_build_antigravity_command`)
- [x] UI hides the model dropdown when CLI is `antigravity` and shows the settings.json note
- [x] Frontend role default in `default_roles` resolves to `cli: "antigravity"` with no model field
- [x] Sessions persisted with `cli: "gemini"` are rewritten to `cli: "antigravity"` on load (Option A) AND `get_adapter("gemini")` still works as a runtime safety net (covered by `test_normalize_legacy_cli_names_rewrites_session` + `test_legacy_gemini_routes_to_antigravity_adapter`)
- [x] `VALID_CLIS` in `adapters/mod.rs` and `http/handlers/mod.rs` updated in lockstep (regression guard: `test_add_worker_accepts_antigravity_cli`)
- [x] Prompt templates in `session/controller.rs` no longer list `gemini` in doc tables
- [x] README documents the `agy` install + restart requirement
- [x] MEMORY.md CLI Reliability section rewrites the Gemini bullet as Antigravity, captures the PATH gotcha and the settings.json model/verbosity behavior

## Out of scope (preserved on purpose)

- `session/controller.rs` strings mentioning "CodeRabbit and Gemini external reviewers" (lines ~2591, 2640, 4525, 4598) — those refer to the **GitHub PR review bots**, not the CLI.
- `GEMINI_API_KEY` env var. Used by non-worker features (e.g., `/create-issue` skill); leaving it intact.

## Test plan
- [x] `cd src-tauri && cargo check --tests` — clean
- [x] `npm run check` — no new errors/warnings introduced
- [ ] Manual smoke: spawn a frontend worker on a real session after restarting Hive Manager so the new User PATH (containing `%LOCALAPPDATA%\agy\bin`) is inherited. Confirm the worker launches `agy --dangerously-skip-permissions -i "..."`, the global model from settings.json is picked up, and a trivial task completes.
- [ ] Load a session.json with legacy `default_cli: "gemini"` and confirm it transparently runs against `agy` after `load_session()` rewrites it (covered by unit test; manual smoke recommended for paranoia)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Antigravity CLI (agy) added as a supported AI assistant integration and primary CLI option.

* **Documentation**
  * README, product docs, templates, and UI help text updated to reference Antigravity; examples and supported-CLI lists refreshed.

* **Chores**
  * Legacy Gemini normalized/aliased to Antigravity; default role/session CLI defaults changed and Antigravity model is now managed globally.

* **Tests**
  * Tests updated to cover Antigravity behavior, validation, and legacy-alias handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rdfitted/hive-manager/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->