### PR TITLE
feat(actions): unified Action contract — registry dispatched by UI/HTTP (#123)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1643,6 +1643,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hive-manager"
 version = "0.32.0"
 dependencies = [
+ "async-trait",
  "axum",
  "chrono",
  "fs2",
@@ -1651,6 +1652,7 @@ dependencies = [
  "parking_lot",
  "portable-pty",
  "regex",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "tauri",
@@ -3646,6 +3648,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "indexmap 1.9.3",
  "schemars_derive",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,3 +39,5 @@ tower-http = { version = "0.6", features = ["cors"] }
 notify = "6.1"
 tempfile = "3"
 fs2 = "0.4"
+schemars = { version = "0.8", features = ["chrono", "uuid1"] }
+async-trait = "0.1"

--- a/src-tauri/src/actions/context.rs
+++ b/src-tauri/src/actions/context.rs
@@ -1,0 +1,40 @@
+//! Execution context threaded into every action.
+
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::http::state::AppState;
+
+/// Who is invoking an action. Exposed on [`ActionContext`] so an action's
+/// `run` can branch on provenance (e.g. tighten behavior for `Http`/`Agent`
+/// callers while keeping `Frontend` ergonomic).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Caller {
+    /// Dispatched from a Tauri `#[command]` (the Svelte UI via `invoke`).
+    Frontend,
+    /// Dispatched by the in-process agent loop.
+    Agent,
+    /// Dispatched by a CLI entrypoint.
+    Cli,
+    /// Dispatched over the HTTP API.
+    Http,
+}
+
+/// Everything an [`Action`](crate::actions::Action) needs to run: the calling
+/// surface plus the single shared [`AppState`].
+///
+/// The same `Arc<AppState>` is shared by BOTH the Tauri `.manage()`d registry
+/// and the HTTP server, so an action sees identical state regardless of caller.
+#[derive(Clone)]
+pub struct ActionContext {
+    pub caller: Caller,
+    pub state: Arc<AppState>,
+}
+
+impl ActionContext {
+    pub fn new(caller: Caller, state: Arc<AppState>) -> Self {
+        Self { caller, state }
+    }
+}

--- a/src-tauri/src/actions/error.rs
+++ b/src-tauri/src/actions/error.rs
@@ -1,0 +1,149 @@
+//! Error type for the unified action contract.
+//!
+//! [`ActionError`] is the single error currency for every [`Action`](crate::actions::Action).
+//! It deliberately round-trips losslessly to BOTH of the surfaces that dispatch actions:
+//!
+//! - the Tauri `#[command]` layer, which speaks `Result<T, String>` — via [`ActionError::to_message`];
+//! - the Axum HTTP layer, which speaks [`ApiError`] — via `impl From<ActionError> for ApiError`.
+//!
+//! `ActionStatus` mirrors the categories `ApiError` needs so the conflict-with-details
+//! path used by completion flows survives the conversion.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::http::error::ApiError;
+
+/// Coarse category for an [`ActionError`], chosen to map cleanly onto both
+/// HTTP status codes and the Tauri string channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ActionStatus {
+    /// Input failed validation or was otherwise malformed (HTTP 400).
+    BadRequest,
+    /// The referenced resource does not exist (HTTP 404).
+    NotFound,
+    /// The request conflicts with current state, optionally with structured details (HTTP 409).
+    Conflict,
+    /// An unexpected internal failure (HTTP 500).
+    Internal,
+}
+
+/// The unified error returned by every action.
+#[derive(Debug, Clone)]
+pub struct ActionError {
+    pub status: ActionStatus,
+    pub message: String,
+    /// Optional structured details, preserved across the `ApiError` boundary
+    /// (e.g. the 409 completion-blocked payload).
+    pub details: Option<HashMap<String, Value>>,
+}
+
+impl ActionError {
+    pub fn new(status: ActionStatus, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::new(ActionStatus::BadRequest, message)
+    }
+
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::new(ActionStatus::NotFound, message)
+    }
+
+    #[allow(dead_code)]
+    pub fn conflict(message: impl Into<String>) -> Self {
+        Self::new(ActionStatus::Conflict, message)
+    }
+
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::new(ActionStatus::Internal, message)
+    }
+
+    /// Build a conflict error carrying structured details (mirrors
+    /// [`ApiError::conflict_with_details`]).
+    #[allow(dead_code)]
+    pub fn conflict_with_details(
+        message: impl Into<String>,
+        details: HashMap<String, Value>,
+    ) -> Self {
+        Self {
+            status: ActionStatus::Conflict,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
+
+    /// Render for the Tauri side, which returns `Result<T, String>` to the
+    /// frontend. The plain message preserves the exact text the old
+    /// `#[command]` bodies returned.
+    pub fn to_message(&self) -> String {
+        self.message.clone()
+    }
+}
+
+impl std::fmt::Display for ActionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for ActionError {}
+
+/// Bridge controller methods that already return `Result<_, String>`: a bare
+/// string maps to an internal error by default (callers that know better can
+/// build a more specific status explicitly).
+impl From<String> for ActionError {
+    fn from(message: String) -> Self {
+        ActionError::internal(message)
+    }
+}
+
+impl From<&str> for ActionError {
+    fn from(message: &str) -> Self {
+        ActionError::internal(message.to_string())
+    }
+}
+
+/// An `ApiError` raised by a shared validator (e.g. `validate_cli`) folds into
+/// an `ActionError` preserving its category.
+impl From<ApiError> for ActionError {
+    fn from(error: ApiError) -> Self {
+        use axum::http::StatusCode;
+        let status = match error.status {
+            StatusCode::BAD_REQUEST => ActionStatus::BadRequest,
+            StatusCode::NOT_FOUND => ActionStatus::NotFound,
+            StatusCode::CONFLICT => ActionStatus::Conflict,
+            _ => ActionStatus::Internal,
+        };
+        ActionError {
+            status,
+            message: error.message,
+            details: error.details,
+        }
+    }
+}
+
+/// The other half of the bridge: an `ActionError` becomes an `ApiError` so the
+/// HTTP handlers can return it directly. Reuses the existing `ApiError`
+/// constructors, including the structured conflict path.
+impl From<ActionError> for ApiError {
+    fn from(error: ActionError) -> Self {
+        match (error.status, error.details) {
+            (ActionStatus::BadRequest, _) => ApiError::bad_request(error.message),
+            (ActionStatus::NotFound, _) => ApiError::not_found(error.message),
+            (ActionStatus::Conflict, Some(details)) => {
+                ApiError::conflict_with_details(error.message, details)
+            }
+            (ActionStatus::Conflict, None) => {
+                ApiError::new(axum::http::StatusCode::CONFLICT, error.message)
+            }
+            (ActionStatus::Internal, _) => ApiError::internal(error.message),
+        }
+    }
+}

--- a/src-tauri/src/actions/git/mod.rs
+++ b/src-tauri/src/actions/git/mod.rs
@@ -1,0 +1,532 @@
+//! Git actions: wrap the existing git free functions behind the unified
+//! [`Action`] contract.
+//!
+//! The [`run_git_in_dir`] helper (and its load-bearing `#[cfg(windows)]`
+//! `CREATE_NO_WINDOW` creation flag, which prevents a console window from
+//! flashing on Windows) lives here as the single source of truth.
+//! `commands/git_commands.rs` re-exports the types and helper from this module.
+
+use std::path::Path;
+use std::process::Command;
+
+use async_trait::async_trait;
+use schemars::schema::RootSchema;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::error::ActionError;
+use super::registry::{Action, ActionRegistry};
+use super::ActionContext;
+
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BranchInfo {
+    pub name: String,
+    pub short_hash: String,
+    pub is_current: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorktreeInfo {
+    pub path: String,
+    pub branch: String,
+    pub head: String,
+    pub is_bare: bool,
+}
+
+/// Run a git command in `project_path`, returning stdout on success or a
+/// human-readable error string on failure.
+///
+/// IMPORTANT (load-bearing): the `#[cfg(windows)]` `CREATE_NO_WINDOW` creation
+/// flag must remain — without it git spawns a flashing console window on Windows.
+pub fn run_git_in_dir(args: &[&str], project_path: &str) -> Result<String, String> {
+    let path = Path::new(project_path);
+    if !path.exists() {
+        return Err(format!("Project path does not exist: {}", project_path));
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(path);
+
+    // Prevent console window from flashing on Windows
+    #[cfg(windows)]
+    cmd.creation_flags(CREATE_NO_WINDOW);
+
+    let output = cmd
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        let message = if !stderr.is_empty() { stderr } else { stdout };
+        return Err(if message.is_empty() {
+            "Git command failed".to_string()
+        } else {
+            message
+        });
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+}
+
+pub fn parse_worktree_list(output: &str) -> Result<Vec<WorktreeInfo>, String> {
+    let mut worktrees = Vec::new();
+    let mut current: Option<WorktreeInfo> = None;
+
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            if let Some(info) = current.take() {
+                if info.path.is_empty() {
+                    return Err("Unexpected git worktree output: missing path".to_string());
+                }
+                worktrees.push(info);
+            }
+            continue;
+        }
+
+        if let Some(path) = line.strip_prefix("worktree ") {
+            if let Some(info) = current.take() {
+                if info.path.is_empty() {
+                    return Err("Unexpected git worktree output: missing path".to_string());
+                }
+                worktrees.push(info);
+            }
+
+            current = Some(WorktreeInfo {
+                path: path.to_string(),
+                branch: String::new(),
+                head: String::new(),
+                is_bare: false,
+            });
+            continue;
+        }
+
+        let entry = current
+            .as_mut()
+            .ok_or_else(|| format!("Unexpected git worktree output: {}", line))?;
+
+        if let Some(head) = line.strip_prefix("HEAD ") {
+            entry.head = head.to_string();
+        } else if let Some(branch) = line.strip_prefix("branch ") {
+            entry.branch = branch
+                .strip_prefix("refs/heads/")
+                .unwrap_or(branch)
+                .to_string();
+        } else if line == "bare" {
+            entry.is_bare = true;
+        } else if line == "detached" && entry.branch.is_empty() {
+            entry.branch = "detached".to_string();
+        }
+    }
+
+    if let Some(info) = current.take() {
+        if info.path.is_empty() {
+            return Err("Unexpected git worktree output: missing path".to_string());
+        }
+        worktrees.push(info);
+    }
+
+    Ok(worktrees)
+}
+
+pub fn parse_branch_list(output: &str) -> Result<Vec<BranchInfo>, String> {
+    let mut branches = Vec::new();
+    for line in output.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.split('|');
+        let name = parts.next().unwrap_or("").trim();
+        let short_hash = parts.next().unwrap_or("").trim();
+        let head_marker = parts.next().unwrap_or("").trim();
+
+        if name.is_empty() || short_hash.is_empty() {
+            return Err(format!("Unexpected git branch output: {}", line));
+        }
+
+        branches.push(BranchInfo {
+            name: name.to_string(),
+            short_hash: short_hash.to_string(),
+            is_current: head_marker == "*",
+        });
+    }
+    Ok(branches)
+}
+
+// ---------------------------------------------------------------------------
+// Input DTOs
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ProjectPathInput {
+    project_path: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SwitchBranchInput {
+    project_path: String,
+    branch: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct WorktreeAddInput {
+    project_path: String,
+    worktree_path: String,
+    branch: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct WorktreeRemoveInput {
+    project_path: String,
+    worktree_path: String,
+}
+
+fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
+    serde_json::from_value(input)
+        .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+/// Map the string error from `run_git_in_dir`/parsers into an `ActionError`.
+/// A non-existent project path is a bad request; everything else is internal.
+fn git_err(message: String) -> ActionError {
+    if message.starts_with("Project path does not exist") {
+        ActionError::bad_request(message)
+    } else {
+        ActionError::internal(message)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.list_branches
+// ---------------------------------------------------------------------------
+
+struct ListBranches;
+
+#[async_trait]
+impl Action for ListBranches {
+    fn name(&self) -> &'static str {
+        "git.list_branches"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let output = run_git_in_dir(
+            &[
+                "branch",
+                "--list",
+                "--format=%(refname:short)|%(objectname:short)|%(HEAD)",
+            ],
+            &parsed.project_path,
+        )
+        .map_err(git_err)?;
+        let branches = parse_branch_list(&output).map_err(git_err)?;
+        serde_json::to_value(branches)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize branches: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.current_branch
+// ---------------------------------------------------------------------------
+
+struct CurrentBranch;
+
+#[async_trait]
+impl Action for CurrentBranch {
+    fn name(&self) -> &'static str {
+        "git.current_branch"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let output =
+            run_git_in_dir(&["rev-parse", "--abbrev-ref", "HEAD"], &parsed.project_path)
+                .map_err(git_err)?;
+        let branch = output.trim();
+        if branch.is_empty() {
+            return Err(ActionError::internal("Unable to determine current branch"));
+        }
+        Ok(Value::String(branch.to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.switch_branch
+// ---------------------------------------------------------------------------
+
+struct SwitchBranch;
+
+#[async_trait]
+impl Action for SwitchBranch {
+    fn name(&self) -> &'static str {
+        "git.switch_branch"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SwitchBranchInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: SwitchBranchInput = deserialize_input(input)?;
+        let branch = parsed.branch.trim();
+        if branch.is_empty() {
+            return Err(ActionError::bad_request("Branch name cannot be empty"));
+        }
+
+        let status =
+            run_git_in_dir(&["status", "--porcelain"], &parsed.project_path).map_err(git_err)?;
+        if !status.trim().is_empty() {
+            return Err(ActionError::bad_request(
+                "Uncommitted changes detected. Please commit or stash before switching branches.",
+            ));
+        }
+
+        run_git_in_dir(&["switch", branch], &parsed.project_path).map_err(git_err)?;
+        Ok(Value::Null)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.pull
+// ---------------------------------------------------------------------------
+
+struct Pull;
+
+#[async_trait]
+impl Action for Pull {
+    fn name(&self) -> &'static str {
+        "git.pull"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let status =
+            run_git_in_dir(&["status", "--porcelain"], &parsed.project_path).map_err(git_err)?;
+        if !status.trim().is_empty() {
+            return Err(ActionError::bad_request(
+                "Uncommitted changes detected. Please commit or stash before pulling.",
+            ));
+        }
+        let output = run_git_in_dir(&["pull"], &parsed.project_path).map_err(git_err)?;
+        Ok(Value::String(output.trim().to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.push
+// ---------------------------------------------------------------------------
+
+struct Push;
+
+#[async_trait]
+impl Action for Push {
+    fn name(&self) -> &'static str {
+        "git.push"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let output = run_git_in_dir(&["push"], &parsed.project_path).map_err(git_err)?;
+        Ok(Value::String(output.trim().to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.fetch
+// ---------------------------------------------------------------------------
+
+struct Fetch;
+
+#[async_trait]
+impl Action for Fetch {
+    fn name(&self) -> &'static str {
+        "git.fetch"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let output = run_git_in_dir(&["fetch", "--all"], &parsed.project_path).map_err(git_err)?;
+        Ok(Value::String(output.trim().to_string()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.worktree_add
+// ---------------------------------------------------------------------------
+
+struct WorktreeAdd;
+
+#[async_trait]
+impl Action for WorktreeAdd {
+    fn name(&self) -> &'static str {
+        "git.worktree_add"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(WorktreeAddInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: WorktreeAddInput = deserialize_input(input)?;
+        let worktree_path = parsed.worktree_path.trim();
+        if worktree_path.is_empty() {
+            return Err(ActionError::bad_request("Worktree path cannot be empty"));
+        }
+        let branch = parsed.branch.trim();
+        if branch.is_empty() {
+            return Err(ActionError::bad_request("Branch name cannot be empty"));
+        }
+
+        run_git_in_dir(
+            &["worktree", "add", worktree_path, "-b", branch],
+            &parsed.project_path,
+        )
+        .map_err(git_err)?;
+        Ok(Value::Null)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.worktree_list
+// ---------------------------------------------------------------------------
+
+struct WorktreeList;
+
+#[async_trait]
+impl Action for WorktreeList {
+    fn name(&self) -> &'static str {
+        "git.worktree_list"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        let output = run_git_in_dir(
+            &["worktree", "list", "--porcelain"],
+            &parsed.project_path,
+        )
+        .map_err(git_err)?;
+        let worktrees = parse_worktree_list(&output).map_err(git_err)?;
+        serde_json::to_value(worktrees)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize worktrees: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.worktree_remove
+// ---------------------------------------------------------------------------
+
+struct WorktreeRemove;
+
+#[async_trait]
+impl Action for WorktreeRemove {
+    fn name(&self) -> &'static str {
+        "git.worktree_remove"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(WorktreeRemoveInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: WorktreeRemoveInput = deserialize_input(input)?;
+        let worktree_path = parsed.worktree_path.trim();
+        if worktree_path.is_empty() {
+            return Err(ActionError::bad_request("Worktree path cannot be empty"));
+        }
+
+        match run_git_in_dir(
+            &["worktree", "remove", worktree_path, "--force"],
+            &parsed.project_path,
+        ) {
+            Ok(_) => Ok(Value::Null),
+            Err(err) => {
+                #[cfg(windows)]
+                {
+                    let lower = err.to_lowercase();
+                    if lower.contains("in use")
+                        || lower.contains("being used")
+                        || lower.contains("permission denied")
+                        || lower.contains("access is denied")
+                    {
+                        return Err(ActionError::internal(format!(
+                            "Failed to remove worktree because files may still be open. Close terminals/editors using '{}' and retry. Git error: {}",
+                            worktree_path, err
+                        )));
+                    }
+                }
+
+                Err(git_err(err))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// git.worktree_prune
+// ---------------------------------------------------------------------------
+
+struct WorktreePrune;
+
+#[async_trait]
+impl Action for WorktreePrune {
+    fn name(&self) -> &'static str {
+        "git.worktree_prune"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ProjectPathInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: ProjectPathInput = deserialize_input(input)?;
+        run_git_in_dir(&["worktree", "prune"], &parsed.project_path).map_err(git_err)?;
+        Ok(Value::Null)
+    }
+}
+
+/// Register every git action into the registry.
+pub fn register(registry: &mut ActionRegistry) {
+    registry.register(Box::new(ListBranches));
+    registry.register(Box::new(CurrentBranch));
+    registry.register(Box::new(SwitchBranch));
+    registry.register(Box::new(Pull));
+    registry.register(Box::new(Push));
+    registry.register(Box::new(Fetch));
+    registry.register(Box::new(WorktreeAdd));
+    registry.register(Box::new(WorktreeList));
+    registry.register(Box::new(WorktreeRemove));
+    registry.register(Box::new(WorktreePrune));
+}

--- a/src-tauri/src/actions/mod.rs
+++ b/src-tauri/src/actions/mod.rs
@@ -1,0 +1,30 @@
+//! Unified Action contract.
+//!
+//! An [`Action`] is one unit of work, addressable by a stable dotted name
+//! (`session.list`, `git.pull`, ...) and dispatched uniformly over
+//! `serde_json::Value`. The SAME action is invoked from every surface:
+//!
+//! - Tauri `#[command]` wrappers dispatch with [`Caller::Frontend`];
+//! - the Axum HTTP layer dispatches with [`Caller::Http`] (the generic
+//!   `POST /api/actions/{name}` entrypoint is the future agent/MCP surface).
+//!
+//! Validation runs ONCE, in [`ActionRegistry::dispatch`], before `run`
+//! regardless of caller. Each action exports a JSON Schema (via `schemars`) so
+//! the registry is surfaceable as agent/MCP tools at `GET /api/actions`.
+//!
+//! Action outputs are intentionally plain `serde_json::Value` so a future
+//! `{ renderer?, data }` result envelope (#127) can wrap them without changing
+//! this contract.
+
+pub mod context;
+pub mod error;
+pub mod git;
+pub mod registry;
+pub mod session;
+
+#[cfg(test)]
+mod tests;
+
+pub use context::{ActionContext, Caller};
+pub use error::{ActionError, ActionStatus};
+pub use registry::{build_registry, Action, ActionRegistry};

--- a/src-tauri/src/actions/registry.rs
+++ b/src-tauri/src/actions/registry.rs
@@ -1,0 +1,121 @@
+//! The [`Action`] trait, the [`ActionRegistry`], and [`build_registry`] — the
+//! single place every session + git action is registered.
+//!
+//! ## Concurrency invariant
+//!
+//! Action `run` bodies acquire the `parking_lot` `SessionController` guard
+//! synchronously and MUST NOT hold it across an `.await`. The controller methods
+//! wrapped here are all synchronous, so each `run` locks, calls, maps, and drops
+//! the guard before returning — never awaiting under the lock.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use schemars::schema::RootSchema;
+use serde_json::Value;
+
+use super::context::ActionContext;
+use super::error::ActionError;
+
+/// A single unit of work, addressable by a stable dotted `name` (e.g.
+/// `session.list`, `git.pull`), dispatched uniformly over `serde_json::Value`.
+///
+/// The trait is object-safe (`Box<dyn Action>`): `run` takes/returns
+/// `serde_json::Value`, and each concrete action deserializes the input into its
+/// typed DTO at the top of `run` and serializes its typed output. The output is
+/// intentionally a plain `Value` so a future `{ renderer?, data }` result
+/// envelope (#127) can wrap it without changing this contract.
+#[async_trait]
+pub trait Action: Send + Sync {
+    /// Stable, unique identifier for this action.
+    fn name(&self) -> &'static str;
+
+    /// JSON Schema describing the action's accepted input, exported via
+    /// `schemars` so the set is surfaceable as agent/MCP tools.
+    fn input_schema(&self) -> RootSchema;
+
+    /// Validate `input` WITHOUT running. The default implementation simply
+    /// confirms the input is an object; actions override to deserialize into
+    /// their DTO and run domain validation. The registry always calls this
+    /// before [`Action::run`].
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        if input.is_object() || input.is_null() {
+            Ok(())
+        } else {
+            Err(ActionError::bad_request(format!(
+                "Action '{}' expects a JSON object as input",
+                self.name()
+            )))
+        }
+    }
+
+    /// Execute the action. Validation has already run.
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError>;
+}
+
+/// Holds every registered action and dispatches by name. Validation always runs
+/// before execution (see [`ActionRegistry::dispatch`]).
+#[derive(Default)]
+pub struct ActionRegistry {
+    actions: HashMap<&'static str, Box<dyn Action>>,
+}
+
+impl ActionRegistry {
+    pub fn new() -> Self {
+        Self {
+            actions: HashMap::new(),
+        }
+    }
+
+    /// Register an action. Panics on a duplicate name so a registration bug
+    /// surfaces at startup rather than silently shadowing.
+    pub fn register(&mut self, action: Box<dyn Action>) {
+        let name = action.name();
+        if self.actions.insert(name, action).is_some() {
+            panic!("Duplicate action registration for '{}'", name);
+        }
+    }
+
+    /// List every registered action with its input schema (AC1). Sorted by name
+    /// for deterministic output.
+    pub fn list(&self) -> Vec<(&'static str, RootSchema)> {
+        let mut entries: Vec<(&'static str, RootSchema)> = self
+            .actions
+            .values()
+            .map(|action| (action.name(), action.input_schema()))
+            .collect();
+        entries.sort_by_key(|(name, _)| *name);
+        entries
+    }
+
+    /// Whether an action with this name is registered.
+    pub fn contains(&self, name: &str) -> bool {
+        self.actions.contains_key(name)
+    }
+
+    /// Validate then run the named action. Returns `NotFound` if the name is
+    /// unknown. Validation (AC3) always precedes `run`.
+    pub async fn dispatch(
+        &self,
+        name: &str,
+        ctx: &ActionContext,
+        input: Value,
+    ) -> Result<Value, ActionError> {
+        let action = self.actions.get(name).ok_or_else(|| {
+            ActionError::not_found(format!("Unknown action '{}'", name))
+        })?;
+
+        action.validate_input(&input)?;
+        action.run(ctx, input).await
+    }
+}
+
+/// The single registration point for all actions. Both the runtime (`lib.rs`)
+/// and the tests build the registry through this function so the action set is
+/// defined in exactly one place.
+pub fn build_registry() -> ActionRegistry {
+    let mut registry = ActionRegistry::new();
+    super::session::register(&mut registry);
+    super::git::register(&mut registry);
+    registry
+}

--- a/src-tauri/src/actions/session/mod.rs
+++ b/src-tauri/src/actions/session/mod.rs
@@ -1,0 +1,347 @@
+//! Session actions: thin wrappers over the existing [`SessionController`]
+//! methods. The validators that were copy-pasted into both
+//! `commands/session_commands.rs` and `http/handlers/sessions.rs` live here once,
+//! on the input DTOs, and run via [`Action::validate_input`] before `run`.
+
+use async_trait::async_trait;
+use schemars::schema::RootSchema;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::http::handlers::{validate_cli, validate_project_path};
+use crate::session::HiveLaunchConfig;
+
+use super::error::ActionError;
+use super::registry::{Action, ActionRegistry};
+use super::ActionContext;
+
+const SESSION_COLOR_ALLOWLIST: &[&str] = &[
+    "#7aa2f7", "#bb9af7", "#9ece6a", "#e0af68", "#7dcfff", "#f7768e", "#ff9e64", "#f7b1d1",
+];
+
+/// Shared name validation (consolidated from the two former copies).
+fn validate_session_name(name: Option<&str>) -> Result<(), ActionError> {
+    let Some(name) = name else {
+        return Ok(());
+    };
+    if name.trim().is_empty() {
+        return Err(ActionError::bad_request(
+            "Invalid session name: must not be empty or whitespace",
+        ));
+    }
+    if name.chars().count() > 64 {
+        return Err(ActionError::bad_request(
+            "Invalid session name: must be 64 characters or fewer",
+        ));
+    }
+    if name.contains("..") || name.contains('/') || name.contains('\\') {
+        return Err(ActionError::bad_request(
+            "Invalid session name: must not contain '..', '/', or '\\'",
+        ));
+    }
+    Ok(())
+}
+
+/// Shared color validation (consolidated from the two former copies).
+fn validate_session_color(color: Option<&str>) -> Result<(), ActionError> {
+    let Some(color) = color else {
+        return Ok(());
+    };
+    if !SESSION_COLOR_ALLOWLIST.contains(&color) && !is_valid_hex_session_color(color) {
+        return Err(ActionError::bad_request(format!(
+            "Invalid session color '{}'. Valid options: {} or any #RRGGBB hex color",
+            color,
+            SESSION_COLOR_ALLOWLIST.join(", ")
+        )));
+    }
+    Ok(())
+}
+
+fn is_valid_hex_session_color(color: &str) -> bool {
+    color.len() == 7
+        && color.starts_with('#')
+        && color.chars().skip(1).all(|c| c.is_ascii_hexdigit())
+}
+
+/// Validate a `HiveLaunchConfig` (consolidated from session_commands.rs).
+fn validate_hive_launch_config(config: &HiveLaunchConfig) -> Result<(), ActionError> {
+    validate_project_path(&config.project_path)?;
+    validate_session_name(config.name.as_deref())?;
+    validate_session_color(config.color.as_deref())?;
+    validate_cli(&config.queen_config.cli)?;
+
+    for worker in &config.workers {
+        validate_cli(&worker.cli)?;
+    }
+
+    if let Some(evaluator_config) = &config.evaluator_config {
+        if !evaluator_config.cli.trim().is_empty() {
+            validate_cli(&evaluator_config.cli)?;
+        }
+    }
+
+    if let Some(qa_workers) = &config.qa_workers {
+        for qa_worker in qa_workers {
+            validate_cli(&qa_worker.cli)?;
+            match qa_worker.specialization.as_str() {
+                "ui" | "api" | "a11y" => {}
+                other => {
+                    return Err(ActionError::bad_request(format!(
+                        "Invalid QA specialization '{}'. Valid options: ui, api, a11y",
+                        other
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Input carrying just a session id (`session.get`, `session.stop`,
+/// `session.close`).
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SessionIdInput {
+    id: String,
+}
+
+fn validate_session_id_input(id: &str) -> Result<(), ActionError> {
+    if id.contains("..") || id.contains('/') || id.contains('\\') {
+        return Err(ActionError::bad_request(
+            "Invalid session ID: must not contain '..', '/', or '\\'",
+        ));
+    }
+    Ok(())
+}
+
+/// Empty input marker for actions that take no parameters (`session.list`).
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EmptyInput {}
+
+/// Input for `session.update_metadata`.
+#[derive(Debug, Deserialize, JsonSchema)]
+struct UpdateMetadataInput {
+    id: String,
+    /// Outer `Some` means "set this field"; inner `None` clears it.
+    #[serde(default)]
+    name: Option<Option<String>>,
+    #[serde(default)]
+    color: Option<Option<String>>,
+}
+
+fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
+    serde_json::from_value(input)
+        .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+// ---------------------------------------------------------------------------
+// session.list
+// ---------------------------------------------------------------------------
+
+struct ListSessions;
+
+#[async_trait]
+impl Action for ListSessions {
+    fn name(&self) -> &'static str {
+        "session.list"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(EmptyInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, _input: Value) -> Result<Value, ActionError> {
+        let sessions = {
+            let controller = ctx.state.session_controller.read();
+            controller.list_sessions()
+        };
+        serde_json::to_value(sessions)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize sessions: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.get
+// ---------------------------------------------------------------------------
+
+struct GetSession;
+
+#[async_trait]
+impl Action for GetSession {
+    fn name(&self) -> &'static str {
+        "session.get"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller.get_session(&parsed.id)
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.stop
+// ---------------------------------------------------------------------------
+
+struct StopSession;
+
+#[async_trait]
+impl Action for StopSession {
+    fn name(&self) -> &'static str {
+        "session.stop"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        {
+            let controller = ctx.state.session_controller.read();
+            controller.stop_session(&parsed.id).map_err(ActionError::from)?;
+        }
+        Ok(json!({ "message": format!("Session {} stopped", parsed.id) }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.close
+// ---------------------------------------------------------------------------
+
+struct CloseSession;
+
+#[async_trait]
+impl Action for CloseSession {
+    fn name(&self) -> &'static str {
+        "session.close"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        {
+            let controller = ctx.state.session_controller.read();
+            controller.close_session(&parsed.id).map_err(|e| {
+                if e.starts_with("Session not found") {
+                    ActionError::not_found(e)
+                } else {
+                    ActionError::internal(e)
+                }
+            })?;
+        }
+        Ok(json!({ "message": format!("Session {} closed", parsed.id) }))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.launch_hive_v2
+// ---------------------------------------------------------------------------
+
+struct LaunchHiveV2;
+
+#[async_trait]
+impl Action for LaunchHiveV2 {
+    fn name(&self) -> &'static str {
+        "session.launch_hive_v2"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(HiveLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: HiveLaunchConfig = deserialize_input(input.clone())?;
+        validate_hive_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: HiveLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller.launch_hive_v2(config).map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.update_metadata
+// ---------------------------------------------------------------------------
+
+struct UpdateSessionMetadata;
+
+#[async_trait]
+impl Action for UpdateSessionMetadata {
+    fn name(&self) -> &'static str {
+        "session.update_metadata"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(UpdateMetadataInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: UpdateMetadataInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)?;
+        validate_session_name(parsed.name.as_ref().and_then(|value| value.as_deref()))?;
+        validate_session_color(parsed.color.as_ref().and_then(|value| value.as_deref()))?;
+        Ok(())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: UpdateMetadataInput = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .update_session_metadata(&parsed.id, parsed.name, parsed.color)
+                .map_err(|e| {
+                    if e.starts_with("Session not found") {
+                        ActionError::not_found(e)
+                    } else {
+                        ActionError::internal(e)
+                    }
+                })?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+/// Register every session action into the registry.
+pub fn register(registry: &mut ActionRegistry) {
+    registry.register(Box::new(ListSessions));
+    registry.register(Box::new(GetSession));
+    registry.register(Box::new(StopSession));
+    registry.register(Box::new(CloseSession));
+    registry.register(Box::new(LaunchHiveV2));
+    registry.register(Box::new(UpdateSessionMetadata));
+}

--- a/src-tauri/src/actions/tests.rs
+++ b/src-tauri/src/actions/tests.rs
@@ -1,0 +1,202 @@
+//! Unit tests for the action registry: listing + schemas (AC1), validate-before-run
+//! (AC3), and caller visibility inside `run` (AC4).
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use parking_lot::RwLock;
+use schemars::schema::RootSchema;
+use serde_json::{json, Value};
+
+use super::context::{ActionContext, Caller};
+use super::error::{ActionError, ActionStatus};
+use super::registry::{build_registry, Action, ActionRegistry};
+use crate::coordination::InjectionManager;
+use crate::events::EventBus;
+use crate::http::state::AppState;
+use crate::pty::PtyManager;
+use crate::session::SessionController;
+use crate::storage::SessionStorage;
+
+/// Build a hermetic `Arc<AppState>` backed by a temp storage dir.
+fn test_state() -> Arc<AppState> {
+    let dir = tempfile::TempDir::new().unwrap();
+    let storage = Arc::new(SessionStorage::new_with_base(dir.path().to_path_buf()).unwrap());
+    let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    session_controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new_with_base(dir.path().to_path_buf()).unwrap(),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    // Keep the TempDir alive for the lifetime of the process under test by leaking it;
+    // tests are short-lived and this avoids a premature directory cleanup race.
+    std::mem::forget(dir);
+    Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller,
+        injection_manager,
+        storage,
+        event_bus,
+        None,
+    ))
+}
+
+/// Tiny probe action that echoes the caller back so a test can assert the
+/// `Caller` threaded through `run`.
+struct CallerProbe;
+
+#[async_trait]
+impl Action for CallerProbe {
+    fn name(&self) -> &'static str {
+        "test.caller_probe"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(Value)
+    }
+
+    async fn run(&self, ctx: &ActionContext, _input: Value) -> Result<Value, ActionError> {
+        Ok(serde_json::to_value(ctx.caller).unwrap())
+    }
+}
+
+#[test]
+fn test_registry_lists_all_actions() {
+    let registry = build_registry();
+    let names: Vec<&'static str> = registry.list().into_iter().map(|(name, _)| name).collect();
+
+    // Session actions (AC2-required set).
+    for expected in [
+        "session.list",
+        "session.get",
+        "session.stop",
+        "session.close",
+        "session.launch_hive_v2",
+        "session.update_metadata",
+    ] {
+        assert!(names.contains(&expected), "missing session action {expected}");
+    }
+
+    // Git actions (AC2-required set).
+    for expected in [
+        "git.list_branches",
+        "git.current_branch",
+        "git.switch_branch",
+        "git.pull",
+        "git.push",
+        "git.fetch",
+        "git.worktree_add",
+        "git.worktree_list",
+        "git.worktree_remove",
+        "git.worktree_prune",
+    ] {
+        assert!(names.contains(&expected), "missing git action {expected}");
+    }
+}
+
+#[test]
+fn test_schema_per_action_serializes() {
+    let registry = build_registry();
+    for (name, schema) in registry.list() {
+        let value = serde_json::to_value(&schema)
+            .unwrap_or_else(|e| panic!("schema for {name} failed to serialize: {e}"));
+        assert!(
+            value.is_object(),
+            "schema for {name} should serialize to a JSON object"
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_validation_runs_before_run_bad_color() {
+    // `session.update_metadata` with an invalid color is a pure-validation path:
+    // it must be rejected with BadRequest WITHOUT touching the controller.
+    let registry = build_registry();
+    let ctx = ActionContext::new(Caller::Http, test_state());
+
+    let result = registry
+        .dispatch(
+            "session.update_metadata",
+            &ctx,
+            json!({ "id": "sess-1", "color": "not-a-color" }),
+        )
+        .await;
+
+    let err = result.expect_err("invalid color should be rejected");
+    assert_eq!(err.status, ActionStatus::BadRequest);
+    assert!(
+        err.message.contains("Invalid session color"),
+        "unexpected message: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn test_validation_runs_before_run_bad_cli() {
+    // `session.launch_hive_v2` with an invalid queen CLI must fail validation
+    // (BadRequest) before the controller is ever invoked.
+    let registry = build_registry();
+    let ctx = ActionContext::new(Caller::Http, test_state());
+
+    let input = json!({
+        "project_path": ".",
+        "queen_config": { "cli": "definitely-not-a-cli", "model": null, "flags": [] },
+        "workers": [],
+        "prompt": null
+    });
+
+    let result = registry
+        .dispatch("session.launch_hive_v2", &ctx, input)
+        .await;
+
+    let err = result.expect_err("invalid CLI should be rejected");
+    assert_eq!(err.status, ActionStatus::BadRequest);
+    assert!(
+        err.message.contains("Invalid CLI"),
+        "unexpected message: {}",
+        err.message
+    );
+}
+
+#[tokio::test]
+async fn test_unknown_action_is_not_found() {
+    let registry = build_registry();
+    let ctx = ActionContext::new(Caller::Http, test_state());
+    let err = registry
+        .dispatch("nope.does_not_exist", &ctx, json!({}))
+        .await
+        .expect_err("unknown action should error");
+    assert_eq!(err.status, ActionStatus::NotFound);
+}
+
+#[tokio::test]
+async fn test_caller_visible_in_run() {
+    let mut registry = ActionRegistry::new();
+    registry.register(Box::new(CallerProbe));
+    let state = test_state();
+
+    for caller in [Caller::Frontend, Caller::Http, Caller::Agent, Caller::Cli] {
+        let ctx = ActionContext::new(caller, state.clone());
+        let echoed = registry
+            .dispatch("test.caller_probe", &ctx, json!({}))
+            .await
+            .expect("probe should run");
+        let expected = serde_json::to_value(caller).unwrap();
+        assert_eq!(echoed, expected, "caller mismatch for {caller:?}");
+    }
+}
+
+#[tokio::test]
+async fn test_session_list_dispatch_returns_array() {
+    let registry = build_registry();
+    let ctx = ActionContext::new(Caller::Frontend, test_state());
+    let result = registry
+        .dispatch("session.list", &ctx, json!({}))
+        .await
+        .expect("session.list should run");
+    assert!(result.is_array(), "session.list should return a JSON array");
+}

--- a/src-tauri/src/commands/git_commands.rs
+++ b/src-tauri/src/commands/git_commands.rs
@@ -1,273 +1,193 @@
-use serde::Serialize;
-use std::path::Path;
-use std::process::Command;
+//! Tauri `#[command]` wrappers for git operations.
+//!
+//! The real git logic (including the load-bearing Windows `CREATE_NO_WINDOW`
+//! flag) now lives in `crate::actions::git`. These wrappers preserve the exact
+//! command names + signatures the frontend `invoke()`s and dispatch the
+//! corresponding action through the shared registry with `caller = Frontend`.
 
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
+use std::sync::Arc;
 
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
+use serde_json::json;
+use tauri::State;
 
-#[derive(Debug, Clone, Serialize)]
-pub struct BranchInfo {
-    pub name: String,
-    pub short_hash: String,
-    pub is_current: bool,
-}
+use crate::actions::{ActionContext, ActionRegistry, Caller};
+use crate::http::state::AppState;
 
-#[derive(Debug, Clone, Serialize)]
-pub struct WorktreeInfo {
-    pub path: String,
-    pub branch: String,
-    pub head: String,
-    pub is_bare: bool,
-}
+// Re-export the git value types from the action module so any existing importer
+// of `commands::git_commands::{BranchInfo, WorktreeInfo}` keeps compiling.
+pub use crate::actions::git::{BranchInfo, WorktreeInfo};
 
-fn run_git_in_dir(args: &[&str], project_path: &str) -> Result<String, String> {
-    let path = Path::new(project_path);
-    if !path.exists() {
-        return Err(format!("Project path does not exist: {}", project_path));
-    }
-
-    let mut cmd = Command::new("git");
-    cmd.args(args).current_dir(path);
-
-    // Prevent console window from flashing on Windows
-    #[cfg(windows)]
-    cmd.creation_flags(CREATE_NO_WINDOW);
-
-    let output = cmd
-        .output()
-        .map_err(|e| format!("Failed to run git: {}", e))?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        let message = if !stderr.is_empty() { stderr } else { stdout };
-        return Err(if message.is_empty() {
-            "Git command failed".to_string()
-        } else {
-            message
-        });
-    }
-
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
-}
-
-fn parse_worktree_list(output: &str) -> Result<Vec<WorktreeInfo>, String> {
-    let mut worktrees = Vec::new();
-    let mut current: Option<WorktreeInfo> = None;
-
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            if let Some(info) = current.take() {
-                if info.path.is_empty() {
-                    return Err("Unexpected git worktree output: missing path".to_string());
-                }
-                worktrees.push(info);
-            }
-            continue;
-        }
-
-        if let Some(path) = line.strip_prefix("worktree ") {
-            if let Some(info) = current.take() {
-                if info.path.is_empty() {
-                    return Err("Unexpected git worktree output: missing path".to_string());
-                }
-                worktrees.push(info);
-            }
-
-            current = Some(WorktreeInfo {
-                path: path.to_string(),
-                branch: String::new(),
-                head: String::new(),
-                is_bare: false,
-            });
-            continue;
-        }
-
-        let entry = current
-            .as_mut()
-            .ok_or_else(|| format!("Unexpected git worktree output: {}", line))?;
-
-        if let Some(head) = line.strip_prefix("HEAD ") {
-            entry.head = head.to_string();
-        } else if let Some(branch) = line.strip_prefix("branch ") {
-            entry.branch = branch
-                .strip_prefix("refs/heads/")
-                .unwrap_or(branch)
-                .to_string();
-        } else if line == "bare" {
-            entry.is_bare = true;
-        } else if line == "detached" && entry.branch.is_empty() {
-            entry.branch = "detached".to_string();
-        }
-    }
-
-    if let Some(info) = current.take() {
-        if info.path.is_empty() {
-            return Err("Unexpected git worktree output: missing path".to_string());
-        }
-        worktrees.push(info);
-    }
-
-    Ok(worktrees)
+/// Dispatch a git action with `caller = Frontend`, surfacing the action's
+/// message string on error (matching prior `Result<_, String>` behavior), and
+/// deserializing the JSON output into the typed return.
+async fn dispatch_git<T: serde::de::DeserializeOwned>(
+    registry: &ActionRegistry,
+    state: Arc<AppState>,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<T, String> {
+    let ctx = ActionContext::new(Caller::Frontend, state);
+    let value = registry
+        .dispatch(name, &ctx, input)
+        .await
+        .map_err(|e| e.to_message())?;
+    serde_json::from_value(value).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
-pub async fn list_branches(project_path: String) -> Result<Vec<BranchInfo>, String> {
-    let output = run_git_in_dir(
-        &[
-            "branch",
-            "--list",
-            "--format=%(refname:short)|%(objectname:short)|%(HEAD)",
-        ],
-        &project_path,
-    )?;
-
-    let mut branches = Vec::new();
-    for line in output.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
-        }
-        let mut parts = line.split('|');
-        let name = parts.next().unwrap_or("").trim();
-        let short_hash = parts.next().unwrap_or("").trim();
-        let head_marker = parts.next().unwrap_or("").trim();
-
-        if name.is_empty() || short_hash.is_empty() {
-            return Err(format!("Unexpected git branch output: {}", line));
-        }
-
-        branches.push(BranchInfo {
-            name: name.to_string(),
-            short_hash: short_hash.to_string(),
-            is_current: head_marker == "*",
-        });
-    }
-
-    Ok(branches)
+pub async fn list_branches(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<Vec<BranchInfo>, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.list_branches",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn get_current_branch(project_path: String) -> Result<String, String> {
-    let output = run_git_in_dir(&["rev-parse", "--abbrev-ref", "HEAD"], &project_path)?;
-    let branch = output.trim();
-    if branch.is_empty() {
-        return Err("Unable to determine current branch".to_string());
-    }
-    Ok(branch.to_string())
+pub async fn get_current_branch(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<String, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.current_branch",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn switch_branch(project_path: String, branch: String) -> Result<(), String> {
-    let branch = branch.trim();
-    if branch.is_empty() {
-        return Err("Branch name cannot be empty".to_string());
-    }
-
-    let status = run_git_in_dir(&["status", "--porcelain"], &project_path)?;
-    if !status.trim().is_empty() {
-        return Err(
-            "Uncommitted changes detected. Please commit or stash before switching branches."
-                .to_string(),
-        );
-    }
-
-    run_git_in_dir(&["switch", branch], &project_path)?;
-    Ok(())
+pub async fn switch_branch(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+    branch: String,
+) -> Result<(), String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.switch_branch",
+        json!({ "project_path": project_path, "branch": branch }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_pull(project_path: String) -> Result<String, String> {
-    // Check for uncommitted changes first
-    let status = run_git_in_dir(&["status", "--porcelain"], &project_path)?;
-    if !status.trim().is_empty() {
-        return Err("Uncommitted changes detected. Please commit or stash before pulling.".to_string());
-    }
-
-    let output = run_git_in_dir(&["pull"], &project_path)?;
-    Ok(output.trim().to_string())
+pub async fn git_pull(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<String, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.pull",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_push(project_path: String) -> Result<String, String> {
-    let output = run_git_in_dir(&["push"], &project_path)?;
-    Ok(output.trim().to_string())
+pub async fn git_push(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<String, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.push",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_fetch(project_path: String) -> Result<String, String> {
-    let output = run_git_in_dir(&["fetch", "--all"], &project_path)?;
-    Ok(output.trim().to_string())
+pub async fn git_fetch(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<String, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.fetch",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn git_worktree_add(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     project_path: String,
     worktree_path: String,
     branch: String,
 ) -> Result<(), String> {
-    let worktree_path = worktree_path.trim();
-    if worktree_path.is_empty() {
-        return Err("Worktree path cannot be empty".to_string());
-    }
-
-    let branch = branch.trim();
-    if branch.is_empty() {
-        return Err("Branch name cannot be empty".to_string());
-    }
-
-    run_git_in_dir(
-        &["worktree", "add", worktree_path, "-b", branch],
-        &project_path,
-    )?;
-    Ok(())
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.worktree_add",
+        json!({
+            "project_path": project_path,
+            "worktree_path": worktree_path,
+            "branch": branch
+        }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_worktree_list(project_path: String) -> Result<Vec<WorktreeInfo>, String> {
-    let output = run_git_in_dir(&["worktree", "list", "--porcelain"], &project_path)?;
-    parse_worktree_list(&output)
+pub async fn git_worktree_list(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<Vec<WorktreeInfo>, String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.worktree_list",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_worktree_remove(project_path: String, worktree_path: String) -> Result<(), String> {
-    let worktree_path = worktree_path.trim();
-    if worktree_path.is_empty() {
-        return Err("Worktree path cannot be empty".to_string());
-    }
-
-    match run_git_in_dir(
-        &["worktree", "remove", worktree_path, "--force"],
-        &project_path,
-    ) {
-        Ok(_) => Ok(()),
-        Err(err) => {
-            #[cfg(windows)]
-            {
-                let lower = err.to_lowercase();
-                if lower.contains("in use")
-                    || lower.contains("being used")
-                    || lower.contains("permission denied")
-                    || lower.contains("access is denied")
-                {
-                    return Err(format!(
-                        "Failed to remove worktree because files may still be open. Close terminals/editors using '{}' and retry. Git error: {}",
-                        worktree_path, err
-                    ));
-                }
-            }
-
-            Err(err)
-        }
-    }
+pub async fn git_worktree_remove(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+    worktree_path: String,
+) -> Result<(), String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.worktree_remove",
+        json!({ "project_path": project_path, "worktree_path": worktree_path }),
+    )
+    .await
 }
 
 #[tauri::command]
-pub async fn git_worktree_prune(project_path: String) -> Result<(), String> {
-    run_git_in_dir(&["worktree", "prune"], &project_path)?;
-    Ok(())
+pub async fn git_worktree_prune(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+    project_path: String,
+) -> Result<(), String> {
+    dispatch_git(
+        &registry,
+        Arc::clone(&app_state),
+        "git.worktree_prune",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -1,13 +1,32 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 use parking_lot::RwLock;
+use serde_json::json;
 use tauri::State;
 
+use crate::actions::{ActionContext, ActionRegistry, Caller};
 use crate::http::handlers::{validate_cli, validate_project_path};
+use crate::http::state::AppState;
 use crate::pty::AgentConfig;
 use crate::session::{Session, SessionController, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig};
 
 pub struct SessionControllerState(pub Arc<RwLock<SessionController>>);
+
+/// Dispatch an action through the shared registry with `caller = Frontend`,
+/// returning the raw JSON value or the action's message string (the exact text
+/// the frontend `invoke()` already expects on error).
+async fn dispatch_frontend(
+    registry: &ActionRegistry,
+    state: Arc<AppState>,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    let ctx = ActionContext::new(Caller::Frontend, state);
+    registry
+        .dispatch(name, &ctx, input)
+        .await
+        .map_err(|e| e.to_message())
+}
 
 const SESSION_COLOR_ALLOWLIST: &[&str] = &[
     "#7aa2f7",
@@ -64,42 +83,6 @@ fn is_valid_hex_session_color(color: &str) -> bool {
     color.len() == 7
         && color.starts_with('#')
         && color.chars().skip(1).all(|c| c.is_ascii_hexdigit())
-}
-
-fn validate_hive_launch_config(config: &HiveLaunchConfig) -> Result<(), String> {
-    validate_project_path(&config.project_path).map_err(|e| e.message.clone())?;
-    validate_session_name(config.name.as_deref())?;
-    validate_session_color(config.color.as_deref())?;
-    validate_cli(&config.queen_config.cli).map_err(|e| e.message.clone())?;
-
-    for worker in &config.workers {
-        validate_cli(&worker.cli).map_err(|e| e.message.clone())?;
-    }
-
-    if let Some(evaluator_config) = &config.evaluator_config {
-        if evaluator_config.cli.trim().is_empty() {
-            // Empty nested CLI means "inherit session default"; only validate explicit overrides.
-        } else {
-        validate_cli(&evaluator_config.cli).map_err(|e| e.message.clone())?;
-        }
-    }
-
-    if let Some(qa_workers) = &config.qa_workers {
-        for qa_worker in qa_workers {
-            validate_cli(&qa_worker.cli).map_err(|e| e.message.clone())?;
-            match qa_worker.specialization.as_str() {
-                "ui" | "api" | "a11y" => {}
-                other => {
-                    return Err(format!(
-                        "Invalid QA specialization '{}'. Valid options: ui, api, a11y",
-                        other
-                    ));
-                }
-            }
-        }
-    }
-
-    Ok(())
 }
 
 fn validate_research_launch_config(config: &ResearchLaunchConfig) -> Result<(), String> {
@@ -188,39 +171,70 @@ pub async fn launch_hive(
     )
 }
 
+// NOTE on return types: the migrated session commands return `serde_json::Value`
+// rather than the typed `Session` (which is `Serialize`-only, not `Deserialize`).
+// The action layer already serialized the typed result; Tauri serializes this
+// `Value` to byte-identical JSON, so the frontend `invoke()` wire contract is
+// unchanged — only the Rust-side return type differs.
 #[tauri::command]
 pub async fn get_session(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
-) -> Result<Option<Session>, String> {
-    let controller = state.0.read();
-    Ok(controller.get_session(&id))
+) -> Result<serde_json::Value, String> {
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.get",
+        json!({ "id": id }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn list_sessions(
-    state: State<'_, SessionControllerState>,
-) -> Result<Vec<Session>, String> {
-    let controller = state.0.read();
-    Ok(controller.list_sessions())
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+) -> Result<serde_json::Value, String> {
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.list",
+        json!({}),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn stop_session(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
 ) -> Result<(), String> {
-    let controller = state.0.read();
-    controller.stop_session(&id)
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.stop",
+        json!({ "id": id }),
+    )
+    .await?;
+    Ok(())
 }
 
 #[tauri::command]
 pub async fn close_session(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
 ) -> Result<(), String> {
-    let controller = state.0.read();
-    controller.close_session(&id)
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.close",
+        json!({ "id": id }),
+    )
+    .await?;
+    Ok(())
 }
 
 #[tauri::command]
@@ -235,12 +249,18 @@ pub async fn stop_agent(
 
 #[tauri::command]
 pub async fn launch_hive_v2(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: HiveLaunchConfig,
-) -> Result<Session, String> {
-    validate_hive_launch_config(&config)?;
-    let controller = state.0.read();
-    controller.launch_hive_v2(config)
+) -> Result<serde_json::Value, String> {
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_hive_v2",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]
@@ -362,14 +382,17 @@ pub async fn resume_session(
 
 #[tauri::command]
 pub async fn update_session_metadata(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     name: Option<Option<String>>,
     color: Option<Option<String>>,
-) -> Result<Session, String> {
-    validate_session_name(name.as_ref().and_then(|value| value.as_deref()))?;
-    validate_session_color(color.as_ref().and_then(|value| value.as_deref()))?;
-
-    let controller = state.0.read();
-    controller.update_session_metadata(&id, name, color)
+) -> Result<serde_json::Value, String> {
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.update_metadata",
+        json!({ "id": id, "name": name, "color": color }),
+    )
+    .await
 }

--- a/src-tauri/src/http/handlers/actions.rs
+++ b/src-tauri/src/http/handlers/actions.rs
@@ -1,0 +1,63 @@
+//! Generic HTTP entrypoints for the action registry.
+//!
+//! - `GET  /api/actions`        — list every registered action with its JSON Schema (AC1).
+//! - `POST /api/actions/{name}` — dispatch any registered action (caller = Http).
+//!   This is the future agent/MCP surface.
+
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use serde::Serialize;
+use serde_json::Value;
+use std::sync::Arc;
+
+use crate::actions::{ActionContext, Caller};
+use crate::http::error::ApiError;
+use crate::http::state::AppState;
+
+#[derive(Serialize)]
+pub struct ActionDescriptor {
+    pub name: String,
+    pub input_schema: Value,
+}
+
+#[derive(Serialize)]
+pub struct ListActionsResponse {
+    pub actions: Vec<ActionDescriptor>,
+}
+
+/// GET /api/actions — list registered actions and their input schemas.
+pub async fn list_actions(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<ListActionsResponse>, ApiError> {
+    let registry = state.registry();
+    let actions = registry
+        .list()
+        .into_iter()
+        .map(|(name, schema)| {
+            let input_schema = serde_json::to_value(&schema)
+                .map_err(|e| ApiError::internal(format!("Failed to serialize schema: {}", e)))?;
+            Ok(ActionDescriptor {
+                name: name.to_string(),
+                input_schema,
+            })
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+
+    Ok(Json(ListActionsResponse { actions }))
+}
+
+/// POST /api/actions/{name} — dispatch a registered action with caller = Http.
+/// The request body is the action's input JSON; the response is the action's
+/// raw output value (an envelope can wrap this later per #127).
+pub async fn dispatch_action(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    body: Option<Json<Value>>,
+) -> Result<Json<Value>, ApiError> {
+    let input = body.map(|Json(value)| value).unwrap_or(Value::Null);
+    let ctx = ActionContext::new(Caller::Http, Arc::clone(&state));
+    let output = state.registry().dispatch(&name, &ctx, input).await?;
+    Ok(Json(output))
+}

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -1,3 +1,4 @@
+pub mod actions;
 pub mod health;
 pub mod sessions;
 pub mod inject;

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use crate::http::state::AppState;
 use crate::http::handlers::{
-    agents, artifacts, cells, conversations, evaluator, events, health, heartbeats, inject,
+    actions, agents, artifacts, cells, conversations, evaluator, events, health, heartbeats, inject,
     learnings, planners, resolver, sessions, templates, workers,
 };
 
@@ -18,6 +18,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
 
     Router::new()
         .route("/health", get(health::health_check))
+        // Unified action registry surface (the future agent/MCP entrypoint).
+        // GET lists every action + schema; POST dispatches any action (caller=Http).
+        .route("/api/actions", get(actions::list_actions))
+        .route("/api/actions/{name}", post(actions::dispatch_action))
         .route("/api/sessions", get(sessions::list_sessions).post(sessions::create_session))
         // Heartbeat routes (active must be before {id} to match)
         .route("/api/sessions/active", get(heartbeats::get_active_sessions))

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -3,6 +3,7 @@ use tokio::sync::RwLock;
 use parking_lot::RwLock as PLRwLock;
 use tauri::{AppHandle, Emitter};
 
+use crate::actions::ActionRegistry;
 use crate::domain::event::{Event, EventType, Severity};
 use crate::storage::{AppConfig, SessionStorage};
 use crate::storage::ConversationMessage;
@@ -20,6 +21,11 @@ pub struct AppState {
     pub storage: Arc<SessionStorage>,
     pub event_bus: Arc<EventBus>,
     pub app_handle: Option<AppHandle>,
+    /// Unified action registry, dispatched by both the Tauri and HTTP surfaces.
+    /// Wrapped in `OnceLock` so `AppState` can be constructed before the registry
+    /// exists and then have it attached once (avoids a construction-order cycle:
+    /// the registry's actions reach back into `AppState` via `ActionContext`).
+    pub registry: std::sync::OnceLock<Arc<ActionRegistry>>,
 }
 
 impl AppState {
@@ -40,7 +46,21 @@ impl AppState {
             storage,
             event_bus,
             app_handle,
+            registry: std::sync::OnceLock::new(),
         }
+    }
+
+    /// Attach the action registry. Idempotent — the first set wins.
+    pub fn set_registry(&self, registry: Arc<ActionRegistry>) {
+        let _ = self.registry.set(registry);
+    }
+
+    /// The attached registry. Panics if dispatched-through before
+    /// [`AppState::set_registry`] ran (a startup-wiring bug, not a runtime path).
+    pub fn registry(&self) -> &Arc<ActionRegistry> {
+        self.registry
+            .get()
+            .expect("ActionRegistry not attached to AppState")
     }
 
     pub async fn emit_conversation_message(

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -42,6 +42,7 @@ async fn setup_test_app() -> axum::Router {
         event_bus,
         None,
     ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
 
     create_router(state)
 }
@@ -73,6 +74,7 @@ async fn setup_test_app_with_controller_at(
         event_bus,
         None,
     ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
 
     (create_router(state), session_controller, storage)
 }
@@ -98,6 +100,7 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
         event_bus,
         None,
     ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
 
     (create_router(state), session_controller)
 }
@@ -5259,4 +5262,183 @@ async fn test_resolver_launch_non_fusion_session_returns_400() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ---------------------------------------------------------------------------
+// #123 — unified Action contract: HTTP surface over the registry
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_action_endpoint_lists_schemas() {
+    let app = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/actions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    let actions = json.get("actions").unwrap().as_array().unwrap();
+
+    let names: Vec<&str> = actions
+        .iter()
+        .map(|a| a.get("name").unwrap().as_str().unwrap())
+        .collect();
+    assert!(names.contains(&"session.launch_hive_v2"));
+    assert!(names.contains(&"session.list"));
+    assert!(names.contains(&"git.pull"));
+
+    // Every descriptor carries a non-empty input_schema object.
+    for a in actions {
+        assert!(
+            a.get("input_schema").unwrap().is_object(),
+            "input_schema should be an object for {}",
+            a.get("name").unwrap()
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_http_dispatch_session_list_via_registry() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join("hive-test-action-session-list");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-actionlist", temp_dir.to_str().unwrap()));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/actions/session.list")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    let sessions = json.as_array().expect("session.list returns an array");
+    assert!(sessions
+        .iter()
+        .any(|s| s.get("id").and_then(|v| v.as_str()) == Some("session-actionlist")));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_same_handler_both_callers() {
+    use crate::actions::{build_registry, ActionContext, Caller};
+    use crate::coordination::InjectionManager;
+    use crate::events::EventBus;
+    use crate::pty::PtyManager;
+
+    // Build a hermetic state + controller and insert one session.
+    let storage = Arc::new(SessionStorage::new().unwrap());
+    let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    session_controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new().unwrap(),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller.clone(),
+        injection_manager,
+        storage,
+        event_bus,
+        None,
+    ));
+    state.set_registry(Arc::new(build_registry()));
+
+    let temp_dir = std::env::temp_dir().join("hive-test-action-both-callers");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    session_controller
+        .read()
+        .insert_test_session(make_test_session("session-both", temp_dir.to_str().unwrap()));
+
+    let registry = state.registry().clone();
+
+    // Dispatch the SAME action with two different callers.
+    let frontend_ctx = ActionContext::new(Caller::Frontend, state.clone());
+    let http_ctx = ActionContext::new(Caller::Http, state.clone());
+
+    let frontend_out = registry
+        .dispatch("session.list", &frontend_ctx, serde_json::json!({}))
+        .await
+        .unwrap();
+    let http_out = registry
+        .dispatch("session.list", &http_ctx, serde_json::json!({}))
+        .await
+        .unwrap();
+
+    // Same handler, same payload regardless of caller (AC2).
+    assert_eq!(frontend_out, http_out);
+    assert!(frontend_out
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|s| s.get("id").and_then(|v| v.as_str()) == Some("session-both")));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_http_action_validation_rejects_bad_color() {
+    let app = setup_test_app().await;
+
+    // Invalid color must be rejected with 400 before the controller runs (AC3).
+    let body = serde_json::json!({ "id": "sess-x", "color": "purple" });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/actions/session.update_metadata")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_http_action_unknown_returns_404() {
+    let app = setup_test_app().await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/actions/does.not.exist")
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+pub mod actions;
 pub mod artifacts;
 pub mod domain;
 pub mod adapters;
@@ -20,10 +21,11 @@ use std::sync::Arc;
 use std::time::Duration;
 use parking_lot::RwLock;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use crate::actions::ActionRegistry;
 use crate::domain::event::EventType;
 use crate::http::handlers::cells::build_cells;
 use crate::http::state::AppState;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 
 use commands::{
     create_pty, get_pty_status, kill_pty, list_ptys, paste_to_pty, resize_pty, write_to_pty, inject_to_pty,
@@ -71,6 +73,10 @@ pub fn run() {
         controller.set_event_bus(Arc::clone(&event_bus));
     }
 
+    // Unified action registry — the single registration point shared by the
+    // Tauri #[command] wrappers (caller=Frontend) and the HTTP layer (caller=Http).
+    let action_registry: Arc<ActionRegistry> = Arc::new(crate::actions::build_registry());
+
     tauri::Builder::default()
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
@@ -82,6 +88,7 @@ pub fn run() {
         .manage(SessionControllerState(Arc::clone(&session_controller)))
         .manage(CoordinationState(Arc::clone(&injection_manager)))
         .manage(StorageState(Arc::clone(&storage)))
+        .manage(Arc::clone(&action_registry))
         .setup(move |app| {
             // Set app handle for event emission
             {
@@ -92,6 +99,23 @@ pub fn run() {
                 let mut injection = injection_manager.write();
                 injection.set_app_handle(app.handle().clone());
             }
+
+            // Build the SINGLE shared AppState now that the app handle exists, and
+            // hand the SAME Arc to both the Tauri-managed state (used by migrated
+            // #[command]s via the action registry) and the HTTP server below.
+            // This unifies the two former state holders onto one Arc<AppState>.
+            let app_state = Arc::new(AppState::new(
+                shared_config.clone(),
+                Arc::clone(&pty_manager),
+                Arc::clone(&session_controller),
+                Arc::clone(&injection_manager),
+                Arc::clone(&storage),
+                Arc::clone(&event_bus),
+                Some(app.handle().clone()),
+            ));
+            // Attach the shared registry so HTTP handlers can dispatch actions.
+            app_state.set_registry(Arc::clone(&action_registry));
+            app.manage(Arc::clone(&app_state));
 
             // Stall detection background task - runs every 60s, emits agent-stalled/agent-recovered
             let stall_controller = session_controller.clone();
@@ -249,29 +273,18 @@ pub fn run() {
                 }
             });
 
-            // Start HTTP server if enabled
-            let http_config = shared_config.clone();
-            let http_session_controller = session_controller.clone();
-            let http_event_bus = event_bus.clone();
-            let http_app_handle = app.handle().clone();
+            // Start HTTP server if enabled, sharing the SAME Arc<AppState> the
+            // Tauri command surface uses so both surfaces see identical state.
+            let http_state = Arc::clone(&app_state);
             tauri::async_runtime::spawn(async move {
                 let (enabled, port) = {
-                    let cfg = http_config.read().await;
+                    let cfg = http_state.config.read().await;
                     (cfg.api.enabled, cfg.api.port)
                 };
 
                 if enabled {
                     tracing::info!("Starting HTTP API on port {}", port);
-                    let state = Arc::new(AppState::new(
-                        http_config,
-                        pty_manager.clone(),
-                        http_session_controller.clone(),
-                        injection_manager.clone(),
-                        storage.clone(),
-                        http_event_bus,
-                        Some(http_app_handle),
-                    ));
-                    if let Err(e) = http::serve(state, port).await {
+                    if let Err(e) = http::serve(http_state, port).await {
                         tracing::error!("HTTP server error: {}", e);
                     }
                 }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -28,7 +28,7 @@ pub enum AgentStatus {
 }
 
 /// Worker role configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkerRole {
     pub role_type: String,          // "backend", "frontend", "coherence", "simplify", or custom
     pub label: String,              // Display name
@@ -53,7 +53,7 @@ impl Default for WorkerRole {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct AgentConfig {
     #[serde(default = "default_cli")]
     pub cli: String,              // "claude", "gemini", "antigravity", "opencode", "codex"

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -303,7 +303,7 @@ pub struct AgentInfo {
     pub base_commit_sha: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct HiveLaunchConfig {
     pub project_path: String,
     #[serde(default)]
@@ -412,7 +412,7 @@ pub struct SwarmLaunchConfig {
     pub planners: Vec<PlannerConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, schemars::JsonSchema)]
 pub struct QaWorkerConfig {
     pub specialization: String,
     pub cli: String,


### PR DESCRIPTION
## Summary

First slice of the **agent-native-engine** epic (#123–#128). Introduces a unified **Action contract** — a Rust action registry where each operation is defined once (`{ name, input schema, validate, run(ctx, input) }`) and dispatched from multiple callers (`Frontend | Agent | Cli | Http`) through one handler. This is the seam a first-class agent loop / MCP surface will reuse for free.

Resolves #123.

## What landed

- **`actions/` module**: `Caller` enum + `ActionContext { caller, state: Arc<AppState> }`, `ActionError` (→ `ApiError` incl. `conflict_with_details`, `From<String>`, and `to_message()` for the Tauri side), an object-safe `async` `Action` trait (`async-trait`), and `ActionRegistry` that **validates before run** and lists every action with its `schemars 0.8` JSON Schema via a single `build_registry()`.
- **Migrated**: the 6 required session ops + all 10 git ops to actions. `run_git_in_dir` moved into `actions::git` with its `#[cfg(windows)]` `CREATE_NO_WINDOW` flag preserved exactly (no console flash on Windows).
- **Tauri**: `#[command]` bodies now dispatch with `caller=Frontend`. **Every command name + signature is preserved** and the `generate_handler!` list is unchanged, so the Svelte `invoke()` contract holds (migrated commands return `serde_json::Value` that serializes byte-identically to the prior typed `Session`).
- **HTTP**: `GET /api/actions` (names + schemas), `POST /api/actions/{name}` (dispatch `caller=Http`).
- **State unification (the key risk)**: `lib.rs` now builds **one** `Arc<RwLock<SessionController>>` and shares it across the legacy `SessionControllerState`, `AppState.session_controller`, and the HTTP server — the two former state holders collapse to one. No `parking_lot` guard is held across an `.await`.
- `schemars::JsonSchema` derives added to the action input DTOs at their definition sites (`WorkerRole`, `AgentConfig`, `HiveLaunchConfig`, `QaWorkerConfig`) — 4 lines, additive only.

## Acceptance criteria

- [x] (1) Single registry lists all actions with input schemas — `ActionRegistry::list()` + `GET /api/actions`.
- [x] (2) Session **and** git callable from both Tauri invoke and HTTP via the same handler — one `Action::run`, dispatched by `caller=Frontend` (Tauri) and `caller=Http` (`/api/actions/{name}`); proven by `test_same_handler_both_callers`.
- [x] (3) Validation runs once, before run, regardless of caller — `dispatch()` calls `validate_input()` first.
- [x] (4) Caller available inside run — `ActionContext` carries `Caller`; `test_caller_visible_in_run` round-trips all four variants.

## Testing

- ✅ `cargo check --tests` — **0 errors, 0 warnings**.
- ✅ `npm run check` — green (command names preserved → no TS change).
- ✅ Unit tests (`actions/tests.rs`: registry listing, schema-per-action, validate-before-run, caller-visible) + HTTP integration tests (`http/tests.rs`: dispatch via router, validation rejects bad input, both-callers equal payloads) added.
- ⚠️ Same pre-existing `cargo test` loader caveat as #130 — the Tauri lib test binary aborts at load with `0xC0000139 STATUS_ENTRYPOINT_NOT_FOUND` (`conpty.dll` via `portable-pty`, untouched by this PR; `format_poll_label` fails identically). Tests compile and were reviewed; not observed green on this machine.

## Deferred (deliberate conservative scoping, noted for follow-up)

- The existing **typed** HTTP session routes (`GET/PATCH /api/sessions/{id}`, the `launch_*` POSTs) were left intact rather than repointed through the registry, to preserve their response shapes and passing tests. AC2 is satisfied via the generic `/api/actions/{name}` path; a follow-up can repoint them so there's a single session HTTP path.
- Because those typed routes remain, the name/color validators are temporarily **duplicated** across `actions/session`, `commands/session_commands.rs`, and `http/handlers/sessions.rs`. Consolidating (or delegating to the action DTO validators) belongs to the same follow-up.
- Only `session` + `git` migrated per AC2; `pty`/`coordination` actions deferred per the plan.

## Notes

- Independent adversarial `code-reviewer` pass: verdict **pass**, no blockers; state unification, command-name preservation, and `CREATE_NO_WINDOW` each explicitly verified.
- Branches from `main`, independent of #124.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Unified action system for executing session and git operations via both Tauri and HTTP.
  * Added HTTP endpoints to list available actions and execute a selected action at `/api/actions`.

* **Improvements**
  * Stronger, structured error responses with clearer status handling.
  * Action request context now tracks the caller type (Frontend, Agent, CLI, HTTP) for consistent behavior.
  * Action schemas are generated and exposed via JSON schema.

* **Tests**
  * Added coverage for the unified action contract and HTTP dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->