### PR TITLE
feat(ui): composer (@-mentions, /-commands) + Ctrl+I context-awareness (#128)

### DIFF
--- a/src-tauri/src/http/handlers/application_state.rs
+++ b/src-tauri/src/http/handlers/application_state.rs
@@ -32,6 +32,12 @@ pub struct WriteBody {
     pub value: serde_json::Value,
 }
 
+/// Request body for an atomic take (read-and-delete).
+#[derive(Debug, Deserialize)]
+pub struct TakeBody {
+    pub key: String,
+}
+
 /// GET /api/sessions/{id}/application-state
 /// Full snapshot of all rows for a session (used for hydrate-on-load / session-switch).
 pub async fn get_application_state(
@@ -101,4 +107,34 @@ pub async fn write_application_state(
         value: body.value,
         updated_at: updated_at_ms,
     }))
+}
+
+/// POST /api/sessions/{id}/application-state/take
+/// Atomically read-and-delete a single key in one transaction, returning the taken row
+/// or `null`. Used by #128 for one-shot context (`pending_selection_context`) with
+/// exactly-one-turn semantics: a lagging/double submit cannot re-consume a key that was
+/// already taken, because the read+delete is a single `BEGIN IMMEDIATE` transaction.
+pub async fn take_application_state(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Json(body): Json<TakeBody>,
+) -> Result<Json<Option<ApplicationStateRow>>, ApiError> {
+    validate_session_id(&session_id)?;
+
+    if body.key.is_empty() || body.key.len() > 256 {
+        return Err(ApiError::bad_request(
+            "Invalid key: must be 1-256 characters",
+        ));
+    }
+
+    let db = Arc::clone(&state.app_state_db);
+    let key = body.key.clone();
+    let session = session_id.clone();
+
+    let row = tokio::task::spawn_blocking(move || db.take_key(&session, &key))
+        .await
+        .map_err(|e| ApiError::internal(format!("Task join error: {e}")))?
+        .map_err(|e| ApiError::internal(format!("Failed to take application state: {e}")))?;
+
+    Ok(Json(row))
 }

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -109,6 +109,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/application-state/poll",
             get(application_state::poll_application_state),
         )
+        // One-shot atomic read-and-delete (#128 Ctrl+I pending_selection_context).
+        .route(
+            "/api/sessions/{id}/application-state/take",
+            post(application_state::take_application_state),
+        )
         // Injection routes
         .route("/api/sessions/{id}/inject", post(inject::operator_inject))
         .route("/api/sessions/{id}/inject/queen", post(inject::queen_inject))

--- a/src-tauri/src/storage/application_state.rs
+++ b/src-tauri/src/storage/application_state.rs
@@ -189,7 +189,6 @@ impl ApplicationStateDb {
     /// Returns the row if it existed (and deletes it), or `None`. Used by #128 for
     /// one-shot context keys (e.g. `pending_selection_context`) with exactly-one-turn
     /// semantics — no TTL needed.
-    #[allow(dead_code)]
     pub fn take_key(
         &self,
         session_id: &str,

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -3,6 +3,7 @@
   import { coordination, type WorkerRole, type AddWorkerRequest } from '$lib/stores/coordination';
   import { activeSession, activeAgents, serdeEnumVariantName } from '$lib/stores/sessions';
   import { cliOptions, defaultRoles } from '$lib/config/clis';
+  import Composer from './composer/Composer.svelte';
 
   export let open = false;
 
@@ -233,14 +234,15 @@
         </div>
 
         <div class="form-section">
-          <label class="section-label" for="task-input">Initial Task (optional)</label>
-          <textarea
-            id="task-input"
-            placeholder="Describe the initial task for this worker..."
-            bind:value={initialTask}
-            rows={3}
-            class="textarea-input"
-          ></textarea>
+          <span class="section-label" id="task-label">Initial Task (optional)</span>
+          <div class="composer-host" aria-labelledby="task-label">
+            <Composer
+              sessionId={$activeSession?.id ?? null}
+              placeholder="Describe the initial task for this worker… (@ to mention, / for commands)"
+              persistDraft={false}
+              bind:value={initialTask}
+            />
+          </div>
         </div>
 
         {#if error}
@@ -388,8 +390,7 @@
   }
 
   .custom-role-input,
-  .select-input,
-  .textarea-input {
+  .select-input {
     width: 100%;
     padding: 10px 12px;
     background: var(--bg-surface);
@@ -400,8 +401,7 @@
   }
 
   .custom-role-input:focus,
-  .select-input:focus,
-  .textarea-input:focus {
+  .select-input:focus {
     outline: none;
     border-color: var(--accent-cyan);
   }
@@ -410,10 +410,8 @@
     margin-top: 12px;
   }
 
-  .textarea-input {
-    resize: vertical;
-    min-height: 60px;
-    font-family: inherit;
+  .composer-host {
+    display: flex;
   }
 
   .cli-description {

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -4,6 +4,7 @@
   import { activeSession } from '$lib/stores/sessions';
   import AgentStatusBar from './AgentStatusBar.svelte';
   import ToolRenderHost from './renderers/ToolRenderHost.svelte';
+  import Composer from './composer/Composer.svelte';
 
   let messageContainer: HTMLDivElement;
   let autoScroll = true;
@@ -88,17 +89,11 @@
     }
   }
 
-  async function sendMessage() {
-    if (!sessionId || !selectedAgent || !messageInput.trim()) return;
-    await conversationStore.sendMessage(sessionId, selectedAgent, 'operator', messageInput.trim());
-    messageInput = '';
-  }
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'Enter' && !e.shiftKey) {
-      e.preventDefault();
-      sendMessage();
-    }
+  // The Composer flattens its contenteditable model (mentions/commands) to a plain string
+  // and prepends any one-shot operator context before handing the final prompt here.
+  async function sendComposerMessage(text: string) {
+    if (!sessionId || !selectedAgent || !text.trim()) return;
+    await conversationStore.sendMessage(sessionId, selectedAgent, 'operator', text.trim());
   }
 
   // Approval widget signals. Wiring approve/reject to the queen/worker is #123's
@@ -206,16 +201,13 @@
   <!-- Input -->
   {#if selectedAgent && selectedAgent !== 'shared'}
     <div class="input-bar">
-      <input
-        type="text"
-        placeholder="Send message as operator..."
+      <Composer
+        sessionId={sessionId}
+        agentId={selectedAgent}
+        placeholder="Send message as operator… (@ to mention, / for commands)"
         bind:value={messageInput}
-        onkeydown={handleKeydown}
-        class="message-input"
+        onsubmit={sendComposerMessage}
       />
-      <button class="send-btn" onclick={sendMessage} disabled={!messageInput.trim()}>
-        Send
-      </button>
     </div>
   {/if}
 
@@ -353,41 +345,6 @@
     padding: 8px 12px;
     border-top: 1px solid var(--border-structural);
     background: var(--bg-surface);
-  }
-
-  .message-input {
-    flex: 1;
-    padding: 6px 10px;
-    font-size: 12px;
-    background: var(--bg-void);
-    border: 1px solid var(--border-structural);
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-  }
-
-  .message-input:focus {
-    outline: none;
-    border-color: var(--accent-cyan);
-  }
-
-  .send-btn {
-    padding: 6px 14px;
-    font-size: 12px;
-    font-weight: 600;
-    background: var(--accent-cyan);
-    border: none;
-    border-radius: var(--radius-sm);
-    color: white;
-    cursor: pointer;
-  }
-
-  .send-btn:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .send-btn:hover:not(:disabled) {
-    opacity: 0.9;
   }
 
   .error {

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -3,6 +3,7 @@
   import { open } from '@tauri-apps/plugin-dialog';
   import AgentConfigEditor from './AgentConfigEditor.svelte';
   import TemplatePicker from './templates/TemplatePicker.svelte';
+  import Composer from './composer/Composer.svelte';
   import { Crown, CaretDown, CaretRight } from 'phosphor-svelte';
   import type { AgentConfig, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig, FusionVariantConfig, SoloLaunchConfig, PlannerConfig, WorkerRole, QaWorkerConfig } from '$lib/stores/sessions';
   import type { SessionTemplate } from '$lib/types/domain';
@@ -918,13 +919,15 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
         {#if mode !== 'solo'}
           <div class="form-group">
-            <label for="prompt">Initial Prompt (optional)</label>
-            <textarea
-              id="prompt"
-              bind:value={prompt}
-              placeholder="Enter a task for the session..."
-              rows="3"
-            ></textarea>
+            <span class="composer-label" id="prompt-label">Initial Prompt (optional)</span>
+            <div class="composer-host" aria-labelledby="prompt-label">
+              <Composer
+                sessionId={null}
+                placeholder="Enter a task for the session… (@ to mention, / for commands)"
+                persistDraft={false}
+                bind:value={prompt}
+              />
+            </div>
           </div>
         {/if}
 
@@ -1079,12 +1082,17 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   }
 
   .form-group label,
-  .form-group .group-label {
+  .form-group .group-label,
+  .composer-label {
     display: block;
     margin-bottom: 6px;
     font-size: 13px;
     font-weight: 500;
     color: var(--text-primary);
+  }
+
+  .composer-host {
+    display: flex;
   }
 
   .form-row {

--- a/src/lib/components/ShortcutsOverlay.svelte
+++ b/src/lib/components/ShortcutsOverlay.svelte
@@ -30,6 +30,12 @@
       ],
     },
     {
+      title: 'Context',
+      shortcuts: [
+        { keys: ['Ctrl', 'I'], action: 'Capture selection / cell context for next turn' },
+      ],
+    },
+    {
       title: 'Help',
       shortcuts: [
         { keys: ['Ctrl', '/'], action: 'Show this overlay' },

--- a/src/lib/components/composer/Composer.svelte
+++ b/src/lib/components/composer/Composer.svelte
@@ -1,0 +1,370 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { get } from 'svelte/store';
+  import MentionMenu from './MentionMenu.svelte';
+  import SlashMenu from './SlashMenu.svelte';
+  import {
+    agentMentions,
+    sessionMentions,
+    filterMentions,
+    flattenMention,
+    type MentionItem,
+  } from '$lib/composer/sources';
+  import { filterCommands, type SlashCommand } from '$lib/composer/commands';
+  import { composerDraft } from '$lib/stores/composerDraft';
+  import { pendingContext } from '$lib/stores/pendingContext';
+  import { activeAgents, sessions as sessionsStore } from '$lib/stores/sessions';
+
+  interface Props {
+    sessionId: string | null;
+    agentId?: string | null;
+    placeholder?: string;
+    /** Bind the flattened plain-text value (two-way for dialogs that read it on their own submit). */
+    value?: string;
+    /** Whether to persist drafts per-session (default true). Dialogs may opt out. */
+    persistDraft?: boolean;
+    /** Called with the flattened plain-text prompt (one-shot context already prepended). */
+    onsubmit?: (text: string) => void;
+    disabled?: boolean;
+  }
+
+  let {
+    sessionId,
+    agentId = null,
+    placeholder = 'Message…',
+    value = $bindable(''),
+    persistDraft = true,
+    onsubmit,
+    disabled = false,
+  }: Props = $props();
+
+  let editor: HTMLDivElement;
+  let menuMode: 'none' | 'mention' | 'slash' = $state('none');
+  let menuQuery = $state('');
+  let menuX = $state(0);
+  let menuY = $state(0);
+  let activeIndex = $state(0);
+  /** Start offset of the active @/ trigger within the current text node. */
+  let triggerStart = -1;
+  let triggerNode: Node | null = null;
+
+  let mentionItems: MentionItem[] = $state([]);
+  let commandItems: SlashCommand[] = $state([]);
+
+  // --- Draft load on session change ---
+  let lastBoundSession: string | null = null;
+  $effect(() => {
+    if (!persistDraft) return;
+    if (sessionId && sessionId !== lastBoundSession) {
+      lastBoundSession = sessionId;
+      const initial = composerDraft.load(sessionId);
+      value = initial;
+      // Reflect into the editor DOM if mounted.
+      if (editor && editor.textContent !== initial) {
+        editor.textContent = initial;
+      }
+    }
+  });
+
+  onMount(() => {
+    if (persistDraft && sessionId) {
+      const initial = composerDraft.load(sessionId);
+      value = initial;
+      lastBoundSession = sessionId;
+    }
+    if (editor && value) editor.textContent = value;
+  });
+
+  function currentText(): string {
+    return editor?.textContent ?? '';
+  }
+
+  function syncValue() {
+    value = currentText();
+    if (persistDraft && sessionId) {
+      composerDraft.update(value);
+    }
+  }
+
+  /** Compute caret anchor in viewport pixels for the menu position. */
+  function caretRect(): { x: number; y: number } {
+    const sel = window.getSelection();
+    if (sel && sel.rangeCount > 0) {
+      const range = sel.getRangeAt(0).cloneRange();
+      const rects = range.getClientRects();
+      const rect = rects.length > 0 ? rects[0] : editor.getBoundingClientRect();
+      return { x: rect.left, y: rect.bottom + 4 };
+    }
+    const r = editor.getBoundingClientRect();
+    return { x: r.left, y: r.bottom + 4 };
+  }
+
+  /** Detect an active @ or / trigger immediately before the caret in the current text node. */
+  function detectTrigger() {
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) {
+      closeMenu();
+      return;
+    }
+    const range = sel.getRangeAt(0);
+    const node = range.startContainer;
+    if (node.nodeType !== Node.TEXT_NODE) {
+      closeMenu();
+      return;
+    }
+    const text = node.textContent ?? '';
+    const offset = range.startOffset;
+    // Walk back from the caret to find a trigger char not preceded by a word char.
+    let i = offset - 1;
+    while (i >= 0) {
+      const ch = text[i];
+      if (ch === '@' || ch === '/') {
+        const prev = i > 0 ? text[i - 1] : '';
+        // Trigger only at start-of-text or after whitespace.
+        if (i === 0 || /\s/.test(prev)) {
+          const query = text.slice(i + 1, offset);
+          // Abort if the query contains whitespace (trigger no longer active).
+          if (/\s/.test(query)) {
+            closeMenu();
+            return;
+          }
+          triggerStart = i;
+          triggerNode = node;
+          menuQuery = query;
+          if (ch === '@') openMentionMenu(query);
+          else openSlashMenu(query);
+          return;
+        }
+        closeMenu();
+        return;
+      }
+      if (/\s/.test(ch)) break;
+      i -= 1;
+    }
+    closeMenu();
+  }
+
+  function openMentionMenu(query: string) {
+    const agents = get(activeAgents);
+    const sess = get(sessionsStore).sessions;
+    const all = [...agentMentions(agents), ...sessionMentions(sess)];
+    mentionItems = filterMentions(all, query);
+    if (mentionItems.length === 0) {
+      closeMenu();
+      return;
+    }
+    menuMode = 'mention';
+    activeIndex = 0;
+    const { x, y } = caretRect();
+    menuX = x;
+    menuY = y;
+  }
+
+  function openSlashMenu(query: string) {
+    commandItems = filterCommands(query);
+    if (commandItems.length === 0) {
+      closeMenu();
+      return;
+    }
+    menuMode = 'slash';
+    activeIndex = 0;
+    const { x, y } = caretRect();
+    menuX = x;
+    menuY = y;
+  }
+
+  function closeMenu() {
+    menuMode = 'none';
+    triggerStart = -1;
+    triggerNode = null;
+  }
+
+  /** Replace the trigger token (`@que` / `/res`) with the given plain text and place caret after. */
+  function replaceTrigger(replacement: string) {
+    if (triggerNode == null || triggerStart < 0) return;
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+    const offset = sel.getRangeAt(0).startOffset;
+    const text = triggerNode.textContent ?? '';
+    const before = text.slice(0, triggerStart);
+    const after = text.slice(offset);
+    const next = before + replacement + after;
+    triggerNode.textContent = next;
+    // Restore caret right after the inserted replacement.
+    const caretPos = before.length + replacement.length;
+    const range = document.createRange();
+    range.setStart(triggerNode, Math.min(caretPos, (triggerNode.textContent ?? '').length));
+    range.collapse(true);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    closeMenu();
+    syncValue();
+  }
+
+  function selectMention(item: MentionItem) {
+    replaceTrigger(flattenMention(item) + ' ');
+  }
+
+  function selectCommand(cmd: SlashCommand) {
+    if (cmd.action === 'clear') {
+      editor.textContent = '';
+      closeMenu();
+      syncValue();
+      return;
+    }
+    // 'insert' and 'attach' both insert the expansion (attach is a no-op placeholder).
+    replaceTrigger(cmd.expand());
+  }
+
+  async function submit() {
+    if (disabled) return;
+    let text = currentText().trim();
+    // Prepend one-shot operator context exactly once.
+    if (sessionId) {
+      const ctx = await pendingContext.consume(sessionId);
+      if (ctx) {
+        const block = pendingContext.render(ctx);
+        text = text ? `${block}\n\n${text}` : block;
+      }
+    }
+    if (!text) return;
+    onsubmit?.(text);
+    // Clear editor + draft.
+    editor.textContent = '';
+    value = '';
+    if (persistDraft && sessionId) composerDraft.clear();
+    closeMenu();
+  }
+
+  function moveActive(delta: number) {
+    const len = menuMode === 'mention' ? mentionItems.length : commandItems.length;
+    if (len === 0) return;
+    activeIndex = (activeIndex + delta + len) % len;
+  }
+
+  function commitActive() {
+    if (menuMode === 'mention') selectMention(mentionItems[activeIndex]);
+    else if (menuMode === 'slash') selectCommand(commandItems[activeIndex]);
+  }
+
+  function handleKeydown(e: KeyboardEvent) {
+    if (menuMode !== 'none') {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        moveActive(1);
+        return;
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        moveActive(-1);
+        return;
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        commitActive();
+        return;
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeMenu();
+        return;
+      }
+    }
+
+    // Enter submits; Shift+Enter inserts a newline (matches the project convention).
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      submit();
+    }
+  }
+
+  function handleInput() {
+    syncValue();
+    detectTrigger();
+  }
+
+  async function handleKeyup(e: KeyboardEvent) {
+    // Arrow/navigation keys can move the caret across triggers; re-detect after.
+    if (['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(e.key)) {
+      await tick();
+      detectTrigger();
+    }
+  }
+</script>
+
+<div class="composer-wrap" class:disabled>
+  <div
+    bind:this={editor}
+    class="composer"
+    data-composer
+    contenteditable="true"
+    role="textbox"
+    tabindex="0"
+    aria-multiline="true"
+    aria-label={placeholder}
+    data-placeholder={placeholder}
+    oninput={handleInput}
+    onkeydown={handleKeydown}
+    onkeyup={handleKeyup}
+    onblur={closeMenu}
+  ></div>
+
+  {#if menuMode === 'mention'}
+    <MentionMenu
+      items={mentionItems}
+      {activeIndex}
+      x={menuX}
+      y={menuY}
+      onselect={selectMention}
+    />
+  {:else if menuMode === 'slash'}
+    <SlashMenu
+      items={commandItems}
+      {activeIndex}
+      x={menuX}
+      y={menuY}
+      onselect={selectCommand}
+    />
+  {/if}
+</div>
+
+<style>
+  .composer-wrap {
+    position: relative;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .composer {
+    width: 100%;
+    min-height: 34px;
+    max-height: 160px;
+    overflow-y: auto;
+    padding: 7px 10px;
+    background: var(--bg-void);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-family: var(--font-mono);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    word-break: break-word;
+    outline: none;
+  }
+
+  .composer:focus {
+    border-color: var(--accent-cyan);
+  }
+
+  .composer:empty::before {
+    content: attr(data-placeholder);
+    color: var(--text-secondary);
+    pointer-events: none;
+  }
+
+  .composer-wrap.disabled .composer {
+    opacity: 0.5;
+    pointer-events: none;
+  }
+</style>

--- a/src/lib/components/composer/Composer.svelte
+++ b/src/lib/components/composer/Composer.svelte
@@ -217,7 +217,9 @@
   }
 
   async function submit() {
-    if (disabled) return;
+    // No submit handler (dialog usage with bind:value): never submit, clear, or consume
+    // the one-shot context — that would wipe the field and silently eat pending context.
+    if (disabled || !onsubmit) return;
     let text = currentText().trim();
     // Prepend one-shot operator context exactly once.
     if (sessionId) {
@@ -271,8 +273,10 @@
       }
     }
 
-    // Enter submits; Shift+Enter inserts a newline (matches the project convention).
-    if (e.key === 'Enter' && !e.shiftKey) {
+    // Enter submits ONLY when this composer has a submit handler (e.g. the chat input).
+    // In dialog usage (bind:value, no onsubmit) Enter inserts a newline like a textarea
+    // instead of clearing the field. Shift+Enter always inserts a newline.
+    if (e.key === 'Enter' && !e.shiftKey && onsubmit) {
       e.preventDefault();
       submit();
     }

--- a/src/lib/components/composer/MentionMenu.svelte
+++ b/src/lib/components/composer/MentionMenu.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import type { MentionItem } from '$lib/composer/sources';
+
+  interface Props {
+    items: MentionItem[];
+    /** Highlighted index (controlled by the parent Composer for keyboard nav). */
+    activeIndex: number;
+    /** Caret-anchor position in viewport pixels. */
+    x: number;
+    y: number;
+    onselect: (item: MentionItem) => void;
+  }
+
+  let { items, activeIndex, x, y, onselect }: Props = $props();
+
+  function kindGlyph(kind: MentionItem['kind']): string {
+    if (kind === 'agent') return '@';
+    if (kind === 'session') return '#';
+    return '□'; // file
+  }
+</script>
+
+{#if items.length > 0}
+  <div class="mention-menu" style="left: {x}px; top: {y}px;" role="listbox" aria-label="Mentions">
+    {#each items as item, i (item.kind + ':' + item.id)}
+      <button
+        type="button"
+        class="mention-item"
+        class:active={i === activeIndex}
+        role="option"
+        aria-selected={i === activeIndex}
+        onmousedown={(e) => { e.preventDefault(); onselect(item); }}
+      >
+        <span class="glyph">{kindGlyph(item.kind)}</span>
+        <span class="label">{item.label}</span>
+        {#if item.detail}<span class="detail">{item.detail}</span>{/if}
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .mention-menu {
+    position: fixed;
+    z-index: 200;
+    min-width: 200px;
+    max-width: 320px;
+    max-height: 240px;
+    overflow-y: auto;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-lg);
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .mention-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 8px;
+    background: none;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-family: var(--font-mono);
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .mention-item:hover,
+  .mention-item.active {
+    background: color-mix(in srgb, var(--accent-cyan) 16%, transparent);
+  }
+
+  .glyph {
+    color: var(--accent-cyan);
+    flex-shrink: 0;
+    width: 12px;
+    text-align: center;
+  }
+
+  .label {
+    font-weight: 600;
+    white-space: nowrap;
+  }
+
+  .detail {
+    color: var(--text-secondary);
+    font-size: 11px;
+    margin-left: auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 160px;
+  }
+</style>

--- a/src/lib/components/composer/SlashMenu.svelte
+++ b/src/lib/components/composer/SlashMenu.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import type { SlashCommand } from '$lib/composer/commands';
+
+  interface Props {
+    items: SlashCommand[];
+    activeIndex: number;
+    x: number;
+    y: number;
+    onselect: (cmd: SlashCommand) => void;
+  }
+
+  let { items, activeIndex, x, y, onselect }: Props = $props();
+</script>
+
+{#if items.length > 0}
+  <div class="slash-menu" style="left: {x}px; top: {y}px;" role="listbox" aria-label="Commands">
+    {#each items as cmd, i (cmd.name)}
+      <button
+        type="button"
+        class="slash-item"
+        class:active={i === activeIndex}
+        role="option"
+        aria-selected={i === activeIndex}
+        onmousedown={(e) => { e.preventDefault(); onselect(cmd); }}
+      >
+        <span class="cmd">{cmd.label}</span>
+        <span class="desc">{cmd.description}</span>
+      </button>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .slash-menu {
+    position: fixed;
+    z-index: 200;
+    min-width: 220px;
+    max-width: 340px;
+    max-height: 240px;
+    overflow-y: auto;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    box-shadow: var(--shadow-lg);
+    padding: 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .slash-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 6px 8px;
+    background: none;
+    border: none;
+    border-radius: var(--radius-sm);
+    color: var(--text-primary);
+    font-size: 12px;
+    font-family: var(--font-mono);
+    cursor: pointer;
+    text-align: left;
+  }
+
+  .slash-item:hover,
+  .slash-item.active {
+    background: color-mix(in srgb, var(--accent-cyan) 16%, transparent);
+  }
+
+  .cmd {
+    color: var(--accent-cyan);
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+
+  .desc {
+    color: var(--text-secondary);
+    font-size: 11px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/src/lib/composer/commands.test.ts
+++ b/src/lib/composer/commands.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { filterCommands, findCommand, SLASH_COMMANDS } from './commands';
+
+// sources.ts pulls in @tauri-apps/api/core (invoke) and the sessions store; mock the Tauri
+// core so importing the flatten/filter helpers stays a pure node test.
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+describe('slash commands', () => {
+  it('filters by typed prefix (case-insensitive)', () => {
+    const res = filterCommands('res');
+    expect(res.map((c) => c.name)).toEqual(['research']);
+
+    const upper = filterCommands('RES');
+    expect(upper.map((c) => c.name)).toEqual(['research']);
+  });
+
+  it('empty query returns every command', () => {
+    expect(filterCommands('').length).toBe(SLASH_COMMANDS.length);
+  });
+
+  it('the three real SessionMode commands resolve to their expansions', () => {
+    expect(findCommand('hive')?.expand()).toBe('/hive ');
+    expect(findCommand('fusion')?.expand()).toBe('/fusion ');
+    expect(findCommand('research')?.expand()).toBe('/research ');
+  });
+
+  it('quick actions are tagged with control actions, not insert', () => {
+    expect(findCommand('clear')?.action).toBe('clear');
+    expect(findCommand('attach')?.action).toBe('attach');
+    expect(findCommand('ask')?.action).toBe('insert');
+  });
+});
+
+describe('mention flatten-to-string', () => {
+  it('flattens agents/sessions/files to plain tokens', async () => {
+    const { flattenMention, filterMentions } = await import('./sources');
+
+    expect(flattenMention({ kind: 'agent', id: 'a1', label: 'Queen' })).toBe('@Queen');
+    expect(flattenMention({ kind: 'session', id: 's1', label: 'my-sess' })).toBe('#my-sess');
+    expect(
+      flattenMention({ kind: 'file', id: 'C:\\repo\\src\\main.rs', label: 'main.rs' })
+    ).toBe('C:\\repo\\src\\main.rs');
+
+    // filter is a case-insensitive substring over label + detail.
+    const items = [
+      { kind: 'agent' as const, id: 'a1', label: 'Backend', detail: 'Worker 0' },
+      { kind: 'agent' as const, id: 'a2', label: 'Frontend', detail: 'Worker 1' },
+    ];
+    expect(filterMentions(items, 'front').map((m) => m.label)).toEqual(['Frontend']);
+    expect(filterMentions(items, '').length).toBe(2);
+  });
+
+  it('builds agent mentions with safe role labels (no object-variant bug)', async () => {
+    const { agentMentions } = await import('./sources');
+    const items = agentMentions([
+      { id: 'q', role: 'Queen', status: 'Running', config: { cli: 'claude', flags: [] }, parent_id: null },
+      {
+        id: 'w0',
+        role: { Worker: { index: 0, parent: null } },
+        status: 'Running',
+        config: { cli: 'claude', flags: [], label: 'Backend' },
+        parent_id: 'q',
+      },
+    ] as never);
+
+    expect(items[0].label).toBe('Queen');
+    // Worker uses its config label when present, role label otherwise — never "[object Object]".
+    expect(items[1].label).toBe('Backend');
+    expect(items[1].detail).toBe('Worker 0');
+  });
+});

--- a/src/lib/composer/commands.ts
+++ b/src/lib/composer/commands.ts
@@ -1,0 +1,91 @@
+/**
+ * Slash-command registry for the Composer (#128).
+ *
+ * Each command has a `label` (the `/token` shown), a `description`, and an `expand()` that
+ * returns the text inserted into the flattened plain-text prompt. The MVP set is locked to
+ * the three real `SessionMode` values (hive / fusion / research) plus a few quick actions;
+ * expanding the set later is purely additive here.
+ *
+ * `clear` and `attach` are control commands: they expand to an empty string (the Composer
+ * intercepts them by `action` rather than inserting text).
+ */
+
+export type SlashCommandAction = 'insert' | 'clear' | 'attach';
+
+export interface SlashCommand {
+  /** The token after the leading slash, e.g. "research". */
+  name: string;
+  /** Human label including the leading slash, e.g. "/research". */
+  label: string;
+  description: string;
+  action: SlashCommandAction;
+  /** Text inserted into the flattened prompt when the command is selected. */
+  expand: () => string;
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+  {
+    name: 'hive',
+    label: '/hive',
+    description: 'Hive orchestration mode',
+    action: 'insert',
+    expand: () => '/hive ',
+  },
+  {
+    name: 'fusion',
+    label: '/fusion',
+    description: 'Fusion (multi-variant) mode',
+    action: 'insert',
+    expand: () => '/fusion ',
+  },
+  {
+    name: 'research',
+    label: '/research',
+    description: 'Research mode',
+    action: 'insert',
+    expand: () => '/research ',
+  },
+  {
+    name: 'ask',
+    label: '/ask',
+    description: 'Ask without making changes',
+    action: 'insert',
+    expand: () => '/ask ',
+  },
+  {
+    name: 'plan',
+    label: '/plan',
+    description: 'Produce a plan, do not implement',
+    action: 'insert',
+    expand: () => '/plan ',
+  },
+  {
+    name: 'clear',
+    label: '/clear',
+    description: 'Clear the composer',
+    action: 'clear',
+    expand: () => '',
+  },
+  {
+    name: 'attach',
+    label: '/attach',
+    description: 'Attach a file or selection',
+    action: 'attach',
+    expand: () => '',
+  },
+];
+
+/**
+ * Filter the command set by a typed prefix (the text after the leading slash). An empty
+ * query returns every command. Matching is case-insensitive against the command name.
+ */
+export function filterCommands(query: string): SlashCommand[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return SLASH_COMMANDS.slice();
+  return SLASH_COMMANDS.filter((c) => c.name.toLowerCase().startsWith(q));
+}
+
+/** Look up a single command by exact name (no leading slash). */
+export function findCommand(name: string): SlashCommand | undefined {
+  return SLASH_COMMANDS.find((c) => c.name.toLowerCase() === name.toLowerCase());
+}

--- a/src/lib/composer/sources.ts
+++ b/src/lib/composer/sources.ts
@@ -1,0 +1,128 @@
+/**
+ * Mention (`@`) data providers for the Composer (#128).
+ *
+ * Three kinds of mention target: agents (from the active session), other sessions, and
+ * files (a debounced Tauri fs read scoped to the active session's project/worktree path).
+ * Every mention resolves to a stable `id` (agent.id / session.id / absolute file path as
+ * received from Rust — NO `path.join`, per the Windows-path risk) plus a display `label`.
+ *
+ * `flattenMention()` is the canonical serialization used when the contenteditable model is
+ * flattened to a plain string on submit: agents -> `@label`, sessions -> `#session`, files
+ * -> the raw path. The backend `send_agent_input` only accepts a flat string, so there is
+ * no persistable rich-document model.
+ */
+
+import { invoke } from '@tauri-apps/api/core';
+import { serdeEnumVariantName } from '$lib/types/domain';
+import type { AgentInfo, Session } from '$lib/stores/sessions';
+
+export type MentionKind = 'agent' | 'session' | 'file';
+
+export interface MentionItem {
+  kind: MentionKind;
+  /** Stable identifier (agent.id / session.id / absolute file path). */
+  id: string;
+  /** Display label (without the leading @). */
+  label: string;
+  /** Secondary line shown in the menu (role, project, etc.). */
+  detail?: string;
+}
+
+/** Friendly role label for an agent, handling serde object-variants safely. */
+function roleLabel(role: AgentInfo['role']): string {
+  const variant = serdeEnumVariantName(role);
+  if (variant === 'Worker' && typeof role === 'object' && role !== null && 'Worker' in role) {
+    const idx = (role as { Worker: { index: number } }).Worker.index;
+    return `Worker ${idx}`;
+  }
+  return variant ?? 'Agent';
+}
+
+/** Build agent mention items from the active session's agents. */
+export function agentMentions(agents: AgentInfo[]): MentionItem[] {
+  return agents.map((a) => ({
+    kind: 'agent' as const,
+    id: a.id,
+    label: a.config?.label || roleLabel(a.role) || a.id.slice(0, 8),
+    detail: roleLabel(a.role),
+  }));
+}
+
+/** Build session mention items from the sessions list. */
+export function sessionMentions(sessions: Session[]): MentionItem[] {
+  return sessions.map((s) => ({
+    kind: 'session' as const,
+    id: s.id,
+    label: s.name || s.id.slice(0, 8),
+    detail: s.project_path,
+  }));
+}
+
+/** Build file mention items from a list of absolute paths returned by Rust. */
+export function fileMentions(paths: string[]): MentionItem[] {
+  return paths.map((p) => {
+    // Display just the basename; keep the full path as the stable id.
+    const idx = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+    const base = idx >= 0 ? p.slice(idx + 1) : p;
+    return { kind: 'file' as const, id: p, label: base, detail: p };
+  });
+}
+
+/**
+ * Debounced file source: lists files under a session's project/worktree path via a Tauri
+ * command. Returns absolute paths exactly as Rust provides them (no client-side joining).
+ * Results are capped and the call is debounced so large worktrees don't thrash.
+ */
+let fileDebounce: ReturnType<typeof setTimeout> | null = null;
+const FILE_DEBOUNCE_MS = 200;
+const FILE_RESULT_CAP = 50;
+
+export function listSessionFiles(
+  rootPath: string,
+  query: string
+): Promise<string[]> {
+  return new Promise((resolve) => {
+    if (fileDebounce) clearTimeout(fileDebounce);
+    fileDebounce = setTimeout(async () => {
+      fileDebounce = null;
+      try {
+        const files = await invoke<string[]>('list_session_files', {
+          rootPath,
+          query,
+        });
+        resolve(files.slice(0, FILE_RESULT_CAP));
+      } catch {
+        // No backing command (or fs error) — file mentions simply yield nothing.
+        resolve([]);
+      }
+    }, FILE_DEBOUNCE_MS);
+  });
+}
+
+/** Case-insensitive prefix/substring filter over mention labels. */
+export function filterMentions(items: MentionItem[], query: string): MentionItem[] {
+  const q = query.trim().toLowerCase();
+  if (q === '') return items;
+  return items.filter(
+    (m) =>
+      m.label.toLowerCase().includes(q) ||
+      (m.detail ? m.detail.toLowerCase().includes(q) : false)
+  );
+}
+
+/**
+ * Flatten a mention to the plain-text token inserted into the outgoing prompt.
+ * agents -> `@label`, sessions -> `#session`, files -> raw path.
+ */
+export function flattenMention(item: MentionItem): string {
+  switch (item.kind) {
+    case 'agent':
+      return `@${item.label}`;
+    case 'session':
+      return `#${item.label}`;
+    case 'file':
+      return item.id;
+    default:
+      return item.label;
+  }
+}

--- a/src/lib/stores/composerDraft.test.ts
+++ b/src/lib/stores/composerDraft.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+
+/**
+ * composerDraft tests run in jsdom (filename includes `.svelte.test`? no — these are pure
+ * store tests that only need a localStorage stub). We provide a Map-backed localStorage so
+ * the node environment has the API the store guards on.
+ */
+
+function installLocalStorage(impl?: Partial<Storage>) {
+  const map = new Map<string, string>();
+  const store: Storage = {
+    get length() {
+      return map.size;
+    },
+    clear: () => map.clear(),
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    key: (i: number) => Array.from(map.keys())[i] ?? null,
+    removeItem: (k: string) => map.delete(k),
+    setItem: (k: string, v: string) => {
+      map.set(k, v);
+    },
+    ...impl,
+  };
+  (globalThis as unknown as { localStorage: Storage }).localStorage = store;
+  return { map, store };
+}
+
+describe('composerDraft store', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    installLocalStorage();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    delete (globalThis as unknown as { localStorage?: Storage }).localStorage;
+  });
+
+  it('writes a draft and reloads it from localStorage (roundtrip)', async () => {
+    const { composerDraft, draftKey } = await import('./composerDraft');
+
+    composerDraft.load('s1');
+    composerDraft.update('hello world');
+    // Debounced write — advance past the debounce window.
+    vi.advanceTimersByTime(500);
+
+    expect(localStorage.getItem(draftKey('s1'))).toBe('hello world');
+
+    // Re-binding the session hydrates the persisted text.
+    composerDraft.load('s2'); // bind elsewhere first
+    const restored = composerDraft.load('s1');
+    expect(restored).toBe('hello world');
+  });
+
+  it('falls back to in-memory when localStorage.setItem throws (quota) without throwing', async () => {
+    installLocalStorage({
+      setItem: () => {
+        throw new DOMException('QuotaExceededError');
+      },
+    });
+    const { composerDraft } = await import('./composerDraft');
+
+    composerDraft.load('quota');
+    expect(() => {
+      composerDraft.update('big draft');
+      vi.advanceTimersByTime(500);
+    }).not.toThrow();
+
+    // In-memory fallback still returns the value via read().
+    expect(composerDraft.read('quota')).toBe('big draft');
+  });
+
+  it('keeps per-session keys isolated', async () => {
+    const { composerDraft, draftKey } = await import('./composerDraft');
+
+    composerDraft.load('alpha');
+    composerDraft.update('alpha draft');
+    vi.advanceTimersByTime(500);
+
+    composerDraft.load('beta');
+    composerDraft.update('beta draft');
+    vi.advanceTimersByTime(500);
+
+    expect(localStorage.getItem(draftKey('alpha'))).toBe('alpha draft');
+    expect(localStorage.getItem(draftKey('beta'))).toBe('beta draft');
+    expect(draftKey('alpha')).not.toBe(draftKey('beta'));
+
+    // Loading alpha does not see beta's text.
+    expect(composerDraft.load('alpha')).toBe('alpha draft');
+  });
+
+  it('clear() removes the persisted draft for the bound session', async () => {
+    const { composerDraft, draftKey } = await import('./composerDraft');
+    composerDraft.load('c1');
+    composerDraft.update('temp');
+    vi.advanceTimersByTime(500);
+    expect(localStorage.getItem(draftKey('c1'))).toBe('temp');
+
+    composerDraft.clear();
+    expect(localStorage.getItem(draftKey('c1'))).toBeNull();
+  });
+});

--- a/src/lib/stores/composerDraft.ts
+++ b/src/lib/stores/composerDraft.ts
@@ -1,0 +1,113 @@
+import { writable } from 'svelte/store';
+
+/**
+ * Per-session composer draft persistence (#128).
+ *
+ * Clones the `layout.ts` `createLayoutStore()` pattern: `loadInitial` reads from
+ * localStorage with an SSR guard, and `updateAndPersist` writes back inside a try/catch so
+ * a quota/privacy failure degrades to in-memory only (never throws). Each session keeps its
+ * own key `hive-composer-draft-{sessionId}` so drafts are isolated. Writes are debounced so
+ * a burst of keystrokes collapses to one localStorage write per session.
+ */
+
+const KEY_PREFIX = 'hive-composer-draft-';
+const DEBOUNCE_MS = 400;
+
+/** Build the per-session storage key. Exported for tests / introspection. */
+export function draftKey(sessionId: string): string {
+  return `${KEY_PREFIX}${sessionId}`;
+}
+
+function loadInitial(sessionId: string): string {
+  if (typeof localStorage === 'undefined') return '';
+  try {
+    return localStorage.getItem(draftKey(sessionId)) ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function createComposerDraftStore() {
+  // Holds the live draft text for whichever session is currently bound.
+  const { subscribe, set } = writable<string>('');
+
+  let boundSessionId: string | null = null;
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  /** In-memory fallback used when localStorage is unavailable (quota/privacy). */
+  const memory = new Map<string, string>();
+
+  function persist(sessionId: string, text: string) {
+    memory.set(sessionId, text);
+    if (typeof localStorage === 'undefined') return;
+    try {
+      if (text.length === 0) {
+        localStorage.removeItem(draftKey(sessionId));
+      } else {
+        localStorage.setItem(draftKey(sessionId), text);
+      }
+    } catch {
+      // Quota or privacy errors — draft persistence is best-effort (in-memory only).
+    }
+  }
+
+  return {
+    subscribe,
+
+    /**
+     * Bind the store to a session, hydrating its persisted (or in-memory) draft. Call on
+     * mount and whenever the active session changes.
+     */
+    load(sessionId: string): string {
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      boundSessionId = sessionId;
+      const initial = memory.has(sessionId) ? memory.get(sessionId)! : loadInitial(sessionId);
+      memory.set(sessionId, initial);
+      set(initial);
+      return initial;
+    },
+
+    /** Update the bound session's draft (debounced persist). */
+    update(text: string) {
+      const sessionId = boundSessionId;
+      set(text);
+      if (!sessionId) return;
+      memory.set(sessionId, text);
+      if (debounceTimer) clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        debounceTimer = null;
+        persist(sessionId, text);
+      }, DEBOUNCE_MS);
+    },
+
+    /** Clear the bound session's draft immediately (e.g. after submit). */
+    clear() {
+      const sessionId = boundSessionId;
+      set('');
+      if (!sessionId) return;
+      if (debounceTimer) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+      }
+      persist(sessionId, '');
+    },
+
+    /** Synchronously read a session's persisted draft without binding (tests/preview). */
+    read(sessionId: string): string {
+      return memory.has(sessionId) ? memory.get(sessionId)! : loadInitial(sessionId);
+    },
+
+    /** Flush any pending debounced write immediately. Mainly for tests. */
+    flush() {
+      if (debounceTimer && boundSessionId) {
+        clearTimeout(debounceTimer);
+        debounceTimer = null;
+        persist(boundSessionId, memory.get(boundSessionId) ?? '');
+      }
+    },
+  };
+}
+
+export const composerDraft = createComposerDraftStore();

--- a/src/lib/stores/pendingContext.test.ts
+++ b/src/lib/stores/pendingContext.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, afterEach, describe, it, expect, vi } from 'vitest';
+import type { PendingContext } from './pendingContext';
+
+/**
+ * pendingContext is backed by #124's application_state via the atomic take endpoint. We
+ * mock fetch with a tiny in-memory KV that mirrors the backend `write` (POST
+ * .../application-state) and `take` (POST .../application-state/take, read-and-delete)
+ * semantics, so the one-turn-expiry guarantee is exercised against realistic responses.
+ */
+
+function makeBackend() {
+  const kv = new Map<string, unknown>(); // key: `${sessionId}:${key}`
+
+  const fetchMock = vi.fn(async (url: string | URL, init?: RequestInit) => {
+    const u = typeof url === 'string' ? url : url.toString();
+    const body = init?.body ? JSON.parse(init.body as string) : {};
+    const sessionMatch = u.match(/\/api\/sessions\/([^/]+)\/application-state(\/take)?$/);
+    const sessionId = sessionMatch?.[1] ?? '';
+    const isTake = !!sessionMatch?.[2];
+
+    if (isTake) {
+      const k = `${sessionId}:${body.key}`;
+      const value = kv.has(k) ? kv.get(k) : null;
+      kv.delete(k); // atomic read-and-delete
+      const row = value == null ? null : { session_id: sessionId, key: body.key, value, updated_at: 1 };
+      return new Response(JSON.stringify(row), { status: 200 });
+    }
+    // write (capture)
+    const k = `${sessionId}:${body.key}`;
+    kv.set(k, body.value);
+    return new Response(
+      JSON.stringify({ session_id: sessionId, key: body.key, value: body.value, updated_at: 1 }),
+      { status: 200 }
+    );
+  });
+
+  return { kv, fetchMock };
+}
+
+describe('pendingContext store', () => {
+  let restoreFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    vi.resetModules();
+    restoreFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = restoreFetch;
+    vi.restoreAllMocks();
+  });
+
+  const ctx = (over: Partial<PendingContext> = {}): PendingContext => ({
+    sessionId: 's1',
+    agentId: null,
+    kind: 'selection',
+    text: 'selected code',
+    capturedAt: 123,
+    ...over,
+  });
+
+  it('capture then consume returns the context once, then null (one-turn expiry)', async () => {
+    const { fetchMock } = makeBackend();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const { pendingContext } = await import('./pendingContext');
+
+    await pendingContext.capture(ctx());
+
+    const first = await pendingContext.consume('s1');
+    expect(first).not.toBeNull();
+    expect(first?.text).toBe('selected code');
+
+    // Second consume: the row was deleted by the atomic take, so null.
+    const second = await pendingContext.consume('s1');
+    expect(second).toBeNull();
+  });
+
+  it('capture twice keeps only the latest context', async () => {
+    const { fetchMock } = makeBackend();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const { pendingContext } = await import('./pendingContext');
+
+    await pendingContext.capture(ctx({ text: 'first' }));
+    await pendingContext.capture(ctx({ text: 'second' }));
+
+    const taken = await pendingContext.consume('s1');
+    expect(taken?.text).toBe('second');
+  });
+
+  it('render() produces a fenced [Operator context] block', async () => {
+    const { fetchMock } = makeBackend();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    const { pendingContext } = await import('./pendingContext');
+
+    const block = pendingContext.render(ctx({ text: 'abc' }));
+    expect(block).toBe('[Operator context]\nabc\n[/Operator context]');
+
+    const cellBlock = pendingContext.render(ctx({ kind: 'cell', cellId: 'cell-9', text: null }));
+    expect(cellBlock).toContain('Selected session cell: cell-9');
+  });
+
+  it('falls back to the in-memory mirror if the backend take fails', async () => {
+    const failing = vi.fn(async (url: string | URL, init?: RequestInit) => {
+      const u = typeof url === 'string' ? url : url.toString();
+      if (u.endsWith('/take')) {
+        return new Response('err', { status: 500 });
+      }
+      return new Response('{}', { status: 200 }); // capture succeeds
+    });
+    globalThis.fetch = failing as unknown as typeof globalThis.fetch;
+    const { pendingContext } = await import('./pendingContext');
+
+    await pendingContext.capture(ctx({ text: 'mirror me' }));
+    const taken = await pendingContext.consume('s1');
+    expect(taken?.text).toBe('mirror me');
+
+    // And it clears after the fallback consume.
+    const again = await pendingContext.consume('s1');
+    expect(again).toBeNull();
+  });
+});

--- a/src/lib/stores/pendingContext.ts
+++ b/src/lib/stores/pendingContext.ts
@@ -1,0 +1,127 @@
+import { writable } from 'svelte/store';
+import { apiUrl } from '$lib/config';
+
+/**
+ * One-shot operator-selection context (#128 Ctrl+I "select -> instruct").
+ *
+ * The operator selects text in a terminal / the page (or a session cell), presses Ctrl+I,
+ * and the selection is captured here. The NEXT composer submit consumes it exactly once,
+ * prepending a fenced `[Operator context]` block to the outgoing prompt, then it expires.
+ *
+ * Source of truth for the one-shot guarantee is #124's `application_state` table via the
+ * atomic `take` endpoint (read-and-delete in a single transaction): a lagging/double submit
+ * cannot re-send the same context because the row is gone after the first take. A thin
+ * in-memory mirror is kept for synchronous UI affordances (e.g. showing "context armed"),
+ * but `consume()` always goes through the backend take so concurrency is handled server-side.
+ */
+
+export type PendingContextKind = 'cell' | 'selection';
+
+export interface PendingContext {
+  sessionId: string;
+  agentId: string | null;
+  kind: PendingContextKind;
+  /** Present for kind === 'cell'. */
+  cellId?: string | null;
+  /** Selected text (normalized) for kind === 'selection'. */
+  text?: string | null;
+  /** Epoch millis when captured. */
+  capturedAt: number;
+}
+
+/** The key under which the one-shot context lives in `application_state`. */
+export const PENDING_CONTEXT_KEY = 'pending_selection_context';
+
+interface PendingContextState {
+  /** The latest armed context, or null when nothing is pending. */
+  current: PendingContext | null;
+}
+
+function createPendingContextStore() {
+  const { subscribe, set } = writable<PendingContextState>({ current: null });
+
+  /** In-memory mirror for synchronous reads (UI badge etc.). Backend is authoritative. */
+  let mirror: PendingContext | null = null;
+
+  /**
+   * Render the operator context as a fenced block to prepend to a prompt.
+   * Exported as a pure helper so the composer (and tests) format it identically.
+   */
+  function render(ctx: PendingContext): string {
+    const body =
+      ctx.kind === 'cell'
+        ? `Selected session cell: ${ctx.cellId ?? '(unknown)'}`
+        : (ctx.text ?? '').trim();
+    return `[Operator context]\n${body}\n[/Operator context]`;
+  }
+
+  return {
+    subscribe,
+
+    /**
+     * Arm a one-shot context. Writes to the backend `application_state` (key
+     * `pending_selection_context`) so it survives until consumed, and overwrites any
+     * prior pending context (capture-twice keeps only the latest).
+     */
+    async capture(ctx: PendingContext): Promise<void> {
+      mirror = ctx;
+      set({ current: ctx });
+      try {
+        await fetch(apiUrl(`/api/sessions/${ctx.sessionId}/application-state`), {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ key: PENDING_CONTEXT_KEY, value: ctx }),
+        });
+      } catch {
+        // Best-effort: the in-memory mirror still lets consume() fall back below.
+      }
+    },
+
+    /**
+     * Read-and-clear the pending context for a session, returning it once then null.
+     * Goes through the atomic backend take endpoint so a double/lagging submit can never
+     * re-consume. Falls back to the in-memory mirror only if the backend is unreachable.
+     */
+    async consume(sessionId: string): Promise<PendingContext | null> {
+      let taken: PendingContext | null = null;
+      try {
+        const resp = await fetch(
+          apiUrl(`/api/sessions/${sessionId}/application-state/take`),
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ key: PENDING_CONTEXT_KEY }),
+          }
+        );
+        if (resp.ok) {
+          const row = (await resp.json()) as { value: PendingContext } | null;
+          taken = row?.value ?? null;
+        } else {
+          // Backend rejected — fall back to the mirror so the feature still works offline.
+          taken = mirror;
+        }
+      } catch {
+        taken = mirror;
+      }
+      // Clear the mirror + store regardless: exactly-one-turn.
+      mirror = null;
+      set({ current: null });
+      return taken;
+    },
+
+    /** Synchronous peek at the in-memory mirror (does NOT consume). */
+    peek(): PendingContext | null {
+      return mirror;
+    },
+
+    /** Discard any pending context without sending (e.g. session switch). */
+    clear() {
+      mirror = null;
+      set({ current: null });
+    },
+
+    render,
+  };
+}
+
+export const pendingContext = createPendingContextStore();

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,6 +12,7 @@
   import { coordination } from '$lib/stores/coordination';
   import { ui } from '$lib/stores/ui';
   import { layout } from '$lib/stores/layout';
+  import { pendingContext } from '$lib/stores/pendingContext';
 
   let showAddWorkerDialog = $state(false);
   let showShortcuts = $state(false);
@@ -113,6 +114,46 @@
     showAddWorkerDialog = false;
   }
 
+  // Read an xterm terminal selection if the focused/under-cursor element is inside one.
+  function readXtermSelection(): string | null {
+    const term = document.querySelector('.xterm-helper-textarea, .xterm') as HTMLElement | null;
+    // xterm exposes selection via the DOM Selection API over the .xterm-rows; the
+    // window selection below covers it, so this is a placeholder for buffer-level reads.
+    if (!term) return null;
+    return null;
+  }
+
+  // Capture the operator's current selection (terminal or page) or selected cell as a
+  // one-shot context for the next composer submit. CRLF is normalized and the text trimmed.
+  function captureSelectionContext(sessionId: string) {
+    const xtermText = readXtermSelection();
+    const winText = window.getSelection()?.toString() ?? '';
+    const raw = (xtermText ?? winText).replace(/\r\n/g, '\n').trim();
+
+    if (raw) {
+      pendingContext.capture({
+        sessionId,
+        agentId: $ui.focusedAgentId,
+        kind: 'selection',
+        text: raw,
+        capturedAt: Date.now(),
+      });
+      return;
+    }
+
+    // No text selection — fall back to the selected session cell, if any.
+    const cellId = $ui.selectedCellId;
+    if (cellId) {
+      pendingContext.capture({
+        sessionId,
+        agentId: $ui.focusedAgentId,
+        kind: 'cell',
+        cellId,
+        capturedAt: Date.now(),
+      });
+    }
+  }
+
   // Keyboard shortcuts (Ctrl on Windows/Linux, Cmd on macOS)
   function handleKeydown(event: KeyboardEvent) {
     const mod = event.ctrlKey || event.metaKey;
@@ -133,6 +174,18 @@
     }
     if (event.key === 'Escape' && showShortcuts) {
       showShortcuts = false;
+    }
+    // Ctrl+I: capture the active selection / cell as one-shot operator context for the
+    // next composer submit. Skip when focus is inside the composer (don't hijack its own
+    // selection). Reads xterm selection first, then the window selection, else the
+    // selected session cell.
+    if (mod && (event.key === 'i' || event.key === 'I')) {
+      const ctxTarget = event.target as HTMLElement | null;
+      if (ctxTarget?.closest('[data-composer]')) return; // composer owns its selection
+      const sid = $activeSession?.id ?? null;
+      if (!sid) return;
+      event.preventDefault();
+      captureSelectionContext(sid);
     }
     // Navigate agents with arrow keys — skip when user is typing in inputs, textareas,
     // contenteditable regions, or terminal panes so we don't hijack their keystrokes.


### PR DESCRIPTION
## Summary

Final issue of the **agent-native-engine** epic (#123–#128). Replaces the basic prompt textarea with a reusable **Svelte-native composer** (`@`-mentions, `/`-commands with typeahead, per-session drafts) and adds **Ctrl+I context-awareness** — select a cell/text and surface it to the agent for exactly one turn, backed by `#124`'s `take_key`.

Resolves #128. Built on the merged surface per the epic contract: Svelte-native (NOT Tiptap — zero new runtime deps); one-shot = `take_key` (no TTL).

## What landed

**Backend (small)**
- `POST /api/sessions/{id}/application-state/take` — wraps `#124`'s `take_key` (atomic read-and-delete in `BEGIN IMMEDIATE`) in `spawn_blocking` with `validate_session_id`; returns the taken row or `null`. This is the one-shot consume path. (Also dropped the now-used `#[allow(dead_code)]` on `take_key`.)

**Frontend (Svelte 5 runes)**
- `composer/Composer.svelte` — contenteditable editor; `@` opens `MentionMenu`, `/` opens `SlashMenu` (caret-anchored, Arrow/Enter/Tab/Escape nav); flattens mentions/commands to plain text on submit. `data-composer` so the global arrow-nav guard ignores it.
- `composer/sources.ts` — mention sources (agents from `activeAgents`, sessions, files; `serdeEnumVariantName` role labels). `composer/commands.ts` — `/hive /fusion /research /ask /plan /clear /attach`.
- `stores/composerDraft.ts` — per-session localStorage drafts (key `hive-composer-draft-{sessionId}`) cloning `layout.ts`'s pattern with a quota guard.
- `stores/pendingContext.ts` — `capture()` POSTs `pending_selection_context`; `consume()` POSTs the new **take** endpoint (atomic read+delete) so a lagging/double submit can't re-send.
- `+page.svelte` — Ctrl+I captures `window`/xterm selection (normalized) or `$ui.selectedCellId`, skips `[data-composer]`, `preventDefault`. `ShortcutsOverlay` documents it.
- Composer integrated into `ConversationViewer` (chat input), `AddWorkerDialog` (Initial Task), `LaunchDialog` (Initial Prompt) — flatten to a plain string so existing send/launch endpoints are unchanged.

## Acceptance criteria

- [x] `@`-mentions and `/`-commands with typeahead — menus fed by `sources.ts`/`commands.ts`; `commands.test.ts` covers prefix filtering + expansion + mention flatten.
- [x] Ctrl+I surfaces context for **exactly one turn, then expires** — `consume()` uses the atomic `take` endpoint; `pendingContext.test.ts` proves first-consume-returns, second-returns-`null`.
- [x] Drafts persist across reload, per-session — `composerDraft.test.ts` covers roundtrip, quota fallback, per-session isolation.

## Testing

- ✅ `npx vitest run` — **33/33** (19 existing + 14 new: composerDraft 4, pendingContext 4, commands 6). Real jsdom/node; reviewer re-ran green.
- ✅ `npm run check` 0/0; `npm run build` ok; `cargo check --tests` 0/0 (backend take endpoint).
- 🔧 **Fix in this PR** (`57f4cd6`, caught by review): in the dialog composers (`bind:value`, no `onsubmit`), Enter was clearing the field and consuming pending context. Enter now inserts a newline there; `submit()` is a no-op without a handler. Re-verified: svelte-check 0/0, vitest 33/33.

## Deferred (documented follow-ups, non-blocking)

- File `@`-mentions call a `list_session_files` Tauri command that doesn't exist yet — degrades gracefully to empty; agent/session mentions are fully wired. (Add the command in a follow-up.)
- `readXtermSelection()` is a placeholder; xterm selection is captured via `window.getSelection()` over the `.xterm-rows` DOM (works for DOM-rendered terminals; a WebGL buffer would want a dedicated bridge).
- Mentions/commands flatten to plain text (no visual pill/chip styling) — functionally correct for the flat-string backend contract; purely a visual nicety.
- Full live two-message Ctrl+I smoke needs the Tauri shell; covered here by unit tests + the backend endpoint.

## Notes

- Adversarial `code-reviewer` pass: verdict **pass**, vitest re-run green; send paths preserved, arrow-nav guard intact, no dependency added.
- Branches from `main` (contains the full foundation + #125 + #126).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
