### PR TITLE
feat(coordination): durable sub-agent run queue with atomic claim (#126)

### DIFF
--- a/src-tauri/src/actions/tests.rs
+++ b/src-tauri/src/actions/tests.rs
@@ -32,6 +32,12 @@ fn test_state() -> Arc<AppState> {
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
     let app_state_db = Arc::new(crate::storage::ApplicationStateDb::open_in_memory().unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
     // Keep the TempDir alive for the lifetime of the process under test by leaking it;
     // tests are short-lived and this avoids a premature directory cleanup race.
     std::mem::forget(dir);
@@ -43,6 +49,7 @@ fn test_state() -> Arc<AppState> {
         storage,
         event_bus,
         app_state_db,
+        queue_manager,
         None,
     ))
 }

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -374,10 +374,28 @@ pub async fn mark_plan_ready(
 #[tauri::command]
 pub async fn resume_session(
     state: State<'_, SessionControllerState>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
 ) -> Result<Session, String> {
-    let controller = state.0.read();
-    controller.resume_session(&session_id)
+    let session = {
+        let controller = state.0.read();
+        controller.resume_session(&session_id)?
+    };
+
+    // #126: repair queue rows orphaned by the crash. Any `agent_run_queue` row still marked
+    // `running` whose worker is NOT among the resumed session's live agents (its PTY did not
+    // survive) is flipped back to `queued` so it becomes claimable again. The queue table
+    // persisted across the restart on its own; reconcile only fixes orphaned `running` rows.
+    let live_worker_ids: Vec<String> = session.agents.iter().map(|a| a.id.clone()).collect();
+    if let Err(e) = app_state
+        .queue_manager
+        .reconcile(&session_id, &live_worker_ids)
+        .await
+    {
+        tracing::warn!("Queue reconcile on resume failed for {session_id}: {e}");
+    }
+
+    Ok(session)
 }
 
 /// #125: read the run journal + side-effect ledger for a session, for the resume modal.

--- a/src-tauri/src/coordination/mod.rs
+++ b/src-tauri/src/coordination/mod.rs
@@ -1,10 +1,12 @@
 mod contracts;
 mod state;
 mod injection;
+pub mod queue_manager;
 
 pub use contracts::*;
 pub use state::*;
 pub use injection::*;
+pub use queue_manager::QueueManager;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/coordination/queue_manager.rs
+++ b/src-tauri/src/coordination/queue_manager.rs
@@ -1,0 +1,317 @@
+//! [`QueueManager`] — the coordination-layer subsystem over the durable run queue (#126).
+//!
+//! Wraps the SQLite-backed [`QueueRepo`] plus the [`EventBus`]. Every mutation persists to
+//! the DB FIRST and emits the matching lifecycle event SECOND, so the UI never observes an
+//! event that the database has not yet committed.
+//!
+//! The queue table is the source of truth for sub-agent runs; the in-memory
+//! `Session.agents` Vec is a UI cache reconciled against the table on resume.
+
+use std::sync::Arc;
+
+use chrono::Utc;
+
+use crate::domain::event::{Event, EventType, Severity};
+use crate::events::EventBus;
+use crate::storage::queue::{QueueRepo, QueueRow, QueueSnapshot, QueueStatus};
+use crate::storage::StorageError;
+
+/// A `running` row whose heartbeat is older than this (millis) is treated as stuck and is
+/// reclaimable. 90s = 3x the 30s maintenance interval, comfortably inside the 180s stall
+/// threshold. Reclaim only flips the row back to claimable — it never kills a live PTY, so a
+/// genuinely-working-but-quiet worker that keeps heartbeating is never reclaimed.
+pub const STUCK_CUTOFF_MS: i64 = 90_000;
+
+/// Finalize a run once it has produced this many continuations (distinct status changes).
+pub const MAX_CONTINUATIONS: i64 = 8;
+
+/// Finalize a run once it has produced this many consecutive no-progress heartbeats.
+pub const MAX_NO_PROGRESS_CONTINUATIONS: i64 = 5;
+
+/// Coordination-layer façade over the durable queue. Cheaply clonable.
+#[derive(Clone)]
+pub struct QueueManager {
+    repo: Arc<QueueRepo>,
+    event_bus: Arc<EventBus>,
+}
+
+impl QueueManager {
+    pub fn new(repo: Arc<QueueRepo>, event_bus: Arc<EventBus>) -> Self {
+        Self { repo, event_bus }
+    }
+
+    /// Current millis-since-epoch.
+    fn now_ms() -> i64 {
+        Utc::now().timestamp_millis()
+    }
+
+    /// Enqueue a worker run BEFORE spawning it. Persists a `queued` row, then emits
+    /// `WorkerQueued`. Idempotent on `id` — a duplicate enqueue does not overwrite an
+    /// already-claimed row.
+    ///
+    /// The arguments map 1:1 onto the queue row's identity columns; bundling them into a
+    /// struct would add ceremony without clarifying the call site.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn enqueue_worker(
+        &self,
+        id: &str,
+        session_id: &str,
+        worker_id: &str,
+        role_type: &str,
+        cli: &str,
+        payload: serde_json::Value,
+        task_id: Option<String>,
+    ) -> Result<(), StorageError> {
+        let now = Self::now_ms();
+        let row = QueueRow {
+            id: id.to_string(),
+            task_id,
+            session_id: session_id.to_string(),
+            worker_id: worker_id.to_string(),
+            role_type: role_type.to_string(),
+            cli: cli.to_string(),
+            status: QueueStatus::Queued,
+            payload,
+            attempts: 0,
+            continuation_count: 0,
+            no_progress_count: 0,
+            last_status: None,
+            heartbeat_at: None,
+            created_at: now,
+            updated_at: now,
+        };
+        self.repo.enqueue(&row)?;
+        self.emit(session_id, worker_id, EventType::WorkerQueued, Severity::Info)
+            .await;
+        Ok(())
+    }
+
+    /// Atomically claim a queued (or stale-running) row, flipping it to `running`. Returns
+    /// `true` iff THIS call won the claim. Emits `WorkerClaimed` on a win and
+    /// `WorkerClaimFailed` on a loss. The HTTP handler proceeds to spawn only on `true`.
+    pub async fn claim_and_spawn(
+        &self,
+        id: &str,
+        session_id: &str,
+        worker_id: &str,
+    ) -> Result<bool, StorageError> {
+        let now = Self::now_ms();
+        let cutoff = now - STUCK_CUTOFF_MS;
+        let won = self.repo.try_claim(id, cutoff, now)?;
+        if won {
+            self.emit(session_id, worker_id, EventType::WorkerClaimed, Severity::Info)
+                .await;
+        } else {
+            self.emit(
+                session_id,
+                worker_id,
+                EventType::WorkerClaimFailed,
+                Severity::Warning,
+            )
+            .await;
+        }
+        Ok(won)
+    }
+
+    /// Record a heartbeat against the queue row, advancing continuation / no-progress
+    /// counters. Returns `true` if a row was updated.
+    pub async fn record_heartbeat(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        status: &str,
+    ) -> Result<bool, StorageError> {
+        let now = Self::now_ms();
+        self.repo.record_heartbeat(session_id, worker_id, status, now)
+    }
+
+    /// Maintenance: flip stale `running` rows back to `queued`. Emits `WorkerReclaimed`
+    /// per reclaimed row.
+    pub async fn reclaim_stuck(&self) -> Result<Vec<String>, StorageError> {
+        let now = Self::now_ms();
+        let cutoff = now - STUCK_CUTOFF_MS;
+        let ids = self.repo.reclaim_stuck(cutoff, now)?;
+        for id in &ids {
+            self.emit_for_row(id, EventType::WorkerReclaimed, Severity::Warning)
+                .await;
+        }
+        Ok(ids)
+    }
+
+    /// Maintenance: finalize runs over the continuation / no-progress budgets. Emits
+    /// `WorkerFinalized` per finalized row.
+    pub async fn finalize_no_progress(&self) -> Result<Vec<String>, StorageError> {
+        let now = Self::now_ms();
+        let ids = self
+            .repo
+            .finalize_no_progress(MAX_CONTINUATIONS, MAX_NO_PROGRESS_CONTINUATIONS, now)?;
+        for id in &ids {
+            self.emit_for_row(id, EventType::WorkerFinalized, Severity::Info)
+                .await;
+        }
+        Ok(ids)
+    }
+
+    /// Run both maintenance passes (called from the 30s background task).
+    pub async fn run_maintenance(&self) -> Result<(), StorageError> {
+        self.reclaim_stuck().await?;
+        self.finalize_no_progress().await?;
+        Ok(())
+    }
+
+    /// Repair orphaned `running` rows on resume: any `running` row whose worker is NOT in
+    /// `live_worker_ids` (its PTY did not survive the crash) is flipped back to `queued`.
+    /// Returns the reclaimed ids.
+    pub async fn reconcile(
+        &self,
+        session_id: &str,
+        live_worker_ids: &[String],
+    ) -> Result<Vec<String>, StorageError> {
+        let now = Self::now_ms();
+        let rows = self.repo.rows_for_session(session_id)?;
+        let mut reclaimed = Vec::new();
+        for row in rows {
+            let orphaned = row.status == QueueStatus::Running
+                && !live_worker_ids.iter().any(|w| w == &row.worker_id);
+            if orphaned && self.repo.requeue_running(&row.id, now)? {
+                reclaimed.push(row.id.clone());
+                self.emit(session_id, &row.worker_id, EventType::WorkerReclaimed, Severity::Warning)
+                    .await;
+            }
+        }
+        Ok(reclaimed)
+    }
+
+    /// Counts + rows for a session's queue (dashboard endpoint).
+    pub fn queue_snapshot(&self, session_id: &str) -> Result<QueueSnapshot, StorageError> {
+        self.repo.snapshot(session_id)
+    }
+
+    /// Borrow the underlying repo (tests / resume reconcile lookups).
+    pub fn repo(&self) -> &Arc<QueueRepo> {
+        &self.repo
+    }
+
+    /// Publish a queue lifecycle event AFTER the DB commit.
+    async fn emit(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        event_type: EventType,
+        severity: Severity,
+    ) {
+        let event = Event {
+            id: uuid::Uuid::new_v4().to_string(),
+            session_id: session_id.to_string(),
+            cell_id: None,
+            agent_id: Some(worker_id.to_string()),
+            event_type,
+            timestamp: Utc::now(),
+            payload: serde_json::json!({ "worker_id": worker_id }),
+            severity,
+        };
+        if let Err(e) = self.event_bus.publish(event).await {
+            tracing::warn!("Failed to publish queue event: {e}");
+        }
+    }
+
+    /// Emit using the session/worker resolved from a row id (used by maintenance passes,
+    /// which only have the id).
+    async fn emit_for_row(&self, id: &str, event_type: EventType, severity: Severity) {
+        match self.repo.get_row(id) {
+            Ok(Some(row)) => {
+                self.emit(&row.session_id, &row.worker_id, event_type, severity)
+                    .await
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!("Failed to load queue row {id} for event: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::application_state::ApplicationStateDb;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn manager() -> (TempDir, QueueManager) {
+        let dir = TempDir::new().unwrap();
+        let db = Arc::new(ApplicationStateDb::open(dir.path()).unwrap());
+        let repo = Arc::new(QueueRepo::new(db));
+        repo.ensure_schema().unwrap();
+        let event_bus = EventBus::new(dir.path().to_path_buf());
+        (dir, QueueManager::new(repo, event_bus))
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_then_claim_lifecycle() {
+        let (_dir, mgr) = manager();
+        mgr.enqueue_worker(
+            "s1-worker-1",
+            "s1",
+            "s1-worker-1",
+            "backend",
+            "codex",
+            json!({ "model": "gpt-5.5" }),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let snap = mgr.queue_snapshot("s1").unwrap();
+        assert_eq!(snap.queued, 1);
+
+        // First claim wins, second loses (already running, fresh).
+        assert!(mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap());
+        assert!(!mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap());
+
+        let snap = mgr.queue_snapshot("s1").unwrap();
+        assert_eq!(snap.running, 1);
+        assert_eq!(snap.queued, 0);
+    }
+
+    #[tokio::test]
+    async fn test_queue_events_emitted() {
+        let (_dir, mgr) = manager();
+        // Subscribe BEFORE the operations so we capture every event.
+        let mut rx = mgr.event_bus.subscribe();
+
+        mgr.enqueue_worker("r1", "s1", "s1-worker-1", "backend", "codex", json!({}), None)
+            .await
+            .unwrap();
+        mgr.claim_and_spawn("r1", "s1", "s1-worker-1").await.unwrap();
+
+        let e1 = rx.recv().await.unwrap();
+        assert_eq!(e1.event_type, EventType::WorkerQueued);
+        assert_eq!(e1.session_id, "s1");
+        assert_eq!(e1.agent_id.as_deref(), Some("s1-worker-1"));
+        let e2 = rx.recv().await.unwrap();
+        assert_eq!(e2.event_type, EventType::WorkerClaimed);
+
+        // A lost claim emits WorkerClaimFailed.
+        mgr.claim_and_spawn("r1", "s1", "s1-worker-1").await.unwrap();
+        let e3 = rx.recv().await.unwrap();
+        assert_eq!(e3.event_type, EventType::WorkerClaimFailed);
+    }
+
+    #[tokio::test]
+    async fn test_reconcile_repairs_orphaned_running() {
+        let (_dir, mgr) = manager();
+        mgr.enqueue_worker("r1", "s1", "s1-worker-1", "backend", "codex", json!({}), None)
+            .await
+            .unwrap();
+        mgr.claim_and_spawn("r1", "s1", "s1-worker-1").await.unwrap();
+        // After a crash there is no live PTY for s1-worker-1 → reconcile requeues it.
+        let reclaimed = mgr.reconcile("s1", &[]).await.unwrap();
+        assert_eq!(reclaimed, vec!["r1".to_string()]);
+        assert_eq!(mgr.queue_snapshot("s1").unwrap().queued, 1);
+
+        // If the worker is still live, reconcile leaves it running.
+        mgr.claim_and_spawn("r1", "s1", "s1-worker-1").await.unwrap();
+        let reclaimed = mgr.reconcile("s1", &["s1-worker-1".to_string()]).await.unwrap();
+        assert!(reclaimed.is_empty());
+        assert_eq!(mgr.queue_snapshot("s1").unwrap().running, 1);
+    }
+}

--- a/src-tauri/src/domain/event.rs
+++ b/src-tauri/src/domain/event.rs
@@ -28,6 +28,12 @@ pub enum EventType {
     AgentFailed,
     ArtifactUpdated,
     ResolverSelectedCandidate,
+    // Durable run-queue lifecycle (#126).
+    WorkerQueued,
+    WorkerClaimed,
+    WorkerClaimFailed,
+    WorkerReclaimed,
+    WorkerFinalized,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]

--- a/src-tauri/src/domain/status.rs
+++ b/src-tauri/src/domain/status.rs
@@ -105,6 +105,12 @@ mod tests {
             EventType::ResolverSelectedCandidate,
             "\"resolver_selected_candidate\"",
         );
+        // #126 durable run-queue lifecycle variants.
+        assert_enum_round_trip(EventType::WorkerQueued, "\"worker_queued\"");
+        assert_enum_round_trip(EventType::WorkerClaimed, "\"worker_claimed\"");
+        assert_enum_round_trip(EventType::WorkerClaimFailed, "\"worker_claim_failed\"");
+        assert_enum_round_trip(EventType::WorkerReclaimed, "\"worker_reclaimed\"");
+        assert_enum_round_trip(EventType::WorkerFinalized, "\"worker_finalized\"");
     }
 
     #[test]

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -64,14 +64,26 @@ pub async fn post_heartbeat(
         ));
     }
 
-    let controller = state.session_controller.read();
-    if controller.get_session(&session_id).is_none() {
-        return Err(ApiError::not_found(format!("Session {} not found", session_id)));
+    // Scope the (non-Send) parking_lot guard so it is dropped before the await below.
+    {
+        let controller = state.session_controller.read();
+        if controller.get_session(&session_id).is_none() {
+            return Err(ApiError::not_found(format!("Session {} not found", session_id)));
+        }
+
+        controller
+            .update_heartbeat(&session_id, &req.agent_id, &req.status, req.summary.as_deref())
+            .map_err(|e| ApiError::internal(e))?;
     }
 
-    controller
-        .update_heartbeat(&session_id, &req.agent_id, &req.status, req.summary.as_deref())
-        .map_err(|e| ApiError::internal(e))?;
+    // #126: record the heartbeat into the durable queue row, advancing the
+    // continuation / no-progress counters. A worker with no matching queue row (e.g. the
+    // Queen) is simply a no-op here.
+    state
+        .queue_manager
+        .record_heartbeat(&session_id, &req.agent_id, &req.status)
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
 
     Ok((
         StatusCode::OK,

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod planners;
 pub mod learnings;
 pub mod conversations;
 pub mod heartbeats;
+pub mod queue;
 pub mod cells;
 pub mod agents;
 pub mod artifacts;

--- a/src-tauri/src/http/handlers/queue.rs
+++ b/src-tauri/src/http/handlers/queue.rs
@@ -1,0 +1,26 @@
+use axum::{
+    extract::{Path, State},
+    Json,
+};
+use std::sync::Arc;
+
+use crate::http::error::ApiError;
+use crate::http::state::AppState;
+use crate::storage::queue::QueueSnapshot;
+use super::validate_session_id;
+
+/// GET /api/sessions/{id}/queue — durable run-queue snapshot for the dashboard.
+///
+/// Reads from the `agent_run_queue` table (the source of truth), not the in-memory
+/// `Session.agents` cache, so the response is accurate across app restarts.
+pub async fn get_queue(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+) -> Result<Json<QueueSnapshot>, ApiError> {
+    validate_session_id(&session_id)?;
+    let snapshot = state
+        .queue_manager
+        .queue_snapshot(&session_id)
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    Ok(Json(snapshot))
+}

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -5,6 +5,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::coordination::{StateManager, WorkerStateInfo};
@@ -108,6 +109,63 @@ pub async fn add_worker(
         role: Some(role.clone()),
         initial_prompt: req.initial_task.clone(),
     };
+
+    // #126: enqueue + atomically claim the worker BEFORE spawning. The queue table is the
+    // source of truth, so we compute the deterministic worker_id the same way the controller
+    // does (`{session}-worker-{index}`, index = existing worker count + 1), enqueue a
+    // `queued` row, then try to claim it. A duplicate POST for the same worker hits an
+    // already-`running` row, loses the claim, and is turned away with 409 — no double spawn.
+    let predicted_index = {
+        let controller = state.session_controller.read();
+        let existing = controller
+            .get_session(&session_id)
+            .map(|s| {
+                s.agents
+                    .iter()
+                    .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
+                    .count()
+            })
+            .unwrap_or(0);
+        (existing + 1) as u8
+    };
+    let predicted_worker_id = format!("{}-worker-{}", session_id, predicted_index);
+    let queue_id = predicted_worker_id.clone();
+    let payload = json!({
+        "role_type": req.role_type,
+        "cli": cli,
+        "model": config.model,
+        "parent_id": req.parent_id,
+        "initial_task": req.initial_task,
+    });
+
+    state
+        .queue_manager
+        .enqueue_worker(
+            &queue_id,
+            &session_id,
+            &predicted_worker_id,
+            &req.role_type,
+            &cli,
+            payload,
+            None,
+        )
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+
+    let claimed = state
+        .queue_manager
+        .claim_and_spawn(&queue_id, &session_id, &predicted_worker_id)
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+    if !claimed {
+        let mut details: HashMap<String, Value> = HashMap::new();
+        details.insert("worker_id".to_string(), json!(predicted_worker_id));
+        details.insert("session_id".to_string(), json!(session_id));
+        return Err(ApiError::conflict_with_details(
+            format!("Worker {} is already claimed and running", predicted_worker_id),
+            details,
+        ));
+    }
 
     // Add worker through session controller
     let (worker_id, worker_index) = {

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -7,7 +7,7 @@ use tower_http::cors::{Any, CorsLayer};
 use crate::http::state::AppState;
 use crate::http::handlers::{
     actions, agents, application_state, artifacts, cells, conversations, evaluator, events, health,
-    heartbeats, inject, learnings, planners, resolver, sessions, templates, workers,
+    heartbeats, inject, learnings, planners, queue, resolver, sessions, templates, workers,
 };
 
 pub fn create_router(state: Arc<AppState>) -> Router {
@@ -48,6 +48,8 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // Worker routes
         .route("/api/sessions/{id}/workers", get(workers::list_workers))
         .route("/api/sessions/{id}/workers", post(workers::add_worker))
+        // Durable run-queue snapshot (#126)
+        .route("/api/sessions/{id}/queue", get(queue::get_queue))
         // Evaluator routes
         .route("/api/sessions/{id}/evaluators", get(evaluator::list_evaluators))
         .route("/api/sessions/{id}/evaluators", post(evaluator::add_evaluator))

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -9,7 +9,7 @@ use crate::storage::{AppConfig, ApplicationStateDb, SessionStorage};
 use crate::storage::ConversationMessage;
 use crate::pty::PtyManager;
 use crate::session::SessionController;
-use crate::coordination::InjectionManager;
+use crate::coordination::{InjectionManager, QueueManager};
 use crate::events::EventBus;
 
 #[allow(dead_code)]
@@ -21,6 +21,9 @@ pub struct AppState {
     pub storage: Arc<SessionStorage>,
     pub event_bus: Arc<EventBus>,
     pub app_state_db: Arc<ApplicationStateDb>,
+    /// Durable sub-agent run queue (#126). The `agent_run_queue` table is the source of
+    /// truth for queued/running/finalized workers; `Session.agents` is a UI cache.
+    pub queue_manager: Arc<QueueManager>,
     pub app_handle: Option<AppHandle>,
     /// Unified action registry, dispatched by both the Tauri and HTTP surfaces.
     /// Wrapped in `OnceLock` so `AppState` can be constructed before the registry
@@ -38,6 +41,7 @@ impl AppState {
         storage: Arc<SessionStorage>,
         event_bus: Arc<EventBus>,
         app_state_db: Arc<ApplicationStateDb>,
+        queue_manager: Arc<QueueManager>,
         app_handle: Option<AppHandle>,
     ) -> Self {
         Self {
@@ -48,6 +52,7 @@ impl AppState {
             storage,
             event_bus,
             app_state_db,
+            queue_manager,
             app_handle,
             registry: std::sync::OnceLock::new(),
         }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -34,6 +34,12 @@ async fn setup_test_app() -> axum::Router {
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
     let app_state_db = Arc::new(crate::storage::ApplicationStateDb::open_in_memory().unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -42,6 +48,7 @@ async fn setup_test_app() -> axum::Router {
         storage,
         event_bus,
         app_state_db,
+        queue_manager,
         None,
     ));
     state.set_registry(Arc::new(crate::actions::build_registry()));
@@ -70,6 +77,12 @@ async fn setup_test_app_with_controller_at(
     let app_state_db = Arc::new(
         crate::storage::ApplicationStateDb::open(storage.base_dir()).unwrap(),
     );
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -78,6 +91,7 @@ async fn setup_test_app_with_controller_at(
         storage.clone(),
         event_bus,
         app_state_db,
+        queue_manager,
         None,
     ));
     state.set_registry(Arc::new(crate::actions::build_registry()));
@@ -98,6 +112,12 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
     let app_state_db = Arc::new(crate::storage::ApplicationStateDb::open_in_memory().unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -106,6 +126,7 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
         storage,
         event_bus,
         app_state_db,
+        queue_manager,
         None,
     ));
     state.set_registry(Arc::new(crate::actions::build_registry()));
@@ -5541,6 +5562,12 @@ async fn test_same_handler_both_callers() {
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
     let app_state_db = Arc::new(crate::storage::ApplicationStateDb::open_in_memory().unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
     let state = Arc::new(AppState::new(
         config,
         pty_manager,
@@ -5549,6 +5576,7 @@ async fn test_same_handler_both_callers() {
         storage,
         event_bus,
         app_state_db,
+        queue_manager,
         None,
     ));
     state.set_registry(Arc::new(build_registry()));
@@ -5712,5 +5740,184 @@ async fn test_get_run_journal_rejects_bad_session_id() {
         .unwrap();
 
     // Axum decodes %2F; the traversal token is rejected by validate_session_id.
+    assert_ne!(response.status(), StatusCode::OK);
+}
+
+// ----------------------------------------------------------------------------
+// #126 — durable sub-agent run queue HTTP integration tests
+// ----------------------------------------------------------------------------
+
+/// Helper: GET /queue and parse the JSON snapshot.
+async fn fetch_queue_snapshot(app: &axum::Router, session_id: &str) -> serde_json::Value {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{session_id}/queue"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn test_queue_endpoint_empty_snapshot() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-empty");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-queue-empty", temp_dir.to_str().unwrap()));
+
+    let snap = fetch_queue_snapshot(&app, "session-queue-empty").await;
+    assert_eq!(snap["queued"], 0);
+    assert_eq!(snap["running"], 0);
+    assert_eq!(snap["rows"].as_array().unwrap().len(), 0);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_add_worker_enqueues_and_claims() {
+    // First POST /workers enqueues a queue row and atomically claims it (-> running). The
+    // downstream PTY/worktree spawn fails in the hermetic test env (temp dir is not a git
+    // repo), so no agent is added — but the queue row is the source of truth and is now
+    // `running`. A duplicate POST for the same worker re-enqueues (no-op), loses the claim
+    // on the already-running fresh row, and is turned away with 409.
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-claim");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-queue-claim", temp_dir.to_str().unwrap()));
+
+    let body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
+
+    // First POST: enqueue + claim succeed; spawn may fail downstream (500), never 409.
+    let first = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-queue-claim/workers")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        first.status(),
+        StatusCode::CONFLICT,
+        "first claim must not be a 409"
+    );
+
+    // The queue row exists and is running, even though the spawn failed.
+    let snap = fetch_queue_snapshot(&app, "session-queue-claim").await;
+    assert_eq!(snap["running"], 1, "first POST claims the row to running");
+    assert_eq!(snap["rows"][0]["worker_id"], "session-queue-claim-worker-1");
+
+    // Second POST for the same worker loses the claim → 409.
+    let second = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-queue-claim/workers")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        second.status(),
+        StatusCode::CONFLICT,
+        "duplicate worker POST must return 409 (lost claim)"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_heartbeat_advances_queue_counters() {
+    // After a worker is claimed (running), heartbeats advance the queue continuation /
+    // no-progress counters via record_heartbeat.
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-heartbeat");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    controller.read().insert_test_session(make_test_session_with_agents(
+        "session-queue-hb",
+        temp_dir.to_str().unwrap(),
+        &["session-queue-hb-worker-1"],
+    ));
+
+    // Claim the worker row directly via the queue path used by add_worker (enqueue+claim).
+    let worker_body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
+    let _ = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-queue-hb/workers")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&worker_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Two identical-status heartbeats: the first is a continuation, the second no-progress.
+    for _ in 0..2 {
+        let hb = serde_json::json!({
+            "agent_id": "session-queue-hb-worker-2",
+            "status": "working"
+        });
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/sessions/session-queue-hb/heartbeat")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&hb).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    let snap = fetch_queue_snapshot(&app, "session-queue-hb").await;
+    // The enqueued worker is worker index 2 (one agent already present), so its row's
+    // heartbeat_at is set after the heartbeats.
+    let row = snap["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["worker_id"] == "session-queue-hb-worker-2")
+        .expect("queue row for worker-2");
+    assert!(row["heartbeat_at"].as_i64().is_some(), "heartbeat recorded onto the queue row");
+    assert_eq!(row["no_progress_count"], 1, "second identical heartbeat is no-progress");
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_queue_endpoint_rejects_bad_session_id() {
+    let (app, _controller) = setup_test_app_with_controller().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/..%2Fevil/queue")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
     assert_ne!(response.status(), StatusCode::OK);
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -83,6 +83,19 @@ pub fn run() {
         .ensure_schema()
         .expect("Failed to initialize run_journal schema");
 
+    // #126: build the durable sub-agent run queue on the same shared SQLite DB and ensure
+    // its `agent_run_queue` table exists (idempotent CREATE TABLE IF NOT EXISTS, run once at
+    // startup). The QueueManager wraps the repo + EventBus and is the source of truth for
+    // queued/running/finalized workers; Session.agents stays a UI cache.
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(Arc::clone(&app_state_db)));
+    queue_repo
+        .ensure_schema()
+        .expect("Failed to initialize agent_run_queue schema");
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        Arc::clone(&queue_repo),
+        Arc::clone(&event_bus),
+    ));
+
     // Set storage on session controller
     {
         let mut controller = session_controller.write();
@@ -130,6 +143,7 @@ pub fn run() {
                 Arc::clone(&storage),
                 Arc::clone(&event_bus),
                 Arc::clone(&app_state_db),
+                Arc::clone(&queue_manager),
                 Some(app.handle().clone()),
             ));
             // Attach the shared registry so HTTP handlers can dispatch actions.
@@ -182,6 +196,26 @@ pub fn run() {
                         }
                     }
                     known_stalled = currently_stalled;
+                }
+            });
+
+            // #126: durable run-queue maintenance — every 30s, reclaim stuck running rows
+            // (heartbeat older than STUCK_CUTOFF flips back to 'queued', emits
+            // WorkerReclaimed) and finalize no-progress / continuation-exceeded runs (emits
+            // WorkerFinalized). Reclaim never kills a live PTY; it only marks a row claimable.
+            let maintenance_queue_manager = Arc::clone(&queue_manager);
+            let maintenance_app_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                let mut interval = tokio::time::interval(Duration::from_secs(30));
+                loop {
+                    interval.tick().await;
+                    match maintenance_queue_manager.run_maintenance().await {
+                        Ok(()) => {
+                            // Nudge the frontend store to refetch /queue after a maintenance pass.
+                            let _ = maintenance_app_handle.emit("queue-updated", serde_json::json!({}));
+                        }
+                        Err(e) => tracing::warn!("Queue maintenance pass failed: {e}"),
+                    }
                 }
             });
 

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -24,6 +24,9 @@ pub use application_state::{ApplicationStateDb, ApplicationStateRow};
 pub mod run_journal;
 pub use run_journal::RunJournalStore;
 
+pub mod queue;
+pub use queue::QueueRepo;
+
 /// Generate a deterministic ID for legacy learnings that lack one.
 /// Uses UUID v5 (SHA-1 namespace hash) from concatenated fields so the same
 /// entry always produces the same ID across reads.

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -193,6 +193,15 @@ impl QueueRepo {
     /// stale (older than `stuck_cutoff_ms`) or absent. Returns `true` iff THIS call won
     /// the claim (`conn.changes() == 1`). Because the statement is atomic and runs under
     /// the process mutex, exactly one of N concurrent claimers wins.
+    ///
+    /// The claim STAMPS `heartbeat_at = now_ms` on the won row. This is load-bearing for
+    /// the no-double-spawn invariant: without it, a just-claimed row keeps `heartbeat_at`
+    /// NULL (every `enqueue` inserts NULL), and a second concurrent claimer would re-match
+    /// the `status='running' AND heartbeat_at IS NULL` branch and ALSO win — a double spawn.
+    /// Stamping the heartbeat makes the freshly-claimed row fresh, so the loser sees a
+    /// non-NULL, non-stale heartbeat and matches 0 rows. The worker's own heartbeats then
+    /// keep the row fresh; if its first heartbeat never arrives within `stuck_cutoff_ms`,
+    /// the row legitimately becomes reclaimable again (the stuck-detection path).
     pub fn try_claim(
         &self,
         id: &str,
@@ -202,7 +211,10 @@ impl QueueRepo {
         self.db.with_conn(|conn| {
             conn.execute(
                 "UPDATE agent_run_queue
-                 SET status = 'running', attempts = attempts + 1, updated_at = ?2
+                 SET status = 'running',
+                     attempts = attempts + 1,
+                     updated_at = ?2,
+                     heartbeat_at = ?2
                  WHERE id = ?1
                    AND (status = 'queued'
                         OR (status = 'running'

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -1,0 +1,631 @@
+//! SQLite-backed durable sub-agent run queue (#126).
+//!
+//! Built on top of #124's [`ApplicationStateDb`] (the single shared `application_state.db`).
+//! This module owns one additive table, `agent_run_queue`, created via an idempotent
+//! [`ensure_schema`] (`CREATE TABLE IF NOT EXISTS` + indexes) called once at startup.
+//!
+//! # The atomic-claim invariant
+//!
+//! [`QueueRepo::try_claim`] is a SINGLE `UPDATE ... WHERE` statement executed under the
+//! shared connection mutex. SQLite executes the statement atomically, and the process-wide
+//! `parking_lot::Mutex<Connection>` serializes concurrent callers, so two claimers can never
+//! both see a `queued` row — exactly one observes `conn.changes() == 1` and wins; the loser
+//! observes `0` and is turned away (HTTP 409). The same `WHERE` clause also treats a
+//! `running` row with a stale (or absent) heartbeat as claimable, which is the
+//! reclaim-after-cutoff guarantee folded into the same statement.
+//!
+//! The queue table is the SOURCE OF TRUTH for sub-agent runs; the in-memory
+//! `Session.agents` Vec is a UI cache that is reconciled against this table on resume.
+
+use std::sync::Arc;
+
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+use super::application_state::ApplicationStateDb;
+use super::StorageError;
+
+/// Lifecycle status of a queued sub-agent run.
+///
+/// `snake_case` on the wire so the frontend store can normalize it the same way it
+/// normalizes the other serde enums (mirrors `domain/status.rs`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueStatus {
+    Queued,
+    Running,
+    Finalized,
+    Failed,
+}
+
+impl QueueStatus {
+    /// Stable lowercase tag stored in the `status` TEXT column.
+    pub fn as_tag(self) -> &'static str {
+        match self {
+            QueueStatus::Queued => "queued",
+            QueueStatus::Running => "running",
+            QueueStatus::Finalized => "finalized",
+            QueueStatus::Failed => "failed",
+        }
+    }
+
+    /// Parse a stored tag back to a [`QueueStatus`]. Unknown tags fall back to `Queued`.
+    pub fn from_tag(tag: &str) -> Self {
+        match tag {
+            "running" => QueueStatus::Running,
+            "finalized" => QueueStatus::Finalized,
+            "failed" => QueueStatus::Failed,
+            _ => QueueStatus::Queued,
+        }
+    }
+}
+
+/// One row of the `agent_run_queue` table.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueueRow {
+    pub id: String,
+    pub task_id: Option<String>,
+    pub session_id: String,
+    pub worker_id: String,
+    pub role_type: String,
+    pub cli: String,
+    pub status: QueueStatus,
+    /// Full spawn context (worktree_path, prompt_file, wsl-converted path, model,
+    /// parent_id) so a claim at a later time has everything it needs — addresses the
+    /// stale-path risk.
+    pub payload: serde_json::Value,
+    pub attempts: i64,
+    pub continuation_count: i64,
+    pub no_progress_count: i64,
+    pub last_status: Option<String>,
+    /// Unix epoch millis of the last heartbeat, or `None` if never heartbeated.
+    pub heartbeat_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Snapshot of a session's queue for the dashboard endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct QueueSnapshot {
+    pub queued: usize,
+    pub running: usize,
+    pub finalized: usize,
+    pub failed: usize,
+    pub rows: Vec<QueueRow>,
+}
+
+/// Create the `agent_run_queue` table (+ indexes) if absent.
+///
+/// Additive-only and idempotent: safe to call at every startup. Uses plain
+/// `IF NOT EXISTS`, leaving #124's `schema_meta` version table untouched.
+pub fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS agent_run_queue (
+            id                 TEXT PRIMARY KEY,
+            task_id            TEXT,
+            session_id         TEXT NOT NULL,
+            worker_id          TEXT NOT NULL,
+            role_type          TEXT NOT NULL,
+            cli                TEXT NOT NULL,
+            status             TEXT NOT NULL,
+            payload            TEXT NOT NULL,
+            attempts           INTEGER NOT NULL DEFAULT 0,
+            continuation_count INTEGER NOT NULL DEFAULT 0,
+            no_progress_count  INTEGER NOT NULL DEFAULT 0,
+            last_status        TEXT,
+            heartbeat_at       INTEGER,
+            created_at         INTEGER NOT NULL,
+            updated_at         INTEGER NOT NULL
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agent_run_queue_session_status
+         ON agent_run_queue(session_id, status)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agent_run_queue_status_heartbeat
+         ON agent_run_queue(status, heartbeat_at)",
+        [],
+    )?;
+    Ok(())
+}
+
+/// Owns all SQL for the `agent_run_queue` table, backed by the shared [`ApplicationStateDb`].
+///
+/// Cheaply clonable (holds an `Arc`).
+#[derive(Clone)]
+pub struct QueueRepo {
+    db: Arc<ApplicationStateDb>,
+}
+
+impl QueueRepo {
+    /// Wrap a shared [`ApplicationStateDb`]. Call [`QueueRepo::ensure_schema`] once at
+    /// startup before first use.
+    pub fn new(db: Arc<ApplicationStateDb>) -> Self {
+        Self { db }
+    }
+
+    /// Run [`ensure_schema`] against the shared connection (idempotent startup step).
+    pub fn ensure_schema(&self) -> Result<(), StorageError> {
+        self.db.with_conn(ensure_schema)
+    }
+
+    /// Insert a freshly-queued run. Idempotent on the primary key `id`: re-enqueuing the
+    /// same logical run is a no-op (the existing row — possibly already `running` — is
+    /// preserved), so a duplicate POST does not resurrect a claimed row.
+    pub fn enqueue(&self, row: &QueueRow) -> Result<(), StorageError> {
+        let payload_text = serde_json::to_string(&row.payload)?;
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "INSERT INTO agent_run_queue
+                    (id, task_id, session_id, worker_id, role_type, cli, status, payload,
+                     attempts, continuation_count, no_progress_count, last_status,
+                     heartbeat_at, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                 ON CONFLICT(id) DO NOTHING",
+                params![
+                    row.id,
+                    row.task_id,
+                    row.session_id,
+                    row.worker_id,
+                    row.role_type,
+                    row.cli,
+                    row.status.as_tag(),
+                    payload_text,
+                    row.attempts,
+                    row.continuation_count,
+                    row.no_progress_count,
+                    row.last_status,
+                    row.heartbeat_at,
+                    row.created_at,
+                    row.updated_at,
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    /// THE atomic claim. A single `UPDATE ... WHERE` flips a claimable row to `running`.
+    ///
+    /// A row is claimable when it is `queued`, OR it is `running` but its heartbeat is
+    /// stale (older than `stuck_cutoff_ms`) or absent. Returns `true` iff THIS call won
+    /// the claim (`conn.changes() == 1`). Because the statement is atomic and runs under
+    /// the process mutex, exactly one of N concurrent claimers wins.
+    pub fn try_claim(
+        &self,
+        id: &str,
+        stuck_cutoff_ms: i64,
+        now_ms: i64,
+    ) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET status = 'running', attempts = attempts + 1, updated_at = ?2
+                 WHERE id = ?1
+                   AND (status = 'queued'
+                        OR (status = 'running'
+                            AND (heartbeat_at IS NULL OR heartbeat_at < ?3)))",
+                params![id, now_ms, stuck_cutoff_ms],
+            )?;
+            Ok(conn.changes() == 1)
+        })
+    }
+
+    /// Record a heartbeat for a running row and advance the progress counters.
+    ///
+    /// State machine: if the incoming `status` equals the stored `last_status`, the worker
+    /// made no progress → `no_progress_count += 1`. If it changed (or there was no prior
+    /// status), it is a continuation → `continuation_count += 1`, `no_progress_count = 0`,
+    /// and `last_status` is updated. Always refreshes `heartbeat_at`. Returns `true` if a
+    /// row was updated.
+    pub fn record_heartbeat(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        status: &str,
+        now_ms: i64,
+    ) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET heartbeat_at = ?3,
+                     updated_at = ?3,
+                     no_progress_count = CASE
+                         WHEN last_status IS NOT NULL AND last_status = ?4
+                         THEN no_progress_count + 1 ELSE 0 END,
+                     continuation_count = CASE
+                         WHEN last_status IS NULL OR last_status <> ?4
+                         THEN continuation_count + 1 ELSE continuation_count END,
+                     last_status = ?4
+                 WHERE session_id = ?1 AND worker_id = ?2",
+                params![session_id, worker_id, now_ms, status],
+            )?;
+            Ok(conn.changes() >= 1)
+        })
+    }
+
+    /// Flip every `running` row whose heartbeat is stale (older than `cutoff`) or absent
+    /// back to `queued`, making it claimable again. Returns the ids that were reclaimed.
+    ///
+    /// This does NOT kill the live PTY — it only marks the row claimable. A genuinely
+    /// working-but-quiet worker keeps its `heartbeat_at` fresh and is therefore untouched.
+    pub fn reclaim_stuck(
+        &self,
+        stuck_cutoff_ms: i64,
+        now_ms: i64,
+    ) -> Result<Vec<String>, StorageError> {
+        self.db.with_conn(|conn| {
+            let ids: Vec<String> = {
+                let mut stmt = conn.prepare(
+                    "SELECT id FROM agent_run_queue
+                     WHERE status = 'running'
+                       AND (heartbeat_at IS NULL OR heartbeat_at < ?1)",
+                )?;
+                let rows = stmt
+                    .query_map(params![stuck_cutoff_ms], |r| r.get::<_, String>(0))?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                rows
+            };
+            if !ids.is_empty() {
+                conn.execute(
+                    "UPDATE agent_run_queue
+                     SET status = 'queued', updated_at = ?2
+                     WHERE status = 'running'
+                       AND (heartbeat_at IS NULL OR heartbeat_at < ?1)",
+                    params![stuck_cutoff_ms, now_ms],
+                )?;
+            }
+            Ok(ids)
+        })
+    }
+
+    /// Finalize non-terminal rows that have exceeded the continuation / no-progress
+    /// budgets. Returns the ids that were finalized.
+    pub fn finalize_no_progress(
+        &self,
+        max_continuations: i64,
+        max_no_progress: i64,
+        now_ms: i64,
+    ) -> Result<Vec<String>, StorageError> {
+        self.db.with_conn(|conn| {
+            let ids: Vec<String> = {
+                let mut stmt = conn.prepare(
+                    "SELECT id FROM agent_run_queue
+                     WHERE status IN ('queued', 'running')
+                       AND (continuation_count >= ?1 OR no_progress_count >= ?2)",
+                )?;
+                let rows = stmt
+                    .query_map(params![max_continuations, max_no_progress], |r| {
+                        r.get::<_, String>(0)
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                rows
+            };
+            if !ids.is_empty() {
+                conn.execute(
+                    "UPDATE agent_run_queue
+                     SET status = 'finalized', updated_at = ?3
+                     WHERE status IN ('queued', 'running')
+                       AND (continuation_count >= ?1 OR no_progress_count >= ?2)",
+                    params![max_continuations, max_no_progress, now_ms],
+                )?;
+            }
+            Ok(ids)
+        })
+    }
+
+    /// Flip a specific `running` row back to `queued` (used by resume reconcile when the
+    /// PTY no longer exists). Returns `true` if a row changed.
+    pub fn requeue_running(&self, id: &str, now_ms: i64) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET status = 'queued', updated_at = ?2
+                 WHERE id = ?1 AND status = 'running'",
+                params![id, now_ms],
+            )?;
+            Ok(conn.changes() == 1)
+        })
+    }
+
+    /// All rows for a session that are not terminal-removed, ordered by creation.
+    pub fn rows_for_session(&self, session_id: &str) -> Result<Vec<QueueRow>, StorageError> {
+        self.db.with_conn(|conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, task_id, session_id, worker_id, role_type, cli, status, payload,
+                        attempts, continuation_count, no_progress_count, last_status,
+                        heartbeat_at, created_at, updated_at
+                 FROM agent_run_queue
+                 WHERE session_id = ?1
+                 ORDER BY created_at, id",
+            )?;
+            let rows = stmt
+                .query_map(params![session_id], row_to_queue_row)?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            Ok(rows)
+        })
+    }
+
+    /// Look up a single row by primary key.
+    pub fn get_row(&self, id: &str) -> Result<Option<QueueRow>, StorageError> {
+        self.db.with_conn(|conn| {
+            let row = conn
+                .query_row(
+                    "SELECT id, task_id, session_id, worker_id, role_type, cli, status, payload,
+                            attempts, continuation_count, no_progress_count, last_status,
+                            heartbeat_at, created_at, updated_at
+                     FROM agent_run_queue WHERE id = ?1",
+                    params![id],
+                    row_to_queue_row,
+                )
+                .optional()?;
+            Ok(row)
+        })
+    }
+
+    /// Build a [`QueueSnapshot`] (counts + rows) for a session.
+    pub fn snapshot(&self, session_id: &str) -> Result<QueueSnapshot, StorageError> {
+        let rows = self.rows_for_session(session_id)?;
+        let mut queued = 0;
+        let mut running = 0;
+        let mut finalized = 0;
+        let mut failed = 0;
+        for r in &rows {
+            match r.status {
+                QueueStatus::Queued => queued += 1,
+                QueueStatus::Running => running += 1,
+                QueueStatus::Finalized => finalized += 1,
+                QueueStatus::Failed => failed += 1,
+            }
+        }
+        Ok(QueueSnapshot {
+            queued,
+            running,
+            finalized,
+            failed,
+            rows,
+        })
+    }
+}
+
+fn row_to_queue_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueRow> {
+    let status_tag: String = row.get(6)?;
+    let payload_text: String = row.get(7)?;
+    let payload: serde_json::Value = serde_json::from_str(&payload_text).map_err(|e| {
+        rusqlite::Error::FromSqlConversionFailure(7, rusqlite::types::Type::Text, Box::new(e))
+    })?;
+    Ok(QueueRow {
+        id: row.get(0)?,
+        task_id: row.get(1)?,
+        session_id: row.get(2)?,
+        worker_id: row.get(3)?,
+        role_type: row.get(4)?,
+        cli: row.get(5)?,
+        status: QueueStatus::from_tag(&status_tag),
+        payload,
+        attempts: row.get(8)?,
+        continuation_count: row.get(9)?,
+        no_progress_count: row.get(10)?,
+        last_status: row.get(11)?,
+        heartbeat_at: row.get(12)?,
+        created_at: row.get(13)?,
+        updated_at: row.get(14)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn repo() -> QueueRepo {
+        let db = Arc::new(ApplicationStateDb::open_in_memory().unwrap());
+        let repo = QueueRepo::new(db);
+        repo.ensure_schema().unwrap();
+        repo
+    }
+
+    fn sample_row(id: &str, session_id: &str, worker_id: &str) -> QueueRow {
+        QueueRow {
+            id: id.to_string(),
+            task_id: None,
+            session_id: session_id.to_string(),
+            worker_id: worker_id.to_string(),
+            role_type: "backend".to_string(),
+            cli: "codex".to_string(),
+            status: QueueStatus::Queued,
+            payload: json!({ "worktree_path": "D:/wt", "model": "gpt-5.5" }),
+            attempts: 0,
+            continuation_count: 0,
+            no_progress_count: 0,
+            last_status: None,
+            heartbeat_at: None,
+            created_at: 1000,
+            updated_at: 1000,
+        }
+    }
+
+    #[test]
+    fn test_ensure_schema_is_idempotent() {
+        let repo = repo();
+        repo.ensure_schema().unwrap();
+        repo.ensure_schema().unwrap();
+    }
+
+    #[test]
+    fn test_worker_queue_status_round_trip() {
+        // Exact-string match, mirroring domain/status.rs.
+        for (status, tag) in [
+            (QueueStatus::Queued, "\"queued\""),
+            (QueueStatus::Running, "\"running\""),
+            (QueueStatus::Finalized, "\"finalized\""),
+            (QueueStatus::Failed, "\"failed\""),
+        ] {
+            let json = serde_json::to_string(&status).unwrap();
+            assert_eq!(json, tag);
+            let decoded: QueueStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, status);
+            assert_eq!(QueueStatus::from_tag(status.as_tag()), status);
+        }
+    }
+
+    #[test]
+    fn test_enqueue_and_snapshot_roundtrip() {
+        let repo = repo();
+        repo.enqueue(&sample_row("r1", "s1", "s1-worker-1")).unwrap();
+        let snap = repo.snapshot("s1").unwrap();
+        assert_eq!(snap.queued, 1);
+        assert_eq!(snap.rows.len(), 1);
+        // payload is parsed JSON, not double-encoded.
+        assert_eq!(snap.rows[0].payload, json!({ "worktree_path": "D:/wt", "model": "gpt-5.5" }));
+
+        // Re-enqueue is a no-op (ON CONFLICT DO NOTHING).
+        repo.enqueue(&sample_row("r1", "s1", "s1-worker-1")).unwrap();
+        assert_eq!(repo.snapshot("s1").unwrap().rows.len(), 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_queue_atomic_claim_no_double_spawn() {
+        let repo = repo();
+        repo.enqueue(&sample_row("r1", "s1", "s1-worker-1")).unwrap();
+
+        let a = repo.clone();
+        let b = repo.clone();
+        // Two concurrent claimers race for the same row.
+        let (ra, rb) = tokio::join!(
+            tokio::task::spawn_blocking(move || a.try_claim("r1", 0, 2000).unwrap()),
+            tokio::task::spawn_blocking(move || b.try_claim("r1", 0, 2000).unwrap()),
+        );
+        let ra = ra.unwrap();
+        let rb = rb.unwrap();
+
+        // Exactly one claimer wins.
+        assert!(ra ^ rb, "exactly one of two concurrent claimers must win");
+
+        let row = repo.get_row("r1").unwrap().unwrap();
+        assert_eq!(row.status, QueueStatus::Running);
+        // The winner incremented attempts exactly once; the loser's UPDATE matched 0 rows.
+        assert_eq!(row.attempts, 1);
+    }
+
+    #[test]
+    fn test_queue_reclaim_after_stuck_cutoff() {
+        let repo = repo();
+        // A running row with a stale heartbeat (heartbeat_at = 100, cutoff = 1000).
+        let mut stale = sample_row("stale", "s1", "s1-worker-1");
+        stale.status = QueueStatus::Running;
+        stale.heartbeat_at = Some(100);
+        repo.enqueue(&stale).unwrap();
+
+        // A running row with a fresh heartbeat (heartbeat_at = 5000, after cutoff).
+        let mut fresh = sample_row("fresh", "s1", "s1-worker-2");
+        fresh.status = QueueStatus::Running;
+        fresh.heartbeat_at = Some(5000);
+        repo.enqueue(&fresh).unwrap();
+
+        let reclaimed = repo.reclaim_stuck(1000, 9999).unwrap();
+        assert_eq!(reclaimed, vec!["stale".to_string()]);
+        assert_eq!(repo.get_row("stale").unwrap().unwrap().status, QueueStatus::Queued);
+        // Fresh row untouched.
+        assert_eq!(repo.get_row("fresh").unwrap().unwrap().status, QueueStatus::Running);
+
+        // The reclaimed row is now claimable again.
+        assert!(repo.try_claim("stale", 1000, 10000).unwrap());
+    }
+
+    #[test]
+    fn test_try_claim_treats_stale_running_as_claimable() {
+        let repo = repo();
+        let mut stale = sample_row("stale", "s1", "s1-worker-1");
+        stale.status = QueueStatus::Running;
+        stale.heartbeat_at = Some(100);
+        repo.enqueue(&stale).unwrap();
+
+        // Even without an explicit reclaim pass, try_claim recovers a stale-running row.
+        assert!(repo.try_claim("stale", 1000, 2000).unwrap());
+        // A fresh-running row is NOT claimable.
+        let mut fresh = sample_row("fresh", "s1", "s1-worker-2");
+        fresh.status = QueueStatus::Running;
+        fresh.heartbeat_at = Some(5000);
+        repo.enqueue(&fresh).unwrap();
+        assert!(!repo.try_claim("fresh", 1000, 2000).unwrap());
+    }
+
+    #[test]
+    fn test_queue_no_progress_finalized() {
+        let repo = repo();
+        let mut row = sample_row("r1", "s1", "s1-worker-1");
+        row.status = QueueStatus::Running;
+        repo.enqueue(&row).unwrap();
+
+        // Heartbeat with identical status N times → no_progress_count climbs.
+        for i in 0..5 {
+            repo.record_heartbeat("s1", "s1-worker-1", "working", 2000 + i)
+                .unwrap();
+        }
+        let after = repo.get_row("r1").unwrap().unwrap();
+        // First heartbeat is a continuation (last_status was NULL); the next four are no-progress.
+        assert_eq!(after.no_progress_count, 4);
+        assert_eq!(after.continuation_count, 1);
+
+        // One more identical heartbeat pushes no_progress to 5 (the MAX), then finalize.
+        repo.record_heartbeat("s1", "s1-worker-1", "working", 3000)
+            .unwrap();
+        assert_eq!(repo.get_row("r1").unwrap().unwrap().no_progress_count, 5);
+
+        let finalized = repo.finalize_no_progress(8, 5, 4000).unwrap();
+        assert_eq!(finalized, vec!["r1".to_string()]);
+        assert_eq!(repo.get_row("r1").unwrap().unwrap().status, QueueStatus::Finalized);
+    }
+
+    #[test]
+    fn test_queue_continuation_exceeded() {
+        let repo = repo();
+        let mut row = sample_row("r1", "s1", "s1-worker-1");
+        row.status = QueueStatus::Running;
+        repo.enqueue(&row).unwrap();
+
+        // Alternate statuses to bump continuation_count each time.
+        let statuses = ["working", "idle", "working", "idle", "working", "idle", "working", "idle"];
+        for (i, s) in statuses.iter().enumerate() {
+            repo.record_heartbeat("s1", "s1-worker-1", s, 2000 + i as i64)
+                .unwrap();
+        }
+        let after = repo.get_row("r1").unwrap().unwrap();
+        assert!(after.continuation_count >= 8, "continuation_count should reach MAX");
+        assert_eq!(after.no_progress_count, 0);
+
+        let finalized = repo.finalize_no_progress(8, 5, 9000).unwrap();
+        assert_eq!(finalized, vec!["r1".to_string()]);
+        assert_eq!(repo.get_row("r1").unwrap().unwrap().status, QueueStatus::Finalized);
+    }
+
+    #[test]
+    fn test_queue_survives_restart() {
+        // Persist to a real file, drop the DB, reopen on the same path, assert rows intact.
+        let dir = tempfile::TempDir::new().unwrap();
+        {
+            let db = Arc::new(ApplicationStateDb::open(dir.path()).unwrap());
+            let repo = QueueRepo::new(db);
+            repo.ensure_schema().unwrap();
+            let mut row = sample_row("r1", "s1", "s1-worker-1");
+            row.status = QueueStatus::Running;
+            row.heartbeat_at = Some(100);
+            repo.enqueue(&row).unwrap();
+        }
+        // Reopen — simulating an app restart against the same base_dir.
+        let db2 = Arc::new(ApplicationStateDb::open(dir.path()).unwrap());
+        let repo2 = QueueRepo::new(db2);
+        repo2.ensure_schema().unwrap();
+        let snap = repo2.snapshot("s1").unwrap();
+        assert_eq!(snap.rows.len(), 1);
+        assert_eq!(snap.rows[0].id, "r1");
+        assert_eq!(snap.running, 1);
+
+        // reconcile-style repair: an orphaned 'running' row flips to 'queued'.
+        assert!(repo2.requeue_running("r1", 200).unwrap());
+        assert_eq!(repo2.get_row("r1").unwrap().unwrap().status, QueueStatus::Queued);
+    }
+}

--- a/src/lib/stores/agents.ts
+++ b/src/lib/stores/agents.ts
@@ -1,4 +1,5 @@
 import { writable } from 'svelte/store';
+import { listen } from '@tauri-apps/api/event';
 import type { Agent } from '../types/domain';
 import { apiUrl } from '$lib/config';
 
@@ -7,6 +8,110 @@ interface AgentsState {
     loading: boolean;
     error: string | null;
 }
+
+/// Durable run-queue (#126) status, normalized from the backend's snake_case serde enum.
+export type QueueStatus = 'queued' | 'running' | 'finalized' | 'failed';
+
+export interface QueueRow {
+    id: string;
+    task_id: string | null;
+    session_id: string;
+    worker_id: string;
+    role_type: string;
+    cli: string;
+    status: QueueStatus;
+    payload: unknown;
+    attempts: number;
+    continuation_count: number;
+    no_progress_count: number;
+    last_status: string | null;
+    heartbeat_at: number | null;
+    created_at: number;
+    updated_at: number;
+}
+
+export interface QueueSnapshot {
+    queued: number;
+    running: number;
+    finalized: number;
+    failed: number;
+    rows: QueueRow[];
+}
+
+interface QueueState {
+    sessionId: string | null;
+    snapshot: QueueSnapshot | null;
+    loading: boolean;
+    error: string | null;
+}
+
+const KNOWN_QUEUE_STATUSES: readonly QueueStatus[] = ['queued', 'running', 'finalized', 'failed'];
+
+/// Normalize an arbitrary status string into a known QueueStatus, mirroring the
+/// serde-enum-normalization pattern used by the other stores. Unknown values fall back
+/// to 'queued' so the UI never renders a raw/unknown tag.
+function normalizeQueueStatus(raw: unknown): QueueStatus {
+    const value = typeof raw === 'string' ? raw.toLowerCase() : '';
+    return (KNOWN_QUEUE_STATUSES as readonly string[]).includes(value)
+        ? (value as QueueStatus)
+        : 'queued';
+}
+
+function normalizeSnapshot(raw: QueueSnapshot): QueueSnapshot {
+    return {
+        ...raw,
+        rows: (raw.rows ?? []).map((row) => ({ ...row, status: normalizeQueueStatus(row.status) })),
+    };
+}
+
+function createQueueStore() {
+    const { subscribe, set, update } = writable<QueueState>({
+        sessionId: null,
+        snapshot: null,
+        loading: false,
+        error: null,
+    });
+
+    // Refresh whenever the backend's 30s maintenance pass (or a queue mutation) fires.
+    void listen('queue-updated', () => {
+        let activeSessionId: string | null = null;
+        const unsub = subscribe((state) => {
+            activeSessionId = state.sessionId;
+        });
+        unsub();
+        if (activeSessionId) {
+            void queueStore.fetchQueue(activeSessionId);
+        }
+    });
+
+    return {
+        subscribe,
+
+        async fetchQueue(sessionId: string) {
+            update((state) => ({ ...state, sessionId, loading: true, error: null }));
+            try {
+                const response = await fetch(apiUrl(`/api/sessions/${sessionId}/queue`));
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch queue: ${response.statusText}`);
+                }
+                const raw: QueueSnapshot = await response.json();
+                update((state) => ({
+                    ...state,
+                    snapshot: normalizeSnapshot(raw),
+                    loading: false,
+                }));
+            } catch (err) {
+                update((state) => ({ ...state, loading: false, error: (err as Error).message }));
+            }
+        },
+
+        reset() {
+            set({ sessionId: null, snapshot: null, loading: false, error: null });
+        },
+    };
+}
+
+export const queueStore = createQueueStore();
 
 function createAgentsStore() {
     const { subscribe, set, update } = writable<AgentsState>({


### PR DESCRIPTION
## Summary

Part of the **agent-native-engine** epic (#123–#128). Replaces in-memory worker tracking with a **durable `agent_run_queue`** on `#124`'s SQLite `application_state.db`: workers are enqueued and **atomically claimed** via a single compare-and-set `UPDATE` (no double-spawn), dead claims are reclaimable after a stuck cutoff, no-progress workers are finalized, and the queue survives app restart.

Resolves #126. Built on the merged `ApplicationStateDb` (`with_conn`/`handle`) per the epic contract — owns `agent_run_queue` via idempotent `CREATE TABLE IF NOT EXISTS`, mirroring `#125`'s `run_journal` pattern.

## What landed

- **`storage/queue.rs`** — `agent_run_queue` DDL (indexes on `(session_id,status)` and `(status,heartbeat_at)`) + `QueueRepo`: the atomic `try_claim`, `enqueue`, `record_heartbeat` (continuation vs no-progress counters), `reclaim_stuck`, `finalize_no_progress`, `requeue_running`, `snapshot`, and `QueueStatus` (serde snake_case + round-trip test).
- **`coordination/queue_manager.rs`** — `QueueManager` over `Arc<QueueRepo>` + `Arc<EventBus>`; owns `STUCK_CUTOFF_MS` (90s) / `MAX_CONTINUATIONS` (8) / `MAX_NO_PROGRESS_CONTINUATIONS` (5); emits events **only after** the DB commit; `reconcile` repairs orphaned `running` rows on resume.
- **Wiring** — `AppState.queue_manager`; `lib.rs` construction + a 30s maintenance task next to stall-detection (DB-only — never touches a live PTY); `add_worker` enqueues + claims **before** spawn and returns **409** on a lost claim; `post_heartbeat` records heartbeats; `resume_session` reconciles; 5 new `EventType` variants (extended round-trip test); `agents.ts` `queueStore` + `GET /api/sessions/{id}/queue`.

## The atomic claim (AC1)

`try_claim` is one statement under the connection mutex:

```sql
UPDATE agent_run_queue SET status='running', attempts=attempts+1, updated_at=?2, heartbeat_at=?2
 WHERE id=?1 AND (status='queued' OR (status='running' AND (heartbeat_at IS NULL OR heartbeat_at < ?3)))
```

returning `conn.changes() == 1`. Exactly one of N concurrent claimers wins.

> **Review caught a real double-spawn race here** and it's fixed in this PR (commit `b5a1999`): the original `try_claim` set only `status='running'` and left `heartbeat_at` NULL, so a *just-claimed* row still matched the `heartbeat_at IS NULL` claimable branch and a second concurrent claimer would **also** win. Stamping `heartbeat_at=?2` on claim makes the row fresh, so the loser matches 0 rows → `false` → 409. (The encoded concurrency test `test_queue_atomic_claim_no_double_spawn` asserts this but can't execute here — see Testing — so it was caught by code review, not a failing run.)

## Acceptance criteria

- [x] (1) Atomic claim, no double-spawn — single CAS `UPDATE` + heartbeat stamp; `test_queue_atomic_claim_no_double_spawn` (two `spawn_blocking` claimers joined) + duplicate-POST → 409.
- [x] (2) Killed worker reclaimable after stuck cutoff — `reclaim_stuck` (90s) + stale-running claimable in `try_claim`.
- [x] (3) No-progress worker finalized after N — `record_heartbeat` counters + `finalize_no_progress`.
- [x] (4) Survives restart; dashboard accurate — table on `application_state.db` + `reconcile`; `GET /queue` + `queueStore`.

## Testing

- ✅ `cargo check --tests` — **0 errors, 0 warnings** (clippy clean on new files); re-verified post-fix.
- ✅ `npm run check` 0/0; `npx vitest run` 19/19.
- ✅ Tests written: atomic-claim concurrency race, reclaim-after-cutoff, no-progress/continuation finalize, survives-restart, reconcile, HTTP enqueue/claim/409, `QueueStatus` + `EventType` round-trips.
- ⚠️ Same pre-existing `cargo test` loader caveat (`0xC0000139` via `conpty.dll`/`portable-pty`; `format_poll_label` fails identically). Tests compile and were reviewed; the atomic-claim fix was hand-traced against the four affected tests.

## Non-blocking notes (from review)

- **Behavioral**: two concurrent duplicate POSTs for the same session both predict the same worker index, collide on the queue id, and one gets a 409 (intended no-double-spawn behavior, not a regression).
- Confirm workers emit their first heartbeat within `STUCK_CUTOFF_MS` (90s) of spawn so `reclaim_stuck` doesn't requeue a healthy-but-quiet worker (heartbeats are independent of git output, so this should hold).
- End-to-end smoke (real Hive session → spawn → `/queue` running→finalized → kill+resume → reclaimable) needs the Tauri shell; not run headlessly.

## Notes

- Adversarial `code-reviewer` pass → found + the fix agent closed the AC1 race → re-reviewed/verified. Contract-clean: real `ApplicationStateDb`, no `hive.db`/`SessionStorage::db()`/new crate; events after commit; no guard held across `.await`.
- Branches from `main` (contains #124 + #123 + #127 + #125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable worker queue with status visibility and lifecycle tracking
  * Automatic background maintenance (every 30 seconds) reclaims stuck and abandoned workers

* **Bug Fixes**
  * Session resume now reconciles orphaned workers left running after crashes
  * Duplicate worker requests are prevented with conflict detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->