### PR TITLE
feat(ui): native tool-render registry — inline DataTable/Diff/Approval widgets (#127)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-manager",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-manager",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",
@@ -27,11 +27,177 @@
         "@sveltejs/kit": "^2.9.0",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
         "@tauri-apps/cli": "^2",
+        "@testing-library/svelte": "^5.2.4",
+        "jsdom": "^25.0.1",
         "svelte": "^5.0.0",
         "svelte-check": "^4.0.0",
         "typescript": "~5.6.2",
         "vite": "^6.0.3",
         "vitest": "^2.1.9"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1208,6 +1374,83 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/svelte": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte/-/svelte-5.3.1.tgz",
+      "integrity": "sha512-8Ez7ZOqW5geRf9PF5rkuopODe5RGy3I9XR+kc7zHh26gBiktLaxTfKmhlGaSHYUOTQE7wFsLMN9xCJVCszw47w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@testing-library/dom": "9.x.x || 10.x.x",
+        "@testing-library/svelte-core": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0",
+        "vite": "*",
+        "vitest": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        },
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/svelte-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/svelte-core/-/svelte-core-1.0.0.tgz",
+      "integrity": "sha512-VkUePoLV6oOYwSUvX6ShA8KLnJqZiYMIbP2JW2t0GLWLkJxKGvuH5qrrZBV/X7cXFnLGuFQEC7RheYiZOW68KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "svelte": "^3 || ^4 || ^5 || ^5.0.0-next.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmmirror.com/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1355,6 +1598,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.2",
       "resolved": "https://registry.npmmirror.com/aria-query/-/aria-query-5.3.2.tgz",
@@ -1374,6 +1650,13 @@
         "node": ">=12"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmmirror.com/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1391,6 +1674,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/chai": {
@@ -1445,6 +1742,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.6.0",
       "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.6.0.tgz",
@@ -1453,6 +1763,41 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -1472,6 +1817,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -1493,11 +1845,86 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/devalue": {
       "version": "5.6.2",
       "resolved": "https://registry.npmmirror.com/devalue/-/devalue-5.6.2.tgz",
       "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1505,6 +1932,35 @@
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1600,6 +2056,23 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.3.tgz",
@@ -1613,6 +2086,171 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-reference": {
       "version": "3.0.3",
@@ -1628,6 +2266,54 @@
       "resolved": "https://registry.npmmirror.com/js-base64/-/js-base64-3.7.8.tgz",
       "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -1652,6 +2338,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
@@ -1659,6 +2362,39 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/mri": {
@@ -1705,6 +2441,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/pathe": {
@@ -1792,6 +2548,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmmirror.com/readdirp/-/readdirp-4.1.2.tgz",
@@ -1851,6 +2639,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sade": {
       "version": "1.8.1",
       "resolved": "https://registry.npmmirror.com/sade/-/sade-1.8.1.tgz",
@@ -1862,6 +2657,26 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -1967,6 +2782,13 @@
         "typescript": ">=5.0.0"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
@@ -2028,6 +2850,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmmirror.com/totalist/-/totalist-3.0.1.tgz",
@@ -2036,6 +2878,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/typescript": {
@@ -3243,6 +4111,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmmirror.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3259,6 +4188,45 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/zimmerframe": {
       "version": "1.1.4",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "tauri": "tauri"
   },
   "license": "MIT",
@@ -31,6 +33,8 @@
     "@sveltejs/kit": "^2.9.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tauri-apps/cli": "^2",
+    "@testing-library/svelte": "^5.2.4",
+    "jsdom": "^25.0.1",
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "typescript": "~5.6.2",

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -3,6 +3,7 @@
   import { conversationStore, type ConversationMessage } from '$lib/stores/conversations';
   import { activeSession } from '$lib/stores/sessions';
   import AgentStatusBar from './AgentStatusBar.svelte';
+  import ToolRenderHost from './renderers/ToolRenderHost.svelte';
 
   let messageContainer: HTMLDivElement;
   let autoScroll = true;
@@ -100,6 +101,16 @@
     }
   }
 
+  // Approval widget signals. Wiring approve/reject to the queen/worker is #123's
+  // Action contract; for #127 we console-log so the widget is demonstrable.
+  function handleApprove(detail: { actionId?: string }) {
+    console.log('[tool-render] approve', detail?.actionId ?? null);
+  }
+
+  function handleReject(detail: { actionId?: string }) {
+    console.log('[tool-render] reject', detail?.actionId ?? null);
+  }
+
   function getSenderColor(from: string): string {
     if (from === 'queen') return 'var(--accent-cyan)';
     if (from === 'system' || from === 'SYSTEM') return 'var(--accent-chrome)';
@@ -176,7 +187,17 @@
         <div class="message">
           <span class="msg-time">{formatTimestamp(msg.timestamp)}</span>
           <span class="msg-sender" style="color: {getSenderColor(msg.from)}">{msg.from}</span>
-          <span class="msg-content">{msg.content}</span>
+          {#if msg.renderer || msg.data}
+            <div class="msg-content msg-widget">
+              <ToolRenderHost
+                message={msg}
+                onapprove={handleApprove}
+                onreject={handleReject}
+              />
+            </div>
+          {:else}
+            <span class="msg-content">{msg.content}</span>
+          {/if}
         </div>
       {/each}
     {/if}
@@ -319,6 +340,11 @@
   .msg-content {
     color: var(--text-primary);
     word-break: break-word;
+  }
+
+  .msg-widget {
+    flex: 1;
+    min-width: 0;
   }
 
   .input-bar {

--- a/src/lib/components/renderers/Approval.svelte
+++ b/src/lib/components/renderers/Approval.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  /**
+   * Approval tool-render widget.
+   *
+   * data shape: { title: string; description?: string; actionId?: string; destructive?: boolean }
+   *
+   * Invokes the optional `onapprove` / `onreject` callback props with
+   * { actionId } (Svelte 5 runes idiom). Wiring these to the queen/worker is OUT
+   * OF SCOPE for #127 (no general "approve tool result" endpoint exists; that
+   * belongs to #123's Action contract). For now ToolRenderHost re-emits them as
+   * Svelte events and ConversationViewer console-logs them, so the widget and
+   * the future contract are independently testable.
+   */
+  import type { ToolRendererProps } from './registry';
+
+  let { data, onapprove, onreject }: ToolRendererProps = $props();
+
+  interface ApprovalData {
+    title?: string;
+    description?: string;
+    actionId?: string;
+    destructive?: boolean;
+  }
+
+  function asApproval(value: unknown): ApprovalData {
+    if (value && typeof value === 'object') return value as ApprovalData;
+    return {};
+  }
+
+  const approval = $derived(asApproval(data));
+
+  function approve() {
+    onapprove?.({ actionId: approval.actionId });
+  }
+
+  function reject() {
+    onreject?.({ actionId: approval.actionId });
+  }
+</script>
+
+<div class="approval-widget" class:destructive={approval.destructive}>
+  <div class="approval-body">
+    <div class="approval-title">{approval.title ?? 'Approval required'}</div>
+    {#if approval.description}
+      <div class="approval-desc">{approval.description}</div>
+    {/if}
+  </div>
+  <div class="approval-actions">
+    <button class="approve-btn" data-testid="approve" onclick={approve}>
+      Approve
+    </button>
+    <button class="reject-btn" data-testid="reject" onclick={reject}>
+      Reject
+    </button>
+  </div>
+</div>
+
+<style>
+  .approval-widget {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    background: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
+    border: 1px solid var(--border-structural);
+    border-left: 3px solid var(--accent-cyan);
+    border-radius: var(--radius-sm);
+    padding: 12px;
+  }
+
+  .approval-widget.destructive {
+    border-left-color: var(--status-error);
+  }
+
+  .approval-title {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .approval-desc {
+    font-size: 11px;
+    color: var(--text-secondary);
+    margin-top: 4px;
+    line-height: 1.5;
+  }
+
+  .approval-actions {
+    display: flex;
+    gap: 8px;
+  }
+
+  .approve-btn,
+  .reject-btn {
+    padding: 5px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    border: none;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+  }
+
+  .approve-btn {
+    background: var(--status-success);
+    color: white;
+  }
+
+  .destructive .approve-btn {
+    background: var(--status-error);
+  }
+
+  .reject-btn {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-structural);
+    color: var(--text-secondary);
+  }
+
+  .approve-btn:hover {
+    opacity: 0.9;
+  }
+
+  .reject-btn:hover {
+    color: var(--text-primary);
+    border-color: var(--text-secondary);
+  }
+</style>

--- a/src/lib/components/renderers/Chart.svelte
+++ b/src/lib/components/renderers/Chart.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  /**
+   * Chart tool-render widget — STUB.
+   *
+   * No charting library is a dependency yet, so this reserves the 'chart' id and
+   * renders the JSON fallback plus a "not yet implemented" note. Deferring real
+   * charting keeps #127 to a single session.
+   */
+  import type { ToolRendererProps } from './registry';
+
+  let { data }: ToolRendererProps = $props();
+
+  const json = $derived(JSON.stringify(data, null, 2));
+</script>
+
+<div class="chart-widget">
+  <div class="chart-note">Chart renderer not yet implemented — showing raw data.</div>
+  <pre class="chart-json">{json}</pre>
+</div>
+
+<style>
+  .chart-widget {
+    background: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .chart-note {
+    padding: 4px 8px;
+    font-size: 10px;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .chart-json {
+    margin: 0;
+    padding: 8px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow-x: auto;
+  }
+</style>

--- a/src/lib/components/renderers/DataTable.svelte
+++ b/src/lib/components/renderers/DataTable.svelte
@@ -1,0 +1,198 @@
+<script lang="ts">
+  /**
+   * DataTable tool-render widget.
+   *
+   * data shape: { columns?: string[]; rows: Record<string, unknown>[] }
+   * Columns auto-infer from the union of the first row's keys when absent.
+   * Click a header to sort (cycles asc -> desc -> none). v1: no virtualization;
+   * a notice is shown above the table past ROW_CAP rows.
+   */
+  import type { ToolRendererProps } from './registry';
+
+  let { data }: ToolRendererProps = $props();
+
+  const ROW_CAP = 500;
+
+  interface TableData {
+    columns?: string[];
+    rows: Record<string, unknown>[];
+  }
+
+  function asTableData(value: unknown): TableData {
+    if (value && typeof value === 'object' && Array.isArray((value as TableData).rows)) {
+      return value as TableData;
+    }
+    return { rows: [] };
+  }
+
+  const table = $derived(asTableData(data));
+
+  const columns = $derived.by<string[]>(() => {
+    if (table.columns && table.columns.length > 0) {
+      return table.columns;
+    }
+    const first = table.rows[0];
+    return first ? Object.keys(first) : [];
+  });
+
+  let sortKey = $state<string | null>(null);
+  let sortDir = $state<'asc' | 'desc'>('asc');
+
+  function cycleSort(key: string) {
+    if (sortKey !== key) {
+      sortKey = key;
+      sortDir = 'asc';
+    } else if (sortDir === 'asc') {
+      sortDir = 'desc';
+    } else {
+      sortKey = null;
+      sortDir = 'asc';
+    }
+  }
+
+  function compare(a: unknown, b: unknown): number {
+    if (a === b) return 0;
+    if (a === null || a === undefined) return -1;
+    if (b === null || b === undefined) return 1;
+    if (typeof a === 'number' && typeof b === 'number') return a - b;
+    return String(a).localeCompare(String(b));
+  }
+
+  const sortedRows = $derived.by<Record<string, unknown>[]>(() => {
+    const rows = table.rows.slice(0, ROW_CAP);
+    if (!sortKey) return rows;
+    const key = sortKey;
+    const dir = sortDir === 'asc' ? 1 : -1;
+    return rows.slice().sort((ra, rb) => compare(ra[key], rb[key]) * dir);
+  });
+
+  function cellText(value: unknown): string {
+    if (value === null || value === undefined) return '';
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  }
+</script>
+
+<div class="data-table-widget">
+  {#if table.rows.length > ROW_CAP}
+    <div class="notice">Showing first {ROW_CAP} of {table.rows.length} rows.</div>
+  {/if}
+  {#if columns.length === 0}
+    <div class="empty">No tabular data.</div>
+  {:else}
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr>
+            {#each columns as col (col)}
+              <th>
+                <button class="th-btn" onclick={() => cycleSort(col)}>
+                  <span>{col}</span>
+                  {#if sortKey === col}
+                    <span class="sort-arrow">{sortDir === 'asc' ? '▲' : '▼'}</span>
+                  {/if}
+                </button>
+              </th>
+            {/each}
+          </tr>
+        </thead>
+        <tbody>
+          {#each sortedRows as row, i (i)}
+            <tr>
+              {#each columns as col (col)}
+                <td>{cellText(row[col])}</td>
+              {/each}
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .data-table-widget {
+    background: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .notice {
+    padding: 4px 8px;
+    font-size: 10px;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .empty {
+    padding: 12px;
+    font-size: 11px;
+    color: var(--text-secondary);
+    font-style: italic;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+    max-height: 360px;
+    overflow-y: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-mono);
+    font-size: 11px;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border-structural);
+    text-align: left;
+    padding: 0;
+    z-index: 1;
+  }
+
+  .th-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    width: 100%;
+    padding: 6px 8px;
+    background: none;
+    border: none;
+    color: var(--accent-cyan);
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .th-btn:hover {
+    color: var(--text-primary);
+  }
+
+  .sort-arrow {
+    font-size: 9px;
+    color: var(--accent-cyan);
+  }
+
+  td {
+    padding: 4px 8px;
+    border-bottom: 1px solid color-mix(in srgb, var(--border-structural) 50%, transparent);
+    color: var(--text-primary);
+    word-break: break-word;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  tbody tr:hover td {
+    background: color-mix(in srgb, var(--accent-cyan) 5%, transparent);
+  }
+</style>

--- a/src/lib/components/renderers/Diff.svelte
+++ b/src/lib/components/renderers/Diff.svelte
@@ -1,0 +1,202 @@
+<script lang="ts" module>
+  /**
+   * Unified-diff line model. Exported from the module context so the parser can
+   * be unit-tested and reused.
+   */
+  export type DiffLineKind = 'add' | 'del' | 'ctx' | 'meta';
+
+  export interface DiffLine {
+    kind: DiffLineKind;
+    text: string;
+  }
+
+  export interface DiffHunk {
+    lines: DiffLine[];
+  }
+
+  export interface DiffFile {
+    path: string;
+    hunks?: DiffHunk[];
+  }
+
+  export interface DiffData {
+    unified?: string;
+    files?: DiffFile[];
+  }
+
+  /**
+   * Parse a unified-diff string into add/del/ctx/meta lines.
+   *  - '+++' / '---' / 'diff '/'index ' headers -> meta
+   *  - '@@' hunk markers -> meta (also delimit context)
+   *  - leading '+' -> add, leading '-' -> del, else -> ctx
+   * Returns [] when the input yields nothing meaningful so the caller can fall
+   * back to a raw <pre>.
+   */
+  export function parseUnifiedDiff(unified: string): DiffLine[] {
+    if (!unified) return [];
+    const out: DiffLine[] = [];
+    for (const raw of unified.split('\n')) {
+      if (
+        raw.startsWith('+++') ||
+        raw.startsWith('---') ||
+        raw.startsWith('diff ') ||
+        raw.startsWith('index ') ||
+        raw.startsWith('@@')
+      ) {
+        out.push({ kind: 'meta', text: raw });
+      } else if (raw.startsWith('+')) {
+        out.push({ kind: 'add', text: raw.slice(1) });
+      } else if (raw.startsWith('-')) {
+        out.push({ kind: 'del', text: raw.slice(1) });
+      } else {
+        out.push({ kind: 'ctx', text: raw.startsWith(' ') ? raw.slice(1) : raw });
+      }
+    }
+    return out;
+  }
+
+  const COUNTABLE: DiffLineKind[] = ['add', 'del', 'ctx'];
+
+  /** True if the parsed result contains at least one real (non-meta) line. */
+  function hasContent(lines: DiffLine[]): boolean {
+    return lines.some((l) => COUNTABLE.includes(l.kind));
+  }
+</script>
+
+<script lang="ts">
+  import type { ToolRendererProps } from './registry';
+
+  let { data }: ToolRendererProps = $props();
+
+  function asDiffData(value: unknown): DiffData {
+    if (value && typeof value === 'object') return value as DiffData;
+    if (typeof value === 'string') return { unified: value };
+    return {};
+  }
+
+  const diff = $derived(asDiffData(data));
+
+  // Prefer structured `files` when present; otherwise parse `unified`.
+  const fromUnified = $derived.by<DiffLine[]>(() =>
+    diff.unified ? parseUnifiedDiff(diff.unified) : [],
+  );
+
+  const structuredLines = $derived.by<DiffLine[]>(() => {
+    if (!diff.files || diff.files.length === 0) return [];
+    const lines: DiffLine[] = [];
+    for (const file of diff.files) {
+      lines.push({ kind: 'meta', text: file.path });
+      for (const hunk of file.hunks ?? []) {
+        for (const ln of hunk.lines ?? []) {
+          lines.push(ln);
+        }
+      }
+    }
+    return lines;
+  });
+
+  const lines = $derived(structuredLines.length > 0 ? structuredLines : fromUnified);
+  const renderable = $derived(hasContent(lines));
+
+  const rawText = $derived(
+    diff.unified ?? (typeof data === 'string' ? data : JSON.stringify(data, null, 2)),
+  );
+
+  function prefix(kind: DiffLineKind): string {
+    if (kind === 'add') return '+';
+    if (kind === 'del') return '-';
+    if (kind === 'meta') return '';
+    return ' ';
+  }
+</script>
+
+<div class="diff-widget">
+  {#if renderable}
+    <div class="diff-body">
+      {#each lines as line, i (i)}
+        <div class="diff-line {line.kind}">
+          <span class="gutter">{prefix(line.kind)}</span>
+          <span class="line-text">{line.text}</span>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <pre class="diff-raw">{rawText}</pre>
+  {/if}
+</div>
+
+<style>
+  .diff-widget {
+    background: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .diff-body {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.5;
+    overflow-x: auto;
+  }
+
+  .diff-line {
+    display: flex;
+    gap: 6px;
+    padding: 0 8px;
+    white-space: pre;
+  }
+
+  .gutter {
+    flex-shrink: 0;
+    width: 10px;
+    text-align: center;
+    color: var(--text-secondary);
+    user-select: none;
+  }
+
+  .line-text {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  .diff-line.add {
+    background: color-mix(in srgb, var(--status-success) 10%, transparent);
+  }
+
+  .diff-line.add .line-text,
+  .diff-line.add .gutter {
+    color: var(--status-success);
+  }
+
+  .diff-line.del {
+    background: color-mix(in srgb, var(--status-error) 10%, transparent);
+  }
+
+  .diff-line.del .line-text,
+  .diff-line.del .gutter {
+    color: var(--status-error);
+  }
+
+  .diff-line.ctx .line-text {
+    color: var(--text-secondary);
+  }
+
+  .diff-line.meta {
+    background: var(--bg-surface);
+  }
+
+  .diff-line.meta .line-text {
+    color: var(--accent-chrome);
+    font-weight: 600;
+  }
+
+  .diff-raw {
+    margin: 0;
+    padding: 8px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+    overflow-x: auto;
+  }
+</style>

--- a/src/lib/components/renderers/ToolRenderHost.svelte
+++ b/src/lib/components/renderers/ToolRenderHost.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+  /**
+   * Dispatch host for tool-render widgets.
+   *
+   * Resolves a renderer for a ConversationMessage and mounts it dynamically
+   * (Svelte 5 runes: components are dynamic by default), forwarding the widget's
+   * approve / reject signals up to the chat core via optional callback props. On
+   * NO match OR any thrown render error, falls back to a formatted-JSON <pre> of
+   * `data ?? content` (issue #127, criterion 3).
+   *
+   * This is the ONLY component the chat core dispatches to — adding a new
+   * renderer never requires editing ConversationViewer (criterion 4).
+   */
+  import type { ConversationMessage } from '$lib/stores/conversations';
+  import { resolveToolRenderer, type ApprovalActionDetail } from './registry';
+  import { registerBuiltinRenderers } from './builtins';
+
+  let {
+    message,
+    onapprove,
+    onreject,
+  }: {
+    message: ConversationMessage;
+    onapprove?: (detail: ApprovalActionDetail) => void;
+    onreject?: (detail: ApprovalActionDetail) => void;
+  } = $props();
+
+  // Ensure built-ins are registered before the first resolve. Idempotent.
+  registerBuiltinRenderers();
+
+  const resolved = $derived(
+    resolveToolRenderer({
+      renderer: message.renderer,
+      toolName: message.from,
+      data: message.data,
+    }),
+  );
+
+  // The data handed to the widget; fall back to the message content when the
+  // envelope carried no structured data.
+  const widgetData = $derived(message.data ?? message.content);
+
+  // Capitalized alias so the template can mount it directly (Svelte 5 runes:
+  // components are dynamic by default, no <svelte:component> needed). A
+  // render-time throw inside the widget is caught by the <svelte:boundary>
+  // below, which drops back to the fallback (criterion 3).
+  const Widget = $derived(resolved?.component ?? null);
+
+  const fallbackJson = $derived.by(() => {
+    const value = message.data ?? message.content;
+    try {
+      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+    } catch {
+      return String(value);
+    }
+  });
+
+  function forwardApprove(detail: ApprovalActionDetail) {
+    onapprove?.(detail);
+  }
+
+  function forwardReject(detail: ApprovalActionDetail) {
+    onreject?.(detail);
+  }
+</script>
+
+<div class="tool-render-host">
+  {#if Widget}
+    <svelte:boundary>
+      <Widget data={widgetData} onapprove={forwardApprove} onreject={forwardReject} />
+      {#snippet failed()}
+        <pre class="tool-render-fallback">{fallbackJson}</pre>
+      {/snippet}
+    </svelte:boundary>
+  {:else}
+    <pre class="tool-render-fallback">{fallbackJson}</pre>
+  {/if}
+</div>
+
+<style>
+  .tool-render-host {
+    width: 100%;
+  }
+
+  .tool-render-fallback {
+    margin: 0;
+    padding: 8px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-secondary);
+    background: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/src/lib/components/renderers/ToolRenderHost.svelte.test.ts
+++ b/src/lib/components/renderers/ToolRenderHost.svelte.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, fireEvent, cleanup } from '@testing-library/svelte';
+import ToolRenderHost from './ToolRenderHost.svelte';
+import type { ConversationMessage } from '$lib/stores/conversations';
+import {
+  rendererCount,
+  registerBuiltinRenderers,
+  resetBuiltinRegistration,
+  clearAllRenderers,
+} from './index';
+
+// @testing-library/svelte mounts real Svelte 5 components in jsdom (this file
+// matches **/*.svelte.test.ts -> jsdom per vite.config). Tauri APIs are never
+// touched here, but conversations.ts imports @tauri-apps/api/event at module
+// load, so stub it to avoid a real Tauri runtime.
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+function message(over: Partial<ConversationMessage>): ConversationMessage {
+  return {
+    timestamp: '2026-06-19T00:00:00Z',
+    from: 'queen',
+    content: 'plain content',
+    ...over,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ToolRenderHost', () => {
+  it('mounts the Diff widget for renderer:"diff" (criterion 2)', () => {
+    const msg = message({
+      renderer: 'diff',
+      data: { unified: '@@ -1 +1 @@\n+added line\n-removed line\n context' },
+    });
+    const { container } = render(ToolRenderHost, { props: { message: msg } });
+
+    // A real diff widget renders add/del lines, NOT raw text.
+    const addLine = container.querySelector('.diff-line.add');
+    const delLine = container.querySelector('.diff-line.del');
+    expect(addLine).not.toBeNull();
+    expect(delLine).not.toBeNull();
+    expect(addLine?.textContent).toContain('added line');
+  });
+
+  it('renders the <pre> JSON fallback for an unknown renderer (criterion 3)', () => {
+    const msg = message({ renderer: 'future-widget', data: { a: 1, b: 'two' } });
+    const { container } = render(ToolRenderHost, { props: { message: msg } });
+
+    const fallback = container.querySelector('pre.tool-render-fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toContain('"a": 1');
+    expect(fallback?.textContent).toContain('"b": "two"');
+    // No widget mounted.
+    expect(container.querySelector('.diff-line')).toBeNull();
+  });
+
+  it('invokes onapprove with the actionId when the Approval card button is clicked', async () => {
+    const msg = message({
+      renderer: 'approval',
+      from: 'queen',
+      data: { title: 'Deploy?', actionId: 'act-42' },
+    });
+    const onapprove = vi.fn();
+    const { container } = render(ToolRenderHost, {
+      props: { message: msg, onapprove },
+    });
+
+    const btn = container.querySelector('[data-testid="approve"]') as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    await fireEvent.click(btn);
+
+    expect(onapprove).toHaveBeenCalledTimes(1);
+    const detail = onapprove.mock.calls[0][0] as { actionId?: string };
+    expect(detail.actionId).toBe('act-42');
+  });
+
+  it('registerBuiltinRenderers is idempotent', () => {
+    // Built-ins were registered during the renders above. Re-running must not
+    // grow the registry.
+    const before = rendererCount();
+    registerBuiltinRenderers();
+    registerBuiltinRenderers();
+    expect(rendererCount()).toBe(before);
+
+    // And from a fully-cleared slate, a single re-registration restores exactly
+    // the four built-ins.
+    clearAllRenderers();
+    resetBuiltinRegistration();
+    registerBuiltinRenderers();
+    registerBuiltinRenderers();
+    expect(rendererCount()).toBe(4);
+  });
+});

--- a/src/lib/components/renderers/builtins.ts
+++ b/src/lib/components/renderers/builtins.ts
@@ -1,0 +1,35 @@
+/**
+ * Built-in renderer registration.
+ *
+ * This is the single place the four built-in widgets are wired to their ids.
+ * `registerBuiltinRenderers()` is idempotent (guarded by a module flag) and is
+ * called once from ToolRenderHost on init.
+ */
+
+import { registerToolRenderer, type ToolRendererComponent } from './registry';
+import DataTable from './DataTable.svelte';
+import Diff from './Diff.svelte';
+import Approval from './Approval.svelte';
+import Chart from './Chart.svelte';
+
+let registered = false;
+
+export function registerBuiltinRenderers(): void {
+  if (registered) {
+    return;
+  }
+  registered = true;
+
+  registerToolRenderer({ id: 'table', component: DataTable as ToolRendererComponent });
+  registerToolRenderer({ id: 'diff', component: Diff as ToolRendererComponent });
+  registerToolRenderer({ id: 'approval', component: Approval as ToolRendererComponent });
+  registerToolRenderer({ id: 'chart', component: Chart as ToolRendererComponent });
+}
+
+/**
+ * Test helper: reset the idempotency guard so a subsequent
+ * registerBuiltinRenderers() re-runs (used after clearAllRenderers()).
+ */
+export function resetBuiltinRegistration(): void {
+  registered = false;
+}

--- a/src/lib/components/renderers/index.ts
+++ b/src/lib/components/renderers/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Tool-render registry barrel.
+ *
+ * Public surface for the native tool-render system (issue #127):
+ *   - registerToolRenderer / resolveToolRenderer + types  (registry.ts)
+ *   - registerBuiltinRenderers                            (builtins.ts)
+ *   - ToolRenderHost component                            (ToolRenderHost.svelte)
+ */
+
+export {
+  registerToolRenderer,
+  resolveToolRenderer,
+  hasToolRenderer,
+  rendererCount,
+  clearCustomRenderers,
+  clearAllRenderers,
+  BUILTIN_RENDERER_IDS,
+  type ToolRenderer,
+  type ToolRendererComponent,
+  type ToolRendererProps,
+  type ResolveInput,
+  type BuiltinRendererId,
+} from './registry';
+
+export { registerBuiltinRenderers, resetBuiltinRegistration } from './builtins';
+
+export { default as ToolRenderHost } from './ToolRenderHost.svelte';

--- a/src/lib/components/renderers/registry.test.ts
+++ b/src/lib/components/renderers/registry.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, it, expect } from 'vitest';
+import {
+  registerToolRenderer,
+  resolveToolRenderer,
+  clearCustomRenderers,
+  clearAllRenderers,
+  rendererCount,
+  type ToolRendererComponent,
+} from './registry';
+// Vite `?raw` import: load registry.ts as a string for the static no-chat-core
+// dependency check (criterion 4) without pulling in node builtins.
+import registrySource from './registry.ts?raw';
+
+// A throwaway stand-in for a Svelte component. Resolution never invokes it, so
+// the registry can be exercised entirely in vitest's node env (no DOM, no Svelte
+// runtime). This is the core of criterion 4: registry.ts has zero chat-core
+// imports and resolves purely from data.
+const fakeComponent = (() => {}) as unknown as ToolRendererComponent;
+
+describe('tool-render registry', () => {
+  beforeEach(() => {
+    // Reset to a known-good state: clear everything, then register the four
+    // built-in ids (without importing the .svelte widgets, which would drag in
+    // the Svelte runtime under node).
+    clearAllRenderers();
+    for (const id of ['table', 'diff', 'approval', 'chart']) {
+      registerToolRenderer({ id, component: fakeComponent });
+    }
+  });
+
+  it('resolves an explicit renderer hint to the matching built-in id', () => {
+    expect(resolveToolRenderer({ renderer: 'diff' })?.id).toBe('diff');
+    expect(resolveToolRenderer({ renderer: 'table' })?.id).toBe('table');
+    expect(resolveToolRenderer({ renderer: 'approval' })?.id).toBe('approval');
+  });
+
+  it('falls back to null for an unknown renderer hint', () => {
+    // Drives ToolRenderHost's JSON <pre> fallback (criterion 3).
+    expect(resolveToolRenderer({ renderer: 'future-widget' })).toBeNull();
+  });
+
+  it('returns null when nothing is provided', () => {
+    expect(resolveToolRenderer({})).toBeNull();
+  });
+
+  it('matches a custom renderer by string toolName', () => {
+    registerToolRenderer({ id: 'gitdiff', match: 'git-diff', component: fakeComponent });
+    expect(resolveToolRenderer({ toolName: 'git-diff' })?.id).toBe('gitdiff');
+  });
+
+  it('matches a custom renderer by string against the renderer hint', () => {
+    registerToolRenderer({ id: 'special', match: 'special-hint', component: fakeComponent });
+    expect(resolveToolRenderer({ renderer: 'special-hint' })?.id).toBe('special');
+  });
+
+  it('matches a custom renderer via a predicate', () => {
+    registerToolRenderer({
+      id: 'shellish',
+      match: (input) => (input.toolName ?? '').startsWith('shell'),
+      component: fakeComponent,
+    });
+    expect(resolveToolRenderer({ toolName: 'shell-table' })?.id).toBe('shellish');
+    expect(resolveToolRenderer({ toolName: 'other' })).toBeNull();
+  });
+
+  it('orders multiple matching custom renderers by descending priority', () => {
+    registerToolRenderer({
+      id: 'low',
+      match: () => true,
+      priority: 1,
+      component: fakeComponent,
+    });
+    registerToolRenderer({
+      id: 'high',
+      match: () => true,
+      priority: 10,
+      component: fakeComponent,
+    });
+    expect(resolveToolRenderer({ toolName: 'anything' })?.id).toBe('high');
+  });
+
+  it('prefers an exact built-in id hint over a matching custom predicate', () => {
+    // A custom renderer that claims everything must NOT shadow a direct
+    // built-in id hit (priority a/b beats c).
+    registerToolRenderer({
+      id: 'greedy',
+      match: () => true,
+      priority: 999,
+      component: fakeComponent,
+    });
+    expect(resolveToolRenderer({ renderer: 'diff' })?.id).toBe('diff');
+  });
+
+  it('clearCustomRenderers removes custom renderers but keeps built-ins', () => {
+    registerToolRenderer({ id: 'temp', match: 'temp', component: fakeComponent });
+    expect(resolveToolRenderer({ toolName: 'temp' })?.id).toBe('temp');
+    clearCustomRenderers();
+    expect(resolveToolRenderer({ toolName: 'temp' })).toBeNull();
+    // Built-ins survive.
+    expect(resolveToolRenderer({ renderer: 'diff' })?.id).toBe('diff');
+  });
+
+  it('registering a custom renderer needs no chat-core import (criterion 4)', () => {
+    // This test file imports ONLY ./registry — never ConversationViewer or
+    // conversations. Registering + resolving works in isolation, proving a new
+    // renderer requires zero chat-core changes.
+    const before = rendererCount();
+    registerToolRenderer({ id: 'standalone', match: 'standalone', component: fakeComponent });
+    expect(rendererCount()).toBe(before + 1);
+    expect(resolveToolRenderer({ toolName: 'standalone' })?.id).toBe('standalone');
+  });
+});
+
+describe('registry.ts has no chat-core dependency (criterion 4, static)', () => {
+  it('registry source imports nothing from the chat core', () => {
+    // No import of the chat-core files. The only permitted import is `svelte`
+    // for the (type-only) Component type.
+    expect(registrySource).not.toMatch(/from\s+['"][^'"]*ConversationViewer/);
+    expect(registrySource).not.toMatch(/from\s+['"][^'"]*stores\/conversations/);
+    expect(registrySource).not.toMatch(/from\s+['"][^'"]*ToolRenderHost/);
+    // And confirm it does import the svelte type (sanity).
+    expect(registrySource).toMatch(/from\s+['"]svelte['"]/);
+  });
+});

--- a/src/lib/components/renderers/registry.ts
+++ b/src/lib/components/renderers/registry.ts
@@ -1,0 +1,187 @@
+/**
+ * Pure-TypeScript tool-render registry.
+ *
+ * Maps a small result envelope (`{ renderer?, data }`) to a Svelte widget. The
+ * resolution logic lives here as plain data + functions so it is unit-testable
+ * in vitest's default `node` environment with NO DOM and NO Svelte runtime
+ * import in the hot path beyond the `Component` *type* (erased at compile time).
+ *
+ * IMPORTANT (issue #127, criterion 4): this module imports NOTHING from the chat
+ * core (no ConversationViewer, no conversations store). Registering a new
+ * renderer is a single `registerToolRenderer()` call and requires zero edits to
+ * chat-core files.
+ *
+ * Resolution priority (highest first):
+ *   (a) exact built-in id === input.renderer
+ *   (b) input.renderer hint matched against any registered renderer's id
+ *   (c) custom renderers whose `match` is a string equal to toolName/renderer
+ *       OR a predicate returning true, ordered by descending `priority`
+ *   (d) null  -> the host renders the JSON/text fallback
+ */
+
+import type { Component } from 'svelte';
+
+/** Detail payload for the Approval widget's approve/reject callbacks. */
+export interface ApprovalActionDetail {
+  actionId?: string;
+}
+
+/**
+ * Props every renderer widget receives.
+ *
+ * `data` is the structured payload. `onapprove` / `onreject` are OPTIONAL
+ * callback props (Svelte 5 runes idiom — typeable, unlike createEventDispatcher
+ * events) that only the Approval widget invokes; other widgets ignore them. The
+ * host wires these to forward up to the chat core.
+ */
+export interface ToolRendererProps {
+  data: unknown;
+  onapprove?: (detail: ApprovalActionDetail) => void;
+  onreject?: (detail: ApprovalActionDetail) => void;
+}
+
+/** A dynamically-mountable tool-render widget. */
+export type ToolRendererComponent = Component<ToolRendererProps>;
+
+/** Input to {@link resolveToolRenderer}. */
+export interface ResolveInput {
+  /** Explicit renderer hint from the result envelope (a literal string). */
+  renderer?: string;
+  /** Originating tool / sender name (e.g. ConversationMessage.from). */
+  toolName?: string;
+  /** The data payload (available to predicate matchers). */
+  data?: unknown;
+}
+
+/** A registered renderer. */
+export interface ToolRenderer {
+  /** Stable id (e.g. 'table', 'diff', 'approval', 'chart'). */
+  id: string;
+  /**
+   * Optional custom match. A string is compared (exact) against the resolve
+   * input's `toolName` then `renderer`. A predicate is called with the full
+   * resolve input and returns true to claim the message.
+   */
+  match?: string | ((input: ResolveInput) => boolean);
+  /** The Svelte component to mount. */
+  component: ToolRendererComponent;
+  /** Higher wins when multiple custom renderers match. Defaults to 0. */
+  priority?: number;
+}
+
+/**
+ * Built-in renderer ids. A hint exactly equal to one of these resolves directly
+ * to the matching built-in (priority a/b), bypassing custom predicate scanning.
+ */
+export const BUILTIN_RENDERER_IDS = ['table', 'diff', 'approval', 'chart'] as const;
+export type BuiltinRendererId = (typeof BUILTIN_RENDERER_IDS)[number];
+
+// Module-level registry. `byId` is the fast lookup; `ordered` preserves
+// registration order for stable, deterministic priority tie-breaking.
+const byId = new Map<string, ToolRenderer>();
+const ordered: ToolRenderer[] = [];
+const builtinIds = new Set<string>(BUILTIN_RENDERER_IDS);
+
+/**
+ * Register (or replace) a renderer. Replacing an existing id updates in place,
+ * preserving the original registration order so priority ties stay stable.
+ */
+export function registerToolRenderer(renderer: ToolRenderer): void {
+  if (!renderer || typeof renderer.id !== 'string' || renderer.id.length === 0) {
+    throw new Error('registerToolRenderer: renderer.id must be a non-empty string');
+  }
+
+  const existing = byId.get(renderer.id);
+  byId.set(renderer.id, renderer);
+
+  if (existing) {
+    const idx = ordered.indexOf(existing);
+    if (idx >= 0) {
+      ordered[idx] = renderer;
+      return;
+    }
+  }
+  ordered.push(renderer);
+}
+
+/**
+ * Resolve a renderer for the given input, or `null` to trigger the host's
+ * formatted-JSON/text fallback. See module doc for the priority order.
+ */
+export function resolveToolRenderer(input: ResolveInput): ToolRenderer | null {
+  const hint = input.renderer;
+
+  // (a) + (b): an explicit hint matching a registered id wins outright. Because
+  // built-ins register under their canonical ids, this covers both "built-in id
+  // === hint" and "hint matched to a registered id".
+  if (hint) {
+    const direct = byId.get(hint);
+    if (direct) {
+      return direct;
+    }
+  }
+
+  // (c): custom (non-built-in) renderers, scanned by descending priority. A
+  // string `match` compares against toolName then the renderer hint; a
+  // predicate gets the full input.
+  const candidates = ordered
+    .filter((r) => !builtinIds.has(r.id) && r.match !== undefined)
+    .filter((r) => matches(r, input))
+    .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+
+  if (candidates.length > 0) {
+    return candidates[0];
+  }
+
+  // (d): no match -> host renders the fallback.
+  return null;
+}
+
+function matches(renderer: ToolRenderer, input: ResolveInput): boolean {
+  const m = renderer.match;
+  if (m === undefined) {
+    return false;
+  }
+  if (typeof m === 'function') {
+    try {
+      return m(input) === true;
+    } catch {
+      return false;
+    }
+  }
+  // String match: exact against toolName, then the renderer hint.
+  return m === input.toolName || m === input.renderer;
+}
+
+/** True if `id` is currently registered. */
+export function hasToolRenderer(id: string): boolean {
+  return byId.has(id);
+}
+
+/** Number of currently-registered renderers (test/diagnostic helper). */
+export function rendererCount(): number {
+  return ordered.length;
+}
+
+/**
+ * Test helper: remove all CUSTOM (non-built-in) renderers, leaving built-ins
+ * intact. Keeps tests isolated without forcing a re-import of builtins.ts.
+ */
+export function clearCustomRenderers(): void {
+  for (let i = ordered.length - 1; i >= 0; i -= 1) {
+    const r = ordered[i];
+    if (!builtinIds.has(r.id)) {
+      ordered.splice(i, 1);
+      byId.delete(r.id);
+    }
+  }
+}
+
+/**
+ * Test helper: clear the ENTIRE registry including built-ins. Used to assert
+ * idempotent built-in registration from a clean slate.
+ */
+export function clearAllRenderers(): void {
+  ordered.length = 0;
+  byId.clear();
+}

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -9,6 +9,15 @@ export interface ConversationMessage {
   content: string;
   agent_id?: string;
   session_id?: string;
+  /**
+   * Native tool-render envelope (issue #127). Optional + backward-compatible:
+   * old messages and the Tauri 'conversation-message' payload deserialize
+   * unchanged, and conversationMessageSignature/dedupe IGNORE these fields, so
+   * the signature hash is stable whether or not a renderer is attached.
+   * `renderer` is a plain string hint; `data` is the structured payload.
+   */
+  renderer?: string;
+  data?: unknown;
 }
 
 export interface HeartbeatInfo {

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -178,6 +178,20 @@ export interface RolePack {
 }
 
 /**
+ * Result envelope for the native tool-render registry (issue #127).
+ *
+ * `renderer` is a PLAIN string hint (e.g. "diff", "table", "approval"), NOT a
+ * serde-tagged enum — the backend (eventually #123's Action contract) emits it
+ * as a literal string merged onto the conversation-message payload, so no
+ * serdeEnumVariantName normalization is needed here. Both fields are optional
+ * and backward-compatible: a message with neither renders as plain text.
+ */
+export interface ToolResultEnvelope {
+    renderer?: string;
+    data?: unknown;
+}
+
+/**
  * Helper to extract the variant name from a Serde-serialized enum with data.
  * If input is a string, returns the string.
  * If input is an object { variant: data }, returns the key.

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+/**
+ * Ambient declaration for Vite's `?raw` import suffix (string contents of a
+ * module). Used by registry.test.ts for the static "no chat-core import" check
+ * (issue #127, criterion 4). vite/client already declares `*?raw` but this
+ * makes the `.ts?raw` form explicit for svelte-check under bundler resolution.
+ */
+declare module '*?raw' {
+  const content: string;
+  export default content;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -29,4 +29,8 @@ export default defineConfig(async () => ({
       ignored: ["**/src-tauri/**"],
     },
   },
+
+  // Vitest test config lives in the dedicated vitest.config.ts (which Vitest
+  // prefers over this file). That config uses the plain `svelte()` plugin
+  // instead of `sveltekit()` to avoid a CSS-preprocess proxy error under jsdom.
 }));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig } from 'vitest/config';
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { svelteTesting } from '@testing-library/svelte/vite';
+import path from 'node:path';
+
+/**
+ * Dedicated Vitest config (issue #127).
+ *
+ * Uses the PLAIN `svelte()` plugin with `configFile: false` instead of the full
+ * `sveltekit()` plugin. SvelteKit's pipeline runs Vite's CSS preprocessor during
+ * Svelte compile, which throws "Cannot create proxy with a non-object" under
+ * Vitest. Skipping svelte.config.js (and thus vitePreprocess) avoids that — the
+ * jsdom component test only asserts DOM structure, so CSS preprocessing is
+ * irrelevant here.
+ *
+ * Default environment is `node` so the pure-TS registry test stays DOM-free and
+ * fast; files matching the svelte-test glob run in jsdom via the per-file
+ * override. `svelteTesting()` adds the `browser` resolve condition + auto-cleanup.
+ *
+ * Vitest prefers vitest.config.ts over vite.config.js; the `test` block in
+ * vite.config.js documents the same intent for the SvelteKit-native tooling.
+ */
+export default defineConfig({
+  plugins: [svelte({ configFile: false, compilerOptions: { dev: true } }), svelteTesting()],
+  resolve: {
+    alias: {
+      $lib: path.resolve(__dirname, './src/lib'),
+    },
+  },
+  test: {
+    environment: 'node',
+    environmentMatchGlobs: [['**/*.svelte.test.ts', 'jsdom']],
+    include: ['src/**/*.{test,spec}.{js,ts}'],
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Summary

Part of the **agent-native-engine** epic (#123–#128). Adds a frontend tool-render registry so tool/worker results can render as **rich inline widgets** (sortable table, diff, approval card) instead of raw text. The agent stays framework-agnostic — it emits `{ renderer?, data }`; the UI decides how to draw it.

Resolves #127.

## What landed (frontend-only — no Rust touched)

- **`renderers/registry.ts`** — pure-TS `registerToolRenderer` / `resolveToolRenderer`. Resolution priority: built-in id === hint → hint matched to a registered id → custom string/predicate match (descending priority) → `null` fallback. **Zero chat-core imports**, so it runs in vitest's node env.
- **`builtins.ts`** — idempotently registers `table` / `diff` / `approval` / `chart`.
- **Widgets** (Svelte 5 runes, lattice tokens): `DataTable` (sortable, column auto-infer), `Diff` (unified-diff parser, `--status-success`/`--status-error` coloring), `Approval` (`onapprove`/`onreject` callbacks), `Chart` (stub → JSON fallback).
- **`ToolRenderHost.svelte`** — resolves + mounts the widget dynamically inside a `<svelte:boundary>`; renders a `<pre>` JSON fallback on no-match **or** render throw.
- **Chat-core wiring (the only edit)** — `ConversationMessage` gains optional `renderer?`/`data?` (ignored by the dedupe/signature hash); `ConversationViewer` branches to `ToolRenderHost` only when `msg.renderer || msg.data`, else keeps the existing raw `<span>`.
- **Test infra** — `jsdom` + `@testing-library/svelte` devDeps, a `test` script, and a dedicated `vitest.config.ts`.

## Acceptance criteria

- [x] (1) Registry with ≥ DataTable + Diff + Approval — `builtins.ts` + the four `.svelte` widgets.
- [x] (2) `renderer:"diff"` renders the Diff widget inline, not raw text — `ToolRenderHost` mounts `Diff.svelte`; test asserts `.diff-line.add`/`.diff-line.del` render.
- [x] (3) Unknown/unhinted → graceful formatted-JSON fallback; plain messages unchanged.
- [x] (4) Registering a new renderer needs **no** chat-core change — test registers a custom renderer importing only `./registry`; static check asserts `registry.ts` has zero chat-core imports.

## Testing

- ✅ `npx vitest run` — **19/19 passing** (11 registry [node] + 4 ToolRenderHost [jsdom] + 4 pre-existing). Independently re-run by the reviewer and again on merge.
- ✅ `npm run check` (svelte-check) — **0 errors, 0 warnings**.
- ✅ `npm run build` — succeeds.

## Deviations (justified)

- Vitest config lives in a dedicated `vitest.config.ts` (plain `svelte()` plugin) rather than a `test` block in `vite.config.js` — the `sveltekit()` plugin throws a "Cannot create proxy" CSS-preprocess error under jsdom. `vite.config.js` documents the pointer.
- Used Svelte 5 callback props (`onapprove`/`onreject`) + a capitalized dynamic `<Widget>` instead of the deprecated `createEventDispatcher` + `<svelte:component>` (svelte-check 4 flags those in runes mode). Same behavior, non-deprecated idiom.

## Deferred (per plan / epic contract)

- `Approval` approve/reject is console-logged; queen/worker wiring belongs to **#123**'s Action contract.
- `Chart` is a deliberate stub (no charting lib added).
- Backend doesn't emit `{ renderer, data }` yet — widgets are exercised via injected/mocked messages until #123 emits the envelope.

## Notes

- Independent adversarial `code-reviewer` pass: verdict **pass**, no blockers; vitest re-run green.
- Branches from `main`, independent of #124/#123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Conversations now render rich interactive content including approval workflows, sortable data tables, visual code diffs, and chart displays.

* **Tests**
  * Added comprehensive test infrastructure and coverage for renderer functionality and registry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->