### PR TITLE
feat: Debate session mode (#120) + agent-native epic follow-ups (#129)

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -22,13 +22,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 
       - name: Rust cache
-        uses: swatinem/rust-cache@v2
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32
         with:
           workspaces: ./src-tauri -> target
 

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,42 @@
+name: Rust Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - "feat/**"
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-test:
+    name: Cargo test
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        working-directory: src-tauri
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Cargo check tests
+        run: cargo check --tests
+
+      - name: Cargo clippy
+        run: cargo clippy
+
+      - name: Cargo test
+        run: cargo test

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -6,8 +6,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::coordination::{StateManager, WorkerStateInfo};
+use crate::coordination::{CoordinationMessage, MessageType, StateManager, WorkerStateInfo};
 use crate::pty::{AgentConfig, AgentRole, WorkerRole};
+use crate::tauri_shim::Emitter;
 
 use super::error::ActionError;
 use super::registry::{Action, ActionRegistry};
@@ -346,7 +347,9 @@ impl Action for AddWorker {
                 })
                 .collect();
 
-            let _ = state_manager.update_workers_file(&workers);
+            state_manager
+                .update_workers_file(&workers)
+                .map_err(|e| ActionError::internal(e.to_string()))?;
         }
 
         serialize_output(agent_info, "agent info")
@@ -391,11 +394,21 @@ impl Action for LogCoordinationMessage {
     async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
         require_frontend(ctx)?;
         let parsed: LogCoordinationMessageInput = deserialize_input(input)?;
-        let manager = ctx.state.injection_manager.read();
-        manager
-            .log_system_message(&parsed.session_id, &parsed.to, &parsed.content)
+        let coord_message = CoordinationMessage::new(
+            &parsed.from,
+            &parsed.to,
+            &parsed.content,
+            MessageType::System,
+        );
+        ctx.state
+            .storage
+            .append_coordination_log(&parsed.session_id, &coord_message)
             .map_err(|e| ActionError::internal(e.to_string()))?;
-        let _ = parsed.from;
+        if let Some(app_handle) = ctx.state.app_handle.as_ref() {
+            app_handle
+                .emit("coordination-message", &coord_message)
+                .map_err(|e| ActionError::internal(e.to_string()))?;
+        }
         Ok(Value::Null)
     }
 }
@@ -764,8 +777,15 @@ fn extract_priority(text: &str) -> (String, Option<String>) {
     ];
 
     for (marker, priority) in priorities {
-        if text.to_uppercase().contains(marker) {
-            let cleaned = text.replace(marker, "").replace(&marker.to_lowercase(), "");
+        if text
+            .split_whitespace()
+            .any(|token| token.eq_ignore_ascii_case(marker))
+        {
+            let cleaned = text
+                .split_whitespace()
+                .filter(|token| !token.eq_ignore_ascii_case(marker))
+                .collect::<Vec<_>>()
+                .join(" ");
             return (cleaned, Some(priority.to_string()));
         }
     }
@@ -774,12 +794,38 @@ fn extract_priority(text: &str) -> (String, Option<String>) {
 }
 
 fn extract_assignee(text: &str) -> (String, Option<String>) {
-    if let Some(pos) = text.find("->") {
-        let (title, assignee) = text.split_at(pos);
-        return (title.to_string(), Some(assignee[2..].trim().to_string()));
+    for separator in ["->", "\u{2192}"] {
+        if let Some((title, assignee)) = text.split_once(separator) {
+            return (title.to_string(), Some(assignee.trim().to_string()));
+        }
     }
 
     (text.to_string(), None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extract_assignee, extract_priority};
+
+    #[test]
+    fn extract_priority_strips_detected_token_case_insensitively() {
+        let (title, priority) = extract_priority("[High] Fix launch regression");
+
+        assert_eq!(title, "Fix launch regression");
+        assert_eq!(priority.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn extract_assignee_supports_ascii_and_unicode_arrows() {
+        assert_eq!(
+            extract_assignee("Fix launch -> worker-8"),
+            ("Fix launch ".to_string(), Some("worker-8".to_string()))
+        );
+        assert_eq!(
+            extract_assignee("Fix launch \u{2192} worker-9"),
+            ("Fix launch ".to_string(), Some("worker-9".to_string()))
+        );
+    }
 }
 
 pub fn register(registry: &mut ActionRegistry) {

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -1,0 +1,801 @@
+//! Coordination and session-state actions behind the unified action registry.
+
+use async_trait::async_trait;
+use schemars::schema::RootSchema;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::coordination::{StateManager, WorkerStateInfo};
+use crate::pty::{AgentConfig, AgentRole, WorkerRole};
+
+use super::error::ActionError;
+use super::registry::{Action, ActionRegistry};
+use super::{ActionContext, Caller};
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct QueenInjectRequest {
+    pub session_id: String,
+    pub queen_id: String,
+    pub target_worker_id: String,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct AddWorkerRequest {
+    pub session_id: String,
+    pub config: AgentConfig,
+    pub role: WorkerRole,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub parent_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct OperatorInjectRequest {
+    pub session_id: String,
+    pub target_agent_id: String,
+    pub message: String,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct WorkerStatusRequest {
+    pub session_id: String,
+    pub queen_id: String,
+    pub worker_id: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct PlanTask {
+    pub id: String,
+    pub title: String,
+    pub description: String,
+    pub status: String,
+    pub assignee: Option<String>,
+    pub priority: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionPlan {
+    pub title: String,
+    pub summary: String,
+    pub tasks: Vec<PlanTask>,
+    pub generated_at: String,
+    pub raw_content: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EmptyInput {}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct QueenSwitchBranchInput {
+    session_id: String,
+    queen_id: String,
+    branch: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CoordinationLogInput {
+    session_id: String,
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LogCoordinationMessageInput {
+    session_id: String,
+    from: String,
+    to: String,
+    content: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct SessionIdInput {
+    session_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct AssignTaskInput {
+    session_id: String,
+    queen_id: String,
+    worker_id: String,
+    task: String,
+    plan_task_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ListStoredSessionsInput {
+    project_path: Option<String>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct UpdateAppConfigInput {
+    config: Value,
+}
+
+fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
+    serde_json::from_value(input)
+        .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+fn serialize_output<T: Serialize>(value: T, label: &str) -> Result<Value, ActionError> {
+    serde_json::to_value(value)
+        .map_err(|e| ActionError::internal(format!("Failed to serialize {}: {}", label, e)))
+}
+
+fn require_frontend(ctx: &ActionContext) -> Result<(), ActionError> {
+    if matches!(ctx.caller, Caller::Frontend) {
+        Ok(())
+    } else {
+        Err(ActionError::bad_request(
+            "Coordination actions are only available through Tauri commands",
+        ))
+    }
+}
+
+struct QueenInject;
+
+#[async_trait]
+impl Action for QueenInject {
+    fn name(&self) -> &'static str {
+        "coordination.queen_inject"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(QueenInjectRequest)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let request: QueenInjectRequest = deserialize_input(input)?;
+        let manager = ctx.state.injection_manager.read();
+        manager
+            .queen_inject(
+                &request.session_id,
+                &request.queen_id,
+                &request.target_worker_id,
+                &request.message,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct QueenSwitchBranch;
+
+#[async_trait]
+impl Action for QueenSwitchBranch {
+    fn name(&self) -> &'static str {
+        "coordination.queen_switch_branch"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(QueenSwitchBranchInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: QueenSwitchBranchInput = deserialize_input(input)?;
+        let worker_ids = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .get_session(&parsed.session_id)
+                .map(|s| {
+                    s.agents
+                        .iter()
+                        .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
+                        .map(|a| a.id.clone())
+                        .collect::<Vec<_>>()
+                })
+                .ok_or_else(|| ActionError::not_found("Session not found"))?
+        };
+
+        let manager = ctx.state.injection_manager.read();
+        let results = manager
+            .queen_switch_branch(
+                &parsed.session_id,
+                &parsed.queen_id,
+                &worker_ids,
+                &parsed.branch,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+
+        serialize_output(
+            results
+                .into_iter()
+                .map(|(id, result)| (id, result.is_ok()))
+                .collect::<Vec<(String, bool)>>(),
+            "branch switch results",
+        )
+    }
+}
+
+struct OperatorInject;
+
+#[async_trait]
+impl Action for OperatorInject {
+    fn name(&self) -> &'static str {
+        "coordination.operator_inject"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(OperatorInjectRequest)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let request: OperatorInjectRequest = deserialize_input(input)?;
+        let manager = ctx.state.injection_manager.read();
+        manager
+            .operator_inject(
+                &request.session_id,
+                &request.target_agent_id,
+                &request.message,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct ReportWorkerStatus;
+
+#[async_trait]
+impl Action for ReportWorkerStatus {
+    fn name(&self) -> &'static str {
+        "coordination.report_worker_status"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(WorkerStatusRequest)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let request: WorkerStatusRequest = deserialize_input(input)?;
+        let manager = ctx.state.injection_manager.read();
+        manager
+            .notify_queen_worker_status(
+                &request.session_id,
+                &request.queen_id,
+                &request.worker_id,
+                &request.status,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct AddWorker;
+
+#[async_trait]
+impl Action for AddWorker {
+    fn name(&self) -> &'static str {
+        "coordination.add_worker"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(AddWorkerRequest)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let request: AddWorkerRequest = deserialize_input(input)?;
+        let controller = ctx.state.session_controller.write();
+
+        let mut config = request.config;
+        let normalize_opt_str = |value: Option<String>| {
+            value.and_then(|v| {
+                let trimmed = v.trim().to_string();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            })
+        };
+        config.name = normalize_opt_str(request.name).or_else(|| normalize_opt_str(config.name));
+        config.description = normalize_opt_str(request.description)
+            .or_else(|| normalize_opt_str(config.description));
+
+        let agent_info = controller
+            .add_worker(
+                &request.session_id,
+                config,
+                request.role.clone(),
+                request.parent_id,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+
+        let coord_manager = ctx.state.injection_manager.read();
+        let queen_id = format!("{}-queen", request.session_id);
+        let worker_state = WorkerStateInfo {
+            id: agent_info.id.clone(),
+            role: request.role,
+            cli: agent_info.config.cli.clone(),
+            status: "Running".to_string(),
+            current_task: None,
+            last_update: chrono::Utc::now(),
+            last_heartbeat: None,
+        };
+        let _ =
+            coord_manager.notify_queen_worker_added(&request.session_id, &queen_id, &worker_state);
+
+        let session_path = ctx.state.storage.session_dir(&request.session_id);
+        let state_manager = StateManager::new(session_path);
+
+        if let Some(session) = controller.get_session(&request.session_id) {
+            let workers: Vec<WorkerStateInfo> = session
+                .agents
+                .iter()
+                .filter(|a| {
+                    !matches!(
+                        a.role,
+                        AgentRole::Queen | AgentRole::Evaluator | AgentRole::QaWorker { .. }
+                    )
+                })
+                .map(|a| WorkerStateInfo {
+                    id: a.id.clone(),
+                    role: a.config.role.clone().unwrap_or_default(),
+                    cli: a.config.cli.clone(),
+                    status: format!("{:?}", a.status),
+                    current_task: None,
+                    last_update: chrono::Utc::now(),
+                    last_heartbeat: None,
+                })
+                .collect();
+
+            let _ = state_manager.update_workers_file(&workers);
+        }
+
+        serialize_output(agent_info, "agent info")
+    }
+}
+
+struct GetCoordinationLog;
+
+#[async_trait]
+impl Action for GetCoordinationLog {
+    fn name(&self) -> &'static str {
+        "coordination.get_log"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(CoordinationLogInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: CoordinationLogInput = deserialize_input(input)?;
+        let manager = ctx.state.injection_manager.read();
+        let log = manager
+            .get_coordination_log(&parsed.session_id, parsed.limit)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        serialize_output(log, "coordination log")
+    }
+}
+
+struct LogCoordinationMessage;
+
+#[async_trait]
+impl Action for LogCoordinationMessage {
+    fn name(&self) -> &'static str {
+        "coordination.log_message"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(LogCoordinationMessageInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: LogCoordinationMessageInput = deserialize_input(input)?;
+        let manager = ctx.state.injection_manager.read();
+        manager
+            .log_system_message(&parsed.session_id, &parsed.to, &parsed.content)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        let _ = parsed.from;
+        Ok(Value::Null)
+    }
+}
+
+struct GetWorkersState;
+
+#[async_trait]
+impl Action for GetWorkersState {
+    fn name(&self) -> &'static str {
+        "coordination.get_workers_state"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        let session_path = ctx.state.storage.session_dir(&parsed.session_id);
+        let state_manager = StateManager::new(session_path);
+        let workers = state_manager
+            .read_workers_file()
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        serialize_output(workers, "workers state")
+    }
+}
+
+struct AssignTask;
+
+#[async_trait]
+impl Action for AssignTask {
+    fn name(&self) -> &'static str {
+        "coordination.assign_task"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(AssignTaskInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: AssignTaskInput = deserialize_input(input)?;
+        let coord_manager = ctx.state.injection_manager.read();
+        coord_manager
+            .queen_inject(
+                &parsed.session_id,
+                &parsed.queen_id,
+                &parsed.worker_id,
+                &parsed.task,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+
+        let session_path = ctx.state.storage.session_dir(&parsed.session_id);
+        let state_manager = StateManager::new(session_path);
+        state_manager
+            .record_assignment(&parsed.worker_id, &parsed.task, parsed.plan_task_id)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct GetSessionStoragePath;
+
+#[async_trait]
+impl Action for GetSessionStoragePath {
+    fn name(&self) -> &'static str {
+        "coordination.get_session_storage_path"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        let path = ctx.state.storage.session_dir(&parsed.session_id);
+        Ok(Value::String(path.to_string_lossy().to_string()))
+    }
+}
+
+struct GetCurrentDirectory;
+
+#[async_trait]
+impl Action for GetCurrentDirectory {
+    fn name(&self) -> &'static str {
+        "coordination.get_current_directory"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(EmptyInput)
+    }
+
+    async fn run(&self, _ctx: &ActionContext, _input: Value) -> Result<Value, ActionError> {
+        require_frontend(_ctx)?;
+        std::env::current_dir()
+            .map(|p| Value::String(p.to_string_lossy().to_string()))
+            .map_err(|e| ActionError::internal(e.to_string()))
+    }
+}
+
+struct ListStoredSessions;
+
+#[async_trait]
+impl Action for ListStoredSessions {
+    fn name(&self) -> &'static str {
+        "coordination.list_stored_sessions"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ListStoredSessionsInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: ListStoredSessionsInput = deserialize_input(input)?;
+        let sessions = ctx
+            .state
+            .storage
+            .list_sessions()
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+
+        let sessions = match parsed.project_path {
+            Some(path) => {
+                let normalize = |p: &str| -> String {
+                    let p = p.trim_end_matches(['/', '\\']);
+                    #[cfg(windows)]
+                    {
+                        p.to_lowercase()
+                    }
+                    #[cfg(not(windows))]
+                    {
+                        p.to_string()
+                    }
+                };
+
+                let target = normalize(&path);
+                sessions
+                    .into_iter()
+                    .filter(|s| normalize(&s.project_path) == target)
+                    .collect()
+            }
+            None => sessions,
+        };
+
+        serialize_output(sessions, "stored sessions")
+    }
+}
+
+struct GetAppConfig;
+
+#[async_trait]
+impl Action for GetAppConfig {
+    fn name(&self) -> &'static str {
+        "coordination.get_app_config"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(EmptyInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, _input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let config = ctx
+            .state
+            .storage
+            .load_config()
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        serialize_output(config, "app config")
+    }
+}
+
+struct UpdateAppConfig;
+
+#[async_trait]
+impl Action for UpdateAppConfig {
+    fn name(&self) -> &'static str {
+        "coordination.update_app_config"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(UpdateAppConfigInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: UpdateAppConfigInput = deserialize_input(input)?;
+        let config = serde_json::from_value(parsed.config)
+            .map_err(|e| ActionError::bad_request(format!("Invalid app config: {}", e)))?;
+        ctx.state
+            .storage
+            .save_config(&config)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct GetSessionPlan;
+
+#[async_trait]
+impl Action for GetSessionPlan {
+    fn name(&self) -> &'static str {
+        "coordination.get_session_plan"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: SessionIdInput = deserialize_input(input)?;
+        let project_plan_path = {
+            let controller = ctx.state.session_controller.read();
+            controller.get_session(&parsed.session_id).map(|session| {
+                session
+                    .project_path
+                    .join(".hive-manager")
+                    .join(&parsed.session_id)
+                    .join("plan.md")
+            })
+        };
+
+        let plan_path = if let Some(ref path) = project_plan_path {
+            if path.exists() {
+                path.clone()
+            } else {
+                ctx.state
+                    .storage
+                    .session_dir(&parsed.session_id)
+                    .join("plan.md")
+            }
+        } else {
+            ctx.state
+                .storage
+                .session_dir(&parsed.session_id)
+                .join("plan.md")
+        };
+
+        if !plan_path.exists() {
+            return Ok(Value::Null);
+        }
+
+        let content = std::fs::read_to_string(&plan_path)
+            .map_err(|e| ActionError::internal(format!("Failed to read plan.md: {}", e)))?;
+        serialize_output(Some(parse_plan_markdown(&content)), "session plan")
+    }
+}
+
+fn parse_plan_markdown(content: &str) -> SessionPlan {
+    let mut title = String::new();
+    let mut summary = String::new();
+    let mut tasks: Vec<PlanTask> = Vec::new();
+    let mut current_section = "";
+    let mut task_counter = 0;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("# ") && title.is_empty() {
+            title = trimmed[2..].trim().to_string();
+            continue;
+        }
+
+        if let Some(section) = trimmed.strip_prefix("## ") {
+            let section_name = section.trim().to_lowercase();
+            if section_name.contains("summary") || section_name.contains("overview") {
+                current_section = "summary";
+            } else if section_name.contains("task") || section_name.contains("plan") {
+                current_section = "tasks";
+            } else {
+                current_section = "";
+            }
+            continue;
+        }
+
+        if current_section == "summary" && !trimmed.is_empty() && !trimmed.starts_with('#') {
+            if !summary.is_empty() {
+                summary.push(' ');
+            }
+            summary.push_str(trimmed);
+            continue;
+        }
+
+        if current_section == "tasks" {
+            if let Some(task) = parse_task_line(trimmed, &mut task_counter) {
+                tasks.push(task);
+            }
+        }
+    }
+
+    if title.is_empty() {
+        title = "Plan in Progress...".to_string();
+    }
+
+    SessionPlan {
+        title,
+        summary,
+        tasks,
+        generated_at: chrono::Utc::now().to_rfc3339(),
+        raw_content: content.to_string(),
+    }
+}
+
+fn parse_task_line(line: &str, counter: &mut i32) -> Option<PlanTask> {
+    let trimmed = line.trim();
+
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let (status, rest) = if trimmed.starts_with("- [ ]") || trimmed.starts_with("* [ ]") {
+        ("pending", trimmed[5..].trim())
+    } else if trimmed.starts_with("- [x]")
+        || trimmed.starts_with("* [x]")
+        || trimmed.starts_with("- [X]")
+        || trimmed.starts_with("* [X]")
+    {
+        ("completed", trimmed[5..].trim())
+    } else if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
+        ("pending", trimmed[2..].trim())
+    } else if trimmed
+        .chars()
+        .next()
+        .map(|c| c.is_ascii_digit())
+        .unwrap_or(false)
+    {
+        if let Some(pos) = trimmed.find(". ") {
+            ("pending", trimmed[pos + 2..].trim())
+        } else {
+            return None;
+        }
+    } else {
+        return None;
+    };
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    *counter += 1;
+    let (title, priority) = extract_priority(rest);
+    let (title, assignee) = extract_assignee(&title);
+
+    Some(PlanTask {
+        id: format!("task-{}", counter),
+        title: title.trim().to_string(),
+        description: String::new(),
+        status: status.to_string(),
+        assignee,
+        priority,
+    })
+}
+
+fn extract_priority(text: &str) -> (String, Option<String>) {
+    let priorities = [
+        ("[HIGH]", "high"),
+        ("[P1]", "high"),
+        ("[CRITICAL]", "high"),
+        ("[MEDIUM]", "medium"),
+        ("[P2]", "medium"),
+        ("[MED]", "medium"),
+        ("[LOW]", "low"),
+        ("[P3]", "low"),
+    ];
+
+    for (marker, priority) in priorities {
+        if text.to_uppercase().contains(marker) {
+            let cleaned = text.replace(marker, "").replace(&marker.to_lowercase(), "");
+            return (cleaned, Some(priority.to_string()));
+        }
+    }
+
+    (text.to_string(), None)
+}
+
+fn extract_assignee(text: &str) -> (String, Option<String>) {
+    if let Some(pos) = text.find("->") {
+        let (title, assignee) = text.split_at(pos);
+        return (title.to_string(), Some(assignee[2..].trim().to_string()));
+    }
+
+    (text.to_string(), None)
+}
+
+pub fn register(registry: &mut ActionRegistry) {
+    registry.register(Box::new(QueenInject));
+    registry.register(Box::new(QueenSwitchBranch));
+    registry.register(Box::new(OperatorInject));
+    registry.register(Box::new(ReportWorkerStatus));
+    registry.register(Box::new(AddWorker));
+    registry.register(Box::new(GetCoordinationLog));
+    registry.register(Box::new(LogCoordinationMessage));
+    registry.register(Box::new(GetWorkersState));
+    registry.register(Box::new(AssignTask));
+    registry.register(Box::new(GetSessionStoragePath));
+    registry.register(Box::new(GetCurrentDirectory));
+    registry.register(Box::new(ListStoredSessions));
+    registry.register(Box::new(GetAppConfig));
+    registry.register(Box::new(UpdateAppConfig));
+    registry.register(Box::new(GetSessionPlan));
+}

--- a/src-tauri/src/actions/mod.rs
+++ b/src-tauri/src/actions/mod.rs
@@ -17,9 +17,12 @@
 //! this contract.
 
 pub mod context;
+pub mod coordination;
 pub mod error;
 pub mod git;
+pub mod pty;
 pub mod registry;
+pub mod render;
 pub mod session;
 
 #[cfg(test)]

--- a/src-tauri/src/actions/pty.rs
+++ b/src-tauri/src/actions/pty.rs
@@ -1,0 +1,312 @@
+//! PTY actions behind the unified action registry.
+
+use async_trait::async_trait;
+use schemars::schema::RootSchema;
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::pty::AgentRole;
+
+use super::error::ActionError;
+use super::registry::{Action, ActionRegistry};
+use super::{ActionContext, Caller};
+
+const MAX_PASTE_SIZE: usize = 5 * 1024 * 1024;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct CreatePtyInput {
+    id: String,
+    command: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+    cols: u16,
+    rows: u16,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PtyDataInput {
+    id: String,
+    data: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct InjectInput {
+    id: String,
+    message: String,
+    send_enter: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ResizeInput {
+    id: String,
+    cols: u16,
+    rows: u16,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct PtyIdInput {
+    id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct EmptyInput {}
+
+fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
+    serde_json::from_value(input)
+        .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+fn check_data_size(data_len: usize) -> Result<(), ActionError> {
+    if data_len > MAX_PASTE_SIZE {
+        return Err(ActionError::bad_request(format!(
+            "Data size {} bytes exceeds maximum allowed {} bytes",
+            data_len, MAX_PASTE_SIZE
+        )));
+    }
+
+    Ok(())
+}
+
+fn require_frontend(ctx: &ActionContext) -> Result<(), ActionError> {
+    if matches!(ctx.caller, Caller::Frontend) {
+        Ok(())
+    } else {
+        Err(ActionError::bad_request(
+            "PTY actions are only available through Tauri commands",
+        ))
+    }
+}
+
+struct CreatePty;
+
+#[async_trait]
+impl Action for CreatePty {
+    fn name(&self) -> &'static str {
+        "pty.create"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(CreatePtyInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: CreatePtyInput = deserialize_input(input)?;
+        let args_refs: Vec<&str> = parsed.args.iter().map(String::as_str).collect();
+        let pty_manager = ctx.state.pty_manager.read();
+        let id = pty_manager
+            .create_session(
+                parsed.id,
+                AgentRole::Worker {
+                    index: 0,
+                    parent: None,
+                },
+                &parsed.command,
+                &args_refs,
+                parsed.cwd.as_deref(),
+                parsed.cols,
+                parsed.rows,
+            )
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::String(id))
+    }
+}
+
+struct WritePty;
+
+#[async_trait]
+impl Action for WritePty {
+    fn name(&self) -> &'static str {
+        "pty.write"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(PtyDataInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: PtyDataInput = deserialize_input(input.clone())?;
+        check_data_size(parsed.data.len())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: PtyDataInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        pty_manager
+            .write(&parsed.id, parsed.data.as_bytes())
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct PastePty;
+
+#[async_trait]
+impl Action for PastePty {
+    fn name(&self) -> &'static str {
+        "pty.paste"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(PtyDataInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: PtyDataInput = deserialize_input(input.clone())?;
+        check_data_size(parsed.data.len())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: PtyDataInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        pty_manager
+            .write_bracketed(&parsed.id, parsed.data.as_bytes())
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct InjectPty;
+
+#[async_trait]
+impl Action for InjectPty {
+    fn name(&self) -> &'static str {
+        "pty.inject"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(InjectInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: InjectInput = deserialize_input(input.clone())?;
+        check_data_size(parsed.message.len())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: InjectInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+
+        tracing::info!(
+            "inject_to_pty: id={}, message_len={}, send_enter={}",
+            parsed.id,
+            parsed.message.len(),
+            parsed.send_enter
+        );
+
+        if parsed.send_enter {
+            let message_with_enter = format!("{}\r", parsed.message);
+            pty_manager
+                .write_bracketed(&parsed.id, message_with_enter.as_bytes())
+                .map_err(|e| ActionError::internal(e.to_string()))?;
+        } else {
+            pty_manager
+                .write_bracketed(&parsed.id, parsed.message.as_bytes())
+                .map_err(|e| ActionError::internal(e.to_string()))?;
+        }
+
+        Ok(Value::Null)
+    }
+}
+
+struct ResizePty;
+
+#[async_trait]
+impl Action for ResizePty {
+    fn name(&self) -> &'static str {
+        "pty.resize"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ResizeInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: ResizeInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        pty_manager
+            .resize(&parsed.id, parsed.cols, parsed.rows)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct KillPty;
+
+#[async_trait]
+impl Action for KillPty {
+    fn name(&self) -> &'static str {
+        "pty.kill"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(PtyIdInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: PtyIdInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        pty_manager
+            .kill(&parsed.id)
+            .map_err(|e| ActionError::internal(e.to_string()))?;
+        Ok(Value::Null)
+    }
+}
+
+struct PtyStatus;
+
+#[async_trait]
+impl Action for PtyStatus {
+    fn name(&self) -> &'static str {
+        "pty.status"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(PtyIdInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let parsed: PtyIdInput = deserialize_input(input)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        serde_json::to_value(pty_manager.get_status(&parsed.id))
+            .map_err(|e| ActionError::internal(format!("Failed to serialize PTY status: {}", e)))
+    }
+}
+
+struct ListPtys;
+
+#[async_trait]
+impl Action for ListPtys {
+    fn name(&self) -> &'static str {
+        "pty.list"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(EmptyInput)
+    }
+
+    async fn run(&self, ctx: &ActionContext, _input: Value) -> Result<Value, ActionError> {
+        require_frontend(ctx)?;
+        let pty_manager = ctx.state.pty_manager.read();
+        serde_json::to_value(pty_manager.list_sessions())
+            .map_err(|e| ActionError::internal(format!("Failed to serialize PTYs: {}", e)))
+    }
+}
+
+pub fn register(registry: &mut ActionRegistry) {
+    registry.register(Box::new(CreatePty));
+    registry.register(Box::new(WritePty));
+    registry.register(Box::new(PastePty));
+    registry.register(Box::new(InjectPty));
+    registry.register(Box::new(ResizePty));
+    registry.register(Box::new(KillPty));
+    registry.register(Box::new(PtyStatus));
+    registry.register(Box::new(ListPtys));
+}

--- a/src-tauri/src/actions/registry.rs
+++ b/src-tauri/src/actions/registry.rs
@@ -101,9 +101,10 @@ impl ActionRegistry {
         ctx: &ActionContext,
         input: Value,
     ) -> Result<Value, ActionError> {
-        let action = self.actions.get(name).ok_or_else(|| {
-            ActionError::not_found(format!("Unknown action '{}'", name))
-        })?;
+        let action = self
+            .actions
+            .get(name)
+            .ok_or_else(|| ActionError::not_found(format!("Unknown action '{}'", name)))?;
 
         action.validate_input(&input)?;
         action.run(ctx, input).await
@@ -117,5 +118,7 @@ pub fn build_registry() -> ActionRegistry {
     let mut registry = ActionRegistry::new();
     super::session::register(&mut registry);
     super::git::register(&mut registry);
+    super::pty::register(&mut registry);
+    super::coordination::register(&mut registry);
     registry
 }

--- a/src-tauri/src/actions/render.rs
+++ b/src-tauri/src/actions/render.rs
@@ -1,0 +1,84 @@
+//! Helpers for wrapping real outputs in the `{ renderer?, data }` envelope.
+
+use serde_json::{Map, Value};
+
+pub fn envelope(data: Value, renderer: Option<&'static str>) -> Value {
+    let mut object = Map::new();
+    if let Some(renderer) = renderer {
+        object.insert("renderer".to_string(), Value::String(renderer.to_string()));
+    }
+    object.insert("data".to_string(), data);
+    Value::Object(object)
+}
+
+pub fn envelope_for_action_result(action_name: &str, data: Value) -> Value {
+    envelope(data.clone(), renderer_for_action_result(action_name, &data))
+}
+
+pub fn envelope_for_content(data: Value, content: &str) -> Value {
+    envelope(data, renderer_for_content(content))
+}
+
+fn renderer_for_action_result(action_name: &str, data: &Value) -> Option<&'static str> {
+    if action_name.starts_with("git.") || action_name.contains("worktree") {
+        return Some("diff");
+    }
+
+    if is_structured_table(data) {
+        return Some("table");
+    }
+
+    None
+}
+
+fn is_structured_table(value: &Value) -> bool {
+    match value {
+        Value::Array(rows) if !rows.is_empty() => rows
+            .iter()
+            .all(|row| matches!(row, Value::Object(_) | Value::Array(_))),
+        Value::Object(object) => object.values().any(is_structured_table),
+        _ => false,
+    }
+}
+
+fn renderer_for_content(content: &str) -> Option<&'static str> {
+    if looks_like_diff(content) {
+        return Some("diff");
+    }
+
+    if looks_like_markdown_table(content) {
+        return Some("table");
+    }
+
+    None
+}
+
+fn looks_like_diff(content: &str) -> bool {
+    let trimmed = content.trim_start();
+    trimmed.starts_with("diff --git")
+        || trimmed.starts_with("Index: ")
+        || (content.contains("\n--- ") && content.contains("\n+++ "))
+        || content.lines().any(|line| line.starts_with("@@ "))
+}
+
+fn looks_like_markdown_table(content: &str) -> bool {
+    let mut previous_was_table_row = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        let is_table_row = trimmed.starts_with('|') && trimmed.ends_with('|');
+        let is_separator = is_table_row
+            && trimmed
+                .trim_matches('|')
+                .split('|')
+                .all(|cell| cell.trim().chars().all(|ch| matches!(ch, '-' | ':' | ' ')));
+
+        if previous_was_table_row && is_separator {
+            return true;
+        }
+
+        previous_was_table_row = is_table_row;
+    }
+
+    false
+}

--- a/src-tauri/src/actions/render.rs
+++ b/src-tauri/src/actions/render.rs
@@ -20,12 +20,12 @@ pub fn envelope_for_content(data: Value, content: &str) -> Value {
 }
 
 fn renderer_for_action_result(action_name: &str, data: &Value) -> Option<&'static str> {
-    if action_name.starts_with("git.") || action_name.contains("worktree") {
-        return Some("diff");
-    }
-
     if is_structured_table(data) {
         return Some("table");
+    }
+
+    if action_name.starts_with("git.") || action_name.contains("worktree") {
+        return Some("diff");
     }
 
     None
@@ -38,6 +38,25 @@ fn is_structured_table(value: &Value) -> bool {
             .all(|row| matches!(row, Value::Object(_) | Value::Array(_))),
         Value::Object(object) => object.values().any(is_structured_table),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::renderer_for_action_result;
+    use serde_json::json;
+
+    #[test]
+    fn structured_git_action_data_renders_as_table_before_diff_heuristic() {
+        let data = json!([
+            {"file": "src/main.rs", "status": "modified"},
+            {"file": "src/lib.rs", "status": "added"}
+        ]);
+
+        assert_eq!(
+            renderer_for_action_result("git.status", &data),
+            Some("table")
+        );
     }
 }
 

--- a/src-tauri/src/actions/session/mod.rs
+++ b/src-tauri/src/actions/session/mod.rs
@@ -6,11 +6,16 @@
 use async_trait::async_trait;
 use schemars::schema::RootSchema;
 use schemars::JsonSchema;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::path::PathBuf;
 
 use crate::http::handlers::{validate_cli, validate_project_path};
-use crate::session::{DebateLaunchConfig, HiveLaunchConfig};
+use crate::session::{
+    DebateLaunchConfig, FusionLaunchConfig, HiveLaunchConfig, ResearchLaunchConfig, Session,
+    SessionType, SwarmLaunchConfig,
+};
+use crate::storage::{PersistedSession, SessionTypeInfo};
 
 use super::error::ActionError;
 use super::registry::{Action, ActionRegistry};
@@ -21,7 +26,7 @@ const SESSION_COLOR_ALLOWLIST: &[&str] = &[
 ];
 
 /// Shared name validation (consolidated from the two former copies).
-fn validate_session_name(name: Option<&str>) -> Result<(), ActionError> {
+pub(crate) fn validate_session_name(name: Option<&str>) -> Result<(), ActionError> {
     let Some(name) = name else {
         return Ok(());
     };
@@ -44,7 +49,7 @@ fn validate_session_name(name: Option<&str>) -> Result<(), ActionError> {
 }
 
 /// Shared color validation (consolidated from the two former copies).
-fn validate_session_color(color: Option<&str>) -> Result<(), ActionError> {
+pub(crate) fn validate_session_color(color: Option<&str>) -> Result<(), ActionError> {
     let Some(color) = color else {
         return Ok(());
     };
@@ -58,14 +63,14 @@ fn validate_session_color(color: Option<&str>) -> Result<(), ActionError> {
     Ok(())
 }
 
-fn is_valid_hex_session_color(color: &str) -> bool {
+pub(crate) fn is_valid_hex_session_color(color: &str) -> bool {
     color.len() == 7
         && color.starts_with('#')
         && color.chars().skip(1).all(|c| c.is_ascii_hexdigit())
 }
 
 /// Validate a `HiveLaunchConfig` (consolidated from session_commands.rs).
-fn validate_hive_launch_config(config: &HiveLaunchConfig) -> Result<(), ActionError> {
+pub(crate) fn validate_hive_launch_config(config: &HiveLaunchConfig) -> Result<(), ActionError> {
     validate_project_path(&config.project_path)?;
     validate_session_name(config.name.as_deref())?;
     validate_session_color(config.color.as_deref())?;
@@ -129,11 +134,113 @@ fn validate_debate_launch_config(config: &DebateLaunchConfig) -> Result<(), Acti
     Ok(())
 }
 
+fn validate_research_launch_config(config: &ResearchLaunchConfig) -> Result<(), ActionError> {
+    validate_project_path(&config.project_path)?;
+    validate_session_name(config.name.as_deref())?;
+    validate_session_color(config.color.as_deref())?;
+    validate_cli(&config.queen_config.cli)?;
+
+    if !(1..=6).contains(&config.workers.len()) {
+        return Err(ActionError::bad_request(format!(
+            "Research sessions require 1 to 6 researchers (got {}).",
+            config.workers.len()
+        )));
+    }
+
+    for worker in &config.workers {
+        validate_cli(&worker.cli)?;
+    }
+
+    Ok(())
+}
+
+fn validate_swarm_launch_config(config: &SwarmLaunchConfig) -> Result<(), ActionError> {
+    validate_project_path(&config.project_path)?;
+    validate_session_name(config.name.as_deref())?;
+    validate_session_color(config.color.as_deref())?;
+    validate_cli(&config.queen_config.cli)?;
+    validate_cli(&config.planner_config.cli)?;
+
+    for worker in &config.workers_per_planner {
+        validate_cli(&worker.cli)?;
+    }
+
+    for planner in &config.planners {
+        validate_cli(&planner.config.cli)?;
+        for worker in &planner.workers {
+            validate_cli(&worker.cli)?;
+        }
+    }
+
+    if let Some(evaluator_config) = &config.evaluator_config {
+        if !evaluator_config.cli.trim().is_empty() {
+            validate_cli(&evaluator_config.cli)?;
+        }
+    }
+
+    if let Some(qa_workers) = &config.qa_workers {
+        for qa_worker in qa_workers {
+            validate_cli(&qa_worker.cli)?;
+            match qa_worker.specialization.as_str() {
+                "ui" | "api" | "a11y" => {}
+                other => {
+                    return Err(ActionError::bad_request(format!(
+                        "Invalid QA specialization '{}'. Valid options: ui, api, a11y",
+                        other
+                    )));
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn validate_fusion_launch_config(config: &FusionLaunchConfig) -> Result<(), ActionError> {
+    if config.variants.is_empty() {
+        return Err(ActionError::bad_request(
+            "Fusion launch requires at least one variant",
+        ));
+    }
+    if config.task_description.trim().is_empty() {
+        return Err(ActionError::bad_request("task_description cannot be empty"));
+    }
+
+    validate_project_path(&config.project_path)?;
+    validate_session_name(config.name.as_deref())?;
+    validate_session_color(config.color.as_deref())?;
+    validate_cli(&config.default_cli)?;
+    validate_cli(&config.judge_config.cli)?;
+
+    if let Some(queen_config) = &config.queen_config {
+        validate_cli(&queen_config.cli)?;
+    }
+
+    for variant in &config.variants {
+        if variant.name.trim().is_empty() {
+            return Err(ActionError::bad_request("variant name cannot be empty"));
+        }
+        validate_cli(&variant.cli)?;
+    }
+
+    Ok(())
+}
+
 /// Input carrying just a session id (`session.get`, `session.stop`,
 /// `session.close`).
 #[derive(Debug, Deserialize, JsonSchema)]
 struct SessionIdInput {
     id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct LegacyHiveLaunchInput {
+    project_path: String,
+    task_description: Option<String>,
+    worker_count: Option<u8>,
+    command: Option<String>,
+    name: Option<String>,
+    color: Option<String>,
 }
 
 fn validate_session_id_input(id: &str) -> Result<(), ActionError> {
@@ -160,9 +267,62 @@ struct UpdateMetadataInput {
     color: Option<Option<String>>,
 }
 
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct SessionInfoOutput {
+    id: String,
+    name: Option<String>,
+    color: Option<String>,
+    session_type: String,
+    status: String,
+    project_path: String,
+    created_at: String,
+    last_activity_at: String,
+}
+
 fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
     serde_json::from_value(input)
         .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+fn session_info_from_session(session: Session) -> SessionInfoOutput {
+    SessionInfoOutput {
+        id: session.id,
+        name: session.name,
+        color: session.color,
+        session_type: match &session.session_type {
+            SessionType::Hive { worker_count } => format!("Hive ({})", worker_count),
+            SessionType::Swarm { planner_count } => format!("Swarm ({})", planner_count),
+            SessionType::Fusion { variants } => format!("Fusion ({})", variants.len()),
+            SessionType::Debate { variants } => format!("Debate ({})", variants.len()),
+            SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
+        },
+        status: format!("{:?}", session.state),
+        project_path: session.project_path.to_string_lossy().to_string(),
+        created_at: session.created_at.to_rfc3339(),
+        last_activity_at: session.last_activity_at.to_rfc3339(),
+    }
+}
+
+fn session_info_from_persisted(persisted: PersistedSession) -> SessionInfoOutput {
+    SessionInfoOutput {
+        id: persisted.id,
+        name: persisted.name,
+        color: persisted.color,
+        session_type: match &persisted.session_type {
+            SessionTypeInfo::Hive { worker_count } => format!("Hive ({})", worker_count),
+            SessionTypeInfo::Swarm { planner_count } => format!("Swarm ({})", planner_count),
+            SessionTypeInfo::Fusion { variants } => format!("Fusion ({})", variants.len()),
+            SessionTypeInfo::Debate { variants } => format!("Debate ({})", variants.len()),
+            SessionTypeInfo::Solo { cli, .. } => format!("Solo ({})", cli),
+        },
+        status: persisted.state,
+        project_path: persisted.project_path,
+        created_at: persisted.created_at.to_rfc3339(),
+        last_activity_at: persisted
+            .last_activity_at
+            .unwrap_or(persisted.created_at)
+            .to_rfc3339(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -220,6 +380,49 @@ impl Action for GetSession {
         };
         serde_json::to_value(session)
             .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.get_info
+// ---------------------------------------------------------------------------
+
+struct GetSessionInfo;
+
+#[async_trait]
+impl Action for GetSessionInfo {
+    fn name(&self) -> &'static str {
+        "session.get_info"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SessionIdInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: SessionIdInput = deserialize_input(input)?;
+
+        if let Some(session) = {
+            let controller = ctx.state.session_controller.read();
+            controller.get_session(&parsed.id)
+        } {
+            return serde_json::to_value(session_info_from_session(session)).map_err(|e| {
+                ActionError::internal(format!("Failed to serialize session info: {}", e))
+            });
+        }
+
+        let persisted = ctx
+            .state
+            .storage
+            .load_session(&parsed.id)
+            .map_err(|_| ActionError::not_found(format!("Session {} not found", parsed.id)))?;
+        serde_json::to_value(session_info_from_persisted(persisted))
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session info: {}", e)))
     }
 }
 
@@ -294,6 +497,53 @@ impl Action for CloseSession {
 }
 
 // ---------------------------------------------------------------------------
+// session.launch_hive
+// ---------------------------------------------------------------------------
+
+struct LaunchHive;
+
+#[async_trait]
+impl Action for LaunchHive {
+    fn name(&self) -> &'static str {
+        "session.launch_hive"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(LegacyHiveLaunchInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: LegacyHiveLaunchInput = deserialize_input(input.clone())?;
+        validate_project_path(&parsed.project_path)?;
+        validate_session_name(parsed.name.as_deref())?;
+        validate_session_color(parsed.color.as_deref())?;
+        let command = parsed.command.as_deref().unwrap_or("claude");
+        validate_cli(command)?;
+        Ok(())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: LegacyHiveLaunchInput = deserialize_input(input)?;
+        let command = parsed.command.unwrap_or_else(|| "claude".to_string());
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .launch_hive(
+                    PathBuf::from(parsed.project_path),
+                    parsed.worker_count.unwrap_or(3),
+                    &command,
+                    parsed.task_description,
+                    parsed.name,
+                    parsed.color,
+                )
+                .map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
 // session.launch_hive_v2
 // ---------------------------------------------------------------------------
 
@@ -320,6 +570,138 @@ impl Action for LaunchHiveV2 {
             let controller = ctx.state.session_controller.read();
             controller
                 .launch_hive_v2(config)
+                .map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.launch_research
+// ---------------------------------------------------------------------------
+
+struct LaunchResearch;
+
+#[async_trait]
+impl Action for LaunchResearch {
+    fn name(&self) -> &'static str {
+        "session.launch_research"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(ResearchLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: ResearchLaunchConfig = deserialize_input(input.clone())?;
+        validate_research_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: ResearchLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .launch_research(config)
+                .map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.launch_swarm
+// ---------------------------------------------------------------------------
+
+struct LaunchSwarm;
+
+#[async_trait]
+impl Action for LaunchSwarm {
+    fn name(&self) -> &'static str {
+        "session.launch_swarm"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(SwarmLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: SwarmLaunchConfig = deserialize_input(input.clone())?;
+        validate_swarm_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: SwarmLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller.launch_swarm(config).map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.launch_solo
+// ---------------------------------------------------------------------------
+
+struct LaunchSolo;
+
+#[async_trait]
+impl Action for LaunchSolo {
+    fn name(&self) -> &'static str {
+        "session.launch_solo"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(HiveLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: HiveLaunchConfig = deserialize_input(input.clone())?;
+        validate_hive_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: HiveLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller.launch_solo(config).map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// session.launch_fusion
+// ---------------------------------------------------------------------------
+
+struct LaunchFusion;
+
+#[async_trait]
+impl Action for LaunchFusion {
+    fn name(&self) -> &'static str {
+        "session.launch_fusion"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(FusionLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: FusionLaunchConfig = deserialize_input(input.clone())?;
+        validate_fusion_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: FusionLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .launch_fusion(config)
                 .map_err(ActionError::from)?
         };
         serde_json::to_value(session)
@@ -404,13 +786,63 @@ impl Action for UpdateSessionMetadata {
     }
 }
 
+// ---------------------------------------------------------------------------
+// session.update_metadata_info
+// ---------------------------------------------------------------------------
+
+struct UpdateSessionMetadataInfo;
+
+#[async_trait]
+impl Action for UpdateSessionMetadataInfo {
+    fn name(&self) -> &'static str {
+        "session.update_metadata_info"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(UpdateMetadataInput)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let parsed: UpdateMetadataInput = deserialize_input(input.clone())?;
+        validate_session_id_input(&parsed.id)?;
+        validate_session_name(parsed.name.as_ref().and_then(|value| value.as_deref()))?;
+        validate_session_color(parsed.color.as_ref().and_then(|value| value.as_deref()))?;
+        Ok(())
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let parsed: UpdateMetadataInput = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .update_session_metadata(&parsed.id, parsed.name, parsed.color)
+                .map_err(|e| {
+                    if e.starts_with("Session not found") {
+                        ActionError::not_found(e)
+                    } else {
+                        ActionError::internal(e)
+                    }
+                })?
+        };
+        serde_json::to_value(session_info_from_session(session))
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session info: {}", e)))
+    }
+}
+
 /// Register every session action into the registry.
 pub fn register(registry: &mut ActionRegistry) {
     registry.register(Box::new(ListSessions));
     registry.register(Box::new(GetSession));
+    registry.register(Box::new(GetSessionInfo));
     registry.register(Box::new(StopSession));
     registry.register(Box::new(CloseSession));
+    registry.register(Box::new(LaunchHive));
     registry.register(Box::new(LaunchHiveV2));
+    registry.register(Box::new(LaunchResearch));
+    registry.register(Box::new(LaunchSwarm));
+    registry.register(Box::new(LaunchSolo));
+    registry.register(Box::new(LaunchFusion));
     registry.register(Box::new(LaunchDebate));
     registry.register(Box::new(UpdateSessionMetadata));
+    registry.register(Box::new(UpdateSessionMetadataInfo));
 }

--- a/src-tauri/src/actions/session/mod.rs
+++ b/src-tauri/src/actions/session/mod.rs
@@ -6,14 +6,14 @@
 use async_trait::async_trait;
 use schemars::schema::RootSchema;
 use schemars::JsonSchema;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
 
 use crate::http::handlers::{validate_cli, validate_project_path};
 use crate::session::{
     DebateLaunchConfig, FusionLaunchConfig, HiveLaunchConfig, ResearchLaunchConfig, Session,
-    SessionType, SwarmLaunchConfig,
+    SessionState, SessionType, SwarmLaunchConfig,
 };
 use crate::storage::{PersistedSession, SessionTypeInfo};
 
@@ -158,6 +158,7 @@ fn validate_swarm_launch_config(config: &SwarmLaunchConfig) -> Result<(), Action
     validate_project_path(&config.project_path)?;
     validate_session_name(config.name.as_deref())?;
     validate_session_color(config.color.as_deref())?;
+    validate_cli(&config.default_cli)?;
     validate_cli(&config.queen_config.cli)?;
     validate_cli(&config.planner_config.cli)?;
 
@@ -261,9 +262,9 @@ struct EmptyInput {}
 struct UpdateMetadataInput {
     id: String,
     /// Outer `Some` means "set this field"; inner `None` clears it.
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_metadata_field")]
     name: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_metadata_field")]
     color: Option<Option<String>>,
 }
 
@@ -282,6 +283,15 @@ struct SessionInfoOutput {
 fn deserialize_input<T: for<'de> Deserialize<'de>>(input: Value) -> Result<T, ActionError> {
     serde_json::from_value(input)
         .map_err(|e| ActionError::bad_request(format!("Invalid input: {}", e)))
+}
+
+fn deserialize_nullable_metadata_field<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
 }
 
 fn session_info_from_session(session: Session) -> SessionInfoOutput {
@@ -323,6 +333,17 @@ fn session_info_from_persisted(persisted: PersistedSession) -> SessionInfoOutput
             .unwrap_or(persisted.created_at)
             .to_rfc3339(),
     }
+}
+
+fn should_reload_session_info_from_storage(session: &Session) -> bool {
+    matches!(
+        session.state,
+        SessionState::QaPassed
+            | SessionState::QaMaxRetriesExceeded
+            | SessionState::Completed
+            | SessionState::Closed
+            | SessionState::Failed(_)
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -411,6 +432,22 @@ impl Action for GetSessionInfo {
             let controller = ctx.state.session_controller.read();
             controller.get_session(&parsed.id)
         } {
+            if should_reload_session_info_from_storage(&session) {
+                let reloaded = {
+                    let controller = ctx.state.session_controller.read();
+                    controller.reload_session_from_storage(&parsed.id).ok()
+                };
+                if let Some(reloaded) = reloaded {
+                    return serde_json::to_value(session_info_from_session(reloaded)).map_err(
+                        |e| {
+                            ActionError::internal(format!(
+                                "Failed to serialize session info: {}",
+                                e
+                            ))
+                        },
+                    );
+                }
+            }
             return serde_json::to_value(session_info_from_session(session)).map_err(|e| {
                 ActionError::internal(format!("Failed to serialize session info: {}", e))
             });

--- a/src-tauri/src/actions/session/mod.rs
+++ b/src-tauri/src/actions/session/mod.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 
 use crate::http::handlers::{validate_cli, validate_project_path};
-use crate::session::HiveLaunchConfig;
+use crate::session::{DebateLaunchConfig, HiveLaunchConfig};
 
 use super::error::ActionError;
 use super::registry::{Action, ActionRegistry};
@@ -96,6 +96,36 @@ fn validate_hive_launch_config(config: &HiveLaunchConfig) -> Result<(), ActionEr
         }
     }
 
+    Ok(())
+}
+
+fn validate_debate_launch_config(config: &DebateLaunchConfig) -> Result<(), ActionError> {
+    validate_project_path(&config.project_path)?;
+    validate_session_name(config.name.as_deref())?;
+    validate_session_color(config.color.as_deref())?;
+    if config.topic.trim().is_empty() {
+        return Err(ActionError::bad_request(
+            "Debate launch requires a non-empty topic",
+        ));
+    }
+    if config.debaters.is_empty() {
+        return Err(ActionError::bad_request(
+            "Debate launch requires at least one debater",
+        ));
+    }
+    if config.rounds == 0 {
+        return Err(ActionError::bad_request(
+            "Debate launch requires at least one round",
+        ));
+    }
+    validate_cli(&config.judge_config.cli)?;
+    validate_cli(&config.default_cli)?;
+    if let Some(queen_config) = &config.queen_config {
+        validate_cli(&queen_config.cli)?;
+    }
+    for debater in &config.debaters {
+        validate_cli(&debater.cli)?;
+    }
     Ok(())
 }
 
@@ -218,7 +248,9 @@ impl Action for StopSession {
         let parsed: SessionIdInput = deserialize_input(input)?;
         {
             let controller = ctx.state.session_controller.read();
-            controller.stop_session(&parsed.id).map_err(ActionError::from)?;
+            controller
+                .stop_session(&parsed.id)
+                .map_err(ActionError::from)?;
         }
         Ok(json!({ "message": format!("Session {} stopped", parsed.id) }))
     }
@@ -286,7 +318,9 @@ impl Action for LaunchHiveV2 {
         let config: HiveLaunchConfig = deserialize_input(input)?;
         let session = {
             let controller = ctx.state.session_controller.read();
-            controller.launch_hive_v2(config).map_err(ActionError::from)?
+            controller
+                .launch_hive_v2(config)
+                .map_err(ActionError::from)?
         };
         serde_json::to_value(session)
             .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
@@ -296,6 +330,40 @@ impl Action for LaunchHiveV2 {
 // ---------------------------------------------------------------------------
 // session.update_metadata
 // ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// session.launch_debate
+// ---------------------------------------------------------------------------
+
+struct LaunchDebate;
+
+#[async_trait]
+impl Action for LaunchDebate {
+    fn name(&self) -> &'static str {
+        "session.launch_debate"
+    }
+
+    fn input_schema(&self) -> RootSchema {
+        schemars::schema_for!(DebateLaunchConfig)
+    }
+
+    fn validate_input(&self, input: &Value) -> Result<(), ActionError> {
+        let config: DebateLaunchConfig = deserialize_input(input.clone())?;
+        validate_debate_launch_config(&config)
+    }
+
+    async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
+        let config: DebateLaunchConfig = deserialize_input(input)?;
+        let session = {
+            let controller = ctx.state.session_controller.read();
+            controller
+                .launch_debate(config)
+                .map_err(ActionError::from)?
+        };
+        serde_json::to_value(session)
+            .map_err(|e| ActionError::internal(format!("Failed to serialize session: {}", e)))
+    }
+}
 
 struct UpdateSessionMetadata;
 
@@ -343,5 +411,6 @@ pub fn register(registry: &mut ActionRegistry) {
     registry.register(Box::new(StopSession));
     registry.register(Box::new(CloseSession));
     registry.register(Box::new(LaunchHiveV2));
+    registry.register(Box::new(LaunchDebate));
     registry.register(Box::new(UpdateSessionMetadata));
 }

--- a/src-tauri/src/actions/tests.rs
+++ b/src-tauri/src/actions/tests.rs
@@ -85,9 +85,13 @@ fn test_registry_lists_all_actions() {
         "session.stop",
         "session.close",
         "session.launch_hive_v2",
+        "session.launch_debate",
         "session.update_metadata",
     ] {
-        assert!(names.contains(&expected), "missing session action {expected}");
+        assert!(
+            names.contains(&expected),
+            "missing session action {expected}"
+        );
     }
 
     // Git actions (AC2-required set).

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -31,7 +31,16 @@ pub use qwen::QwenAdapter;
 /// `gemini` and `antigravity` are both first-class CLIs. `antigravity` (`agy`)
 /// is the default for the frontend role; the legacy Gemini CLI is retained as
 /// a selectable peer until Google deprecates it on 2026-06-18.
-pub const VALID_CLIS: &[&str] = &["claude", "gemini", "antigravity", "codex", "opencode", "cursor", "droid", "qwen"];
+pub const VALID_CLIS: &[&str] = &[
+    "claude",
+    "gemini",
+    "antigravity",
+    "codex",
+    "opencode",
+    "cursor",
+    "droid",
+    "qwen",
+];
 
 /// Validate a CLI name against the allowlist.
 pub fn is_valid_cli(cli: &str) -> bool {
@@ -106,8 +115,12 @@ impl LaunchCommand {
     }
 
     /// Add multiple environment variables.
-    pub fn envs(mut self, envs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>) -> Self {
-        self.env.extend(envs.into_iter().map(|(k, v)| (k.into(), v.into())));
+    pub fn envs(
+        mut self,
+        envs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.env
+            .extend(envs.into_iter().map(|(k, v)| (k.into(), v.into())));
         self
     }
 }
@@ -227,7 +240,10 @@ mod tests {
             .env("KEY", "value");
 
         assert_eq!(cmd.binary, "claude");
-        assert_eq!(cmd.args, vec!["--dangerously-skip-permissions", "--model", "opus"]);
+        assert_eq!(
+            cmd.args,
+            vec!["--dangerously-skip-permissions", "--model", "opus"]
+        );
         assert_eq!(cmd.env.get("KEY"), Some(&"value".to_string()));
     }
 

--- a/src-tauri/src/commands/coordination_commands.rs
+++ b/src-tauri/src/commands/coordination_commands.rs
@@ -1,574 +1,289 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use serde::{Deserialize, Serialize};
+use serde::de::DeserializeOwned;
+use serde_json::json;
 use tauri::State;
 
-use crate::coordination::{
-    CoordinationMessage, InjectionManager, StateManager, WorkerStateInfo,
-};
-use crate::pty::{AgentConfig, AgentRole, WorkerRole};
+use crate::actions::{ActionContext, ActionRegistry, Caller};
+use crate::coordination::{CoordinationMessage, InjectionManager, WorkerStateInfo};
+use crate::http::state::AppState;
 use crate::session::AgentInfo;
 use crate::storage::SessionStorage;
 
-/// State wrapper for coordination
+#[allow(unused_imports)]
+pub use crate::actions::coordination::{
+    AddWorkerRequest, OperatorInjectRequest, PlanTask, QueenInjectRequest, SessionPlan,
+    WorkerStatusRequest,
+};
+
+/// State wrapper for coordination.
+#[allow(dead_code)]
 pub struct CoordinationState(pub Arc<RwLock<InjectionManager>>);
 
-/// State wrapper for storage
+/// State wrapper for storage.
+#[allow(dead_code)]
 pub struct StorageState(pub Arc<SessionStorage>);
 
-/// Request to inject a message from Queen to a worker
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct QueenInjectRequest {
-    pub session_id: String,
-    pub queen_id: String,
-    pub target_worker_id: String,
-    pub message: String,
+async fn dispatch_coordination<T: DeserializeOwned>(
+    registry: &ActionRegistry,
+    state: Arc<AppState>,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<T, String> {
+    let ctx = ActionContext::new(Caller::Frontend, state);
+    let value = registry
+        .dispatch(name, &ctx, input)
+        .await
+        .map_err(|e| e.to_message())?;
+    serde_json::from_value(value).map_err(|e| e.to_string())
 }
 
-/// Request to add a worker to a session
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AddWorkerRequest {
-    pub session_id: String,
-    pub config: AgentConfig,
-    pub role: WorkerRole,
-    pub name: Option<String>,
-    pub description: Option<String>,
-    pub parent_id: Option<String>,
-}
-
-/// Queen injects a message to a worker
 #[tauri::command]
 pub async fn queen_inject(
-    state: State<'_, CoordinationState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     request: QueenInjectRequest,
 ) -> Result<(), String> {
-    let manager = state.0.read();
-    manager
-        .queen_inject(
-            &request.session_id,
-            &request.queen_id,
-            &request.target_worker_id,
-            &request.message,
-        )
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.queen_inject",
+        json!(request),
+    )
+    .await
 }
 
-/// Queen initiates a branch switch for all workers
 #[tauri::command]
 pub async fn queen_switch_branch(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
     queen_id: String,
     branch: String,
-    state: State<'_, CoordinationState>,
-    session_state: State<'_, super::SessionControllerState>,
 ) -> Result<Vec<(String, bool)>, String> {
-    let worker_ids = {
-        let controller = session_state.0.read();
-        controller
-            .get_session(&session_id)
-            .map(|s| {
-                s.agents
-                    .iter()
-                    .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
-                    .map(|a| a.id.clone())
-                    .collect::<Vec<_>>()
-            })
-            .ok_or("Session not found")?
-    };
-
-    let manager = state.0.read();
-    let results = manager
-        .queen_switch_branch(&session_id, &queen_id, &worker_ids, &branch)
-        .map_err(|e| e.to_string())?;
-
-    Ok(results
-        .into_iter()
-        .map(|(id, r)| (id, r.is_ok()))
-        .collect())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.queen_switch_branch",
+        json!({
+            "session_id": session_id,
+            "queen_id": queen_id,
+            "branch": branch,
+        }),
+    )
+    .await
 }
 
-/// Request for operator injection
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct OperatorInjectRequest {
-    pub session_id: String,
-    pub target_agent_id: String,
-    pub message: String,
-}
-
-/// Request for worker status notification
-#[allow(dead_code)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct WorkerStatusRequest {
-    pub session_id: String,
-    pub queen_id: String,
-    pub worker_id: String,
-    pub status: String,
-}
-
-/// Operator injects a message to any agent (including Queen)
 #[tauri::command]
 pub async fn operator_inject(
-    state: State<'_, CoordinationState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     request: OperatorInjectRequest,
 ) -> Result<(), String> {
-    let manager = state.0.read();
-    manager
-        .operator_inject(
-            &request.session_id,
-            &request.target_agent_id,
-            &request.message,
-        )
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.operator_inject",
+        json!(request),
+    )
+    .await
 }
 
-/// Report worker status change to Queen
 #[allow(dead_code)]
 #[tauri::command]
 pub async fn report_worker_status(
-    state: State<'_, CoordinationState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     request: WorkerStatusRequest,
 ) -> Result<(), String> {
-    let manager = state.0.read();
-    manager
-        .notify_queen_worker_status(
-            &request.session_id,
-            &request.queen_id,
-            &request.worker_id,
-            &request.status,
-        )
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.report_worker_status",
+        json!(request),
+    )
+    .await
 }
 
-/// Add a worker to an existing session
 #[tauri::command]
 pub async fn add_worker_to_session(
-    session_state: State<'_, super::SessionControllerState>,
-    coord_state: State<'_, CoordinationState>,
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     request: AddWorkerRequest,
 ) -> Result<AgentInfo, String> {
-    let controller = session_state.0.write();
-
-    // Add worker through session controller
-    let mut config = request.config;
-    let normalize_opt_str = |value: Option<String>| {
-        value.and_then(|v| {
-            let trimmed = v.trim().to_string();
-            if trimmed.is_empty() {
-                None
-            } else {
-                Some(trimmed)
-            }
-        })
-    };
-    config.name = normalize_opt_str(request.name).or_else(|| normalize_opt_str(config.name));
-    config.description =
-        normalize_opt_str(request.description).or_else(|| normalize_opt_str(config.description));
-
-    let agent_info = controller
-        .add_worker(
-            &request.session_id,
-            config,
-            request.role.clone(),
-            request.parent_id,
-        )
-        .map_err(|e| e.to_string())?;
-
-    // Notify Queen about new worker
-    let coord_manager = coord_state.0.read();
-
-    // Find Queen ID
-    let queen_id = format!("{}-queen", request.session_id);
-
-    // Create worker state info for notification
-    let worker_state = WorkerStateInfo {
-        id: agent_info.id.clone(),
-        role: request.role,
-        cli: agent_info.config.cli.clone(),
-        status: "Running".to_string(),
-        current_task: None,
-        last_update: chrono::Utc::now(),
-        last_heartbeat: None,
-    };
-
-    // Notify Queen
-    let _ = coord_manager.notify_queen_worker_added(&request.session_id, &queen_id, &worker_state);
-
-    // Update workers.md
-    let session_path = storage_state.0.session_dir(&request.session_id);
-    let state_manager = StateManager::new(session_path);
-
-    // Get all current workers and update the file
-    if let Some(session) = controller.get_session(&request.session_id) {
-        let workers: Vec<WorkerStateInfo> = session
-            .agents
-            .iter()
-            .filter(|a| {
-                !matches!(
-                    a.role,
-                    crate::pty::AgentRole::Queen
-                        | crate::pty::AgentRole::Evaluator
-                        | crate::pty::AgentRole::QaWorker { .. }
-                )
-            })
-            .map(|a| WorkerStateInfo {
-                id: a.id.clone(),
-                role: a.config.role.clone().unwrap_or_default(),
-                cli: a.config.cli.clone(),
-                status: format!("{:?}", a.status),
-                current_task: None,
-                last_update: chrono::Utc::now(),
-                last_heartbeat: None,
-            })
-            .collect();
-
-        let _ = state_manager.update_workers_file(&workers);
-    }
-
-    Ok(agent_info)
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.add_worker",
+        json!(request),
+    )
+    .await
 }
 
-/// Get the coordination log for a session
 #[tauri::command]
 pub async fn get_coordination_log(
-    state: State<'_, CoordinationState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
     limit: Option<usize>,
 ) -> Result<Vec<CoordinationMessage>, String> {
-    let manager = state.0.read();
-    manager
-        .get_coordination_log(&session_id, limit)
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_log",
+        json!({ "session_id": session_id, "limit": limit }),
+    )
+    .await
 }
 
-/// Log a system message to coordination
 #[tauri::command]
 pub async fn log_coordination_message(
-    state: State<'_, CoordinationState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
-    _from: String,
+    from: String,
     to: String,
     content: String,
 ) -> Result<(), String> {
-    let manager = state.0.read();
-    manager
-        .log_system_message(&session_id, &to, &content)
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.log_message",
+        json!({
+            "session_id": session_id,
+            "from": from,
+            "to": to,
+            "content": content,
+        }),
+    )
+    .await
 }
 
-/// Get workers state for a session
 #[tauri::command]
 pub async fn get_workers_state(
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
 ) -> Result<Vec<WorkerStateInfo>, String> {
-    let session_path = storage_state.0.session_dir(&session_id);
-    let state_manager = StateManager::new(session_path);
-    state_manager
-        .read_workers_file()
-        .map_err(|e: crate::coordination::StateError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_workers_state",
+        json!({ "session_id": session_id }),
+    )
+    .await
 }
 
-/// Record a task assignment
 #[tauri::command]
 pub async fn assign_task(
-    coord_state: State<'_, CoordinationState>,
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
     queen_id: String,
     worker_id: String,
     task: String,
     plan_task_id: Option<String>,
 ) -> Result<(), String> {
-    // Log the injection
-    let coord_manager = coord_state.0.read();
-    coord_manager
-        .queen_inject(&session_id, &queen_id, &worker_id, &task)
-        .map_err(|e: crate::coordination::InjectionError| e.to_string())?;
-
-    // Record the assignment
-    let session_path = storage_state.0.session_dir(&session_id);
-    let state_manager = StateManager::new(session_path);
-    state_manager
-        .record_assignment(&worker_id, &task, plan_task_id)
-        .map_err(|e: crate::coordination::StateError| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.assign_task",
+        json!({
+            "session_id": session_id,
+            "queen_id": queen_id,
+            "worker_id": worker_id,
+            "task": task,
+            "plan_task_id": plan_task_id,
+        }),
+    )
+    .await
 }
 
-/// Get session storage path
 #[tauri::command]
 pub async fn get_session_storage_path(
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
 ) -> Result<String, String> {
-    let path = storage_state.0.session_dir(&session_id);
-    Ok(path.to_string_lossy().to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_session_storage_path",
+        json!({ "session_id": session_id }),
+    )
+    .await
 }
 
-/// Get current working directory
 #[tauri::command]
-pub async fn get_current_directory() -> Result<String, String> {
-    std::env::current_dir()
-        .map(|p| p.to_string_lossy().to_string())
-        .map_err(|e| e.to_string())
+pub async fn get_current_directory(
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
+) -> Result<String, String> {
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_current_directory",
+        json!({}),
+    )
+    .await
 }
 
-/// List stored sessions, optionally filtered by project path
 #[tauri::command]
 pub async fn list_stored_sessions(
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     project_path: Option<String>,
 ) -> Result<Vec<crate::storage::SessionSummary>, String> {
-    let sessions = storage_state.0.list_sessions().map_err(|e| e.to_string())?;
-
-    match project_path {
-        Some(path) => {
-            // Normalize paths for comparison (handle trailing slashes, case on Windows)
-            let normalize = |p: &str| -> String {
-                let p = p.trim_end_matches(['/', '\\']);
-                #[cfg(windows)]
-                { p.to_lowercase() }
-                #[cfg(not(windows))]
-                { p.to_string() }
-            };
-
-            let target = normalize(&path);
-            Ok(sessions.into_iter()
-                .filter(|s| normalize(&s.project_path) == target)
-                .collect())
-        }
-        None => Ok(sessions),
-    }
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.list_stored_sessions",
+        json!({ "project_path": project_path }),
+    )
+    .await
 }
 
-/// Get app config
 #[tauri::command]
 pub async fn get_app_config(
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
 ) -> Result<crate::storage::AppConfig, String> {
-    storage_state.0.load_config().map_err(|e| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_app_config",
+        json!({}),
+    )
+    .await
 }
 
-/// Update app config
 #[tauri::command]
 pub async fn update_app_config(
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: crate::storage::AppConfig,
 ) -> Result<(), String> {
-    storage_state.0.save_config(&config).map_err(|e| e.to_string())
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.update_app_config",
+        json!({ "config": config }),
+    )
+    .await
 }
 
-/// Plan task structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PlanTask {
-    pub id: String,
-    pub title: String,
-    pub description: String,
-    pub status: String,
-    pub assignee: Option<String>,
-    pub priority: Option<String>,
-}
-
-/// Session plan structure
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SessionPlan {
-    pub title: String,
-    pub summary: String,
-    pub tasks: Vec<PlanTask>,
-    pub generated_at: String,
-    pub raw_content: String,  // Raw markdown content for display
-}
-
-/// Get the session plan (parsed from plan.md)
-/// Looks in project-local .hive-manager/{session_id}/plan.md first,
-/// then falls back to app storage
 #[tauri::command]
 pub async fn get_session_plan(
-    session_state: State<'_, super::SessionControllerState>,
-    storage_state: State<'_, StorageState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     session_id: String,
 ) -> Result<Option<SessionPlan>, String> {
-    // First, try to get the project path from the active session
-    let project_plan_path = {
-        let controller = session_state.0.read();
-        if let Some(session) = controller.get_session(&session_id) {
-            let project_path = &session.project_path;
-            Some(project_path.join(".hive-manager").join(&session_id).join("plan.md"))
-        } else {
-            None
-        }
-    };
-
-    // Try project-local path first
-    let plan_path = if let Some(ref path) = project_plan_path {
-        if path.exists() {
-            path.clone()
-        } else {
-            // Fall back to app storage
-            let session_path = storage_state.0.session_dir(&session_id);
-            session_path.join("plan.md")
-        }
-    } else {
-        // No session found, try app storage
-        let session_path = storage_state.0.session_dir(&session_id);
-        session_path.join("plan.md")
-    };
-
-    if !plan_path.exists() {
-        return Ok(None);
-    }
-
-    let content = std::fs::read_to_string(&plan_path)
-        .map_err(|e| format!("Failed to read plan.md: {}", e))?;
-
-    // Parse the plan.md content, include raw content
-    let plan = parse_plan_markdown(&content);
-    Ok(Some(plan))
-}
-
-/// Parse plan.md markdown content into structured plan
-/// Never fails - returns what it can parse, includes raw content
-fn parse_plan_markdown(content: &str) -> SessionPlan {
-    let mut title = String::new();
-    let mut summary = String::new();
-    let mut tasks: Vec<PlanTask> = Vec::new();
-    let mut current_section = "";
-    let mut task_counter = 0;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        // Parse title (first H1)
-        if trimmed.starts_with("# ") && title.is_empty() {
-            title = trimmed[2..].trim().to_string();
-            continue;
-        }
-
-        // Detect sections
-        if trimmed.starts_with("## ") {
-            let section_name = trimmed[3..].trim().to_lowercase();
-            if section_name.contains("summary") || section_name.contains("overview") {
-                current_section = "summary";
-            } else if section_name.contains("task") || section_name.contains("plan") {
-                current_section = "tasks";
-            } else {
-                current_section = "";
-            }
-            continue;
-        }
-
-        // Parse summary
-        if current_section == "summary" && !trimmed.is_empty() && !trimmed.starts_with("#") {
-            if !summary.is_empty() {
-                summary.push(' ');
-            }
-            summary.push_str(trimmed);
-            continue;
-        }
-
-        // Parse tasks (look for list items or numbered items)
-        if current_section == "tasks" {
-            // Match patterns like: - [ ] Task, - [x] Task, 1. Task, - Task
-            if let Some(task) = parse_task_line(trimmed, &mut task_counter) {
-                tasks.push(task);
-            }
-        }
-    }
-
-    // If no title found, use "Plan in Progress"
-    if title.is_empty() {
-        title = "Plan in Progress...".to_string();
-    }
-
-    SessionPlan {
-        title,
-        summary,
-        tasks,
-        generated_at: chrono::Utc::now().to_rfc3339(),
-        raw_content: content.to_string(),
-    }
-}
-
-/// Parse a single task line
-fn parse_task_line(line: &str, counter: &mut i32) -> Option<PlanTask> {
-    let trimmed = line.trim();
-
-    // Skip empty lines and headers
-    if trimmed.is_empty() || trimmed.starts_with("#") {
-        return None;
-    }
-
-    // Check for checkbox format: - [ ] or - [x]
-    let (status, rest) = if trimmed.starts_with("- [ ]") || trimmed.starts_with("* [ ]") {
-        ("pending", trimmed[5..].trim())
-    } else if trimmed.starts_with("- [x]") || trimmed.starts_with("* [x]")
-           || trimmed.starts_with("- [X]") || trimmed.starts_with("* [X]") {
-        ("completed", trimmed[5..].trim())
-    } else if trimmed.starts_with("- ") || trimmed.starts_with("* ") {
-        ("pending", trimmed[2..].trim())
-    } else if trimmed.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false) {
-        // Numbered list: 1. Task
-        if let Some(pos) = trimmed.find(". ") {
-            ("pending", trimmed[pos + 2..].trim())
-        } else {
-            return None;
-        }
-    } else {
-        return None;
-    };
-
-    if rest.is_empty() {
-        return None;
-    }
-
-    *counter += 1;
-
-    // Extract priority from brackets like [HIGH], [P1], etc.
-    let (title, priority) = extract_priority(rest);
-
-    // Extract assignee from arrow notation: -> Worker 1
-    let (title, assignee) = extract_assignee(&title);
-
-    Some(PlanTask {
-        id: format!("task-{}", counter),
-        title: title.trim().to_string(),
-        description: String::new(),
-        status: status.to_string(),
-        assignee,
-        priority,
-    })
-}
-
-/// Extract priority from task title
-fn extract_priority(text: &str) -> (String, Option<String>) {
-    let priorities = [
-        ("[HIGH]", "high"), ("[P1]", "high"), ("[CRITICAL]", "high"),
-        ("[MEDIUM]", "medium"), ("[P2]", "medium"), ("[MED]", "medium"),
-        ("[LOW]", "low"), ("[P3]", "low"),
-    ];
-
-    for (marker, priority) in priorities {
-        if text.to_uppercase().contains(marker) {
-            let cleaned = text.replace(marker, "").replace(&marker.to_lowercase(), "");
-            return (cleaned, Some(priority.to_string()));
-        }
-    }
-
-    (text.to_string(), None)
-}
-
-/// Extract assignee from task title
-fn extract_assignee(text: &str) -> (String, Option<String>) {
-    // Look for patterns like "-> Worker 1" or "→ Queen"
-    if let Some(pos) = text.find("->") {
-        let (title, assignee) = text.split_at(pos);
-        return (title.to_string(), Some(assignee[2..].trim().to_string()));
-    }
-    if let Some(pos) = text.find("→") {
-        let (title, assignee) = text.split_at(pos);
-        return (title.to_string(), Some(assignee[3..].trim().to_string())); // → is 3 bytes
-    }
-
-    (text.to_string(), None)
+    dispatch_coordination(
+        &registry,
+        Arc::clone(&app_state),
+        "coordination.get_session_plan",
+        json!({ "session_id": session_id }),
+    )
+    .await
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,9 +1,9 @@
-mod pty_commands;
-mod session_commands;
 mod coordination_commands;
 mod git_commands;
+mod pty_commands;
+mod session_commands;
 
-pub use pty_commands::*;
-pub use session_commands::*;
 pub use coordination_commands::*;
 pub use git_commands::*;
+pub use pty_commands::*;
+pub use session_commands::*;

--- a/src-tauri/src/commands/pty_commands.rs
+++ b/src-tauri/src/commands/pty_commands.rs
@@ -1,18 +1,38 @@
-use tauri::State;
-use std::sync::Arc;
 use parking_lot::RwLock;
+use serde::de::DeserializeOwned;
+use serde_json::json;
+use std::sync::Arc;
+use tauri::State;
 
+use crate::actions::{ActionContext, ActionRegistry, Caller};
+use crate::http::state::AppState;
 use crate::pty::{AgentRole, AgentStatus, PtyManager};
 
+#[allow(dead_code)]
 pub struct PtyManagerState(pub Arc<RwLock<PtyManager>>);
 
 // PtyManagerState is Send + Sync because Arc<RwLock<T>> is Send + Sync when T is Send
 unsafe impl Send for PtyManagerState {}
 unsafe impl Sync for PtyManagerState {}
 
+async fn dispatch_pty<T: DeserializeOwned>(
+    registry: &ActionRegistry,
+    state: Arc<AppState>,
+    name: &str,
+    input: serde_json::Value,
+) -> Result<T, String> {
+    let ctx = ActionContext::new(Caller::Frontend, state);
+    let value = registry
+        .dispatch(name, &ctx, input)
+        .await
+        .map_err(|e| e.to_message())?;
+    serde_json::from_value(value).map_err(|e| e.to_string())
+}
+
 #[tauri::command]
 pub async fn create_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     command: String,
     args: Vec<String>,
@@ -20,119 +40,123 @@ pub async fn create_pty(
     cols: u16,
     rows: u16,
 ) -> Result<String, String> {
-    let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-    let pty_manager = state.0.read();
-    pty_manager
-        .create_session(
-            id,
-            AgentRole::Worker { index: 0, parent: None },
-            &command,
-            &args_refs,
-            cwd.as_deref(),
-            cols,
-            rows,
-        )
-        .map_err(|e| e.to_string())
-}
-
-/// Maximum allowed paste size (5MB) - prevents DoS via oversized pastes
-const MAX_PASTE_SIZE: usize = 5 * 1024 * 1024;
-
-fn check_data_size(data_len: usize) -> Result<(), String> {
-    if data_len > MAX_PASTE_SIZE {
-        return Err(format!(
-            "Data size {} bytes exceeds maximum allowed {} bytes",
-            data_len, MAX_PASTE_SIZE
-        ));
-    }
-
-    Ok(())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.create",
+        json!({
+            "id": id,
+            "command": command,
+            "args": args,
+            "cwd": cwd,
+            "cols": cols,
+            "rows": rows,
+        }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn write_to_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     data: String,
 ) -> Result<(), String> {
-    check_data_size(data.len())?;
-
-    let pty_manager = state.0.read();
-
-    pty_manager.write(&id, data.as_bytes()).map_err(|e| e.to_string())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.write",
+        json!({ "id": id, "data": data }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn paste_to_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     data: String,
 ) -> Result<(), String> {
-    check_data_size(data.len())?;
-
-    let pty_manager = state.0.read();
-    pty_manager.write_bracketed(&id, data.as_bytes()).map_err(|e| e.to_string())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.paste",
+        json!({ "id": id, "data": data }),
+    )
+    .await
 }
 
 /// Write a string message to a PTY and optionally send Enter
 #[tauri::command]
 pub async fn inject_to_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     message: String,
     send_enter: bool,
 ) -> Result<(), String> {
-    check_data_size(message.len())?;
-
-    let pty_manager = state.0.read();
-
-    tracing::info!("inject_to_pty: id={}, message_len={}, send_enter={}", id, message.len(), send_enter);
-
-    if send_enter {
-        // For messages with Enter, we send message with bracketed paste + CR
-        let message_with_enter = format!("{}\r", message);
-        pty_manager.write_bracketed(&id, message_with_enter.as_bytes()).map_err(|e| e.to_string())?;
-    } else {
-        // Use bracketed paste for consistency
-        pty_manager.write_bracketed(&id, message.as_bytes()).map_err(|e| e.to_string())?;
-    }
-
-    Ok(())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.inject",
+        json!({ "id": id, "message": message, "send_enter": send_enter }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn resize_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
     cols: u16,
     rows: u16,
 ) -> Result<(), String> {
-    let pty_manager = state.0.read();
-    pty_manager.resize(&id, cols, rows).map_err(|e| e.to_string())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.resize",
+        json!({ "id": id, "cols": cols, "rows": rows }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn kill_pty(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
 ) -> Result<(), String> {
-    let pty_manager = state.0.read();
-    pty_manager.kill(&id).map_err(|e| e.to_string())
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.kill",
+        json!({ "id": id }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn get_pty_status(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     id: String,
 ) -> Result<Option<AgentStatus>, String> {
-    let pty_manager = state.0.read();
-    Ok(pty_manager.get_status(&id))
+    dispatch_pty(
+        &registry,
+        Arc::clone(&app_state),
+        "pty.status",
+        json!({ "id": id }),
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn list_ptys(
-    state: State<'_, PtyManagerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
 ) -> Result<Vec<(String, AgentRole, AgentStatus)>, String> {
-    let pty_manager = state.0.read();
-    Ok(pty_manager.list_sessions())
+    dispatch_pty(&registry, Arc::clone(&app_state), "pty.list", json!({})).await
 }

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -1,11 +1,9 @@
 use parking_lot::RwLock;
 use serde_json::json;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tauri::State;
 
 use crate::actions::{ActionContext, ActionRegistry, Caller};
-use crate::http::handlers::{validate_cli, validate_project_path};
 use crate::http::state::AppState;
 use crate::pty::AgentConfig;
 use crate::session::{
@@ -31,140 +29,31 @@ async fn dispatch_frontend(
         .map_err(|e| e.to_message())
 }
 
-const SESSION_COLOR_ALLOWLIST: &[&str] = &[
-    "#7aa2f7", "#bb9af7", "#9ece6a", "#e0af68", "#7dcfff", "#f7768e", "#ff9e64", "#f7b1d1",
-];
-
 // SessionControllerState is Send + Sync because Arc<RwLock<T>> is Send + Sync when T is Send
 unsafe impl Send for SessionControllerState {}
 unsafe impl Sync for SessionControllerState {}
 
-fn validate_session_name(name: Option<&str>) -> Result<(), String> {
-    let Some(name) = name else {
-        return Ok(());
-    };
-
-    if name.trim().is_empty() {
-        return Err("Invalid session name: must not be empty or whitespace".to_string());
-    }
-
-    if name.chars().count() > 64 {
-        return Err("Invalid session name: must be 64 characters or fewer".to_string());
-    }
-
-    if name.contains("..") || name.contains('/') || name.contains('\\') {
-        return Err("Invalid session name: must not contain '..', '/', or '\\'".to_string());
-    }
-
-    Ok(())
-}
-
-fn validate_session_color(color: Option<&str>) -> Result<(), String> {
-    let Some(color) = color else {
-        return Ok(());
-    };
-
-    if !SESSION_COLOR_ALLOWLIST.contains(&color) && !is_valid_hex_session_color(color) {
-        return Err(format!(
-            "Invalid session color '{}'. Valid options: {} or any #RRGGBB hex color",
-            color,
-            SESSION_COLOR_ALLOWLIST.join(", ")
-        ));
-    }
-
-    Ok(())
-}
-
-fn is_valid_hex_session_color(color: &str) -> bool {
-    color.len() == 7
-        && color.starts_with('#')
-        && color.chars().skip(1).all(|c| c.is_ascii_hexdigit())
-}
-
-fn validate_research_launch_config(config: &ResearchLaunchConfig) -> Result<(), String> {
-    validate_project_path(&config.project_path).map_err(|e| e.message.clone())?;
-    validate_session_name(config.name.as_deref())?;
-    validate_session_color(config.color.as_deref())?;
-    validate_cli(&config.queen_config.cli).map_err(|e| e.message.clone())?;
-
-    // Research requires a roster of 1..=6 researchers. These are NOT pre-spawned:
-    // the Queen spawns them on demand, so the roster must list at least one entry for
-    // the Queen to draw from (and is capped like the launch dialog does at 6).
-    if !(1..=6).contains(&config.workers.len()) {
-        return Err(format!(
-            "Research sessions require 1 to 6 researchers (got {}).",
-            config.workers.len()
-        ));
-    }
-
-    for worker in &config.workers {
-        validate_cli(&worker.cli).map_err(|e| e.message.clone())?;
-    }
-
-    Ok(())
-}
-
-fn validate_swarm_launch_config(config: &SwarmLaunchConfig) -> Result<(), String> {
-    validate_project_path(&config.project_path).map_err(|e| e.message.clone())?;
-    validate_session_name(config.name.as_deref())?;
-    validate_session_color(config.color.as_deref())?;
-    validate_cli(&config.queen_config.cli).map_err(|e| e.message.clone())?;
-    validate_cli(&config.planner_config.cli).map_err(|e| e.message.clone())?;
-
-    for worker in &config.workers_per_planner {
-        validate_cli(&worker.cli).map_err(|e| e.message.clone())?;
-    }
-
-    for planner in &config.planners {
-        validate_cli(&planner.config.cli).map_err(|e| e.message.clone())?;
-        for worker in &planner.workers {
-            validate_cli(&worker.cli).map_err(|e| e.message.clone())?;
-        }
-    }
-
-    if let Some(evaluator_config) = &config.evaluator_config {
-        if evaluator_config.cli.trim().is_empty() {
-            // Empty nested CLI means "inherit session default"; only validate explicit overrides.
-        } else {
-            validate_cli(&evaluator_config.cli).map_err(|e| e.message.clone())?;
-        }
-    }
-
-    if let Some(qa_workers) = &config.qa_workers {
-        for qa_worker in qa_workers {
-            validate_cli(&qa_worker.cli).map_err(|e| e.message.clone())?;
-            match qa_worker.specialization.as_str() {
-                "ui" | "api" | "a11y" => {}
-                other => {
-                    return Err(format!(
-                        "Invalid QA specialization '{}'. Valid options: ui, api, a11y",
-                        other
-                    ));
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
 #[tauri::command]
 pub async fn launch_hive(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     project_path: String,
     worker_count: u8,
     command: String,
     prompt: Option<String>,
-) -> Result<Session, String> {
-    let controller = state.0.read();
-    controller.launch_hive(
-        PathBuf::from(project_path),
-        worker_count,
-        &command,
-        prompt,
-        None,
-        None,
+) -> Result<serde_json::Value, String> {
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_hive",
+        json!({
+            "project_path": project_path,
+            "worker_count": worker_count,
+            "command": command,
+            "task_description": prompt,
+        }),
     )
+    .await
 }
 
 // NOTE on return types: the migrated session commands return `serde_json::Value`
@@ -255,27 +144,40 @@ pub async fn launch_hive_v2(
 
 #[tauri::command]
 pub async fn launch_research(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: ResearchLaunchConfig,
-) -> Result<Session, String> {
-    validate_research_launch_config(&config)?;
-    let controller = state.0.read();
-    controller.launch_research(config)
+) -> Result<serde_json::Value, String> {
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_research",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn launch_swarm(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: SwarmLaunchConfig,
-) -> Result<Session, String> {
-    validate_swarm_launch_config(&config)?;
-    let controller = state.0.read();
-    controller.launch_swarm(config)
+) -> Result<serde_json::Value, String> {
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_swarm",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn launch_solo(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     project_path: String,
     task_description: Option<String>,
     cli: String,
@@ -283,10 +185,7 @@ pub async fn launch_solo(
     flags: Option<Vec<String>>,
     evaluator_cli: Option<String>,
     evaluator_model: Option<String>,
-) -> Result<Session, String> {
-    validate_project_path(&project_path).map_err(|e| e.message.clone())?;
-    validate_cli(&cli).map_err(|e| e.message.clone())?;
-
+) -> Result<serde_json::Value, String> {
     let agent_config = AgentConfig {
         cli: cli.clone(),
         model,
@@ -300,7 +199,6 @@ pub async fn launch_solo(
 
     // Build evaluator_config: validate if provided, else fall back to cli silently
     let evaluator_config = if let Some(ref eval_cli) = evaluator_cli {
-        validate_cli(eval_cli).map_err(|e| e.message.clone())?;
         Some(AgentConfig {
             cli: eval_cli.clone(),
             model: evaluator_model,
@@ -330,26 +228,46 @@ pub async fn launch_solo(
         smoke_test: false,
     };
 
-    let controller = state.0.read();
-    controller.launch_solo(config)
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_solo",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn launch_fusion(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: FusionLaunchConfig,
-) -> Result<Session, String> {
-    let controller = state.0.read();
-    controller.launch_fusion(config)
+) -> Result<serde_json::Value, String> {
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_fusion",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]
 pub async fn launch_debate(
-    state: State<'_, SessionControllerState>,
+    registry: State<'_, Arc<ActionRegistry>>,
+    app_state: State<'_, Arc<AppState>>,
     config: DebateLaunchConfig,
-) -> Result<Session, String> {
-    let controller = state.0.read();
-    controller.launch_debate(config)
+) -> Result<serde_json::Value, String> {
+    let input = serde_json::to_value(config).map_err(|e| e.to_string())?;
+    dispatch_frontend(
+        &registry,
+        Arc::clone(&app_state),
+        "session.launch_debate",
+        input,
+    )
+    .await
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -1,14 +1,17 @@
-use std::path::PathBuf;
-use std::sync::Arc;
 use parking_lot::RwLock;
 use serde_json::json;
+use std::path::PathBuf;
+use std::sync::Arc;
 use tauri::State;
 
 use crate::actions::{ActionContext, ActionRegistry, Caller};
 use crate::http::handlers::{validate_cli, validate_project_path};
 use crate::http::state::AppState;
 use crate::pty::AgentConfig;
-use crate::session::{Session, SessionController, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig};
+use crate::session::{
+    DebateLaunchConfig, FusionLaunchConfig, HiveLaunchConfig, ResearchLaunchConfig, Session,
+    SessionController, SwarmLaunchConfig,
+};
 
 pub struct SessionControllerState(pub Arc<RwLock<SessionController>>);
 
@@ -29,14 +32,7 @@ async fn dispatch_frontend(
 }
 
 const SESSION_COLOR_ALLOWLIST: &[&str] = &[
-    "#7aa2f7",
-    "#bb9af7",
-    "#9ece6a",
-    "#e0af68",
-    "#7dcfff",
-    "#f7768e",
-    "#ff9e64",
-    "#f7b1d1",
+    "#7aa2f7", "#bb9af7", "#9ece6a", "#e0af68", "#7dcfff", "#f7768e", "#ff9e64", "#f7b1d1",
 ];
 
 // SessionControllerState is Send + Sync because Arc<RwLock<T>> is Send + Sync when T is Send
@@ -130,7 +126,7 @@ fn validate_swarm_launch_config(config: &SwarmLaunchConfig) -> Result<(), String
         if evaluator_config.cli.trim().is_empty() {
             // Empty nested CLI means "inherit session default"; only validate explicit overrides.
         } else {
-        validate_cli(&evaluator_config.cli).map_err(|e| e.message.clone())?;
+            validate_cli(&evaluator_config.cli).map_err(|e| e.message.clone())?;
         }
     }
 
@@ -196,13 +192,7 @@ pub async fn list_sessions(
     registry: State<'_, Arc<ActionRegistry>>,
     app_state: State<'_, Arc<AppState>>,
 ) -> Result<serde_json::Value, String> {
-    dispatch_frontend(
-        &registry,
-        Arc::clone(&app_state),
-        "session.list",
-        json!({}),
-    )
-    .await
+    dispatch_frontend(&registry, Arc::clone(&app_state), "session.list", json!({})).await
 }
 
 #[tauri::command]
@@ -351,6 +341,15 @@ pub async fn launch_fusion(
 ) -> Result<Session, String> {
     let controller = state.0.read();
     controller.launch_fusion(config)
+}
+
+#[tauri::command]
+pub async fn launch_debate(
+    state: State<'_, SessionControllerState>,
+    config: DebateLaunchConfig,
+) -> Result<Session, String> {
+    let controller = state.0.read();
+    controller.launch_debate(config)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/session_commands.rs
+++ b/src-tauri/src/commands/session_commands.rs
@@ -1,5 +1,8 @@
 use parking_lot::RwLock;
 use serde_json::json;
+use std::collections::{HashSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tauri::State;
 
@@ -32,6 +35,111 @@ async fn dispatch_frontend(
 // SessionControllerState is Send + Sync because Arc<RwLock<T>> is Send + Sync when T is Send
 unsafe impl Send for SessionControllerState {}
 unsafe impl Sync for SessionControllerState {}
+
+const SESSION_FILE_RESULT_CAP: usize = 100;
+const SESSION_FILE_VISIT_CAP: usize = 5_000;
+
+fn validate_session_id_for_command(session_id: &str) -> Result<(), String> {
+    if session_id.contains("..") || session_id.contains('/') || session_id.contains('\\') {
+        return Err("Invalid session ID format".to_string());
+    }
+    Ok(())
+}
+
+fn is_ignored_file_dir(path: &Path) -> bool {
+    let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+        return false;
+    };
+    matches!(
+        name,
+        ".git" | ".hive-manager" | ".svelte-kit" | "node_modules" | "target" | "dist" | "build"
+    )
+}
+
+fn path_within_any_root(path: &Path, canonical_roots: &[PathBuf]) -> bool {
+    canonical_roots.iter().any(|root| path.starts_with(root))
+}
+
+fn dedupe_canonical_roots(roots: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    let mut canonical_roots = Vec::new();
+
+    for root in roots {
+        let Ok(canonical) = fs::canonicalize(root) else {
+            continue;
+        };
+        let key = canonical.to_string_lossy().to_lowercase();
+        if seen.insert(key) {
+            canonical_roots.push(canonical);
+        }
+    }
+
+    canonical_roots
+}
+
+fn file_matches_query(path: &Path, query: &str) -> bool {
+    if query.is_empty() {
+        return true;
+    }
+
+    let path_text = path.to_string_lossy().to_lowercase();
+    let name_text = path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or_default()
+        .to_lowercase();
+    path_text.contains(query) || name_text.contains(query)
+}
+
+fn list_files_under_roots(roots: Vec<PathBuf>, query: String) -> Result<Vec<String>, String> {
+    let canonical_roots = dedupe_canonical_roots(roots);
+    let query = query.trim().to_lowercase();
+    let mut pending: VecDeque<PathBuf> = canonical_roots.iter().cloned().collect();
+    let mut results = Vec::new();
+    let mut visited = 0usize;
+
+    while let Some(dir) = pending.pop_front() {
+        if visited >= SESSION_FILE_VISIT_CAP || results.len() >= SESSION_FILE_RESULT_CAP {
+            break;
+        }
+        visited += 1;
+
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            if results.len() >= SESSION_FILE_RESULT_CAP || visited >= SESSION_FILE_VISIT_CAP {
+                break;
+            }
+
+            let path = entry.path();
+            let Ok(canonical_path) = fs::canonicalize(&path) else {
+                continue;
+            };
+            if !path_within_any_root(&canonical_path, &canonical_roots) {
+                continue;
+            }
+
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+
+            if file_type.is_dir() {
+                if !is_ignored_file_dir(&path) {
+                    pending.push_back(path);
+                }
+                continue;
+            }
+
+            if file_type.is_file() && file_matches_query(&path, &query) {
+                results.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+
+    Ok(results)
+}
 
 #[tauri::command]
 pub async fn launch_hive(
@@ -321,9 +429,7 @@ pub async fn get_run_journal(
     app_state: State<'_, Arc<AppState>>,
     session_id: String,
 ) -> Result<serde_json::Value, String> {
-    if session_id.contains("..") || session_id.contains('/') || session_id.contains('\\') {
-        return Err("Invalid session ID format".to_string());
-    }
+    validate_session_id_for_command(&session_id)?;
     let store = crate::storage::RunJournalStore::new(Arc::clone(&app_state.app_state_db));
     let journal = store
         .read_journal(&session_id)
@@ -332,6 +438,32 @@ pub async fn get_run_journal(
         .read_ledger(&session_id)
         .map_err(|e| format!("Failed to read run ledger: {e}"))?;
     Ok(json!({ "journal": journal, "ledger": ledger }))
+}
+
+#[tauri::command]
+pub async fn list_session_files(
+    state: State<'_, SessionControllerState>,
+    session_id: String,
+    query: String,
+) -> Result<Vec<String>, String> {
+    validate_session_id_for_command(&session_id)?;
+
+    let roots = {
+        let controller = state.0.read();
+        let session = controller
+            .get_session(&session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        let mut roots = vec![session.project_path];
+        if let Some(worktree_path) = session.worktree_path {
+            roots.push(PathBuf::from(worktree_path));
+        }
+        roots
+    };
+
+    tauri::async_runtime::spawn_blocking(move || list_files_under_roots(roots, query))
+        .await
+        .map_err(|e| format!("Failed to list session files: {e}"))?
 }
 
 #[tauri::command]
@@ -349,4 +481,22 @@ pub async fn update_session_metadata(
         json!({ "id": id, "name": name, "color": color }),
     )
     .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::path_within_any_root;
+    use std::path::PathBuf;
+
+    #[test]
+    fn path_scope_rejects_sibling_paths() {
+        let root = std::env::temp_dir().join("hm-session-root");
+        let inside = root.join("src").join("main.rs");
+        let outside = std::env::temp_dir()
+            .join("hm-session-root-sibling")
+            .join("main.rs");
+
+        assert!(path_within_any_root(&inside, &[PathBuf::from(&root)]));
+        assert!(!path_within_any_root(&outside, &[root]));
+    }
 }

--- a/src-tauri/src/coordination/injection.rs
+++ b/src-tauri/src/coordination/injection.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use tauri::{AppHandle, Emitter};
 use thiserror::Error;
 
 use crate::pty::PtyManager;
 use crate::storage::SessionStorage;
+use crate::tauri_shim::{AppHandle, Emitter};
 
 use super::{CoordinationMessage, StateManager, WorkerStateInfo};
 

--- a/src-tauri/src/coordination/mod.rs
+++ b/src-tauri/src/coordination/mod.rs
@@ -1,12 +1,12 @@
 mod contracts;
-mod state;
 mod injection;
 pub mod queue_manager;
+mod state;
 
 pub use contracts::*;
-pub use state::*;
 pub use injection::*;
 pub use queue_manager::QueueManager;
+pub use state::*;
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};

--- a/src-tauri/src/domain/session.rs
+++ b/src-tauri/src/domain/session.rs
@@ -26,6 +26,7 @@ pub struct Session {
 pub enum SessionMode {
     Hive,
     Fusion,
+    Debate,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]

--- a/src-tauri/src/domain/status.rs
+++ b/src-tauri/src/domain/status.rs
@@ -28,6 +28,7 @@ mod tests {
     fn session_mode_round_trip() {
         assert_enum_round_trip(SessionMode::Hive, "\"hive\"");
         assert_enum_round_trip(SessionMode::Fusion, "\"fusion\"");
+        assert_enum_round_trip(SessionMode::Debate, "\"debate\"");
     }
 
     #[test]
@@ -91,7 +92,10 @@ mod tests {
     #[test]
     fn event_type_round_trip() {
         assert_enum_round_trip(EventType::SessionCreated, "\"session_created\"");
-        assert_enum_round_trip(EventType::SessionStatusChanged, "\"session_status_changed\"");
+        assert_enum_round_trip(
+            EventType::SessionStatusChanged,
+            "\"session_status_changed\"",
+        );
         assert_enum_round_trip(EventType::CellCreated, "\"cell_created\"");
         assert_enum_round_trip(EventType::CellStatusChanged, "\"cell_status_changed\"");
         assert_enum_round_trip(EventType::ConversationMessage, "\"conversation_message\"");

--- a/src-tauri/src/http/handlers/actions.rs
+++ b/src-tauri/src/http/handlers/actions.rs
@@ -12,6 +12,7 @@ use serde::Serialize;
 use serde_json::Value;
 use std::sync::Arc;
 
+use crate::actions::render::envelope_for_action_result;
 use crate::actions::{ActionContext, Caller};
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
@@ -50,7 +51,7 @@ pub async fn list_actions(
 
 /// POST /api/actions/{name} — dispatch a registered action with caller = Http.
 /// The request body is the action's input JSON; the response is the action's
-/// raw output value (an envelope can wrap this later per #127).
+/// raw output value wrapped in the `{ renderer?, data }` envelope.
 pub async fn dispatch_action(
     State(state): State<Arc<AppState>>,
     Path(name): Path<String>,
@@ -59,5 +60,5 @@ pub async fn dispatch_action(
     let input = body.map(|Json(value)| value).unwrap_or(Value::Null);
     let ctx = ActionContext::new(Caller::Http, Arc::clone(&state));
     let output = state.registry().dispatch(&name, &ctx, input).await?;
-    Ok(Json(output))
+    Ok(Json(envelope_for_action_result(&name, output)))
 }

--- a/src-tauri/src/http/handlers/artifacts.rs
+++ b/src-tauri/src/http/handlers/artifacts.rs
@@ -97,6 +97,22 @@ fn session_state_from_persisted(state: &str) -> SessionState {
                 .unwrap_or(1);
             SessionState::SpawningFusionVariant(index)
         }
+        value if value.starts_with("SpawningDebateRound(") => {
+            let round = value
+                .trim_start_matches("SpawningDebateRound(")
+                .trim_end_matches(')')
+                .parse()
+                .unwrap_or(1);
+            SessionState::SpawningDebateRound(round)
+        }
+        value if value.starts_with("WaitingForDebateRound(") => {
+            let round = value
+                .trim_start_matches("WaitingForDebateRound(")
+                .trim_end_matches(')')
+                .parse()
+                .unwrap_or(1);
+            SessionState::WaitingForDebateRound(round)
+        }
         value if value.starts_with("QaInProgress") => {
             SessionState::QaInProgress { iteration: None }
         }
@@ -108,6 +124,24 @@ fn session_state_from_persisted(state: &str) -> SessionState {
                 .to_string(),
         ),
         _ => SessionState::Completed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::session_state_from_persisted;
+    use crate::session::SessionState;
+
+    #[test]
+    fn persisted_indexed_debate_states_keep_round_index() {
+        assert_eq!(
+            session_state_from_persisted("SpawningDebateRound(2)"),
+            SessionState::SpawningDebateRound(2)
+        );
+        assert_eq!(
+            session_state_from_persisted("WaitingForDebateRound(3)"),
+            SessionState::WaitingForDebateRound(3)
+        );
     }
 }
 

--- a/src-tauri/src/http/handlers/artifacts.rs
+++ b/src-tauri/src/http/handlers/artifacts.rs
@@ -27,6 +27,9 @@ fn session_type_from_persisted(session_type: &crate::storage::SessionTypeInfo) -
         crate::storage::SessionTypeInfo::Fusion { variants } => SessionType::Fusion {
             variants: variants.clone(),
         },
+        crate::storage::SessionTypeInfo::Debate { variants } => SessionType::Debate {
+            variants: variants.clone(),
+        },
         crate::storage::SessionTypeInfo::Solo { cli, model } => SessionType::Solo {
             cli: cli.clone(),
             model: model.clone(),
@@ -40,6 +43,8 @@ fn session_state_from_persisted(state: &str) -> SessionState {
         "PlanReady" => SessionState::PlanReady,
         "Starting" => SessionState::Starting,
         "WaitingForFusionVariants" => SessionState::WaitingForFusionVariants,
+        "SpawningDebateRound" => SessionState::SpawningDebateRound(0),
+        "WaitingForDebateRound" => SessionState::WaitingForDebateRound(0),
         "SpawningJudge" => SessionState::SpawningJudge,
         "Judging" => SessionState::Judging,
         "AwaitingVerdictSelection" => SessionState::AwaitingVerdictSelection,
@@ -92,7 +97,9 @@ fn session_state_from_persisted(state: &str) -> SessionState {
                 .unwrap_or(1);
             SessionState::SpawningFusionVariant(index)
         }
-        value if value.starts_with("QaInProgress") => SessionState::QaInProgress { iteration: None },
+        value if value.starts_with("QaInProgress") => {
+            SessionState::QaInProgress { iteration: None }
+        }
         value if value.starts_with("QaFailed") => SessionState::QaFailed { iteration: 1 },
         value if value.starts_with("Failed(") => SessionState::Failed(
             value
@@ -113,9 +120,7 @@ fn session_from_persisted(persisted: PersistedSession) -> Session {
         project_path: persisted.project_path.into(),
         state: session_state_from_persisted(&persisted.state),
         created_at: persisted.created_at,
-        last_activity_at: persisted
-            .last_activity_at
-            .unwrap_or(persisted.created_at),
+        last_activity_at: persisted.last_activity_at.unwrap_or(persisted.created_at),
         agents: vec![],
         default_cli: persisted.default_cli,
         default_model: persisted.default_model,
@@ -140,9 +145,10 @@ fn load_session_for_cells(state: &AppState, session_id: &str) -> Result<Session,
 
     match state.storage.load_session(session_id) {
         Ok(session) => Ok(session_from_persisted(session)),
-        Err(StorageError::SessionNotFound(_)) => {
-            Err(ApiError::not_found(format!("Session {} not found", session_id)))
-        }
+        Err(StorageError::SessionNotFound(_)) => Err(ApiError::not_found(format!(
+            "Session {} not found",
+            session_id
+        ))),
         Err(err) => Err(ApiError::internal(err.to_string())),
     }
 }
@@ -188,7 +194,9 @@ pub async fn post_artifact(
         return Err(ApiError::bad_request("artifact.commits must not be empty"));
     }
     if req.artifact.changed_files.is_empty() {
-        return Err(ApiError::bad_request("artifact.changed_files must not be empty"));
+        return Err(ApiError::bad_request(
+            "artifact.changed_files must not be empty",
+        ));
     }
 
     state

--- a/src-tauri/src/http/handlers/cells.rs
+++ b/src-tauri/src/http/handlers/cells.rs
@@ -25,7 +25,9 @@ pub(crate) use crate::session::cell_status::agent_in_cell;
 
 pub(crate) fn build_cells(session: &Session, storage: &SessionStorage) -> Vec<Cell> {
     match &session.session_type {
-        SessionType::Fusion { variants } if !variants.is_empty() => {
+        SessionType::Fusion { variants } | SessionType::Debate { variants }
+            if !variants.is_empty() =>
+        {
             let mut cells: Vec<Cell> = variants
                 .iter()
                 .map(|variant| build_fusion_cell(session, storage, variant))
@@ -38,7 +40,11 @@ pub(crate) fn build_cells(session: &Session, storage: &SessionStorage) -> Vec<Ce
     }
 }
 
-pub(crate) fn find_cell(session: &Session, storage: &SessionStorage, cell_id: &str) -> Option<Cell> {
+pub(crate) fn find_cell(
+    session: &Session,
+    storage: &SessionStorage,
+    cell_id: &str,
+) -> Option<Cell> {
     build_cells(session, storage)
         .into_iter()
         .find(|cell| cell.id == cell_id)
@@ -64,8 +70,15 @@ fn build_primary_cell(session: &Session, storage: &SessionStorage) -> Cell {
             CellType::Hive,
             PRIMARY_CELL_ID,
         ),
-        agents: session.agents.iter().map(|agent| agent.id.clone()).collect(),
-        artifacts: storage.load_artifact(&session.id, PRIMARY_CELL_ID).ok().flatten(),
+        agents: session
+            .agents
+            .iter()
+            .map(|agent| agent.id.clone())
+            .collect(),
+        artifacts: storage
+            .load_artifact(&session.id, PRIMARY_CELL_ID)
+            .ok()
+            .flatten(),
         events: vec![],
         depends_on: vec![],
     }
@@ -88,7 +101,11 @@ fn build_fusion_cell(session: &Session, storage: &SessionStorage, variant: &str)
         cell_type: CellType::Hive,
         name: variant.to_string(),
         status,
-        objective: format!("Fusion variant {}", variant),
+        objective: if matches!(&session.session_type, SessionType::Debate { .. }) {
+            format!("Debate debater {}", variant)
+        } else {
+            format!("Fusion variant {}", variant)
+        },
         workspace: synthetic_workspace(
             session,
             WorkspaceStrategy::IsolatedCell,
@@ -126,7 +143,10 @@ fn build_resolver_cell(session: &Session, storage: &SessionStorage) -> Cell {
             RESOLVER_CELL_ID,
         ),
         agents,
-        artifacts: storage.load_artifact(&session.id, RESOLVER_CELL_ID).ok().flatten(),
+        artifacts: storage
+            .load_artifact(&session.id, RESOLVER_CELL_ID)
+            .ok()
+            .flatten(),
         events: vec![],
         depends_on: vec![],
     }
@@ -154,8 +174,9 @@ fn synthetic_workspace(
 }
 
 fn session_mode(session: &Session) -> SessionMode {
-    match session.session_type {
+    match &session.session_type {
         SessionType::Fusion { .. } => SessionMode::Fusion,
+        SessionType::Debate { .. } => SessionMode::Debate,
         SessionType::Hive { .. } | SessionType::Swarm { .. } | SessionType::Solo { .. } => {
             SessionMode::Hive
         }

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -1,11 +1,15 @@
-use axum::{extract::{Path, State}, http::StatusCode, Json};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
+use super::validate_agent_id;
+use super::validate_session_id;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
-use super::validate_session_id;
-use super::validate_agent_id;
 
 /// POST /api/sessions/{id}/heartbeat - Body
 #[derive(Debug, Deserialize)]
@@ -68,11 +72,19 @@ pub async fn post_heartbeat(
     {
         let controller = state.session_controller.read();
         if controller.get_session(&session_id).is_none() {
-            return Err(ApiError::not_found(format!("Session {} not found", session_id)));
+            return Err(ApiError::not_found(format!(
+                "Session {} not found",
+                session_id
+            )));
         }
 
         controller
-            .update_heartbeat(&session_id, &req.agent_id, &req.status, req.summary.as_deref())
+            .update_heartbeat(
+                &session_id,
+                &req.agent_id,
+                &req.status,
+                req.summary.as_deref(),
+            )
             .map_err(|e| ApiError::internal(e))?;
     }
 
@@ -130,6 +142,7 @@ pub async fn get_active_sessions(
                         format!("Swarm ({})", planner_count)
                     }
                     crate::session::SessionType::Fusion { .. } => "Fusion".to_string(),
+                    crate::session::SessionType::Debate { .. } => "Debate".to_string(),
                     crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
                 },
                 project_path: session.project_path.to_string_lossy().to_string(),

--- a/src-tauri/src/http/handlers/learnings.rs
+++ b/src-tauri/src/http/handlers/learnings.rs
@@ -9,10 +9,10 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use super::validate_session_id;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
-use crate::storage::Learning;
-use super::validate_session_id;
+use crate::storage::{Learning, StorageError};
 
 /// Request to submit a learning
 #[derive(Debug, Deserialize)]
@@ -38,7 +38,9 @@ fn resolve_project_path(state: &AppState) -> Result<PathBuf, ApiError> {
     let sessions = controller.list_sessions();
 
     if sessions.is_empty() {
-        return Err(ApiError::bad_request("No active session to determine project path"));
+        return Err(ApiError::bad_request(
+            "No active session to determine project path",
+        ));
     }
 
     let first_path = sessions[0].project_path.clone();
@@ -47,7 +49,7 @@ fn resolve_project_path(state: &AppState) -> Result<PathBuf, ApiError> {
             "Multiple active sessions with different project paths. \
              Use session-scoped endpoints instead: \
              GET/POST /api/sessions/{session_id}/learnings, \
-             GET /api/sessions/{session_id}/project-dna"
+             GET /api/sessions/{session_id}/project-dna",
         ));
     }
 
@@ -148,6 +150,24 @@ fn filter_learnings(learnings: Vec<Learning>, params: &LearningsFilter) -> Vec<V
         .collect()
 }
 
+fn ensure_session_exists(state: &AppState, session_id: &str) -> Result<(), ApiError> {
+    if {
+        let controller = state.session_controller.read();
+        controller.get_session(session_id).is_some()
+    } {
+        return Ok(());
+    }
+
+    match state.storage.load_session(session_id) {
+        Ok(_) => Ok(()),
+        Err(StorageError::SessionNotFound(_)) => Err(ApiError::not_found(format!(
+            "Session {} not found",
+            session_id
+        ))),
+        Err(err) => Err(ApiError::internal(err.to_string())),
+    }
+}
+
 /// POST /api/learnings - Submit a learning (project-scoped, legacy)
 /// DEPRECATED: Use POST /api/sessions/{session_id}/learnings for new code
 pub async fn submit_learning(
@@ -195,9 +215,7 @@ pub async fn list_learnings(
 
 /// GET /api/project-dna - Get curated project DNA content (project-scoped, legacy)
 /// DEPRECATED: Use GET /api/sessions/{session_id}/project-dna for new code
-pub async fn get_project_dna(
-    State(state): State<Arc<AppState>>,
-) -> Result<Json<Value>, ApiError> {
+pub async fn get_project_dna(State(state): State<Arc<AppState>>) -> Result<Json<Value>, ApiError> {
     let project_path = resolve_project_path(&state)?;
 
     let content = state
@@ -241,6 +259,7 @@ pub async fn list_learnings_for_session(
     Query(params): Query<LearningsFilter>,
 ) -> Result<Json<Value>, ApiError> {
     validate_session_id(&session_id)?;
+    ensure_session_exists(&state, &session_id)?;
 
     // Use session-scoped storage
     let learnings = state
@@ -284,6 +303,7 @@ pub async fn get_project_dna_for_session(
     Path(session_id): Path<String>,
 ) -> Result<Json<Value>, ApiError> {
     validate_session_id(&session_id)?;
+    ensure_session_exists(&state, &session_id)?;
 
     // Use session-scoped storage
     let content = state

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -1,21 +1,21 @@
 pub mod actions;
-pub mod health;
-pub mod application_state;
-pub mod sessions;
-pub mod inject;
-pub mod workers;
-pub mod evaluator;
-pub mod planners;
-pub mod learnings;
-pub mod conversations;
-pub mod heartbeats;
-pub mod queue;
-pub mod cells;
 pub mod agents;
+pub mod application_state;
 pub mod artifacts;
+pub mod cells;
+pub mod conversations;
+pub mod evaluator;
 pub mod events;
+pub mod health;
+pub mod heartbeats;
+pub mod inject;
+pub mod learnings;
+pub mod planners;
+pub mod queue;
 pub mod resolver;
+pub mod sessions;
 pub mod templates;
+pub mod workers;
 
 use crate::http::error::ApiError;
 use std::collections::HashSet;
@@ -23,7 +23,16 @@ use std::collections::HashSet;
 // gemini and antigravity are peers (see adapters/mod.rs::VALID_CLIS).
 // antigravity is the worker default; gemini is retained as a selectable peer
 // until Google deprecates it on 2026-06-18.
-const VALID_CLIS: &[&str] = &["claude", "gemini", "antigravity", "codex", "opencode", "cursor", "droid", "qwen"];
+const VALID_CLIS: &[&str] = &[
+    "claude",
+    "gemini",
+    "antigravity",
+    "codex",
+    "opencode",
+    "cursor",
+    "droid",
+    "qwen",
+];
 
 /// Validate session_id for path traversal attacks
 pub fn validate_session_id(session_id: &str) -> Result<(), ApiError> {
@@ -70,7 +79,10 @@ pub fn validate_agent_id(agent_id: &str) -> Result<(), ApiError> {
             "Invalid agent ID: must not contain '..', '/', or '\\'",
         ));
     }
-    if !agent_id.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+    if !agent_id
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+    {
         return Err(ApiError::bad_request(
             "Invalid agent ID: only alphanumeric characters and hyphens are allowed",
         ));
@@ -140,14 +152,14 @@ pub fn validate_cli(cli: &str) -> Result<(), ApiError> {
 /// Validate project path for path traversal and existence
 pub fn validate_project_path(path: &str) -> Result<(), ApiError> {
     use std::path::Path;
-    
+
     // Check for path traversal sequences
     if path.contains("..") {
         return Err(ApiError::bad_request(
             "Invalid project path: must not contain '..' (path traversal)",
         ));
     }
-    
+
     // Verify the path exists and is a directory
     let project_path = Path::new(path);
     if !project_path.exists() {
@@ -162,6 +174,6 @@ pub fn validate_project_path(path: &str) -> Result<(), ApiError> {
             path
         )));
     }
-    
+
     Ok(())
 }

--- a/src-tauri/src/http/handlers/resolver.rs
+++ b/src-tauri/src/http/handlers/resolver.rs
@@ -16,8 +16,14 @@ use super::{validate_candidate_ids, validate_session_id};
 
 fn completion_blocked_to_api_error(error: CompletionBlockedError) -> ApiError {
     let mut details = std::collections::HashMap::new();
-    details.insert("current_state".to_string(), serde_json::json!(error.current_state));
-    details.insert("unblock_paths".to_string(), serde_json::json!(error.unblock_paths));
+    details.insert(
+        "current_state".to_string(),
+        serde_json::json!(error.current_state),
+    );
+    details.insert(
+        "unblock_paths".to_string(),
+        serde_json::json!(error.unblock_paths),
+    );
     details.insert(
         "remaining_quiescence_seconds".to_string(),
         serde_json::json!(error.remaining_quiescence_seconds),
@@ -52,7 +58,7 @@ pub async fn launch_resolver(
         return Err(ApiError::bad_request("candidate_ids must not be empty"));
     }
 
-    // Check session exists and is Fusion mode
+    // Check session exists and is Fusion/Debate mode
     let session = {
         let controller = state.session_controller.read();
         controller.get_session(&session_id)
@@ -61,6 +67,7 @@ pub async fn launch_resolver(
     let variants = if let Some(ref session) = session {
         match &session.session_type {
             SessionType::Fusion { variants } => Some(variants.clone()),
+            SessionType::Debate { variants } => Some(variants.clone()),
             _ => None,
         }
     } else {
@@ -68,6 +75,7 @@ pub async fn launch_resolver(
         match state.storage.load_session(&session_id) {
             Ok(persisted) => match persisted.session_type {
                 crate::storage::SessionTypeInfo::Fusion { variants } => Some(variants),
+                crate::storage::SessionTypeInfo::Debate { variants } => Some(variants),
                 _ => None,
             },
             Err(StorageError::SessionNotFound(_)) => {
@@ -83,9 +91,9 @@ pub async fn launch_resolver(
     let variants = match variants {
         Some(variants) => variants,
         None => {
-        return Err(ApiError::bad_request(
-            "Resolver launch is only available for Fusion sessions",
-        ))
+            return Err(ApiError::bad_request(
+                "Resolver launch is only available for Fusion or Debate sessions",
+            ))
         }
     };
 
@@ -96,7 +104,7 @@ pub async fn launch_resolver(
         .find(|candidate_id| !allowed_candidates.contains(candidate_id.as_str()))
     {
         return Err(ApiError::bad_request(format!(
-            "Unknown candidate ID '{}' for Fusion session {}",
+            "Unknown candidate ID '{}' for Fusion/Debate session {}",
             unknown_candidate, session_id
         )));
     }
@@ -122,17 +130,18 @@ pub async fn launch_resolver(
             let resolver = Resolver::new(wait_storage);
             resolver.wait_for_candidates(&session_id, &candidate_ids, timeout)
         })
-            .await
-            .map_err(|err| ApiError::internal(format!("Resolver wait task failed: {}", err)))?
-            .map_err(|err| match err {
-                ResolverError::Timeout => {
-                    ApiError::new(StatusCode::REQUEST_TIMEOUT, "Timed out waiting for candidate artifacts")
-                }
-                ResolverError::NoCandidates => {
-                    ApiError::bad_request("No candidate artifacts available")
-                }
-                other => ApiError::internal(other.to_string()),
-            })?;
+        .await
+        .map_err(|err| ApiError::internal(format!("Resolver wait task failed: {}", err)))?
+        .map_err(|err| match err {
+            ResolverError::Timeout => ApiError::new(
+                StatusCode::REQUEST_TIMEOUT,
+                "Timed out waiting for candidate artifacts",
+            ),
+            ResolverError::NoCandidates => {
+                ApiError::bad_request("No candidate artifacts available")
+            }
+            other => ApiError::internal(other.to_string()),
+        })?;
     }
 
     let output = resolver
@@ -198,7 +207,9 @@ pub async fn get_resolver_output(
         .storage
         .load_resolver_output(&session_id)
         .map_err(|err| ApiError::internal(err.to_string()))?
-        .ok_or_else(|| ApiError::not_found(format!("Resolver output not found for {}", session_id)))?;
+        .ok_or_else(|| {
+            ApiError::not_found(format!("Resolver output not found for {}", session_id))
+        })?;
 
     Ok(Json(output))
 }

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -5,7 +5,7 @@ use axum::{
     http::StatusCode,
     Json,
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -270,10 +270,19 @@ pub struct LaunchSessionRequest {
 
 #[derive(Deserialize)]
 pub struct UpdateSessionRequest {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     pub name: Option<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_nullable_update_field")]
     pub color: Option<Option<String>>,
+}
+
+fn deserialize_nullable_update_field<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
 }
 
 #[derive(Deserialize)]
@@ -724,6 +733,8 @@ pub async fn launch_swarm(
         project_path: req.project_path,
         name: req.name,
         color: req.color,
+        default_cli,
+        default_model,
         queen_config,
         planner_count: req.planner_count.unwrap_or(2),
         planner_config,
@@ -888,6 +899,9 @@ pub async fn launch_debate(
     validate_cli(&judge_cli)?;
 
     let rounds = req.rounds.unwrap_or(3);
+    if rounds == 0 {
+        return Err(ApiError::bad_request("rounds must be greater than zero"));
+    }
 
     let debaters = req
         .debaters
@@ -953,10 +967,29 @@ pub async fn update_session(
     Path(id): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<Json<SessionInfo>, ApiError> {
+    let mut payload = serde_json::Map::new();
+    payload.insert("id".to_string(), Value::String(id));
+    if let Some(name) = req.name {
+        payload.insert(
+            "name".to_string(),
+            serde_json::to_value(name).map_err(|e| {
+                ApiError::internal(format!("Failed to serialize name update: {}", e))
+            })?,
+        );
+    }
+    if let Some(color) = req.color {
+        payload.insert(
+            "color".to_string(),
+            serde_json::to_value(color).map_err(|e| {
+                ApiError::internal(format!("Failed to serialize color update: {}", e))
+            })?,
+        );
+    }
+
     let output = dispatch_session_action(
         &state,
         "session.update_metadata_info",
-        serde_json::json!({ "id": id, "name": req.name, "color": req.color }),
+        Value::Object(payload),
     )
     .await?;
     Ok(Json(decode_action_output(

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -1,9 +1,9 @@
+use crate::cli::CliRegistry;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
-use crate::cli::CliRegistry;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -12,20 +12,14 @@ use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use crate::pty::AgentConfig;
 use crate::session::{
-    CompletionBlockedError, CompletionError, FusionLaunchConfig, FusionVariantConfig,
-    FusionVariantStatus, HiveLaunchConfig, QaWorkerConfig,
+    CompletionBlockedError, CompletionError, DebateDebaterConfig, DebateDebaterStatus,
+    DebateLaunchConfig, FusionLaunchConfig, FusionVariantConfig, FusionVariantStatus,
+    HiveLaunchConfig, QaWorkerConfig,
 };
 use crate::storage::SessionTypeInfo;
 
 const SESSION_COLOR_ALLOWLIST: &[&str] = &[
-    "#7aa2f7",
-    "#bb9af7",
-    "#9ece6a",
-    "#e0af68",
-    "#7dcfff",
-    "#f7768e",
-    "#ff9e64",
-    "#f7b1d1",
+    "#7aa2f7", "#bb9af7", "#9ece6a", "#e0af68", "#7dcfff", "#f7768e", "#ff9e64", "#f7b1d1",
 ];
 
 fn validate_session_name(name: Option<&str>) -> Result<(), ApiError> {
@@ -122,8 +116,14 @@ fn evaluator_config_from_request(
 
 fn completion_blocked_to_api_error(error: CompletionBlockedError) -> ApiError {
     let mut details = std::collections::HashMap::new();
-    details.insert("current_state".to_string(), serde_json::json!(error.current_state));
-    details.insert("unblock_paths".to_string(), serde_json::json!(error.unblock_paths));
+    details.insert(
+        "current_state".to_string(),
+        serde_json::json!(error.current_state),
+    );
+    details.insert(
+        "unblock_paths".to_string(),
+        serde_json::json!(error.unblock_paths),
+    );
     details.insert(
         "remaining_quiescence_seconds".to_string(),
         serde_json::json!(error.remaining_quiescence_seconds),
@@ -213,6 +213,30 @@ pub struct LaunchFusionRequest {
 }
 
 #[derive(Deserialize)]
+pub struct LaunchDebateDebaterRequest {
+    pub name: String,
+    pub stance: Option<String>,
+    pub cli: Option<String>,
+    pub model: Option<String>,
+    pub flags: Option<Vec<String>>,
+}
+
+#[derive(Deserialize)]
+pub struct LaunchDebateRequest {
+    pub project_path: String,
+    pub topic: String,
+    pub rounds: Option<u8>,
+    pub debaters: Vec<LaunchDebateDebaterRequest>,
+    pub judge_cli: Option<String>,
+    pub judge_model: Option<String>,
+    pub with_planning: Option<bool>,
+    pub default_cli: Option<String>,
+    pub default_model: Option<String>,
+    pub name: Option<String>,
+    pub color: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct LaunchSoloRequest {
     pub project_path: String,
     pub task_description: Option<String>,
@@ -236,6 +260,8 @@ pub struct CreateSessionRequest {
     pub worker_count: Option<u8>,
     pub workers: Option<Vec<AgentConfig>>,
     pub variants: Option<Vec<LaunchFusionVariantRequest>>,
+    pub debaters: Option<Vec<LaunchDebateDebaterRequest>>,
+    pub rounds: Option<u8>,
     pub judge_cli: Option<String>,
     pub judge_model: Option<String>,
     pub with_planning: Option<bool>,
@@ -283,6 +309,21 @@ pub struct FusionStatusResponse {
 
 #[derive(Serialize)]
 pub struct FusionEvaluationResponse {
+    pub session_id: String,
+    pub state: String,
+    pub report_path: String,
+    pub report: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct DebateStatusResponse {
+    pub session_id: String,
+    pub state: String,
+    pub debaters: Vec<DebateDebaterStatus>,
+}
+
+#[derive(Serialize)]
+pub struct DebateEvaluationResponse {
     pub session_id: String,
     pub state: String,
     pub report_path: String,
@@ -347,7 +388,9 @@ pub async fn create_session(
                 req.evaluator_config,
                 req.evaluator_cli,
                 req.evaluator_model,
-                req.with_evaluator.unwrap_or(false).then_some(default_cli.as_str()),
+                req.with_evaluator
+                    .unwrap_or(false)
+                    .then_some(default_cli.as_str()),
             )?;
             let with_evaluator = req.with_evaluator.unwrap_or(false) || evaluator_config.is_some();
 
@@ -382,7 +425,9 @@ pub async fn create_session(
             let variants = req
                 .variants
                 .filter(|variants| !variants.is_empty())
-                .ok_or_else(|| ApiError::bad_request("Fusion sessions require at least one variant"))?
+                .ok_or_else(|| {
+                    ApiError::bad_request("Fusion sessions require at least one variant")
+                })?
                 .into_iter()
                 .map(|variant| {
                     let cli = variant.cli.unwrap_or_else(|| default_cli.clone());
@@ -399,7 +444,9 @@ pub async fn create_session(
             let task_description = req
                 .objective
                 .filter(|value| !value.trim().is_empty())
-                .ok_or_else(|| ApiError::bad_request("Fusion sessions require a non-empty objective"))?;
+                .ok_or_else(|| {
+                    ApiError::bad_request("Fusion sessions require a non-empty objective")
+                })?;
 
             let judge_cli = req.judge_cli.unwrap_or_else(|| default_cli.clone());
             validate_cli(&judge_cli)?;
@@ -439,8 +486,82 @@ pub async fn create_session(
                 }),
             ))
         }
+        "debate" => {
+            let debaters = req
+                .debaters
+                .filter(|debaters| !debaters.is_empty())
+                .ok_or_else(|| {
+                    ApiError::bad_request("Debate sessions require at least one debater")
+                })?
+                .into_iter()
+                .map(|debater| {
+                    let cli = debater.cli.unwrap_or_else(|| default_cli.clone());
+                    validate_cli(&cli)?;
+                    Ok(DebateDebaterConfig {
+                        name: debater.name,
+                        stance: debater.stance,
+                        cli,
+                        model: debater.model,
+                        flags: debater.flags.unwrap_or_default(),
+                    })
+                })
+                .collect::<Result<Vec<_>, ApiError>>()?;
+
+            let topic = req
+                .objective
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| {
+                    ApiError::bad_request("Debate sessions require a non-empty objective")
+                })?;
+
+            let rounds = req.rounds.unwrap_or(3);
+            if rounds == 0 {
+                return Err(ApiError::bad_request(
+                    "Debate sessions require at least one round",
+                ));
+            }
+
+            let judge_cli = req.judge_cli.unwrap_or_else(|| default_cli.clone());
+            validate_cli(&judge_cli)?;
+
+            let config = DebateLaunchConfig {
+                project_path: req.project_path,
+                name: req.name,
+                color: req.color,
+                debaters,
+                topic,
+                rounds,
+                judge_config: AgentConfig {
+                    cli: judge_cli,
+                    model: req.judge_model.or(req.default_model.clone()),
+                    flags: vec![],
+                    label: Some("Debate Judge".to_string()),
+                    name: None,
+                    description: None,
+                    role: None,
+                    initial_prompt: None,
+                },
+                queen_config: None,
+                with_planning: req.with_planning.unwrap_or(false),
+                default_cli,
+                default_model: req.default_model,
+            };
+
+            let controller = state.session_controller.write();
+            let session = controller
+                .launch_debate(config)
+                .map_err(ApiError::internal)?;
+
+            Ok((
+                StatusCode::CREATED,
+                Json(LaunchResponse {
+                    session_id: session.id,
+                    message: "Session created".to_string(),
+                }),
+            ))
+        }
         _ => Err(ApiError::bad_request(
-            "Unsupported mode. Valid options: hive, fusion",
+            "Unsupported mode. Valid options: hive, fusion, debate",
         )),
     }
 }
@@ -461,7 +582,9 @@ pub async fn launch_session(
 pub async fn list_sessions(
     State(state): State<Arc<AppState>>,
 ) -> Result<Json<SessionListResponse>, ApiError> {
-    let persisted = state.storage.list_sessions()
+    let persisted = state
+        .storage
+        .list_sessions()
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
     let active_sessions = state.session_controller.read().list_sessions();
@@ -501,6 +624,9 @@ pub async fn list_sessions(
                     crate::session::SessionType::Fusion { variants } => {
                         format!("Fusion ({})", variants.len())
                     }
+                    crate::session::SessionType::Debate { variants } => {
+                        format!("Debate ({})", variants.len())
+                    }
                     crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
                 },
                 status: format!("{:?}", session.state),
@@ -531,9 +657,18 @@ pub async fn get_session(
             name: session.name.clone(),
             color: session.color.clone(),
             session_type: match &session.session_type {
-                crate::session::SessionType::Hive { worker_count } => format!("Hive ({})", worker_count),
-                crate::session::SessionType::Swarm { planner_count } => format!("Swarm ({})", planner_count),
-                crate::session::SessionType::Fusion { variants } => format!("Fusion ({})", variants.len()),
+                crate::session::SessionType::Hive { worker_count } => {
+                    format!("Hive ({})", worker_count)
+                }
+                crate::session::SessionType::Swarm { planner_count } => {
+                    format!("Swarm ({})", planner_count)
+                }
+                crate::session::SessionType::Fusion { variants } => {
+                    format!("Fusion ({})", variants.len())
+                }
+                crate::session::SessionType::Debate { variants } => {
+                    format!("Debate ({})", variants.len())
+                }
                 crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
             },
             status: format!("{:?}", session.state),
@@ -544,7 +679,9 @@ pub async fn get_session(
     }
 
     // Try loading from storage if not active
-    let persisted = state.storage.load_session(&id)
+    let persisted = state
+        .storage
+        .load_session(&id)
         .map_err(|_| ApiError::not_found(format!("Session {} not found", id)))?;
 
     Ok(Json(SessionInfo {
@@ -555,6 +692,7 @@ pub async fn get_session(
             SessionTypeInfo::Hive { worker_count } => format!("Hive ({})", worker_count),
             SessionTypeInfo::Swarm { planner_count } => format!("Swarm ({})", planner_count),
             SessionTypeInfo::Fusion { variants } => format!("Fusion ({})", variants.len()),
+            SessionTypeInfo::Debate { variants } => format!("Debate ({})", variants.len()),
             SessionTypeInfo::Solo { cli, .. } => format!("Solo ({})", cli),
         },
         status: persisted.state,
@@ -581,14 +719,16 @@ pub async fn launch_hive(
     let command = req.command.unwrap_or_else(|| "claude".to_string());
     validate_cli(&command)?;
 
-    let session = controller.launch_hive(
-        project_path,
-        req.worker_count.unwrap_or(3),
-        &command,
-        req.task_description,
-        req.name,
-        req.color,
-    ).map_err(ApiError::internal)?;
+    let session = controller
+        .launch_hive(
+            project_path,
+            req.worker_count.unwrap_or(3),
+            &command,
+            req.task_description,
+            req.name,
+            req.color,
+        )
+        .map_err(ApiError::internal)?;
 
     Ok((
         StatusCode::CREATED,
@@ -664,7 +804,8 @@ pub async fn launch_swarm(
         planners: vec![],
     };
 
-    let session = controller.launch_swarm(config)
+    let session = controller
+        .launch_swarm(config)
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
     Ok((
@@ -739,7 +880,9 @@ pub async fn launch_fusion(
     Json(req): Json<LaunchFusionRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
     if req.variants.is_empty() {
-        return Err(ApiError::bad_request("Fusion launch requires at least one variant"));
+        return Err(ApiError::bad_request(
+            "Fusion launch requires at least one variant",
+        ));
     }
     if req.task_description.trim().is_empty() {
         return Err(ApiError::bad_request("task_description cannot be empty"));
@@ -809,6 +952,92 @@ pub async fn launch_fusion(
     ))
 }
 
+/// POST /api/sessions/debate - Launch a new Debate session
+pub async fn launch_debate(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<LaunchDebateRequest>,
+) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
+    if req.debaters.is_empty() {
+        return Err(ApiError::bad_request(
+            "Debate launch requires at least one debater",
+        ));
+    }
+    if req.topic.trim().is_empty() {
+        return Err(ApiError::bad_request("topic cannot be empty"));
+    }
+
+    validate_project_path(&req.project_path)?;
+    validate_session_name(req.name.as_deref())?;
+    validate_session_color(req.color.as_deref())?;
+
+    let default_cli = req.default_cli.unwrap_or_else(|| "claude".to_string());
+    validate_cli(&default_cli)?;
+
+    let judge_cli = req.judge_cli.unwrap_or_else(|| default_cli.clone());
+    validate_cli(&judge_cli)?;
+
+    let rounds = req.rounds.unwrap_or(3);
+    if rounds == 0 {
+        return Err(ApiError::bad_request(
+            "Debate launch requires at least one round",
+        ));
+    }
+
+    let debaters = req
+        .debaters
+        .into_iter()
+        .map(|d| {
+            let cli = d.cli.unwrap_or_else(|| default_cli.clone());
+            validate_cli(&cli)?;
+            Ok(DebateDebaterConfig {
+                name: d.name,
+                stance: d.stance,
+                cli,
+                model: d.model,
+                flags: d.flags.unwrap_or_default(),
+            })
+        })
+        .collect::<Result<Vec<_>, ApiError>>()?;
+
+    let judge_config = AgentConfig {
+        cli: judge_cli,
+        model: req.judge_model.or(req.default_model.clone()),
+        flags: vec![],
+        label: Some("Debate Judge".to_string()),
+        name: None,
+        description: None,
+        role: None,
+        initial_prompt: None,
+    };
+
+    let config = DebateLaunchConfig {
+        project_path: req.project_path,
+        name: req.name,
+        color: req.color,
+        debaters,
+        topic: req.topic,
+        rounds,
+        judge_config,
+        queen_config: None,
+        with_planning: req.with_planning.unwrap_or(false),
+        default_cli,
+        default_model: req.default_model,
+    };
+
+    let controller = state.session_controller.write();
+    let session = controller
+        .launch_debate(config)
+        .map_err(ApiError::internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(LaunchResponse {
+            session_id: session.id,
+            message: "Debate session launched".to_string(),
+        }),
+    ))
+}
+
 /// PATCH /api/sessions/{id} - Update session metadata
 pub async fn update_session(
     State(state): State<Arc<AppState>>,
@@ -835,9 +1064,18 @@ pub async fn update_session(
         name: session.name,
         color: session.color,
         session_type: match &session.session_type {
-            crate::session::SessionType::Hive { worker_count } => format!("Hive ({})", worker_count),
-            crate::session::SessionType::Swarm { planner_count } => format!("Swarm ({})", planner_count),
-            crate::session::SessionType::Fusion { variants } => format!("Fusion ({})", variants.len()),
+            crate::session::SessionType::Hive { worker_count } => {
+                format!("Hive ({})", worker_count)
+            }
+            crate::session::SessionType::Swarm { planner_count } => {
+                format!("Swarm ({})", planner_count)
+            }
+            crate::session::SessionType::Fusion { variants } => {
+                format!("Fusion ({})", variants.len())
+            }
+            crate::session::SessionType::Debate { variants } => {
+                format!("Debate ({})", variants.len())
+            }
             crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
         },
         status: format!("{:?}", session.state),
@@ -924,6 +1162,61 @@ pub async fn get_fusion_evaluation(
     }))
 }
 
+/// GET /api/sessions/{id}/debate/status - Get debate debater statuses
+pub async fn get_debate_status(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<DebateStatusResponse>, ApiError> {
+    validate_session_id(&id)?;
+
+    let controller = state.session_controller.read();
+    if controller.get_session(&id).is_none() {
+        return Err(ApiError::not_found(format!("Session {} not found", id)));
+    }
+
+    let debaters = controller
+        .get_debate_debater_statuses(&id)
+        .map_err(ApiError::internal)?;
+    let state_str = controller
+        .get_session(&id)
+        .map(|s| format!("{:?}", s.state))
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    Ok(Json(DebateStatusResponse {
+        session_id: id,
+        state: state_str,
+        debaters,
+    }))
+}
+
+/// GET /api/sessions/{id}/debate/evaluation - Get debate judge verdict
+pub async fn get_debate_evaluation(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+) -> Result<Json<DebateEvaluationResponse>, ApiError> {
+    validate_session_id(&id)?;
+
+    let controller = state.session_controller.read();
+    if controller.get_session(&id).is_none() {
+        return Err(ApiError::not_found(format!("Session {} not found", id)));
+    }
+
+    let (report_path, report) = controller
+        .get_debate_evaluation(&id)
+        .map_err(ApiError::internal)?;
+    let state_str = controller
+        .get_session(&id)
+        .map(|s| format!("{:?}", s.state))
+        .unwrap_or_else(|| "Unknown".to_string());
+
+    Ok(Json(DebateEvaluationResponse {
+        session_id: id,
+        state: state_str,
+        report_path,
+        report,
+    }))
+}
+
 /// POST /api/sessions/{id}/stop - Stop a session
 pub async fn stop_session(
     State(state): State<Arc<AppState>>,
@@ -932,7 +1225,8 @@ pub async fn stop_session(
     validate_session_id(&id)?;
 
     let controller = state.session_controller.write();
-    controller.stop_session(&id)
+    controller
+        .stop_session(&id)
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
     Ok(Json(serde_json::json!({
@@ -948,14 +1242,13 @@ pub async fn close_session(
     validate_session_id(&id)?;
 
     let controller = state.session_controller.write();
-    controller.close_session(&id)
-        .map_err(|e| {
-            if e.starts_with("Session not found") {
-                ApiError::not_found(e)
-            } else {
-                ApiError::internal(e)
-            }
-        })?;
+    controller.close_session(&id).map_err(|e| {
+        if e.starts_with("Session not found") {
+            ApiError::not_found(e)
+        } else {
+            ApiError::internal(e)
+        }
+    })?;
 
     Ok(Json(serde_json::json!({
         "message": format!("Session {} closed", id)
@@ -998,15 +1291,17 @@ pub async fn get_run_journal(
     validate_session_id(&id)?;
 
     let store = crate::storage::RunJournalStore::new(Arc::clone(&state.app_state_db));
-    let response = tokio::task::spawn_blocking(move || -> Result<RunJournalResponse, crate::storage::StorageError> {
-        // Defensive: ensure the journal/ledger tables exist (idempotent CREATE TABLE IF NOT
-        // EXISTS). Production creates them at startup, but a fresh/in-memory DB (e.g. tests)
-        // may not have run that path, in which case read_journal would hit "no such table".
-        store.ensure_schema()?;
-        let journal = store.read_journal(&id)?;
-        let ledger = store.read_ledger(&id)?;
-        Ok(RunJournalResponse { journal, ledger })
-    })
+    let response = tokio::task::spawn_blocking(
+        move || -> Result<RunJournalResponse, crate::storage::StorageError> {
+            // Defensive: ensure the journal/ledger tables exist (idempotent CREATE TABLE IF NOT
+            // EXISTS). Production creates them at startup, but a fresh/in-memory DB (e.g. tests)
+            // may not have run that path, in which case read_journal would hit "no such table".
+            store.ensure_schema()?;
+            let journal = store.read_journal(&id)?;
+            let ledger = store.read_ledger(&id)?;
+            Ok(RunJournalResponse { journal, ledger })
+        },
+    )
     .await
     .map_err(|e| ApiError::internal(format!("Task join error: {e}")))?
     .map_err(|e| ApiError::internal(format!("Failed to read run journal: {e}")))?;

--- a/src-tauri/src/http/handlers/sessions.rs
+++ b/src-tauri/src/http/handlers/sessions.rs
@@ -1,13 +1,15 @@
+use crate::actions::{ActionContext, Caller};
 use crate::cli::CliRegistry;
 use axum::{
     extract::{Path, State},
     http::StatusCode,
     Json,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
 use std::sync::Arc;
 
-use super::{validate_cli, validate_project_path, validate_session_id};
+use super::{validate_cli, validate_session_id};
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use crate::pty::AgentConfig;
@@ -16,57 +18,42 @@ use crate::session::{
     DebateLaunchConfig, FusionLaunchConfig, FusionVariantConfig, FusionVariantStatus,
     HiveLaunchConfig, QaWorkerConfig,
 };
-use crate::storage::SessionTypeInfo;
 
-const SESSION_COLOR_ALLOWLIST: &[&str] = &[
-    "#7aa2f7", "#bb9af7", "#9ece6a", "#e0af68", "#7dcfff", "#f7768e", "#ff9e64", "#f7b1d1",
-];
-
-fn validate_session_name(name: Option<&str>) -> Result<(), ApiError> {
-    let Some(name) = name else {
-        return Ok(());
-    };
-
-    if name.trim().is_empty() {
-        return Err(ApiError::bad_request(
-            "Invalid session name: must not be empty or whitespace",
-        ));
-    }
-
-    if name.chars().count() > 64 {
-        return Err(ApiError::bad_request(
-            "Invalid session name: must be 64 characters or fewer",
-        ));
-    }
-    if name.contains("..") || name.contains('/') || name.contains('\\') {
-        return Err(ApiError::bad_request(
-            "Invalid session name: must not contain '..', '/', or '\\'",
-        ));
-    }
-
-    Ok(())
+async fn dispatch_session_action(
+    state: &Arc<AppState>,
+    action: &str,
+    input: Value,
+) -> Result<Value, ApiError> {
+    let ctx = ActionContext::new(Caller::Http, Arc::clone(state));
+    state
+        .registry()
+        .dispatch(action, &ctx, input)
+        .await
+        .map_err(ApiError::from)
 }
 
-fn validate_session_color(color: Option<&str>) -> Result<(), ApiError> {
-    let Some(color) = color else {
-        return Ok(());
-    };
-
-    if !SESSION_COLOR_ALLOWLIST.contains(&color) && !is_valid_hex_session_color(color) {
-        return Err(ApiError::bad_request(format!(
-            "Invalid session color '{}'. Valid options: {} or any #RRGGBB hex color",
-            color,
-            SESSION_COLOR_ALLOWLIST.join(", ")
-        )));
-    }
-
-    Ok(())
+fn decode_action_output<T: DeserializeOwned>(action: &str, value: Value) -> Result<T, ApiError> {
+    serde_json::from_value(value).map_err(|e| {
+        ApiError::internal(format!(
+            "Action {} returned an unexpected payload: {}",
+            action, e
+        ))
+    })
 }
 
-fn is_valid_hex_session_color(color: &str) -> bool {
-    color.len() == 7
-        && color.starts_with('#')
-        && color.chars().skip(1).all(|c| c.is_ascii_hexdigit())
+fn launch_response_from_action_output(
+    value: &Value,
+    message: &str,
+) -> Result<LaunchResponse, ApiError> {
+    let session_id = value
+        .get("id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ApiError::internal("Launch action returned a session without an id"))?
+        .to_string();
+    Ok(LaunchResponse {
+        session_id,
+        message: message.to_string(),
+    })
 }
 
 fn evaluator_config_from_request(
@@ -139,7 +126,7 @@ fn map_completion_error(error: CompletionError) -> ApiError {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SessionInfo {
     pub id: String,
     pub name: Option<String>,
@@ -338,10 +325,6 @@ pub async fn create_session(
     State(state): State<Arc<AppState>>,
     Json(req): Json<CreateSessionRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    validate_project_path(&req.project_path)?;
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
     let mode = req.mode.trim().to_ascii_lowercase();
     let default_cli = req.default_cli.unwrap_or_else(|| "claude".to_string());
     validate_cli(&default_cli)?;
@@ -408,17 +391,21 @@ pub async fn create_session(
                 smoke_test: req.smoke_test.unwrap_or(false),
             };
 
-            let controller = state.session_controller.write();
-            let session = controller
-                .launch_hive_v2(config)
-                .map_err(ApiError::internal)?;
+            let output = dispatch_session_action(
+                &state,
+                "session.launch_hive_v2",
+                serde_json::to_value(config).map_err(|e| {
+                    ApiError::internal(format!("Failed to serialize launch config: {}", e))
+                })?,
+            )
+            .await?;
 
             Ok((
                 StatusCode::CREATED,
-                Json(LaunchResponse {
-                    session_id: session.id,
-                    message: "Session created".to_string(),
-                }),
+                Json(launch_response_from_action_output(
+                    &output,
+                    "Session created",
+                )?),
             ))
         }
         "fusion" => {
@@ -473,17 +460,21 @@ pub async fn create_session(
                 default_model: req.default_model,
             };
 
-            let controller = state.session_controller.write();
-            let session = controller
-                .launch_fusion(config)
-                .map_err(ApiError::internal)?;
+            let output = dispatch_session_action(
+                &state,
+                "session.launch_fusion",
+                serde_json::to_value(config).map_err(|e| {
+                    ApiError::internal(format!("Failed to serialize launch config: {}", e))
+                })?,
+            )
+            .await?;
 
             Ok((
                 StatusCode::CREATED,
-                Json(LaunchResponse {
-                    session_id: session.id,
-                    message: "Session created".to_string(),
-                }),
+                Json(launch_response_from_action_output(
+                    &output,
+                    "Session created",
+                )?),
             ))
         }
         "debate" => {
@@ -547,17 +538,21 @@ pub async fn create_session(
                 default_model: req.default_model,
             };
 
-            let controller = state.session_controller.write();
-            let session = controller
-                .launch_debate(config)
-                .map_err(ApiError::internal)?;
+            let output = dispatch_session_action(
+                &state,
+                "session.launch_debate",
+                serde_json::to_value(config).map_err(|e| {
+                    ApiError::internal(format!("Failed to serialize launch config: {}", e))
+                })?,
+            )
+            .await?;
 
             Ok((
                 StatusCode::CREATED,
-                Json(LaunchResponse {
-                    session_id: session.id,
-                    message: "Session created".to_string(),
-                }),
+                Json(launch_response_from_action_output(
+                    &output,
+                    "Session created",
+                )?),
             ))
         }
         _ => Err(ApiError::bad_request(
@@ -648,61 +643,10 @@ pub async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<SessionInfo>, ApiError> {
-    validate_session_id(&id)?;
-
-    let controller = state.session_controller.read();
-    if let Some(session) = controller.get_session(&id) {
-        return Ok(Json(SessionInfo {
-            id: session.id.clone(),
-            name: session.name.clone(),
-            color: session.color.clone(),
-            session_type: match &session.session_type {
-                crate::session::SessionType::Hive { worker_count } => {
-                    format!("Hive ({})", worker_count)
-                }
-                crate::session::SessionType::Swarm { planner_count } => {
-                    format!("Swarm ({})", planner_count)
-                }
-                crate::session::SessionType::Fusion { variants } => {
-                    format!("Fusion ({})", variants.len())
-                }
-                crate::session::SessionType::Debate { variants } => {
-                    format!("Debate ({})", variants.len())
-                }
-                crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
-            },
-            status: format!("{:?}", session.state),
-            project_path: session.project_path.to_string_lossy().to_string(),
-            created_at: session.created_at.to_rfc3339(),
-            last_activity_at: session.last_activity_at.to_rfc3339(),
-        }));
-    }
-
-    // Try loading from storage if not active
-    let persisted = state
-        .storage
-        .load_session(&id)
-        .map_err(|_| ApiError::not_found(format!("Session {} not found", id)))?;
-
-    Ok(Json(SessionInfo {
-        id: persisted.id,
-        name: persisted.name,
-        color: persisted.color,
-        session_type: match &persisted.session_type {
-            SessionTypeInfo::Hive { worker_count } => format!("Hive ({})", worker_count),
-            SessionTypeInfo::Swarm { planner_count } => format!("Swarm ({})", planner_count),
-            SessionTypeInfo::Fusion { variants } => format!("Fusion ({})", variants.len()),
-            SessionTypeInfo::Debate { variants } => format!("Debate ({})", variants.len()),
-            SessionTypeInfo::Solo { cli, .. } => format!("Solo ({})", cli),
-        },
-        status: persisted.state,
-        project_path: persisted.project_path,
-        created_at: persisted.created_at.to_rfc3339(),
-        last_activity_at: persisted
-            .last_activity_at
-            .unwrap_or(persisted.created_at)
-            .to_rfc3339(),
-    }))
+    let output =
+        dispatch_session_action(&state, "session.get_info", serde_json::json!({ "id": id }))
+            .await?;
+    Ok(Json(decode_action_output("session.get_info", output)?))
 }
 
 /// POST /api/sessions/hive - Launch a new Hive session
@@ -710,32 +654,26 @@ pub async fn launch_hive(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LaunchHiveRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
-    let controller = state.session_controller.write();
-    let project_path = std::path::PathBuf::from(req.project_path);
-
-    let command = req.command.unwrap_or_else(|| "claude".to_string());
-    validate_cli(&command)?;
-
-    let session = controller
-        .launch_hive(
-            project_path,
-            req.worker_count.unwrap_or(3),
-            &command,
-            req.task_description,
-            req.name,
-            req.color,
-        )
-        .map_err(ApiError::internal)?;
+    let output = dispatch_session_action(
+        &state,
+        "session.launch_hive",
+        serde_json::json!({
+            "project_path": req.project_path,
+            "task_description": req.task_description,
+            "worker_count": req.worker_count,
+            "command": req.command,
+            "name": req.name,
+            "color": req.color,
+        }),
+    )
+    .await?;
 
     Ok((
         StatusCode::CREATED,
-        Json(LaunchResponse {
-            session_id: session.id,
-            message: "Hive session launched".to_string(),
-        }),
+        Json(launch_response_from_action_output(
+            &output,
+            "Hive session launched",
+        )?),
     ))
 }
 
@@ -744,11 +682,6 @@ pub async fn launch_swarm(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LaunchSwarmRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
-    let controller = state.session_controller.write();
-
     let default_cli = req.default_cli.unwrap_or_else(|| "claude".to_string());
     validate_cli(&default_cli)?;
     let default_model = req
@@ -804,16 +737,20 @@ pub async fn launch_swarm(
         planners: vec![],
     };
 
-    let session = controller
-        .launch_swarm(config)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let output = dispatch_session_action(
+        &state,
+        "session.launch_swarm",
+        serde_json::to_value(config)
+            .map_err(|e| ApiError::internal(format!("Failed to serialize launch config: {}", e)))?,
+    )
+    .await?;
 
     Ok((
         StatusCode::CREATED,
-        Json(LaunchResponse {
-            session_id: session.id,
-            message: "Swarm session launched".to_string(),
-        }),
+        Json(launch_response_from_action_output(
+            &output,
+            "Swarm session launched",
+        )?),
     ))
 }
 
@@ -822,11 +759,6 @@ pub async fn launch_solo(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LaunchSoloRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    validate_project_path(&req.project_path)?;
-    validate_cli(&req.cli)?;
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
     let agent_config = AgentConfig {
         cli: req.cli.clone(),
         model: req.model,
@@ -860,17 +792,20 @@ pub async fn launch_solo(
         smoke_test: false,
     };
 
-    let controller = state.session_controller.write();
-    let session = controller
-        .launch_solo(config)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    let output = dispatch_session_action(
+        &state,
+        "session.launch_solo",
+        serde_json::to_value(config)
+            .map_err(|e| ApiError::internal(format!("Failed to serialize launch config: {}", e)))?,
+    )
+    .await?;
 
     Ok((
         StatusCode::CREATED,
-        Json(LaunchResponse {
-            session_id: session.id,
-            message: "Solo session launched".to_string(),
-        }),
+        Json(launch_response_from_action_output(
+            &output,
+            "Solo session launched",
+        )?),
     ))
 }
 
@@ -879,20 +814,6 @@ pub async fn launch_fusion(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LaunchFusionRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    if req.variants.is_empty() {
-        return Err(ApiError::bad_request(
-            "Fusion launch requires at least one variant",
-        ));
-    }
-    if req.task_description.trim().is_empty() {
-        return Err(ApiError::bad_request("task_description cannot be empty"));
-    }
-
-    // Validate project path for security (prevent path traversal)
-    validate_project_path(&req.project_path)?;
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
     let default_cli = req.default_cli.unwrap_or_else(|| "claude".to_string());
     validate_cli(&default_cli)?;
 
@@ -938,17 +859,20 @@ pub async fn launch_fusion(
         default_model: req.default_model,
     };
 
-    let controller = state.session_controller.write();
-    let session = controller
-        .launch_fusion(config)
-        .map_err(ApiError::internal)?;
+    let output = dispatch_session_action(
+        &state,
+        "session.launch_fusion",
+        serde_json::to_value(config)
+            .map_err(|e| ApiError::internal(format!("Failed to serialize launch config: {}", e)))?,
+    )
+    .await?;
 
     Ok((
         StatusCode::CREATED,
-        Json(LaunchResponse {
-            session_id: session.id,
-            message: "Fusion session launched".to_string(),
-        }),
+        Json(launch_response_from_action_output(
+            &output,
+            "Fusion session launched",
+        )?),
     ))
 }
 
@@ -957,19 +881,6 @@ pub async fn launch_debate(
     State(state): State<Arc<AppState>>,
     Json(req): Json<LaunchDebateRequest>,
 ) -> Result<(StatusCode, Json<LaunchResponse>), ApiError> {
-    if req.debaters.is_empty() {
-        return Err(ApiError::bad_request(
-            "Debate launch requires at least one debater",
-        ));
-    }
-    if req.topic.trim().is_empty() {
-        return Err(ApiError::bad_request("topic cannot be empty"));
-    }
-
-    validate_project_path(&req.project_path)?;
-    validate_session_name(req.name.as_deref())?;
-    validate_session_color(req.color.as_deref())?;
-
     let default_cli = req.default_cli.unwrap_or_else(|| "claude".to_string());
     validate_cli(&default_cli)?;
 
@@ -977,11 +888,6 @@ pub async fn launch_debate(
     validate_cli(&judge_cli)?;
 
     let rounds = req.rounds.unwrap_or(3);
-    if rounds == 0 {
-        return Err(ApiError::bad_request(
-            "Debate launch requires at least one round",
-        ));
-    }
 
     let debaters = req
         .debaters
@@ -1024,17 +930,20 @@ pub async fn launch_debate(
         default_model: req.default_model,
     };
 
-    let controller = state.session_controller.write();
-    let session = controller
-        .launch_debate(config)
-        .map_err(ApiError::internal)?;
+    let output = dispatch_session_action(
+        &state,
+        "session.launch_debate",
+        serde_json::to_value(config)
+            .map_err(|e| ApiError::internal(format!("Failed to serialize launch config: {}", e)))?,
+    )
+    .await?;
 
     Ok((
         StatusCode::CREATED,
-        Json(LaunchResponse {
-            session_id: session.id,
-            message: "Debate session launched".to_string(),
-        }),
+        Json(launch_response_from_action_output(
+            &output,
+            "Debate session launched",
+        )?),
     ))
 }
 
@@ -1044,45 +953,16 @@ pub async fn update_session(
     Path(id): Path<String>,
     Json(req): Json<UpdateSessionRequest>,
 ) -> Result<Json<SessionInfo>, ApiError> {
-    validate_session_id(&id)?;
-    validate_session_name(req.name.as_ref().and_then(|name| name.as_deref()))?;
-    validate_session_color(req.color.as_ref().and_then(|color| color.as_deref()))?;
-
-    let controller = state.session_controller.write();
-    let session = controller
-        .update_session_metadata(&id, req.name, req.color)
-        .map_err(|e| {
-            if e.starts_with("Session not found") {
-                ApiError::not_found(e)
-            } else {
-                ApiError::internal(e)
-            }
-        })?;
-
-    Ok(Json(SessionInfo {
-        id: session.id,
-        name: session.name,
-        color: session.color,
-        session_type: match &session.session_type {
-            crate::session::SessionType::Hive { worker_count } => {
-                format!("Hive ({})", worker_count)
-            }
-            crate::session::SessionType::Swarm { planner_count } => {
-                format!("Swarm ({})", planner_count)
-            }
-            crate::session::SessionType::Fusion { variants } => {
-                format!("Fusion ({})", variants.len())
-            }
-            crate::session::SessionType::Debate { variants } => {
-                format!("Debate ({})", variants.len())
-            }
-            crate::session::SessionType::Solo { cli, .. } => format!("Solo ({})", cli),
-        },
-        status: format!("{:?}", session.state),
-        project_path: session.project_path.to_string_lossy().to_string(),
-        created_at: session.created_at.to_rfc3339(),
-        last_activity_at: session.last_activity_at.to_rfc3339(),
-    }))
+    let output = dispatch_session_action(
+        &state,
+        "session.update_metadata_info",
+        serde_json::json!({ "id": id, "name": req.name, "color": req.color }),
+    )
+    .await?;
+    Ok(Json(decode_action_output(
+        "session.update_metadata_info",
+        output,
+    )?))
 }
 
 /// POST /api/sessions/{id}/fusion/select-winner - Select and squash-merge winner
@@ -1222,16 +1102,9 @@ pub async fn stop_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    validate_session_id(&id)?;
-
-    let controller = state.session_controller.write();
-    controller
-        .stop_session(&id)
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-
-    Ok(Json(serde_json::json!({
-        "message": format!("Session {} stopped", id)
-    })))
+    let output =
+        dispatch_session_action(&state, "session.stop", serde_json::json!({ "id": id })).await?;
+    Ok(Json(output))
 }
 
 /// POST /api/sessions/{id}/close - Close a session
@@ -1239,20 +1112,9 @@ pub async fn close_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, ApiError> {
-    validate_session_id(&id)?;
-
-    let controller = state.session_controller.write();
-    controller.close_session(&id).map_err(|e| {
-        if e.starts_with("Session not found") {
-            ApiError::not_found(e)
-        } else {
-            ApiError::internal(e)
-        }
-    })?;
-
-    Ok(Json(serde_json::json!({
-        "message": format!("Session {} closed", id)
-    })))
+    let output =
+        dispatch_session_action(&state, "session.close", serde_json::json!({ "id": id })).await?;
+    Ok(Json(output))
 }
 
 /// POST /api/sessions/{id}/complete - Mark a session as completed

--- a/src-tauri/src/http/mod.rs
+++ b/src-tauri/src/http/mod.rs
@@ -1,7 +1,7 @@
 pub mod error;
+pub mod handlers;
 pub mod routes;
 pub mod state;
-pub mod handlers;
 #[cfg(test)]
 pub mod tests;
 

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -1,14 +1,14 @@
+use crate::http::handlers::{
+    actions, agents, application_state, artifacts, cells, conversations, evaluator, events, health,
+    heartbeats, inject, learnings, planners, queue, resolver, sessions, templates, workers,
+};
+use crate::http::state::AppState;
 use axum::{
     routing::{delete, get, post},
     Router,
 };
 use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
-use crate::http::state::AppState;
-use crate::http::handlers::{
-    actions, agents, application_state, artifacts, cells, conversations, evaluator, events, health,
-    heartbeats, inject, learnings, planners, queue, resolver, sessions, templates, workers,
-};
 
 pub fn create_router(state: Arc<AppState>) -> Router {
     let cors = CorsLayer::new()
@@ -22,10 +22,16 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // GET lists every action + schema; POST dispatches any action (caller=Http).
         .route("/api/actions", get(actions::list_actions))
         .route("/api/actions/{name}", post(actions::dispatch_action))
-        .route("/api/sessions", get(sessions::list_sessions).post(sessions::create_session))
+        .route(
+            "/api/sessions",
+            get(sessions::list_sessions).post(sessions::create_session),
+        )
         // Heartbeat routes (active must be before {id} to match)
         .route("/api/sessions/active", get(heartbeats::get_active_sessions))
-        .route("/api/sessions/{id}/heartbeat", post(heartbeats::post_heartbeat))
+        .route(
+            "/api/sessions/{id}/heartbeat",
+            post(heartbeats::post_heartbeat),
+        )
         .route(
             "/api/sessions/{id}",
             get(sessions::get_session)
@@ -37,27 +43,75 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/sessions/swarm", post(sessions::launch_swarm))
         .route("/api/sessions/solo", post(sessions::launch_solo))
         .route("/api/sessions/fusion", post(sessions::launch_fusion))
-        .route("/api/sessions/{id}/fusion/select-winner", post(sessions::select_fusion_winner))
-        .route("/api/sessions/{id}/fusion/status", get(sessions::get_fusion_status))
-        .route("/api/sessions/{id}/fusion/evaluation", get(sessions::get_fusion_evaluation))
-        .route("/api/sessions/{id}/resolver", get(resolver::get_resolver_output))
-        .route("/api/sessions/{id}/resolver/launch", post(resolver::launch_resolver))
+        .route("/api/sessions/debate", post(sessions::launch_debate))
+        .route(
+            "/api/sessions/{id}/fusion/select-winner",
+            post(sessions::select_fusion_winner),
+        )
+        .route(
+            "/api/sessions/{id}/fusion/status",
+            get(sessions::get_fusion_status),
+        )
+        .route(
+            "/api/sessions/{id}/fusion/evaluation",
+            get(sessions::get_fusion_evaluation),
+        )
+        .route(
+            "/api/sessions/{id}/debate/status",
+            get(sessions::get_debate_status),
+        )
+        .route(
+            "/api/sessions/{id}/debate/evaluation",
+            get(sessions::get_debate_evaluation),
+        )
+        .route(
+            "/api/sessions/{id}/resolver",
+            get(resolver::get_resolver_output),
+        )
+        .route(
+            "/api/sessions/{id}/resolver/launch",
+            post(resolver::launch_resolver),
+        )
         .route("/api/sessions/{id}/stop", post(sessions::stop_session))
         .route("/api/sessions/{id}/close", post(sessions::close_session))
-        .route("/api/sessions/{id}/complete", post(sessions::complete_session))
+        .route(
+            "/api/sessions/{id}/complete",
+            post(sessions::complete_session),
+        )
         // Worker routes
         .route("/api/sessions/{id}/workers", get(workers::list_workers))
         .route("/api/sessions/{id}/workers", post(workers::add_worker))
         // Durable run-queue snapshot (#126)
         .route("/api/sessions/{id}/queue", get(queue::get_queue))
         // Evaluator routes
-        .route("/api/sessions/{id}/evaluators", get(evaluator::list_evaluators))
-        .route("/api/sessions/{id}/evaluators", post(evaluator::add_evaluator))
-        .route("/api/sessions/{id}/qa-workers", post(evaluator::add_qa_worker))
-        .route("/api/sessions/{id}/auth/dev-login", get(evaluator::dev_login))
-        .route("/api/sessions/{id}/qa/verdict", post(evaluator::post_verdict))
-        .route("/api/sessions/{id}/qa/force-pass", post(evaluator::force_pass))
-        .route("/api/sessions/{id}/qa/force-fail", post(evaluator::force_fail))
+        .route(
+            "/api/sessions/{id}/evaluators",
+            get(evaluator::list_evaluators),
+        )
+        .route(
+            "/api/sessions/{id}/evaluators",
+            post(evaluator::add_evaluator),
+        )
+        .route(
+            "/api/sessions/{id}/qa-workers",
+            post(evaluator::add_qa_worker),
+        )
+        .route(
+            "/api/sessions/{id}/auth/dev-login",
+            get(evaluator::dev_login),
+        )
+        .route(
+            "/api/sessions/{id}/qa/verdict",
+            post(evaluator::post_verdict),
+        )
+        .route(
+            "/api/sessions/{id}/qa/force-pass",
+            post(evaluator::force_pass),
+        )
+        .route(
+            "/api/sessions/{id}/qa/force-fail",
+            post(evaluator::force_fail),
+        )
         // Planner routes (Swarm mode)
         .route("/api/sessions/{id}/planners", get(planners::list_planners))
         .route("/api/sessions/{id}/planners", post(planners::add_planner))
@@ -71,7 +125,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/cells/{cid}/agents",
             get(agents::list_agents_in_cell),
         )
-        .route("/api/sessions/{id}/agents/{aid}", delete(agents::stop_agent))
+        .route(
+            "/api/sessions/{id}/agents/{aid}",
+            delete(agents::stop_agent),
+        )
         .route(
             "/api/sessions/{id}/agents/{aid}/input",
             post(agents::send_agent_input),
@@ -80,25 +137,52 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/cells/{cid}/artifacts",
             get(artifacts::list_artifacts).post(artifacts::post_artifact),
         )
-        .route("/api/templates", get(templates::list_templates).post(templates::create_template))
-        .route("/api/templates/{id}", get(templates::get_template).delete(templates::delete_template))
+        .route(
+            "/api/templates",
+            get(templates::list_templates).post(templates::create_template),
+        )
+        .route(
+            "/api/templates/{id}",
+            get(templates::get_template).delete(templates::delete_template),
+        )
         // Learning routes (legacy - work when single project active)
         .route("/api/learnings", get(learnings::list_learnings))
         .route("/api/learnings", post(learnings::submit_learning))
         .route("/api/project-dna", get(learnings::get_project_dna))
         // Session-scoped learning routes (preferred - work with multiple projects)
-        .route("/api/sessions/{id}/learnings", get(learnings::list_learnings_for_session))
-        .route("/api/sessions/{id}/learnings", post(learnings::submit_learning_for_session))
-        .route("/api/sessions/{id}/learnings/{learning_id}", delete(learnings::delete_learning_for_session))
-        .route("/api/sessions/{id}/project-dna", get(learnings::get_project_dna_for_session))
+        .route(
+            "/api/sessions/{id}/learnings",
+            get(learnings::list_learnings_for_session),
+        )
+        .route(
+            "/api/sessions/{id}/learnings",
+            post(learnings::submit_learning_for_session),
+        )
+        .route(
+            "/api/sessions/{id}/learnings/{learning_id}",
+            delete(learnings::delete_learning_for_session),
+        )
+        .route(
+            "/api/sessions/{id}/project-dna",
+            get(learnings::get_project_dna_for_session),
+        )
         // Conversation routes
-        .route("/api/sessions/{id}/conversations/{agent}", get(conversations::read_conversation))
-        .route("/api/sessions/{id}/conversations/{agent}/append", post(conversations::append_conversation))
+        .route(
+            "/api/sessions/{id}/conversations/{agent}",
+            get(conversations::read_conversation),
+        )
+        .route(
+            "/api/sessions/{id}/conversations/{agent}/append",
+            post(conversations::append_conversation),
+        )
         // Event routes
         .route("/api/sessions/{id}/events", get(events::get_events))
         .route("/api/sessions/{id}/stream", get(events::stream_events))
         // Run journal + ledger (#125): per-step status for a resumable run
-        .route("/api/sessions/{id}/run-journal", get(sessions::get_run_journal))
+        .route(
+            "/api/sessions/{id}/run-journal",
+            get(sessions::get_run_journal),
+        )
         // Application-state routes (SQLite-backed nav/UI state + watermark polling)
         .route(
             "/api/sessions/{id}/application-state",
@@ -116,8 +200,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         // Injection routes
         .route("/api/sessions/{id}/inject", post(inject::operator_inject))
-        .route("/api/sessions/{id}/inject/queen", post(inject::queen_inject))
-        .route("/api/sessions/{id}/inject/evaluator", post(inject::evaluator_inject))
+        .route(
+            "/api/sessions/{id}/inject/queen",
+            post(inject::queen_inject),
+        )
+        .route(
+            "/api/sessions/{id}/inject/evaluator",
+            post(inject::evaluator_inject),
+        )
         .layer(cors)
         .with_state(state)
 }

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -1,6 +1,6 @@
 use parking_lot::RwLock as PLRwLock;
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter};
+use crate::tauri_shim::{AppHandle, Emitter};
 use tokio::sync::RwLock;
 
 use crate::actions::render::envelope_for_content;

--- a/src-tauri/src/http/state.rs
+++ b/src-tauri/src/http/state.rs
@@ -1,16 +1,17 @@
-use std::sync::Arc;
-use tokio::sync::RwLock;
 use parking_lot::RwLock as PLRwLock;
+use std::sync::Arc;
 use tauri::{AppHandle, Emitter};
+use tokio::sync::RwLock;
 
+use crate::actions::render::envelope_for_content;
 use crate::actions::ActionRegistry;
+use crate::coordination::{InjectionManager, QueueManager};
 use crate::domain::event::{Event, EventType, Severity};
-use crate::storage::{AppConfig, ApplicationStateDb, SessionStorage};
-use crate::storage::ConversationMessage;
+use crate::events::EventBus;
 use crate::pty::PtyManager;
 use crate::session::SessionController;
-use crate::coordination::{InjectionManager, QueueManager};
-use crate::events::EventBus;
+use crate::storage::ConversationMessage;
+use crate::storage::{AppConfig, ApplicationStateDb, SessionStorage};
 
 #[allow(dead_code)]
 pub struct AppState {
@@ -77,15 +78,24 @@ impl AppState {
         agent_id: &str,
         message: &ConversationMessage,
     ) -> Result<(), String> {
+        let data = serde_json::json!({
+            "session_id": session_id,
+            "agent_id": agent_id,
+            "timestamp": message.timestamp,
+            "from": message.from,
+            "content": message.content,
+        });
+        let envelope = envelope_for_content(data.clone(), &message.content);
+        let mut payload = data;
+        if let (Some(payload), Some(envelope)) = (payload.as_object_mut(), envelope.as_object()) {
+            for (key, value) in envelope {
+                payload.insert(key.clone(), value.clone());
+            }
+        }
+
         if let Some(app_handle) = self.app_handle.as_ref() {
             app_handle
-                .emit("conversation-message", serde_json::json!({
-                    "session_id": session_id,
-                    "agent_id": agent_id,
-                    "timestamp": message.timestamp,
-                    "from": message.from,
-                    "content": message.content,
-                }))
+                .emit("conversation-message", payload.clone())
                 .map_err(|error| format!("Failed to emit Tauri conversation message: {error}"))?;
         }
 
@@ -97,11 +107,7 @@ impl AppState {
                 agent_id: Some(agent_id.to_string()),
                 event_type: EventType::ConversationMessage,
                 timestamp: message.timestamp,
-                payload: serde_json::json!({
-                    "timestamp": message.timestamp,
-                    "from": message.from,
-                    "content": message.content,
-                }),
+                payload,
                 severity: Severity::Info,
             })
             .await

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -1,21 +1,24 @@
+use crate::coordination::InjectionManager;
+use crate::coordination::{PeerMessageRecord, StateManager};
+use crate::events::EventBus;
+use crate::http::routes::create_router;
+use crate::http::state::AppState;
+use crate::pty::PtyManager;
+use crate::pty::{AgentConfig, AgentRole, AgentStatus};
+use crate::session::{
+    AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
+    DEFAULT_MAX_QA_ITERATIONS,
+};
+use crate::storage::{PersistedSession, SessionStorage, SessionTypeInfo};
 use axum::{
     body::Body,
     http::{Request, StatusCode},
 };
+use parking_lot::RwLock;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tower::ServiceExt;
-use crate::http::routes::create_router;
-use crate::http::state::AppState;
-use crate::coordination::{PeerMessageRecord, StateManager};
-use crate::storage::{SessionStorage, PersistedSession, SessionTypeInfo};
-use crate::pty::PtyManager;
-use crate::session::{Session, SessionController, SessionState, SessionType, AgentInfo, AuthStrategy, DEFAULT_MAX_QA_ITERATIONS};
-use crate::pty::{AgentRole, AgentStatus, AgentConfig};
-use crate::coordination::InjectionManager;
-use crate::events::EventBus;
-use parking_lot::RwLock;
 
 /// Helper to get the default max_qa_iterations for test fixtures
 fn test_default_max_qa_iterations() -> u8 {
@@ -74,9 +77,8 @@ async fn setup_test_app_with_controller_at(
         SessionStorage::new_with_base(base_dir).unwrap(),
     )));
     let event_bus = EventBus::new(storage.base_dir().clone());
-    let app_state_db = Arc::new(
-        crate::storage::ApplicationStateDb::open(storage.base_dir()).unwrap(),
-    );
+    let app_state_db =
+        Arc::new(crate::storage::ApplicationStateDb::open(storage.base_dir()).unwrap());
     let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
     queue_repo.ensure_schema().unwrap();
     let queue_manager = Arc::new(crate::coordination::QueueManager::new(
@@ -234,7 +236,12 @@ async fn test_health_check() {
     let app = setup_test_app().await;
 
     let response = app
-        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
         .await
         .unwrap();
 
@@ -282,9 +289,10 @@ async fn test_patch_session_updates_name_and_color() {
     let temp_dir = std::env::temp_dir().join("hive-test-patch-session");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-patch", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-patch",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "name": "Alpha Session",
@@ -305,10 +313,18 @@ async fn test_patch_session_updates_name_and_color() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-    assert_eq!(response_json.get("name").unwrap().as_str().unwrap(), "Alpha Session");
-    assert_eq!(response_json.get("color").unwrap().as_str().unwrap(), "#7aa2f7");
+    assert_eq!(
+        response_json.get("name").unwrap().as_str().unwrap(),
+        "Alpha Session"
+    );
+    assert_eq!(
+        response_json.get("color").unwrap().as_str().unwrap(),
+        "#7aa2f7"
+    );
 
     let session = controller.read().get_session("session-patch").unwrap();
     assert_eq!(session.name.as_deref(), Some("Alpha Session"));
@@ -432,9 +448,10 @@ async fn test_patch_session_rejects_invalid_color() {
     let temp_dir = std::env::temp_dir().join("hive-test-patch-invalid-color");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-patch-color", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-patch-color",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "name": "Alpha Session",
@@ -465,9 +482,10 @@ async fn test_patch_session_rejects_whitespace_name() {
     let temp_dir = std::env::temp_dir().join("hive-test-patch-whitespace-name");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-patch-whitespace", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-patch-whitespace",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "name": "   ",
@@ -498,9 +516,10 @@ async fn test_patch_session_rejects_invalid_name() {
     let temp_dir = std::env::temp_dir().join("hive-test-patch-invalid-name");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-patch-name", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-patch-name",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "name": "../escape",
@@ -537,7 +556,10 @@ async fn test_patch_session_updates_persisted_session_not_loaded_in_memory() {
         name: Some("Stored".to_string()),
         color: Some("#7aa2f7".to_string()),
         session_type: SessionTypeInfo::Hive { worker_count: 1 },
-        project_path: std::env::temp_dir().join("hive-test-persisted-update").to_string_lossy().to_string(),
+        project_path: std::env::temp_dir()
+            .join("hive-test-persisted-update")
+            .to_string_lossy()
+            .to_string(),
         created_at: chrono::Utc::now(),
         last_activity_at: None,
         agents: vec![],
@@ -623,9 +645,9 @@ async fn test_session_scoped_list_learnings_for_valid_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-session-a");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-a", temp_dir.to_str().unwrap())
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-a", temp_dir.to_str().unwrap()));
 
     let response = app
         .oneshot(
@@ -650,9 +672,9 @@ async fn test_session_scoped_project_dna_for_valid_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-session-dna");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-dna", temp_dir.to_str().unwrap())
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-dna", temp_dir.to_str().unwrap()));
 
     let response = app
         .oneshot(
@@ -676,9 +698,10 @@ async fn test_legacy_learnings_works_with_single_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-single-session");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-single", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-single",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let response = app
         .oneshot(
@@ -706,12 +729,14 @@ async fn test_legacy_learnings_returns_error_with_multiple_projects() {
     let _ = std::fs::create_dir_all(&temp_dir_b);
 
     // Insert two sessions with different project paths
-    controller.read().insert_test_session(
-        make_test_session("session-multi-a", temp_dir_a.to_str().unwrap())
-    );
-    controller.read().insert_test_session(
-        make_test_session("session-multi-b", temp_dir_b.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-multi-a",
+        temp_dir_a.to_str().unwrap(),
+    ));
+    controller.read().insert_test_session(make_test_session(
+        "session-multi-b",
+        temp_dir_b.to_str().unwrap(),
+    ));
 
     let response = app
         .oneshot(
@@ -739,12 +764,12 @@ async fn test_session_scoped_learnings_work_with_multiple_projects() {
     let _ = std::fs::create_dir_all(&temp_dir_a);
     let _ = std::fs::create_dir_all(&temp_dir_b);
 
-    controller.read().insert_test_session(
-        make_test_session("scoped-a", temp_dir_a.to_str().unwrap())
-    );
-    controller.read().insert_test_session(
-        make_test_session("scoped-b", temp_dir_b.to_str().unwrap())
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session("scoped-a", temp_dir_a.to_str().unwrap()));
+    controller
+        .read()
+        .insert_test_session(make_test_session("scoped-b", temp_dir_b.to_str().unwrap()));
 
     // Session-scoped endpoint should work even with multiple projects
     let response = app
@@ -770,9 +795,10 @@ async fn test_session_scoped_submit_learning_validates_input() {
     let temp_dir = std::env::temp_dir().join("hive-test-submit-validation");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-submit", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-submit",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit with empty insight should fail
     let body = serde_json::json!({
@@ -808,9 +834,10 @@ async fn test_session_scoped_submit_learning_rejects_path_traversal() {
     let temp_dir = std::env::temp_dir().join("hive-test-path-traversal");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-traversal", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-traversal",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit with path traversal in files_touched should fail
     let body = serde_json::json!({
@@ -846,9 +873,9 @@ async fn test_session_scoped_submit_learning_success() {
     let temp_dir = std::env::temp_dir().join("hive-test-submit-success");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-ok", temp_dir.to_str().unwrap())
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session("session-ok", temp_dir.to_str().unwrap()));
 
     let body = serde_json::json!({
         "session": "session-ok",
@@ -938,9 +965,10 @@ async fn test_session_scoped_submit_learning_validates_empty_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-empty-session");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-empty-session", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-empty-session",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "session": "",
@@ -975,9 +1003,10 @@ async fn test_session_scoped_submit_learning_validates_empty_task() {
     let temp_dir = std::env::temp_dir().join("hive-test-empty-task");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-empty-task", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-empty-task",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "session": "session-empty-task",
@@ -1012,9 +1041,10 @@ async fn test_session_scoped_submit_learning_validates_invalid_outcome() {
     let temp_dir = std::env::temp_dir().join("hive-test-invalid-outcome");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-invalid-outcome", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-invalid-outcome",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "session": "session-invalid-outcome",
@@ -1049,9 +1079,10 @@ async fn test_session_scoped_submit_learning_validates_all_outcomes() {
     let temp_dir = std::env::temp_dir().join("hive-test-all-outcomes");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-outcomes", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-outcomes",
+        temp_dir.to_str().unwrap(),
+    ));
 
     for outcome in ["success", "partial", "failed"] {
         let body = serde_json::json!({
@@ -1089,9 +1120,10 @@ async fn test_session_scoped_submit_learning_rejects_absolute_paths() {
     let temp_dir = std::env::temp_dir().join("hive-test-absolute-path");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-absolute", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-absolute",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Test absolute Unix path
     let body = serde_json::json!({
@@ -1152,9 +1184,10 @@ async fn test_session_scoped_submit_learning_returns_learning_id() {
     let temp_dir = std::env::temp_dir().join("hive-test-learning-id");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-learning-id", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-learning-id",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "session": "session-learning-id",
@@ -1179,12 +1212,22 @@ async fn test_session_scoped_submit_learning_returns_learning_id() {
 
     assert_eq!(response.status(), StatusCode::CREATED);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     assert!(response_json.get("learning_id").is_some());
-    assert_eq!(response_json.get("message").unwrap().as_str().unwrap(), "Learning submitted successfully");
-    assert!(!response_json.get("learning_id").unwrap().as_str().unwrap().is_empty());
+    assert_eq!(
+        response_json.get("message").unwrap().as_str().unwrap(),
+        "Learning submitted successfully"
+    );
+    assert!(!response_json
+        .get("learning_id")
+        .unwrap()
+        .as_str()
+        .unwrap()
+        .is_empty());
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -1196,12 +1239,16 @@ async fn test_session_scoped_list_learnings_with_filtering_by_category() {
     let temp_dir = std::env::temp_dir().join("hive-test-filter-category");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-filter", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-filter",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit multiple learnings with different outcomes
-    for (i, outcome) in ["success", "partial", "failed", "success"].iter().enumerate() {
+    for (i, outcome) in ["success", "partial", "failed", "success"]
+        .iter()
+        .enumerate()
+    {
         let body = serde_json::json!({
             "session": "session-filter",
             "task": format!("task {}", i),
@@ -1239,12 +1286,16 @@ async fn test_session_scoped_list_learnings_with_filtering_by_category() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 2);
-    assert!(learnings.iter().all(|l| l.get("outcome").unwrap().as_str().unwrap() == "success"));
+    assert!(learnings
+        .iter()
+        .all(|l| l.get("outcome").unwrap().as_str().unwrap() == "success"));
 
     // Filter by failed
     let response = app
@@ -1259,12 +1310,17 @@ async fn test_session_scoped_list_learnings_with_filtering_by_category() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 1);
-    assert_eq!(learnings[0].get("outcome").unwrap().as_str().unwrap(), "failed");
+    assert_eq!(
+        learnings[0].get("outcome").unwrap().as_str().unwrap(),
+        "failed"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -1276,9 +1332,10 @@ async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
     let temp_dir = std::env::temp_dir().join("hive-test-filter-keywords");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-filter-kw", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-filter-kw",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit learnings with different keywords
     let test_cases = vec![
@@ -1326,13 +1383,19 @@ async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 2);
-    assert!(learnings.iter().any(|l| l.get("task").unwrap().as_str().unwrap() == "task 1"));
-    assert!(learnings.iter().any(|l| l.get("task").unwrap().as_str().unwrap() == "task 3"));
+    assert!(learnings
+        .iter()
+        .any(|l| l.get("task").unwrap().as_str().unwrap() == "task 1"));
+    assert!(learnings
+        .iter()
+        .any(|l| l.get("task").unwrap().as_str().unwrap() == "task 3"));
 
     // Filter by multiple keywords (comma-separated)
     let response = app
@@ -1348,7 +1411,9 @@ async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
@@ -1368,7 +1433,9 @@ async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
@@ -1384,9 +1451,10 @@ async fn test_session_scoped_list_learnings_with_combined_filters() {
     let temp_dir = std::env::temp_dir().join("hive-test-combined-filters");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-combined", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-combined",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit learnings with different combinations
     let test_cases = vec![
@@ -1433,13 +1501,21 @@ async fn test_session_scoped_list_learnings_with_combined_filters() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 1);
-    assert_eq!(learnings[0].get("task").unwrap().as_str().unwrap(), "task 1");
-    assert_eq!(learnings[0].get("outcome").unwrap().as_str().unwrap(), "success");
+    assert_eq!(
+        learnings[0].get("task").unwrap().as_str().unwrap(),
+        "task 1"
+    );
+    assert_eq!(
+        learnings[0].get("outcome").unwrap().as_str().unwrap(),
+        "success"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -1451,9 +1527,10 @@ async fn test_session_scoped_list_learnings_returns_correct_structure() {
     let temp_dir = std::env::temp_dir().join("hive-test-structure");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-structure", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-structure",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit a learning
     let body = serde_json::json!({
@@ -1491,7 +1568,9 @@ async fn test_session_scoped_list_learnings_returns_correct_structure() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
     assert!(response_json.get("learnings").is_some());
@@ -1504,11 +1583,20 @@ async fn test_session_scoped_list_learnings_returns_correct_structure() {
     let learning = &learnings[0];
     assert!(learning.get("id").is_some());
     assert!(learning.get("date").is_some());
-    assert_eq!(learning.get("session").unwrap().as_str().unwrap(), "session-structure");
+    assert_eq!(
+        learning.get("session").unwrap().as_str().unwrap(),
+        "session-structure"
+    );
     assert_eq!(learning.get("task").unwrap().as_str().unwrap(), "test task");
-    assert_eq!(learning.get("outcome").unwrap().as_str().unwrap(), "success");
-    assert_eq!(learning.get("insight").unwrap().as_str().unwrap(), "test insight");
-    
+    assert_eq!(
+        learning.get("outcome").unwrap().as_str().unwrap(),
+        "success"
+    );
+    assert_eq!(
+        learning.get("insight").unwrap().as_str().unwrap(),
+        "test insight"
+    );
+
     let keywords = learning.get("keywords").unwrap().as_array().unwrap();
     assert_eq!(keywords.len(), 2);
     assert!(keywords.iter().any(|k| k.as_str().unwrap() == "test"));
@@ -1529,9 +1617,10 @@ async fn test_session_scoped_delete_learning_success() {
     let temp_dir = std::env::temp_dir().join("hive-test-delete-success");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-delete", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-delete",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit a learning
     let body = serde_json::json!({
@@ -1558,7 +1647,9 @@ async fn test_session_scoped_delete_learning_success() {
 
     assert_eq!(response.status(), StatusCode::CREATED);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learning_id = response_json.get("learning_id").unwrap().as_str().unwrap();
 
@@ -1568,7 +1659,10 @@ async fn test_session_scoped_delete_learning_success() {
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri(format!("/api/sessions/session-delete/learnings/{}", learning_id))
+                .uri(format!(
+                    "/api/sessions/session-delete/learnings/{}",
+                    learning_id
+                ))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1590,7 +1684,9 @@ async fn test_session_scoped_delete_learning_success() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 0);
@@ -1605,9 +1701,10 @@ async fn test_session_scoped_delete_learning_not_found() {
     let temp_dir = std::env::temp_dir().join("hive-test-delete-notfound");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-delete-nf", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-delete-nf",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Try to delete a non-existent learning
     let response = app
@@ -1651,9 +1748,10 @@ async fn test_session_scoped_delete_learning_preserves_other_learnings() {
     let temp_dir = std::env::temp_dir().join("hive-test-delete-preserve");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-delete-preserve", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-delete-preserve",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit two learnings
     let mut learning_ids = Vec::new();
@@ -1682,9 +1780,16 @@ async fn test_session_scoped_delete_learning_preserves_other_learnings() {
 
         assert_eq!(response.status(), StatusCode::CREATED);
 
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-        let learning_id = response_json.get("learning_id").unwrap().as_str().unwrap().to_string();
+        let learning_id = response_json
+            .get("learning_id")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .to_string();
         learning_ids.push(learning_id);
     }
 
@@ -1694,7 +1799,10 @@ async fn test_session_scoped_delete_learning_preserves_other_learnings() {
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri(format!("/api/sessions/session-delete-preserve/learnings/{}", learning_ids[0]))
+                .uri(format!(
+                    "/api/sessions/session-delete-preserve/learnings/{}",
+                    learning_ids[0]
+                ))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1716,11 +1824,16 @@ async fn test_session_scoped_delete_learning_preserves_other_learnings() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 1);
-    assert_eq!(learnings[0].get("task").unwrap().as_str().unwrap(), "task 1");
+    assert_eq!(
+        learnings[0].get("task").unwrap().as_str().unwrap(),
+        "task 1"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -1732,9 +1845,10 @@ async fn test_legacy_submit_learning_validates_input() {
     let temp_dir = std::env::temp_dir().join("hive-test-legacy-submit");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-legacy", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-legacy",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Test empty session
     let body = serde_json::json!({
@@ -1795,9 +1909,10 @@ async fn test_legacy_list_learnings_with_filtering() {
     let temp_dir = std::env::temp_dir().join("hive-test-legacy-filter");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-legacy-filter", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-legacy-filter",
+        temp_dir.to_str().unwrap(),
+    ));
 
     // Submit learnings via legacy endpoint
     for (i, outcome) in ["success", "failed"].iter().enumerate() {
@@ -1838,11 +1953,16 @@ async fn test_legacy_list_learnings_with_filtering() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 1);
-    assert_eq!(learnings[0].get("outcome").unwrap().as_str().unwrap(), "success");
+    assert_eq!(
+        learnings[0].get("outcome").unwrap().as_str().unwrap(),
+        "success"
+    );
 
     // Filter by keywords
     let response = app
@@ -1857,7 +1977,9 @@ async fn test_legacy_list_learnings_with_filtering() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 2);
@@ -1876,12 +1998,14 @@ async fn test_e2e_session_isolation() {
     let _ = std::fs::create_dir_all(&temp_dir_a);
     let _ = std::fs::create_dir_all(&temp_dir_b);
 
-    controller.read().insert_test_session(
-        make_test_session("iso-session-a", temp_dir_a.to_str().unwrap())
-    );
-    controller.read().insert_test_session(
-        make_test_session("iso-session-b", temp_dir_b.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "iso-session-a",
+        temp_dir_a.to_str().unwrap(),
+    ));
+    controller.read().insert_test_session(make_test_session(
+        "iso-session-b",
+        temp_dir_b.to_str().unwrap(),
+    ));
 
     // POST a learning to session A only
     let body = serde_json::json!({
@@ -1921,11 +2045,16 @@ async fn test_e2e_session_isolation() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings_a = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings_a.len(), 1);
-    assert_eq!(learnings_a[0].get("task").unwrap().as_str().unwrap(), "implement isolation feature");
+    assert_eq!(
+        learnings_a[0].get("task").unwrap().as_str().unwrap(),
+        "implement isolation feature"
+    );
 
     // Verify session B has NO learnings (isolation)
     let response = app
@@ -1940,10 +2069,16 @@ async fn test_e2e_session_isolation() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings_b = response_json.get("learnings").unwrap().as_array().unwrap();
-    assert_eq!(learnings_b.len(), 0, "Session B should have no learnings - session isolation violated");
+    assert_eq!(
+        learnings_b.len(),
+        0,
+        "Session B should have no learnings - session isolation violated"
+    );
 
     // Now POST to session B and verify both are independent
     let body_b = serde_json::json!({
@@ -1982,10 +2117,16 @@ async fn test_e2e_session_isolation() {
         .await
         .unwrap();
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings_a = response_json.get("learnings").unwrap().as_array().unwrap();
-    assert_eq!(learnings_a.len(), 1, "Session A should still have exactly 1 learning after B got a new one");
+    assert_eq!(
+        learnings_a.len(),
+        1,
+        "Session A should still have exactly 1 learning after B got a new one"
+    );
 
     // Check session B has exactly 1 learning
     let response = app
@@ -1998,11 +2139,16 @@ async fn test_e2e_session_isolation() {
         .await
         .unwrap();
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings_b = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings_b.len(), 1);
-    assert_eq!(learnings_b[0].get("outcome").unwrap().as_str().unwrap(), "partial");
+    assert_eq!(
+        learnings_b[0].get("outcome").unwrap().as_str().unwrap(),
+        "partial"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir_a);
     let _ = std::fs::remove_dir_all(&temp_dir_b);
@@ -2017,12 +2163,12 @@ async fn test_e2e_delete_does_not_affect_other_sessions() {
     let _ = std::fs::create_dir_all(&temp_dir_a);
     let _ = std::fs::create_dir_all(&temp_dir_b);
 
-    controller.read().insert_test_session(
-        make_test_session("del-iso-a", temp_dir_a.to_str().unwrap())
-    );
-    controller.read().insert_test_session(
-        make_test_session("del-iso-b", temp_dir_b.to_str().unwrap())
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session("del-iso-a", temp_dir_a.to_str().unwrap()));
+    controller
+        .read()
+        .insert_test_session(make_test_session("del-iso-b", temp_dir_b.to_str().unwrap()));
 
     // POST learnings to both sessions
     for (session_id, task) in [("del-iso-a", "task A"), ("del-iso-b", "task B")] {
@@ -2063,7 +2209,9 @@ async fn test_e2e_delete_does_not_affect_other_sessions() {
         .await
         .unwrap();
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     let learning_id = learnings[0].get("id").unwrap().as_str().unwrap();
@@ -2095,7 +2243,9 @@ async fn test_e2e_delete_does_not_affect_other_sessions() {
         .await
         .unwrap();
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
     assert_eq!(learnings.len(), 0);
@@ -2111,11 +2261,20 @@ async fn test_e2e_delete_does_not_affect_other_sessions() {
         .await
         .unwrap();
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let learnings = response_json.get("learnings").unwrap().as_array().unwrap();
-    assert_eq!(learnings.len(), 1, "Session B should still have its learning after deleting from session A");
-    assert_eq!(learnings[0].get("task").unwrap().as_str().unwrap(), "task B");
+    assert_eq!(
+        learnings.len(),
+        1,
+        "Session B should still have its learning after deleting from session A"
+    );
+    assert_eq!(
+        learnings[0].get("task").unwrap().as_str().unwrap(),
+        "task B"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir_a);
     let _ = std::fs::remove_dir_all(&temp_dir_b);
@@ -2147,9 +2306,10 @@ async fn test_add_worker_rejects_invalid_cli() {
     let temp_dir = std::env::temp_dir().join("hive-test-invalid-cli");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session("session-cli-test", temp_dir.to_str().unwrap())
-    );
+    controller.read().insert_test_session(make_test_session(
+        "session-cli-test",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "role_type": "backend",
@@ -2170,10 +2330,16 @@ async fn test_add_worker_rejects_invalid_cli() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
-    assert!(error_msg.contains("Invalid CLI"), "Error should mention invalid CLI: {}", error_msg);
+    assert!(
+        error_msg.contains("Invalid CLI"),
+        "Error should mention invalid CLI: {}",
+        error_msg
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -2201,10 +2367,16 @@ async fn test_add_worker_rejects_path_traversal_session_id() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
-    assert!(error_msg.contains("Invalid session ID"), "Error should mention invalid session ID: {}", error_msg);
+    assert!(
+        error_msg.contains("Invalid session ID"),
+        "Error should mention invalid session ID: {}",
+        error_msg
+    );
 }
 
 #[tokio::test]
@@ -2375,7 +2547,9 @@ async fn test_add_worker_accepts_latest_worker_models() {
             "{cli}/{model} should be accepted as a worker model"
         );
         if status == StatusCode::CREATED {
-            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
             let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
             let worker_id = response_json
                 .get("worker_id")
@@ -2400,16 +2574,15 @@ async fn test_add_worker_accepts_latest_worker_models() {
 
 #[test]
 fn test_add_worker_request_accepts_name_and_description_fields() {
-    let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
-        serde_json::json!({
+    let request: crate::http::handlers::workers::AddWorkerRequest =
+        serde_json::from_value(serde_json::json!({
             "role_type": "frontend",
             "cli": "codex",
             "name": "Worker 2 (Frontend)",
             "description": "SSE resync + chat/timeline event handling",
             "initial_task": "Handle SSE lagged events"
-        }),
-    )
-    .unwrap();
+        }))
+        .unwrap();
 
     assert_eq!(request.name.as_deref(), Some("Worker 2 (Frontend)"));
     assert_eq!(
@@ -2421,16 +2594,15 @@ fn test_add_worker_request_accepts_name_and_description_fields() {
 #[test]
 fn test_add_worker_request_blank_name_deserializes_to_none() {
     for raw_name in ["", "   "] {
-        let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
-            serde_json::json!({
+        let request: crate::http::handlers::workers::AddWorkerRequest =
+            serde_json::from_value(serde_json::json!({
                 "role_type": "frontend",
                 "cli": "codex",
                 "name": raw_name,
                 "description": "SSE resync + chat/timeline event handling",
                 "initial_task": "Handle SSE lagged events"
-            }),
-        )
-        .unwrap();
+            }))
+            .unwrap();
 
         assert!(
             request.name.is_none(),
@@ -2443,16 +2615,15 @@ fn test_add_worker_request_blank_name_deserializes_to_none() {
 #[test]
 fn test_add_worker_request_blank_description_deserializes_to_none() {
     for raw_description in ["", "   "] {
-        let request: crate::http::handlers::workers::AddWorkerRequest = serde_json::from_value(
-            serde_json::json!({
+        let request: crate::http::handlers::workers::AddWorkerRequest =
+            serde_json::from_value(serde_json::json!({
                 "role_type": "frontend",
                 "cli": "codex",
                 "name": "Worker 2 (Frontend)",
                 "description": raw_description,
                 "initial_task": "Handle SSE lagged events"
-            }),
-        )
-        .unwrap();
+            }))
+            .unwrap();
 
         assert!(
             request.description.is_none(),
@@ -2496,7 +2667,9 @@ fn test_persisted_agent_config_blank_name_round_trip_uses_indexed_default_behavi
             cli: "codex".to_string(),
             model: Some("gpt-5.5".to_string()),
             flags: vec![],
-            label: Some("Worker 2 (Frontend) — SSE resync + chat/timeline event handling".to_string()),
+            label: Some(
+                "Worker 2 (Frontend) — SSE resync + chat/timeline event handling".to_string(),
+            ),
             name: Some(raw_name.to_string()),
             description: Some("SSE resync + chat/timeline event handling".to_string()),
             role_type: Some("frontend".to_string()),
@@ -2525,9 +2698,10 @@ async fn test_add_qa_worker_rejects_invalid_cli() {
     let temp_dir = std::env::temp_dir().join("hive-test-invalid-qa-cli");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-qa-cli-test", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-qa-cli-test",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "specialization": "ui",
@@ -2548,10 +2722,16 @@ async fn test_add_qa_worker_rejects_invalid_cli() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
-    assert!(error_msg.contains("Invalid CLI"), "Error should mention invalid CLI: {}", error_msg);
+    assert!(
+        error_msg.contains("Invalid CLI"),
+        "Error should mention invalid CLI: {}",
+        error_msg
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -2563,9 +2743,10 @@ async fn test_add_qa_worker_rejects_invalid_specialization() {
     let temp_dir = std::env::temp_dir().join("hive-test-invalid-qa-specialization");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-qa-specialization", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-qa-specialization",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({
         "specialization": "performance"
@@ -2585,10 +2766,16 @@ async fn test_add_qa_worker_rejects_invalid_specialization() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
-    assert!(error_msg.contains("Invalid QA specialization"), "Error should mention invalid specialization: {}", error_msg);
+    assert!(
+        error_msg.contains("Invalid QA specialization"),
+        "Error should mention invalid specialization: {}",
+        error_msg
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -2615,10 +2802,16 @@ async fn test_add_qa_worker_rejects_path_traversal_session_id() {
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
-    assert!(error_msg.contains("Invalid session ID"), "Error should mention invalid session ID: {}", error_msg);
+    assert!(
+        error_msg.contains("Invalid session ID"),
+        "Error should mention invalid session ID: {}",
+        error_msg
+    );
 }
 
 #[tokio::test]
@@ -2764,6 +2957,39 @@ async fn test_launch_fusion_success() {
 }
 
 #[tokio::test]
+async fn test_launch_debate_success() {
+    let app = setup_test_app().await;
+
+    let body = serde_json::json!({
+        "project_path": std::env::temp_dir().to_str().unwrap(),
+        "topic": "Should we adopt approach X?",
+        "rounds": 2,
+        "debaters": [
+            { "name": "affirmative", "stance": "Argue for approach X" },
+            { "name": "negative", "stance": "Argue against approach X" }
+        ]
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/debate")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let status = response.status();
+    assert!(
+        status == StatusCode::CREATED || status == StatusCode::INTERNAL_SERVER_ERROR,
+        "launch should either create the session or fail at PTY/worktree setup, got {status}"
+    );
+}
+
+#[tokio::test]
 async fn test_create_hive_accepts_per_worker_model_overrides() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = TempDir::new().unwrap();
@@ -2809,7 +3035,9 @@ async fn test_create_hive_accepts_per_worker_model_overrides() {
         "launch should either create the session or fail at PTY/worktree setup, got {status}"
     );
     if status == StatusCode::CREATED {
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let launch_response: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let session_id = launch_response
             .get("session_id")
@@ -2902,7 +3130,10 @@ async fn test_create_hive_with_evaluator_config_propagates_to_evaluator() {
         assert_eq!(evaluator.config.model.as_deref(), Some("gpt-5.5"));
         assert_eq!(evaluator.config.flags, vec!["--search".to_string()]);
         assert_eq!(evaluator.config.label.as_deref(), Some("Config evaluator"));
-        assert_eq!(session.state, SessionState::QaInProgress { iteration: None });
+        assert_eq!(
+            session.state,
+            SessionState::QaInProgress { iteration: None }
+        );
 
         controller.write().close_session(session_id).unwrap();
     }
@@ -2956,7 +3187,9 @@ async fn test_launch_swarm_accepts_model_capable_configs() {
         "launch should either create the session or fail at PTY/worktree setup, got {status}"
     );
     if status == StatusCode::CREATED {
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let launch_response: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let session_id = launch_response
             .get("session_id")
@@ -3017,7 +3250,9 @@ async fn test_launch_swarm_rejects_explicit_empty_workers_per_planner() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let error_msg = response_json.get("error").unwrap().as_str().unwrap();
     assert!(
@@ -3057,7 +3292,9 @@ async fn test_launch_solo_accepts_droid_model_config() {
         "launch should either create the session or fail at PTY/worktree setup, got {status}"
     );
     if status == StatusCode::CREATED {
-        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
         let launch_response: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
         let session_id = launch_response
             .get("session_id")
@@ -3480,7 +3717,10 @@ async fn test_append_conversation_and_verify_file_content() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/sessions/{}/conversations/worker-1/append", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/conversations/worker-1/append",
+                    session_id
+                ))
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&body).unwrap()))
                 .unwrap(),
@@ -3521,7 +3761,10 @@ async fn test_read_conversation_since_filter() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/sessions/{}/conversations/shared/append", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/conversations/shared/append",
+                    session_id
+                ))
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&body_1).unwrap()))
                 .unwrap(),
@@ -3542,7 +3785,10 @@ async fn test_read_conversation_since_filter() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/sessions/{}/conversations/shared/append", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/conversations/shared/append",
+                    session_id
+                ))
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&body_2).unwrap()))
                 .unwrap(),
@@ -3564,11 +3810,16 @@ async fn test_read_conversation_since_filter() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let messages = response_json.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 1);
-    assert_eq!(messages[0].get("from").unwrap().as_str().unwrap(), "worker-1");
+    assert_eq!(
+        messages[0].get("from").unwrap().as_str().unwrap(),
+        "worker-1"
+    );
     assert_eq!(
         messages[0].get("content").unwrap().as_str().unwrap(),
         "After marker"
@@ -3639,7 +3890,10 @@ async fn test_conversation_concurrent_appends() {
                 .oneshot(
                     Request::builder()
                         .method("POST")
-                        .uri(format!("/api/sessions/{}/conversations/shared/append", session_id_clone))
+                        .uri(format!(
+                            "/api/sessions/{}/conversations/shared/append",
+                            session_id_clone
+                        ))
                         .header("content-type", "application/json")
                         .body(Body::from(serde_json::to_string(&body).unwrap()))
                         .unwrap(),
@@ -3666,7 +3920,9 @@ async fn test_conversation_concurrent_appends() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let messages = response_json.get("messages").unwrap().as_array().unwrap();
     assert_eq!(messages.len(), 5);
@@ -3703,9 +3959,7 @@ async fn test_force_pass_hot_reloads_clean_session_from_session_json() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
-    session.state = SessionState::QaInProgress {
-        iteration: Some(1),
-    };
+    session.state = SessionState::QaInProgress { iteration: Some(1) };
     controller.write().insert_test_session(session);
 
     let response = app
@@ -3775,9 +4029,7 @@ async fn test_post_verdict_persists_commit_sha_and_rationale() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
-    session.state = SessionState::QaInProgress {
-        iteration: Some(2),
-    };
+    session.state = SessionState::QaInProgress { iteration: Some(2) };
     session.agents.push(AgentInfo {
         id: format!("{session_id}-evaluator"),
         role: AgentRole::Evaluator,
@@ -3813,15 +4065,21 @@ async fn test_post_verdict_persists_commit_sha_and_rationale() {
         .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(
-        response_json.get("verdict").and_then(|value| value.as_str()),
+        response_json
+            .get("verdict")
+            .and_then(|value| value.as_str()),
         Some("PASS")
     );
     assert_eq!(
-        response_json.get("new_state").and_then(|value| value.as_str()),
+        response_json
+            .get("new_state")
+            .and_then(|value| value.as_str()),
         Some("QaPassed")
     );
     assert_eq!(
-        response_json.get("commit_sha").and_then(|value| value.as_str()),
+        response_json
+            .get("commit_sha")
+            .and_then(|value| value.as_str()),
         Some("abc123def")
     );
 
@@ -3858,15 +4116,21 @@ async fn test_post_verdict_persists_commit_sha_and_rationale() {
     assert!(!record.content.contains('\n'));
     let audit_payload: serde_json::Value = serde_json::from_str(&record.content).unwrap();
     assert_eq!(
-        audit_payload.get("verdict").and_then(|value| value.as_str()),
+        audit_payload
+            .get("verdict")
+            .and_then(|value| value.as_str()),
         Some("PASS")
     );
     assert_eq!(
-        audit_payload.get("rationale").and_then(|value| value.as_str()),
+        audit_payload
+            .get("rationale")
+            .and_then(|value| value.as_str()),
         Some("Looks good")
     );
     assert_eq!(
-        audit_payload.get("commit_sha").and_then(|value| value.as_str()),
+        audit_payload
+            .get("commit_sha")
+            .and_then(|value| value.as_str()),
         Some("abc123def")
     );
 }
@@ -3880,9 +4144,7 @@ async fn test_post_verdict_fail_persists_commit_sha_and_failure_state() {
     let temp_dir = TempDir::new().unwrap();
 
     let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
-    session.state = SessionState::QaInProgress {
-        iteration: Some(2),
-    };
+    session.state = SessionState::QaInProgress { iteration: Some(2) };
     session.agents.push(AgentInfo {
         id: format!("{session_id}-evaluator"),
         role: AgentRole::Evaluator,
@@ -3918,11 +4180,15 @@ async fn test_post_verdict_fail_persists_commit_sha_and_failure_state() {
         .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(
-        response_json.get("verdict").and_then(|value| value.as_str()),
+        response_json
+            .get("verdict")
+            .and_then(|value| value.as_str()),
         Some("FAIL")
     );
     assert_eq!(
-        response_json.get("commit_sha").and_then(|value| value.as_str()),
+        response_json
+            .get("commit_sha")
+            .and_then(|value| value.as_str()),
         Some("deadbeef")
     );
 
@@ -3963,11 +4229,15 @@ async fn test_post_verdict_fail_persists_commit_sha_and_failure_state() {
     assert!(!record.content.contains('\n'));
     let audit_payload: serde_json::Value = serde_json::from_str(&record.content).unwrap();
     assert_eq!(
-        audit_payload.get("verdict").and_then(|value| value.as_str()),
+        audit_payload
+            .get("verdict")
+            .and_then(|value| value.as_str()),
         Some("FAIL")
     );
     assert_eq!(
-        audit_payload.get("rationale").and_then(|value| value.as_str()),
+        audit_payload
+            .get("rationale")
+            .and_then(|value| value.as_str()),
         Some("Needs follow-up")
     );
 }
@@ -3978,7 +4248,12 @@ fn test_peer_message_record_commit_sha_round_trips_through_peer_json() {
     let manager = StateManager::new(temp_dir.path().to_path_buf());
 
     manager
-        .write_qa_verdict("session-evaluator", "session-queen", "QA_VERDICT: PASS", Some("abc123def"))
+        .write_qa_verdict(
+            "session-evaluator",
+            "session-queen",
+            "QA_VERDICT: PASS",
+            Some("abc123def"),
+        )
         .unwrap();
 
     let record: PeerMessageRecord = serde_json::from_str(
@@ -3997,9 +4272,13 @@ async fn test_list_cells_returns_primary_cell_for_hive_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-cells-primary");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-cells", temp_dir.to_str().unwrap(), &["session-cells-queen", "session-cells-worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-cells",
+            temp_dir.to_str().unwrap(),
+            &["session-cells-queen", "session-cells-worker-1"],
+        ));
 
     let response = app
         .oneshot(
@@ -4013,12 +4292,17 @@ async fn test_list_cells_returns_primary_cell_for_hive_session() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let cells = response_json.as_array().unwrap();
     assert_eq!(cells.len(), 1);
     assert_eq!(cells[0].get("id").unwrap().as_str().unwrap(), "primary");
-    assert_eq!(cells[0].get("session_id").unwrap().as_str().unwrap(), "session-cells");
+    assert_eq!(
+        cells[0].get("session_id").unwrap().as_str().unwrap(),
+        "session-cells"
+    );
     assert_eq!(cells[0].get("status").unwrap().as_str().unwrap(), "running");
 
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -4048,9 +4332,10 @@ async fn test_stop_cell_returns_bad_request() {
     let temp_dir = std::env::temp_dir().join("hive-test-stop-cell");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-stop-cell", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-stop-cell",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let response = app
         .clone()
@@ -4079,9 +4364,13 @@ async fn test_list_agents_in_cell_returns_session_agents() {
     let temp_dir = std::env::temp_dir().join("hive-test-cell-agents");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-cell-agents", temp_dir.to_str().unwrap(), &["worker-1", "worker-2"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-cell-agents",
+            temp_dir.to_str().unwrap(),
+            &["worker-1", "worker-2"],
+        ));
 
     let response = app
         .oneshot(
@@ -4095,12 +4384,20 @@ async fn test_list_agents_in_cell_returns_session_agents() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let agents = response_json.as_array().unwrap();
     assert_eq!(agents.len(), 2);
-    assert_eq!(agents[0].get("cell_id").unwrap().as_str().unwrap(), "primary");
-    assert_eq!(agents[0].get("status").unwrap().as_str().unwrap(), "running");
+    assert_eq!(
+        agents[0].get("cell_id").unwrap().as_str().unwrap(),
+        "primary"
+    );
+    assert_eq!(
+        agents[0].get("status").unwrap().as_str().unwrap(),
+        "running"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -4129,9 +4426,10 @@ async fn test_list_artifacts_returns_empty_for_synthetic_cell() {
     let temp_dir = std::env::temp_dir().join("hive-test-cell-artifacts");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-cell-artifacts", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-cell-artifacts",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let response = app
         .oneshot(
@@ -4145,7 +4443,9 @@ async fn test_list_artifacts_returns_empty_for_synthetic_cell() {
 
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(response_json.as_array().unwrap().len(), 0);
 
@@ -4203,7 +4503,10 @@ async fn test_list_artifacts_uses_persisted_session_fallback() {
     let response = app
         .oneshot(
             Request::builder()
-                .uri(format!("/api/sessions/{}/cells/primary/artifacts", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/cells/primary/artifacts",
+                    session_id
+                ))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -4211,7 +4514,9 @@ async fn test_list_artifacts_uses_persisted_session_fallback() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let artifacts = response_json.as_array().unwrap();
     assert_eq!(artifacts.len(), 1);
@@ -4246,12 +4551,10 @@ async fn test_post_artifact_round_trip_and_cell_projection() {
     let storage = SessionStorage::new().unwrap();
     let _cleanup = TestPathCleanup::new(vec![storage.session_dir(&session_id)]);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session(
-            &session_id,
-            temp_dir.path().to_str().unwrap(),
-        ));
+    controller.read().insert_test_session(make_test_session(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+    ));
 
     let artifact = serde_json::json!({
         "artifact": {
@@ -4272,7 +4575,10 @@ async fn test_post_artifact_round_trip_and_cell_projection() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/sessions/{}/cells/primary/artifacts", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/cells/primary/artifacts",
+                    session_id
+                ))
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&artifact).unwrap()))
                 .unwrap(),
@@ -4286,7 +4592,10 @@ async fn test_post_artifact_round_trip_and_cell_projection() {
         .clone()
         .oneshot(
             Request::builder()
-                .uri(format!("/api/sessions/{}/cells/primary/artifacts", session_id))
+                .uri(format!(
+                    "/api/sessions/{}/cells/primary/artifacts",
+                    session_id
+                ))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -4294,11 +4603,16 @@ async fn test_post_artifact_round_trip_and_cell_projection() {
         .unwrap();
 
     assert_eq!(get_response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(get_response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(get_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let artifacts = response_json.as_array().unwrap();
     assert_eq!(artifacts.len(), 1);
-    assert_eq!(artifacts[0].get("branch").unwrap().as_str().unwrap(), "feature/artifacts");
+    assert_eq!(
+        artifacts[0].get("branch").unwrap().as_str().unwrap(),
+        "feature/artifacts"
+    );
 
     let cell_response = app
         .oneshot(
@@ -4311,7 +4625,9 @@ async fn test_post_artifact_round_trip_and_cell_projection() {
         .unwrap();
 
     assert_eq!(cell_response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(cell_response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(cell_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(
         response_json
@@ -4333,12 +4649,10 @@ async fn test_get_resolver_output_endpoint_returns_persisted_output() {
     let storage = SessionStorage::new().unwrap();
     let _cleanup = TestPathCleanup::new(vec![storage.session_dir(&session_id)]);
 
-    controller
-        .read()
-        .insert_test_session(make_test_session(
-            &session_id,
-            temp_dir.path().to_str().unwrap(),
-        ));
+    controller.read().insert_test_session(make_test_session(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+    ));
 
     storage
         .save_resolver_output(
@@ -4364,7 +4678,9 @@ async fn test_get_resolver_output_endpoint_returns_persisted_output() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert_eq!(
         response_json
@@ -4462,7 +4778,9 @@ async fn test_template_crud_endpoints() {
         .await
         .unwrap();
     assert_eq!(list_response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(list_response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(list_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(response_json
         .get("templates")
@@ -4471,13 +4789,15 @@ async fn test_template_crud_endpoints() {
         .unwrap()
         .iter()
         .any(|item| item.get("id").unwrap().as_str().unwrap() == template_id));
-    assert!(response_json
-        .get("role_packs")
-        .unwrap()
-        .as_array()
-        .unwrap()
-        .len()
-        >= 4);
+    assert!(
+        response_json
+            .get("role_packs")
+            .unwrap()
+            .as_array()
+            .unwrap()
+            .len()
+            >= 4
+    );
 
     let delete_response = app
         .clone()
@@ -4514,9 +4834,13 @@ async fn test_send_agent_input_rejects_empty_input() {
     let temp_dir = std::env::temp_dir().join("hive-test-agent-input");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-agent-input", temp_dir.to_str().unwrap(), &["worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-agent-input",
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
 
     let response = app
         .oneshot(
@@ -4611,9 +4935,13 @@ async fn test_post_heartbeat_updates_timestamp() {
     let temp_dir = std::env::temp_dir().join("hive-test-heartbeat");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-hb", temp_dir.to_str().unwrap(), &["worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-hb",
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
 
     let response = app
         .oneshot(
@@ -4641,9 +4969,13 @@ async fn test_post_heartbeat_rejects_invalid_status() {
     let temp_dir = std::env::temp_dir().join("hive-test-heartbeat-invalid");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-hb-inv", temp_dir.to_str().unwrap(), &["worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-hb-inv",
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
 
     let response = app
         .oneshot(
@@ -4671,9 +5003,13 @@ async fn test_get_active_sessions_returns_only_running() {
     let temp_dir = std::env::temp_dir().join("hive-test-active");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-running", temp_dir.to_str().unwrap(), &["worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-running",
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
 
     let response = app
         .oneshot(
@@ -4686,11 +5022,16 @@ async fn test_get_active_sessions_returns_only_running() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let sessions = response_json.get("sessions").unwrap().as_array().unwrap();
     assert_eq!(sessions.len(), 1);
-    assert_eq!(sessions[0].get("id").unwrap().as_str().unwrap(), "session-running");
+    assert_eq!(
+        sessions[0].get("id").unwrap().as_str().unwrap(),
+        "session-running"
+    );
     let agents = sessions[0].get("agents").unwrap().as_array().unwrap();
     assert_eq!(agents.len(), 1);
 
@@ -4704,12 +5045,17 @@ async fn test_get_active_sessions_includes_heartbeat_after_post() {
     let temp_dir = std::env::temp_dir().join("hive-test-active-hb");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(
-        make_test_session_with_agents("session-active-hb", temp_dir.to_str().unwrap(), &["worker-1"]),
-    );
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-active-hb",
+            temp_dir.to_str().unwrap(),
+            &["worker-1"],
+        ));
 
     // POST heartbeat first
-    let _ = app.clone()
+    let _ = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -4735,15 +5081,23 @@ async fn test_get_active_sessions_includes_heartbeat_after_post() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let sessions = response_json.get("sessions").unwrap().as_array().unwrap();
     assert_eq!(sessions.len(), 1);
     let agents = sessions[0].get("agents").unwrap().as_array().unwrap();
     assert_eq!(agents.len(), 1);
     assert!(agents[0].get("last_activity").unwrap().as_str().is_some());
-    assert_eq!(agents[0].get("status").unwrap().as_str().unwrap(), "working");
-    assert_eq!(agents[0].get("summary").unwrap().as_str().unwrap(), "2/3 done");
+    assert_eq!(
+        agents[0].get("status").unwrap().as_str().unwrap(),
+        "working"
+    );
+    assert_eq!(
+        agents[0].get("summary").unwrap().as_str().unwrap(),
+        "2/3 done"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
@@ -4767,9 +5121,7 @@ async fn test_list_sessions_reflects_fresh_heartbeat_activity_and_persists_it() 
         ));
     {
         let sessions = controller.write();
-        let session = sessions
-            .get_session(&session_id)
-            .expect("session inserted");
+        let session = sessions.get_session(&session_id).expect("session inserted");
         let mut updated = session.clone();
         updated.last_activity_at = before;
         updated.created_at = before - chrono::Duration::minutes(1);
@@ -4803,15 +5155,17 @@ async fn test_list_sessions_reflects_fresh_heartbeat_activity_and_persists_it() 
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
     let listed = response_json
         .get("sessions")
         .and_then(|sessions| sessions.as_array())
         .and_then(|sessions| {
-            sessions
-                .iter()
-                .find(|session| session.get("id").and_then(|id| id.as_str()) == Some(session_id.as_str()))
+            sessions.iter().find(|session| {
+                session.get("id").and_then(|id| id.as_str()) == Some(session_id.as_str())
+            })
         })
         .expect("session should be listed");
 
@@ -4837,13 +5191,15 @@ async fn test_complete_session_returns_conflict_when_not_quiescent() {
     let temp_dir = std::env::temp_dir().join("hive-test-complete-blocked");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(make_test_session_for_completion(
-        "session-complete-blocked",
-        temp_dir.to_str().unwrap(),
-        SessionState::Running,
-        chrono::Utc::now() - chrono::Duration::minutes(11),
-        true,
-    ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_for_completion(
+            "session-complete-blocked",
+            temp_dir.to_str().unwrap(),
+            SessionState::Running,
+            chrono::Utc::now() - chrono::Duration::minutes(11),
+            true,
+        ));
 
     let response = app
         .oneshot(
@@ -4858,9 +5214,14 @@ async fn test_complete_session_returns_conflict_when_not_quiescent() {
 
     assert_eq!(response.status(), StatusCode::CONFLICT);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let error = response_json.get("error").and_then(|value| value.as_str()).unwrap();
+    let error = response_json
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap();
     assert!(error.contains("QaPassed"));
 
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -4872,13 +5233,15 @@ async fn test_complete_session_returns_conflict_for_recent_qa_passed_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-complete-recent-pass");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(make_test_session_for_completion(
-        "session-complete-recent-pass",
-        temp_dir.to_str().unwrap(),
-        SessionState::QaPassed,
-        chrono::Utc::now() - chrono::Duration::minutes(5),
-        true,
-    ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_for_completion(
+            "session-complete-recent-pass",
+            temp_dir.to_str().unwrap(),
+            SessionState::QaPassed,
+            chrono::Utc::now() - chrono::Duration::minutes(5),
+            true,
+        ));
 
     let response = app
         .oneshot(
@@ -4893,9 +5256,14 @@ async fn test_complete_session_returns_conflict_for_recent_qa_passed_session() {
 
     assert_eq!(response.status(), StatusCode::CONFLICT);
 
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-    let error = response_json.get("error").and_then(|value| value.as_str()).unwrap();
+    let error = response_json
+        .get("error")
+        .and_then(|value| value.as_str())
+        .unwrap();
     assert!(error.contains("10 minutes"));
 
     let _ = std::fs::remove_dir_all(&temp_dir);
@@ -4907,13 +5275,15 @@ async fn test_complete_session_allows_quiet_evaluator_backed_session() {
     let temp_dir = std::env::temp_dir().join("hive-test-complete-ok");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(make_test_session_for_completion(
-        "session-complete-ok",
-        temp_dir.to_str().unwrap(),
-        SessionState::QaPassed,
-        chrono::Utc::now() - chrono::Duration::minutes(11),
-        true,
-    ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_for_completion(
+            "session-complete-ok",
+            temp_dir.to_str().unwrap(),
+            SessionState::QaPassed,
+            chrono::Utc::now() - chrono::Duration::minutes(11),
+            true,
+        ));
 
     let response = app
         .oneshot(
@@ -4942,13 +5312,15 @@ async fn test_complete_session_allows_quiet_fusion_session_without_evaluator() {
     let temp_dir = std::env::temp_dir().join("hive-test-complete-fusion");
     let _ = std::fs::create_dir_all(&temp_dir);
 
-    controller.read().insert_test_session(make_test_session_for_completion(
-        "session-complete-fusion",
-        temp_dir.to_str().unwrap(),
-        SessionState::Running,
-        chrono::Utc::now() - chrono::Duration::minutes(11),
-        false,
-    ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_for_completion(
+            "session-complete-fusion",
+            temp_dir.to_str().unwrap(),
+            SessionState::Running,
+            chrono::Utc::now() - chrono::Duration::minutes(11),
+            false,
+        ));
 
     let response = app
         .oneshot(
@@ -4990,7 +5362,9 @@ async fn test_get_events_returns_empty_for_new_session() {
     // Should return OK with empty array for non-existent session
     assert_eq!(response.status(), StatusCode::OK);
 
-    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     let response_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
     let events = response_json.as_array().unwrap();
     assert_eq!(events.len(), 0);
@@ -5033,8 +5407,9 @@ async fn test_stream_events_endpoint_exists() {
     // SSE endpoint should return OK (it will keep connection open)
     // The response should have content-type: text/event-stream
     assert_eq!(response.status(), StatusCode::OK);
-    
-    let content_type = response.headers()
+
+    let content_type = response
+        .headers()
         .get("content-type")
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
@@ -5066,7 +5441,9 @@ fn make_fusion_session(id: &str, project_path: &str) -> Session {
         id: id.to_string(),
         name: None,
         color: None,
-        session_type: SessionType::Fusion { variants: vec!["variant-a".to_string(), "variant-b".to_string()] },
+        session_type: SessionType::Fusion {
+            variants: vec!["variant-a".to_string(), "variant-b".to_string()],
+        },
         project_path: PathBuf::from(project_path),
         state: SessionState::Running,
         created_at: now,
@@ -5514,9 +5891,10 @@ async fn test_http_dispatch_session_list_via_registry() {
 
     let temp_dir = std::env::temp_dir().join("hive-test-action-session-list");
     let _ = std::fs::create_dir_all(&temp_dir);
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-actionlist", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-actionlist",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let response = app
         .oneshot(
@@ -5585,7 +5963,10 @@ async fn test_same_handler_both_callers() {
     let _ = std::fs::create_dir_all(&temp_dir);
     session_controller
         .read()
-        .insert_test_session(make_test_session("session-both", temp_dir.to_str().unwrap()));
+        .insert_test_session(make_test_session(
+            "session-both",
+            temp_dir.to_str().unwrap(),
+        ));
 
     let registry = state.registry().clone();
 
@@ -5695,9 +6076,17 @@ async fn test_get_run_journal_returns_seeded_entries() {
         .record_step_started(run_id, StepKind::GitCommit, 1, Some("worker-1"))
         .unwrap();
     store
-        .record_ledger(run_id, &step_id, "git_commit", Some("abc123"), Confidence::High)
+        .record_ledger(
+            run_id,
+            &step_id,
+            "git_commit",
+            Some("abc123"),
+            Confidence::High,
+        )
         .unwrap();
-    store.confirm_ledger(run_id, &step_id, None, Confidence::High).unwrap();
+    store
+        .confirm_ledger(run_id, &step_id, None, Confidence::High)
+        .unwrap();
     store
         .record_step_finished(run_id, &step_id, StepStatus::Completed)
         .unwrap();
@@ -5760,7 +6149,9 @@ async fn fetch_queue_snapshot(app: &axum::Router, session_id: &str) -> serde_jso
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
     serde_json::from_slice(&bytes).unwrap()
 }
 
@@ -5769,9 +6160,10 @@ async fn test_queue_endpoint_empty_snapshot() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = std::env::temp_dir().join("hive-test-queue-empty");
     let _ = std::fs::create_dir_all(&temp_dir);
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-queue-empty", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-queue-empty",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let snap = fetch_queue_snapshot(&app, "session-queue-empty").await;
     assert_eq!(snap["queued"], 0);
@@ -5791,9 +6183,10 @@ async fn test_add_worker_enqueues_and_claims() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = std::env::temp_dir().join("hive-test-queue-claim");
     let _ = std::fs::create_dir_all(&temp_dir);
-    controller
-        .read()
-        .insert_test_session(make_test_session("session-queue-claim", temp_dir.to_str().unwrap()));
+    controller.read().insert_test_session(make_test_session(
+        "session-queue-claim",
+        temp_dir.to_str().unwrap(),
+    ));
 
     let body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
 
@@ -5850,11 +6243,13 @@ async fn test_heartbeat_advances_queue_counters() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = std::env::temp_dir().join("hive-test-queue-heartbeat");
     let _ = std::fs::create_dir_all(&temp_dir);
-    controller.read().insert_test_session(make_test_session_with_agents(
-        "session-queue-hb",
-        temp_dir.to_str().unwrap(),
-        &["session-queue-hb-worker-1"],
-    ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-queue-hb",
+            temp_dir.to_str().unwrap(),
+            &["session-queue-hb-worker-1"],
+        ));
 
     // Claim the worker row directly via the queue path used by add_worker (enqueue+claim).
     let worker_body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
@@ -5901,8 +6296,14 @@ async fn test_heartbeat_advances_queue_counters() {
         .iter()
         .find(|r| r["worker_id"] == "session-queue-hb-worker-2")
         .expect("queue row for worker-2");
-    assert!(row["heartbeat_at"].as_i64().is_some(), "heartbeat recorded onto the queue row");
-    assert_eq!(row["no_progress_count"], 1, "second identical heartbeat is no-progress");
+    assert!(
+        row["heartbeat_at"].as_i64().is_some(),
+        "heartbeat recorded onto the queue row"
+    );
+    assert_eq!(
+        row["no_progress_count"], 1,
+        "second identical heartbeat is no-progress"
+    );
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -9,7 +9,7 @@ use crate::session::{
     AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
     DEFAULT_MAX_QA_ITERATIONS,
 };
-use crate::storage::{PersistedSession, SessionStorage, SessionTypeInfo};
+use crate::storage::{ConversationMessage, PersistedSession, SessionStorage, SessionTypeInfo};
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -57,6 +57,39 @@ async fn setup_test_app() -> axum::Router {
     state.set_registry(Arc::new(crate::actions::build_registry()));
 
     create_router(state)
+}
+
+async fn setup_test_state() -> Arc<AppState> {
+    let storage = Arc::new(SessionStorage::new().unwrap());
+    let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    session_controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new().unwrap(),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    let app_state_db = Arc::new(crate::storage::ApplicationStateDb::open_in_memory().unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller,
+        injection_manager,
+        storage,
+        event_bus,
+        app_state_db,
+        queue_manager,
+        None,
+    ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
+    state
 }
 
 /// Setup test app with a specific storage base dir (hermetic). Returns router, controller, and the storage.
@@ -5913,7 +5946,11 @@ async fn test_http_dispatch_session_list_via_registry() {
         .await
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
-    let sessions = json.as_array().expect("session.list returns an array");
+    assert_eq!(json.get("renderer").and_then(|v| v.as_str()), Some("table"));
+    let sessions = json
+        .get("data")
+        .and_then(|v| v.as_array())
+        .expect("session.list data returns an array");
     assert!(sessions
         .iter()
         .any(|s| s.get("id").and_then(|v| v.as_str()) == Some("session-actionlist")));
@@ -6032,6 +6069,41 @@ async fn test_http_action_unknown_returns_404() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_conversation_emit_includes_render_envelope() {
+    let state = setup_test_state().await;
+    let mut events = state.event_bus.subscribe_session("session-render".to_string());
+
+    let table_message = ConversationMessage {
+        timestamp: chrono::Utc::now(),
+        from: "worker-3".to_string(),
+        content: "| file | status |\n| --- | --- |\n| src/lib.rs | changed |".to_string(),
+    };
+    state
+        .emit_conversation_message("session-render", "worker-3", &table_message)
+        .await
+        .unwrap();
+
+    let table_event = events.recv().await.unwrap();
+    assert_eq!(table_event.payload["renderer"], "table");
+    assert_eq!(table_event.payload["data"]["content"], table_message.content);
+    assert_eq!(table_event.payload["data"]["agent_id"], "worker-3");
+
+    let diff_message = ConversationMessage {
+        timestamp: chrono::Utc::now(),
+        from: "worker-3".to_string(),
+        content: "diff --git a/src/lib.rs b/src/lib.rs\n@@ -1 +1 @@\n-old\n+new".to_string(),
+    };
+    state
+        .emit_conversation_message("session-render", "worker-3", &diff_message)
+        .await
+        .unwrap();
+
+    let diff_event = events.recv().await.unwrap();
+    assert_eq!(diff_event.payload["renderer"], "diff");
+    assert_eq!(diff_event.payload["data"]["content"], diff_message.content);
 }
 
 // ---- #125 run-journal endpoint ----

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -15,7 +15,8 @@ use axum::{
     http::{Request, StatusCode},
 };
 use parking_lot::RwLock;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::sync::Arc;
 use tempfile::TempDir;
 use tower::ServiceExt;
@@ -134,6 +135,18 @@ async fn setup_test_app_with_controller_at(
     (create_router(state), session_controller, storage)
 }
 
+async fn setup_isolated_test_app_with_controller() -> (
+    TempDir,
+    axum::Router,
+    Arc<RwLock<SessionController>>,
+    Arc<SessionStorage>,
+) {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    (storage_dir, app, controller, storage)
+}
+
 /// Setup test app and return both the router and session controller for inserting test sessions
 async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionController>>) {
     let storage = Arc::new(SessionStorage::new().unwrap());
@@ -167,6 +180,24 @@ async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionCo
     state.set_registry(Arc::new(crate::actions::build_registry()));
 
     (create_router(state), session_controller)
+}
+
+fn run_git_for_test(repo_path: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .status()
+        .expect("run git command");
+    assert!(status.success(), "git {:?} should succeed", args);
+}
+
+fn init_git_repo_for_launch_fixture(repo_path: &Path) {
+    run_git_for_test(repo_path, &["init", "-q"]);
+    run_git_for_test(repo_path, &["config", "user.email", "hive@example.com"]);
+    run_git_for_test(repo_path, &["config", "user.name", "Hive Test"]);
+    std::fs::write(repo_path.join("README.md"), "launch fixture\n").expect("write fixture file");
+    run_git_for_test(repo_path, &["add", "README.md"]);
+    run_git_for_test(repo_path, &["commit", "-q", "-m", "initial commit"]);
 }
 
 fn make_test_session(id: &str, project_path: &str) -> Session {
@@ -488,7 +519,7 @@ async fn test_patch_session_rejects_invalid_color() {
 
     let body = serde_json::json!({
         "name": "Alpha Session",
-        "color": "#ffffff"
+        "color": "not-a-color"
     });
 
     let response = app
@@ -1267,7 +1298,7 @@ async fn test_session_scoped_submit_learning_returns_learning_id() {
 
 #[tokio::test]
 async fn test_session_scoped_list_learnings_with_filtering_by_category() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir = std::env::temp_dir().join("hive-test-filter-category");
     let _ = std::fs::create_dir_all(&temp_dir);
@@ -1360,7 +1391,7 @@ async fn test_session_scoped_list_learnings_with_filtering_by_category() {
 
 #[tokio::test]
 async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir = std::env::temp_dir().join("hive-test-filter-keywords");
     let _ = std::fs::create_dir_all(&temp_dir);
@@ -1479,7 +1510,7 @@ async fn test_session_scoped_list_learnings_with_filtering_by_keywords() {
 
 #[tokio::test]
 async fn test_session_scoped_list_learnings_with_combined_filters() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir = std::env::temp_dir().join("hive-test-combined-filters");
     let _ = std::fs::create_dir_all(&temp_dir);
@@ -1555,7 +1586,7 @@ async fn test_session_scoped_list_learnings_with_combined_filters() {
 
 #[tokio::test]
 async fn test_session_scoped_list_learnings_returns_correct_structure() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir = std::env::temp_dir().join("hive-test-structure");
     let _ = std::fs::create_dir_all(&temp_dir);
@@ -1776,7 +1807,7 @@ async fn test_session_scoped_delete_learning_returns_404_for_nonexistent_session
 
 #[tokio::test]
 async fn test_session_scoped_delete_learning_preserves_other_learnings() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir = std::env::temp_dir().join("hive-test-delete-preserve");
     let _ = std::fs::create_dir_all(&temp_dir);
@@ -2024,7 +2055,7 @@ async fn test_legacy_list_learnings_with_filtering() {
 
 #[tokio::test]
 async fn test_e2e_session_isolation() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir_a = std::env::temp_dir().join("hive-test-isolation-a");
     let temp_dir_b = std::env::temp_dir().join("hive-test-isolation-b");
@@ -2189,7 +2220,7 @@ async fn test_e2e_session_isolation() {
 
 #[tokio::test]
 async fn test_e2e_delete_does_not_affect_other_sessions() {
-    let (app, controller) = setup_test_app_with_controller().await;
+    let (_storage_dir, app, controller, _storage) = setup_isolated_test_app_with_controller().await;
 
     let temp_dir_a = std::env::temp_dir().join("hive-test-delete-iso-a");
     let temp_dir_b = std::env::temp_dir().join("hive-test-delete-iso-b");
@@ -3241,20 +3272,35 @@ async fn test_launch_swarm_accepts_model_capable_configs() {
             .expect("swarm session should include queen");
         assert_eq!(queen.config.cli, "qwen");
         assert_eq!(queen.config.model.as_deref(), Some("qwen3-coder"));
-        let planner = session
-            .agents
-            .iter()
-            .find(|agent| matches!(agent.role, AgentRole::Planner { .. }))
-            .expect("swarm session should include planner");
-        assert_eq!(planner.config.cli, "droid");
-        assert_eq!(planner.config.model.as_deref(), Some("glm-5.1"));
-        let worker = session
-            .agents
-            .iter()
-            .find(|agent| matches!(agent.role, AgentRole::Worker { .. }))
-            .expect("swarm session should include worker");
-        assert_eq!(worker.config.cli, "codex");
-        assert_eq!(worker.config.model.as_deref(), Some("gpt-5.5"));
+        let planners_path = temp_dir
+            .path()
+            .join(".hive-manager")
+            .join(session_id)
+            .join("swarm-planners.json");
+        let planners_json = std::fs::read_to_string(planners_path).unwrap();
+        let planners: Vec<serde_json::Value> = serde_json::from_str(&planners_json).unwrap();
+        let planner_config = planners[0].get("config").unwrap();
+        assert_eq!(
+            planner_config.get("cli").and_then(|value| value.as_str()),
+            Some("droid")
+        );
+        assert_eq!(
+            planner_config.get("model").and_then(|value| value.as_str()),
+            Some("glm-5.1")
+        );
+        let worker_config = planners[0]
+            .get("workers")
+            .and_then(|workers| workers.as_array())
+            .and_then(|workers| workers.first())
+            .unwrap();
+        assert_eq!(
+            worker_config.get("cli").and_then(|value| value.as_str()),
+            Some("codex")
+        );
+        assert_eq!(
+            worker_config.get("model").and_then(|value| value.as_str()),
+            Some("gpt-5.5")
+        );
     }
 }
 
@@ -3444,6 +3490,7 @@ async fn test_launch_solo_with_evaluator_uses_solo_defaults() {
 async fn test_launch_solo_with_same_cli_evaluator_preserves_custom_session_model() {
     let (app, controller) = setup_test_app_with_controller().await;
     let temp_dir = TempDir::new().unwrap();
+    init_git_repo_for_launch_fixture(temp_dir.path());
 
     let body = serde_json::json!({
         "project_path": temp_dir.path().to_string_lossy(),
@@ -3807,6 +3854,7 @@ async fn test_read_conversation_since_filter() {
 
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
     let marker = chrono::Utc::now().to_rfc3339();
+    let encoded_marker = marker.replace('+', "%2B").replace(':', "%3A");
     tokio::time::sleep(std::time::Duration::from_millis(20)).await;
 
     let body_2 = serde_json::json!({
@@ -3834,7 +3882,7 @@ async fn test_read_conversation_since_filter() {
             Request::builder()
                 .uri(format!(
                     "/api/sessions/{}/conversations/shared?since={}",
-                    session_id, marker
+                    session_id, encoded_marker
                 ))
                 .body(Body::empty())
                 .unwrap(),
@@ -3889,7 +3937,7 @@ async fn test_conversation_rejects_path_traversal_and_invalid_agent_id() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/sessions/session-safe/conversations/worker 1/append")
+                .uri("/api/sessions/session-safe/conversations/worker%201/append")
                 .header("content-type", "application/json")
                 .body(Body::from(serde_json::to_string(&body).unwrap()))
                 .unwrap(),
@@ -4355,7 +4403,8 @@ async fn test_get_cell_rejects_invalid_cell_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -4449,7 +4498,8 @@ async fn test_list_agents_in_cell_rejects_invalid_cell_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -4573,7 +4623,8 @@ async fn test_list_artifacts_rejects_invalid_cell_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -4908,7 +4959,8 @@ async fn test_send_agent_input_rejects_invalid_agent_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -5417,7 +5469,8 @@ async fn test_get_events_rejects_path_traversal_session_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -5463,7 +5516,8 @@ async fn test_stream_events_rejects_path_traversal_session_id() {
         .await
         .unwrap();
 
-    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    // Path traversal is rejected before handler validation by route matching.
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
 // ── Resolver launch endpoint tests ──────────────────────────────────────
@@ -5540,6 +5594,8 @@ async fn test_resolver_launch_success_with_artifacts() {
 
     // Register Fusion session in controller
     let session = make_fusion_session(&session_id, &std::env::temp_dir().to_string_lossy());
+    let mut session = session;
+    session.last_activity_at = chrono::Utc::now() - chrono::Duration::minutes(11);
     controller.write().insert_test_session(session);
 
     let body = serde_json::json!({
@@ -6074,7 +6130,9 @@ async fn test_http_action_unknown_returns_404() {
 #[tokio::test]
 async fn test_conversation_emit_includes_render_envelope() {
     let state = setup_test_state().await;
-    let mut events = state.event_bus.subscribe_session("session-render".to_string());
+    let mut events = state
+        .event_bus
+        .subscribe_session("session-render".to_string());
 
     let table_message = ConversationMessage {
         timestamp: chrono::Utc::now(),
@@ -6088,7 +6146,10 @@ async fn test_conversation_emit_includes_render_envelope() {
 
     let table_event = events.recv().await.unwrap();
     assert_eq!(table_event.payload["renderer"], "table");
-    assert_eq!(table_event.payload["data"]["content"], table_message.content);
+    assert_eq!(
+        table_event.payload["data"]["content"],
+        table_message.content
+    );
     assert_eq!(table_event.payload["data"]["agent_id"], "worker-3");
 
     let diff_message = ConversationMessage {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,10 +47,11 @@ use commands::{
     get_workers_state, git_fetch, git_pull, git_push, git_worktree_add, git_worktree_list,
     git_worktree_prune, git_worktree_remove, inject_to_pty, kill_pty, launch_debate, launch_fusion,
     launch_hive, launch_hive_v2, launch_research, launch_solo, launch_swarm, list_branches,
-    list_ptys, list_sessions, list_stored_sessions, log_coordination_message, mark_plan_ready,
-    operator_inject, paste_to_pty, queen_inject, queen_switch_branch, resize_pty, resume_session,
-    stop_agent, stop_session, switch_branch, update_app_config, update_session_metadata,
-    write_to_pty, CoordinationState, PtyManagerState, SessionControllerState, StorageState,
+    list_ptys, list_session_files, list_sessions, list_stored_sessions, log_coordination_message,
+    mark_plan_ready, operator_inject, paste_to_pty, queen_inject, queen_switch_branch, resize_pty,
+    resume_session, stop_agent, stop_session, switch_branch, update_app_config,
+    update_session_metadata, write_to_pty, CoordinationState, PtyManagerState,
+    SessionControllerState, StorageState,
 };
 #[cfg(not(test))]
 use pty::PtyManager;
@@ -590,6 +591,7 @@ pub fn run() {
             mark_plan_ready,
             resume_session,
             get_run_journal,
+            list_session_files,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,48 +1,49 @@
-mod commands;
 pub mod actions;
-pub mod artifacts;
-pub mod domain;
 pub mod adapters;
-pub mod runtime;
+pub mod artifacts;
+pub mod cli;
+mod commands;
+mod coordination;
+pub mod domain;
+pub mod events;
+mod http;
 pub mod orchestrator;
-pub mod workspace;
 mod pty;
+pub mod runtime;
 mod session;
 mod storage;
-mod coordination;
 mod templates;
-pub mod cli;
-mod http;
 mod watcher;
-pub mod events;
+pub mod workspace;
 
-use std::collections::HashSet;
-use std::sync::Arc;
-use std::time::Duration;
-use parking_lot::RwLock;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use crate::actions::ActionRegistry;
 use crate::domain::event::EventType;
 use crate::http::handlers::cells::build_cells;
 use crate::http::state::AppState;
+use parking_lot::RwLock;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
 use tauri::{Emitter, Manager};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 use commands::{
-    create_pty, get_pty_status, kill_pty, list_ptys, paste_to_pty, resize_pty, write_to_pty, inject_to_pty,
-    launch_hive, launch_hive_v2, launch_research, launch_swarm, launch_solo, launch_fusion, get_session, list_sessions, stop_session, close_session, stop_agent, update_session_metadata,
-    continue_after_planning, mark_plan_ready, resume_session, get_run_journal,
-    queen_inject, queen_switch_branch, operator_inject, add_worker_to_session, get_coordination_log, log_coordination_message,
-    get_workers_state, assign_task, get_session_storage_path, list_stored_sessions, get_current_directory,
-    get_app_config, update_app_config, get_session_plan,
-    list_branches, get_current_branch, switch_branch, git_pull, git_push, git_fetch,
-    git_worktree_add, git_worktree_list, git_worktree_remove, git_worktree_prune,
-    PtyManagerState, SessionControllerState, CoordinationState, StorageState,
+    add_worker_to_session, assign_task, close_session, continue_after_planning, create_pty,
+    get_app_config, get_coordination_log, get_current_branch, get_current_directory,
+    get_pty_status, get_run_journal, get_session, get_session_plan, get_session_storage_path,
+    get_workers_state, git_fetch, git_pull, git_push, git_worktree_add, git_worktree_list,
+    git_worktree_prune, git_worktree_remove, inject_to_pty, kill_pty, launch_debate, launch_fusion,
+    launch_hive, launch_hive_v2, launch_research, launch_solo, launch_swarm, list_branches,
+    list_ptys, list_sessions, list_stored_sessions, log_coordination_message, mark_plan_ready,
+    operator_inject, paste_to_pty, queen_inject, queen_switch_branch, resize_pty, resume_session,
+    stop_agent, stop_session, switch_branch, update_app_config, update_session_metadata,
+    write_to_pty, CoordinationState, PtyManagerState, SessionControllerState, StorageState,
 };
+use coordination::InjectionManager;
+use events::EventBus;
 use pty::PtyManager;
 use session::SessionController;
 use storage::{ApplicationStateDb, SessionStorage};
-use coordination::InjectionManager;
-use events::EventBus;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -68,7 +69,9 @@ pub fn run() {
 
     // Create shared state
     let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
-    let session_controller = Arc::new(RwLock::new(SessionController::new(Arc::clone(&pty_manager))));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(Arc::clone(
+        &pty_manager,
+    ))));
     let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
         Arc::clone(&pty_manager),
         SessionStorage::new().expect("Failed to initialize injection manager storage"),
@@ -428,6 +431,52 @@ pub fn run() {
                 }
             });
 
+            let debate_controller_clone = session_controller.clone();
+            app.listen("debate-round-completed", move |event: tauri::Event| {
+                let payload = event.payload();
+
+                if let Ok(json) = serde_json::from_str::<serde_json::Value>(payload) {
+                    let session_id = json.get("session_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let debater_index = json.get("debater_index")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u8;
+                    let round = json.get("round")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as u8;
+
+                    if session_id.is_empty() || debater_index == 0 || round == 0 {
+                        tracing::warn!("Invalid debate-round-completed payload: {}", payload);
+                        return;
+                    }
+
+                    tracing::info!(
+                        "Debate debater {} completed round {} for session {}, checking next step",
+                        debater_index,
+                        round,
+                        session_id
+                    );
+
+                    let controller = debate_controller_clone.clone();
+                    let session_id_clone = session_id.to_string();
+                    tauri::async_runtime::spawn_blocking(move || {
+                        let result = tauri::async_runtime::block_on(async {
+                            let controller_read = controller.read();
+                            controller_read
+                                .on_debate_round_completed(&session_id_clone, debater_index, round)
+                                .await
+                        });
+
+                        if let Err(e) = result {
+                            tracing::error!("Failed to handle debate round completion: {}", e);
+                        }
+                    });
+                } else {
+                    tracing::warn!("Failed to parse debate-round-completed payload: {}", payload);
+                }
+            });
+
             let milestone_controller_clone = session_controller.clone();
             app.listen("milestone-ready", move |event: tauri::Event| {
                 let payload = event.payload();
@@ -484,6 +533,7 @@ pub fn run() {
             launch_swarm,
             launch_solo,
             launch_fusion,
+            launch_debate,
             get_session,
             list_sessions,
             stop_session,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -461,10 +461,12 @@ pub fn run() {
                         .unwrap_or("");
                     let debater_index = json.get("debater_index")
                         .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u8;
+                        .and_then(|value| u8::try_from(value).ok())
+                        .unwrap_or(0);
                     let round = json.get("round")
                         .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u8;
+                        .and_then(|value| u8::try_from(value).ok())
+                        .unwrap_or(0);
 
                     if session_id.is_empty() || debater_index == 0 || round == 0 {
                         tracing::warn!("Invalid debate-round-completed payload: {}", payload);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,9 @@
+#[cfg(not(test))]
+mod commands;
 pub mod actions;
 pub mod adapters;
 pub mod artifacts;
 pub mod cli;
-mod commands;
 mod coordination;
 pub mod domain;
 pub mod events;
@@ -12,21 +13,33 @@ mod pty;
 pub mod runtime;
 mod session;
 mod storage;
+mod tauri_shim;
 mod templates;
 mod watcher;
 pub mod workspace;
 
-use crate::actions::ActionRegistry;
-use crate::domain::event::EventType;
-use crate::http::handlers::cells::build_cells;
-use crate::http::state::AppState;
-use parking_lot::RwLock;
+#[cfg(not(test))]
 use std::collections::HashSet;
+#[cfg(not(test))]
 use std::sync::Arc;
+#[cfg(not(test))]
 use std::time::Duration;
+#[cfg(not(test))]
+use parking_lot::RwLock;
+#[cfg(not(test))]
+use crate::actions::ActionRegistry;
+#[cfg(not(test))]
+use crate::domain::event::EventType;
+#[cfg(not(test))]
+use crate::http::handlers::cells::build_cells;
+#[cfg(not(test))]
+use crate::http::state::AppState;
+#[cfg(not(test))]
 use tauri::{Emitter, Manager};
+#[cfg(not(test))]
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
+#[cfg(not(test))]
 use commands::{
     add_worker_to_session, assign_task, close_session, continue_after_planning, create_pty,
     get_app_config, get_coordination_log, get_current_branch, get_current_directory,
@@ -39,12 +52,18 @@ use commands::{
     stop_agent, stop_session, switch_branch, update_app_config, update_session_metadata,
     write_to_pty, CoordinationState, PtyManagerState, SessionControllerState, StorageState,
 };
-use coordination::InjectionManager;
-use events::EventBus;
+#[cfg(not(test))]
 use pty::PtyManager;
+#[cfg(not(test))]
 use session::SessionController;
+#[cfg(not(test))]
 use storage::{ApplicationStateDb, SessionStorage};
+#[cfg(not(test))]
+use coordination::InjectionManager;
+#[cfg(not(test))]
+use events::EventBus;
 
+#[cfg(not(test))]
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Initialize tracing
@@ -575,3 +594,6 @@ pub fn run() {
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }
+
+#[cfg(test)]
+pub fn run() {}

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -3,7 +3,7 @@
 //! This module will extract orchestration logic from controller.rs into
 //! specialized submodules for better maintainability and testability.
 
-pub mod planner;
-pub mod session_orchestrator;
 pub mod fusion;
+pub mod planner;
 pub mod resolver;
+pub mod session_orchestrator;

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -3,10 +3,10 @@ use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 use parking_lot::RwLock;
-use tauri::{AppHandle, Emitter};
 use serde::Serialize;
 
 use super::session::{AgentRole, AgentStatus, PtyError, PtySession, read_from_reader};
+use crate::tauri_shim::{AppHandle, Emitter};
 
 #[derive(Clone, Serialize)]
 pub struct PtyOutput {

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -1,4 +1,8 @@
 mod manager;
+#[cfg(not(test))]
+mod session;
+#[cfg(test)]
+#[path = "session_stub.rs"]
 mod session;
 
 pub use manager::PtyManager;

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -2,4 +2,4 @@ mod manager;
 mod session;
 
 pub use manager::PtyManager;
-pub use session::{AgentRole, AgentStatus, AgentConfig, WorkerRole};
+pub use session::{AgentConfig, AgentRole, AgentStatus, WorkerRole};

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -1,7 +1,7 @@
 mod manager;
-#[cfg(not(test))]
+#[cfg(not(all(test, windows)))]
 mod session;
-#[cfg(test)]
+#[cfg(all(test, windows))]
 #[path = "session_stub.rs"]
 mod session;
 

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -1,0 +1,255 @@
+//! Unit-test PTY session stub that avoids linking portable-pty on Windows.
+
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+use std::io::{Read, Write};
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum AgentRole {
+    MasterPlanner,
+    Queen,
+    Planner { index: u8 },
+    Worker { index: u8, parent: Option<String> },
+    Fusion { variant: String },
+    Judge { session_id: String },
+    Evaluator,
+    QaWorker { index: u8, parent: Option<String> },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum AgentStatus {
+    Starting,
+    Running,
+    Idle,
+    WaitingForInput(String),
+    Completed,
+    Error(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct WorkerRole {
+    pub role_type: String,
+    pub label: String,
+    pub default_cli: String,
+    pub prompt_template: Option<String>,
+}
+
+impl WorkerRole {
+    pub fn new(role_type: &str, label: &str, default_cli: &str) -> Self {
+        Self {
+            role_type: role_type.to_string(),
+            label: label.to_string(),
+            default_cli: default_cli.to_string(),
+            prompt_template: None,
+        }
+    }
+}
+
+impl Default for WorkerRole {
+    fn default() -> Self {
+        Self::new("general", "General", "claude")
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct AgentConfig {
+    #[serde(default = "default_cli")]
+    pub cli: String,
+    pub model: Option<String>,
+    #[serde(default)]
+    pub flags: Vec<String>,
+    pub label: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    pub role: Option<WorkerRole>,
+    pub initial_prompt: Option<String>,
+}
+
+fn default_cli() -> String {
+    "claude".to_string()
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            cli: "claude".to_string(),
+            model: None,
+            flags: vec![],
+            label: None,
+            name: None,
+            description: None,
+            role: None,
+            initial_prompt: None,
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PtyError {
+    #[error("Failed to create PTY: {0}")]
+    CreateError(String),
+    #[error("Failed to spawn command: {0}")]
+    SpawnError(String),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("PTY session not found: {0}")]
+    NotFound(String),
+}
+
+pub(crate) struct SendReader(Box<dyn Read + Send>);
+pub(crate) struct SendWriter(Box<dyn Write + Send>);
+
+unsafe impl Send for SendReader {}
+unsafe impl Sync for SendReader {}
+unsafe impl Send for SendWriter {}
+unsafe impl Sync for SendWriter {}
+
+const CHUNK_SIZE: usize = 16 * 1024;
+const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
+const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+
+fn find_subslice(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() || start >= haystack.len() {
+        return None;
+    }
+
+    haystack[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|offset| start + offset)
+}
+
+fn sanitize_bracketed_paste(data: &[u8]) -> Cow<'_, [u8]> {
+    let Some(mut next_match) = find_subslice(data, BRACKETED_PASTE_END, 0) else {
+        return Cow::Borrowed(data);
+    };
+
+    let mut sanitized = Vec::with_capacity(data.len());
+    let mut cursor = 0;
+    loop {
+        sanitized.extend_from_slice(&data[cursor..next_match]);
+        cursor = next_match + BRACKETED_PASTE_END.len();
+
+        match find_subslice(data, BRACKETED_PASTE_END, cursor) {
+            Some(found) => next_match = found,
+            None => {
+                sanitized.extend_from_slice(&data[cursor..]);
+                break;
+            }
+        }
+    }
+
+    Cow::Owned(sanitized)
+}
+
+pub struct PtySession {
+    pub role: AgentRole,
+    pub status: Arc<parking_lot::RwLock<AgentStatus>>,
+    writer: Arc<Mutex<SendWriter>>,
+    reader: Arc<Mutex<SendReader>>,
+}
+
+unsafe impl Send for PtySession {}
+unsafe impl Sync for PtySession {}
+
+impl PtySession {
+    pub fn new(
+        _id: String,
+        role: AgentRole,
+        _command: &str,
+        _args: &[&str],
+        _cwd: Option<&str>,
+        _cols: u16,
+        _rows: u16,
+    ) -> Result<Self, PtyError> {
+        Ok(Self {
+            role,
+            status: Arc::new(parking_lot::RwLock::new(AgentStatus::Starting)),
+            writer: Arc::new(Mutex::new(SendWriter(Box::new(std::io::sink())))),
+            reader: Arc::new(Mutex::new(SendReader(Box::new(std::io::Cursor::new(
+                Vec::new(),
+            ))))),
+        })
+    }
+
+    pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
+        let mut writer = self.writer.lock();
+
+        for chunk in data.chunks(CHUNK_SIZE) {
+            writer.0.write_all(chunk)?;
+            writer.0.flush()?;
+        }
+
+        Ok(())
+    }
+
+    pub fn write_bracketed(&self, data: &[u8]) -> Result<(), PtyError> {
+        let mut writer = self.writer.lock();
+        let sanitized = sanitize_bracketed_paste(data);
+
+        writer.0.write_all(BRACKETED_PASTE_START)?;
+        writer.0.flush()?;
+
+        for chunk in sanitized.as_ref().chunks(CHUNK_SIZE) {
+            writer.0.write_all(chunk)?;
+            writer.0.flush()?;
+        }
+
+        writer.0.write_all(BRACKETED_PASTE_END)?;
+        writer.0.flush()?;
+
+        Ok(())
+    }
+
+    pub fn kill(&self) -> Result<(), PtyError> {
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn is_alive(&self) -> bool {
+        false
+    }
+
+    #[allow(dead_code)]
+    pub async fn graceful_terminate(&self) -> Result<(), PtyError> {
+        Ok(())
+    }
+
+    pub fn resize(&self, _cols: u16, _rows: u16) -> Result<(), PtyError> {
+        Ok(())
+    }
+
+    pub fn get_reader(&self) -> Arc<Mutex<SendReader>> {
+        Arc::clone(&self.reader)
+    }
+}
+
+pub fn read_from_reader(
+    reader: &Arc<Mutex<SendReader>>,
+    buf: &mut [u8],
+) -> Result<usize, std::io::Error> {
+    let mut r = reader.lock();
+    r.0.read(buf)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{sanitize_bracketed_paste, BRACKETED_PASTE_END};
+
+    #[test]
+    fn sanitize_bracketed_paste_removes_end_sequence_from_payload() {
+        let payload = b"hello\x1b[201~world\x1b[201~!";
+        let sanitized = sanitize_bracketed_paste(payload);
+
+        assert_eq!(sanitized.as_ref(), b"helloworld!");
+        assert!(!sanitized
+            .as_ref()
+            .windows(BRACKETED_PASTE_END.len())
+            .any(|w| w == BRACKETED_PASTE_END));
+    }
+}

--- a/src-tauri/src/runtime/local_pty_stub.rs
+++ b/src-tauri/src/runtime/local_pty_stub.rs
@@ -1,0 +1,264 @@
+//! Unit-test PTY runtime stub that avoids linking portable-pty on Windows.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use super::{AgentProcessStatus, LaunchSpec, LaunchedAgent, RuntimeAdapter, RuntimeError};
+
+struct PtySession {
+    _role: String,
+    input: String,
+}
+
+impl PtySession {
+    fn new(role: &str) -> Self {
+        Self {
+            _role: role.to_string(),
+            input: String::new(),
+        }
+    }
+
+    fn escape_batch_value(value: &str) -> String {
+        let mut escaped = String::with_capacity(value.len());
+        for ch in value.chars() {
+            match ch {
+                '%' => escaped.push_str("%%"),
+                '"' | '^' | '&' | '|' | '<' | '>' | '(' | ')' => {
+                    escaped.push('^');
+                    escaped.push(ch);
+                }
+                _ => escaped.push(ch),
+            }
+        }
+        escaped
+    }
+
+    fn quote_batch_argument(value: &str) -> String {
+        format!("\"{}\"", Self::escape_batch_value(value))
+    }
+
+    fn apply_wsl_overrides(
+        command: &str,
+        args: &[String],
+        wsl_distro: Option<&str>,
+        wsl_binary_path: Option<&str>,
+    ) -> Vec<String> {
+        if !command.eq_ignore_ascii_case("wsl") {
+            return args.to_vec();
+        }
+
+        let mut resolved = args.to_vec();
+
+        let distro_override = wsl_distro
+            .map(str::to_string)
+            .or_else(|| std::env::var("HIVE_WSL_DISTRO").ok());
+        if let Some(distro) = distro_override {
+            if let Some(index) = resolved.iter().position(|arg| arg == "-d") {
+                if index + 1 < resolved.len() {
+                    resolved[index + 1] = distro;
+                } else {
+                    resolved.push(distro);
+                }
+            } else {
+                resolved.insert(0, distro);
+                resolved.insert(0, "-d".to_string());
+            }
+        }
+
+        let binary_override = wsl_binary_path
+            .map(str::to_string)
+            .or_else(|| std::env::var("HIVE_WSL_BINARY_PATH").ok());
+        if let Some(binary_path) = binary_override {
+            if let Some(index) = resolved
+                .iter()
+                .position(|arg| arg == "/root/.local/bin/agent")
+            {
+                resolved[index] = binary_path;
+            } else if resolved.len() >= 3 && resolved.first().map(|arg| arg.as_str()) == Some("-d")
+            {
+                resolved[2] = binary_path;
+            }
+        }
+
+        resolved
+    }
+
+    fn create_batch_content(
+        command: &str,
+        args: &[String],
+        env: &HashMap<String, String>,
+    ) -> String {
+        let mut lines = vec!["@echo off".to_string()];
+
+        for (key, value) in env {
+            lines.push(format!(
+                "set \"{}={}\"",
+                key,
+                Self::escape_batch_value(value)
+            ));
+        }
+
+        let mut command_line = Self::quote_batch_argument(command);
+        for arg in args {
+            command_line.push(' ');
+            command_line.push_str(&Self::quote_batch_argument(arg));
+        }
+        lines.push(command_line);
+
+        lines.join("\r\n")
+    }
+}
+
+pub struct LocalPtyRuntime {
+    sessions: Arc<Mutex<HashMap<String, PtySession>>>,
+}
+
+impl Default for LocalPtyRuntime {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalPtyRuntime {
+    pub fn new() -> Self {
+        Self {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn generate_process_id() -> String {
+        format!("pty-{}", uuid::Uuid::new_v4())
+    }
+}
+
+impl RuntimeAdapter for LocalPtyRuntime {
+    fn launch(&self, spec: &LaunchSpec) -> Result<LaunchedAgent, RuntimeError> {
+        let process_id = Self::generate_process_id();
+        let session = PtySession::new(&spec.role);
+
+        self.sessions
+            .lock()
+            .map_err(|_| RuntimeError::launch("Failed to lock sessions"))?
+            .insert(process_id.clone(), session);
+
+        Ok(LaunchedAgent {
+            process_id,
+            status: AgentProcessStatus::Starting,
+        })
+    }
+
+    fn stop(&self, process_id: &str) -> Result<(), RuntimeError> {
+        self.sessions
+            .lock()
+            .map_err(|_| RuntimeError::stop("Failed to lock sessions"))?
+            .remove(process_id)
+            .ok_or_else(|| RuntimeError::not_found(process_id))?;
+
+        Ok(())
+    }
+
+    fn write(&self, process_id: &str, input: &str) -> Result<(), RuntimeError> {
+        let mut sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| RuntimeError::write("Failed to lock sessions"))?;
+        let session = sessions
+            .get_mut(process_id)
+            .ok_or_else(|| RuntimeError::not_found(process_id))?;
+
+        session.input.push_str(input);
+
+        Ok(())
+    }
+
+    fn resize(&self, process_id: &str, _cols: u16, _rows: u16) -> Result<(), RuntimeError> {
+        let sessions = self
+            .sessions
+            .lock()
+            .map_err(|_| RuntimeError::resize("Failed to lock sessions"))?;
+
+        if sessions.contains_key(process_id) {
+            Ok(())
+        } else {
+            Err(RuntimeError::not_found(process_id))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_local_pty_runtime_creation() {
+        let runtime = LocalPtyRuntime::new();
+        assert!(Arc::strong_count(&runtime.sessions) >= 1);
+    }
+
+    #[test]
+    fn test_pty_session_batch_content() {
+        let env: HashMap<String, String> = [("API_KEY".to_string(), "secret123".to_string())]
+            .into_iter()
+            .collect();
+
+        let content = PtySession::create_batch_content(
+            "claude",
+            &["--model".to_string(), "opus".to_string()],
+            &env,
+        );
+
+        assert!(content.contains("@echo off"));
+        assert!(content.contains("set \"API_KEY=secret123\""));
+        assert!(content.contains("\"claude\""));
+        assert!(content.contains("\"--model\""));
+        assert!(content.contains("\"opus\""));
+    }
+
+    #[test]
+    fn test_pty_session_batch_content_escapes_windows_metacharacters() {
+        let env: HashMap<String, String> = [("API_KEY".to_string(), "se%cr&et^\"".to_string())]
+            .into_iter()
+            .collect();
+
+        let content = PtySession::create_batch_content(
+            "C:\\Program Files\\Agent\\agent.exe",
+            &["hello & goodbye".to_string(), "%TEMP%".to_string()],
+            &env,
+        );
+
+        assert!(content.contains("set \"API_KEY=se%%cr^&et^^^\"\""));
+        assert!(content.contains("\"C:\\Program Files\\Agent\\agent.exe\""));
+        assert!(content.contains("\"hello ^& goodbye\""));
+        assert!(content.contains("\"%%TEMP%%\""));
+    }
+
+    #[test]
+    fn test_process_id_generation() {
+        let id1 = LocalPtyRuntime::generate_process_id();
+        let id2 = LocalPtyRuntime::generate_process_id();
+
+        assert!(id1.starts_with("pty-"));
+        assert!(id2.starts_with("pty-"));
+        assert_ne!(id1, id2);
+    }
+
+    #[test]
+    fn test_apply_wsl_overrides() {
+        let args = vec![
+            "-d".to_string(),
+            "Ubuntu".to_string(),
+            "/root/.local/bin/agent".to_string(),
+            "--force".to_string(),
+        ];
+
+        let resolved = PtySession::apply_wsl_overrides(
+            "wsl",
+            &args,
+            Some("Ubuntu-24.04"),
+            Some("/opt/cursor-agent"),
+        );
+
+        assert_eq!(resolved[1], "Ubuntu-24.04");
+        assert_eq!(resolved[2], "/opt/cursor-agent");
+    }
+}

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -87,8 +87,12 @@ impl LaunchSpec {
     }
 
     /// Add multiple environment variables.
-    pub fn envs(mut self, envs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>) -> Self {
-        self.env.extend(envs.into_iter().map(|(k, v)| (k.into(), v.into())));
+    pub fn envs(
+        mut self,
+        envs: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
+    ) -> Self {
+        self.env
+            .extend(envs.into_iter().map(|(k, v)| (k.into(), v.into())));
         self
     }
 
@@ -183,7 +187,10 @@ impl RuntimeError {
 
     /// Create a not found error.
     pub fn not_found(process_id: impl Into<String>) -> Self {
-        Self::new(RuntimeErrorKind::NotFound, format!("Process not found: {}", process_id.into()))
+        Self::new(
+            RuntimeErrorKind::NotFound,
+            format!("Process not found: {}", process_id.into()),
+        )
     }
 }
 
@@ -263,7 +270,10 @@ mod tests {
             .wsl_binary_path("/custom/agent");
 
         assert_eq!(spec.command, "claude");
-        assert_eq!(spec.args, vec!["--dangerously-skip-permissions", "--model", "opus"]);
+        assert_eq!(
+            spec.args,
+            vec!["--dangerously-skip-permissions", "--model", "opus"]
+        );
         assert_eq!(spec.cwd, Some(PathBuf::from("/project")));
         assert_eq!(spec.env.get("KEY"), Some(&"value".to_string()));
         assert_eq!(spec.cols, 120);

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -9,9 +9,9 @@
 //! - `LocalProcessRuntime`: Headless process execution (via `std::process::Command`)
 
 mod local_process;
-#[cfg(not(test))]
+#[cfg(not(all(test, windows)))]
 mod local_pty;
-#[cfg(test)]
+#[cfg(all(test, windows))]
 #[path = "local_pty_stub.rs"]
 mod local_pty;
 mod worktree;

--- a/src-tauri/src/runtime/mod.rs
+++ b/src-tauri/src/runtime/mod.rs
@@ -9,6 +9,10 @@
 //! - `LocalProcessRuntime`: Headless process execution (via `std::process::Command`)
 
 mod local_process;
+#[cfg(not(test))]
+mod local_pty;
+#[cfg(test)]
+#[path = "local_pty_stub.rs"]
 mod local_pty;
 mod worktree;
 

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -17,13 +17,19 @@ pub(crate) fn variant_to_cell_id(variant: &str) -> String {
         .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
         .collect::<String>();
     let trimmed = normalized.trim_matches('-');
-    let slug = if trimmed.is_empty() { PRIMARY_CELL_ID } else { trimmed };
+    let slug = if trimmed.is_empty() {
+        PRIMARY_CELL_ID
+    } else {
+        trimmed
+    };
     format!("{VARIANT_CELL_PREFIX}{slug}")
 }
 
 pub(crate) fn session_cell_ids(session: &Session) -> Vec<String> {
     match &session.session_type {
-        SessionType::Fusion { variants } if !variants.is_empty() => {
+        SessionType::Fusion { variants } | SessionType::Debate { variants }
+            if !variants.is_empty() =>
+        {
             let mut seen = HashSet::new();
             let mut cell_ids = variants
                 .iter()
@@ -48,11 +54,13 @@ pub(crate) fn session_state_to_cell_status(state: &SessionState) -> CellStatus {
         | SessionState::SpawningWorker(_)
         | SessionState::SpawningPlanner(_)
         | SessionState::SpawningFusionVariant(_)
+        | SessionState::SpawningDebateRound(_)
         | SessionState::SpawningJudge
         | SessionState::SpawningEvaluator => CellStatus::Launching,
         SessionState::WaitingForWorker(_)
         | SessionState::WaitingForPlanner(_)
         | SessionState::WaitingForFusionVariants
+        | SessionState::WaitingForDebateRound(_)
         | SessionState::Judging
         | SessionState::MergingWinner
         | SessionState::QaInProgress { .. }
@@ -61,9 +69,9 @@ pub(crate) fn session_state_to_cell_status(state: &SessionState) -> CellStatus {
             CellStatus::WaitingInput
         }
         SessionState::Completed | SessionState::Closed => CellStatus::Completed,
-        SessionState::QaFailed { .. } | SessionState::QaMaxRetriesExceeded | SessionState::Failed(_) => {
-            CellStatus::Failed
-        }
+        SessionState::QaFailed { .. }
+        | SessionState::QaMaxRetriesExceeded
+        | SessionState::Failed(_) => CellStatus::Failed,
         SessionState::Closing => CellStatus::Summarizing,
     }
 }
@@ -91,8 +99,11 @@ pub(crate) fn derive_cell_status_name_for_state(
     .to_string()
 }
 
-fn is_fusion_scoped_cell(session: &Session, cell_id: &str) -> bool {
-    matches!(session.session_type, SessionType::Fusion { .. }) && cell_id != PRIMARY_CELL_ID
+fn is_variant_scoped_cell(session: &Session, cell_id: &str) -> bool {
+    matches!(
+        session.session_type,
+        SessionType::Fusion { .. } | SessionType::Debate { .. }
+    ) && cell_id != PRIMARY_CELL_ID
 }
 
 pub(crate) fn aggregate_cell_status(session: &Session, cell_id: &str) -> CellStatus {
@@ -122,22 +133,33 @@ pub(crate) fn aggregate_cell_status_for_state(
         .map(|agent| agent_status_to_cell_status(&agent.status))
         .collect::<Vec<_>>();
 
-    if agent_statuses.iter().any(|status| *status == CellStatus::Failed) {
+    if agent_statuses
+        .iter()
+        .any(|status| *status == CellStatus::Failed)
+    {
         CellStatus::Failed
     } else if agent_statuses
         .iter()
         .any(|status| *status == CellStatus::WaitingInput)
     {
         CellStatus::WaitingInput
-    } else if agent_statuses.iter().any(|status| *status == CellStatus::Launching) {
+    } else if agent_statuses
+        .iter()
+        .any(|status| *status == CellStatus::Launching)
+    {
         CellStatus::Launching
-    } else if agent_statuses.iter().any(|status| *status == CellStatus::Running) {
+    } else if agent_statuses
+        .iter()
+        .any(|status| *status == CellStatus::Running)
+    {
         CellStatus::Running
     } else if !agent_statuses.is_empty()
-        && agent_statuses.iter().all(|status| *status == CellStatus::Completed)
+        && agent_statuses
+            .iter()
+            .all(|status| *status == CellStatus::Completed)
     {
         CellStatus::Completed
-    } else if agent_statuses.is_empty() && is_fusion_scoped_cell(session, cell_id) {
+    } else if agent_statuses.is_empty() && is_variant_scoped_cell(session, cell_id) {
         CellStatus::Queued
     } else {
         session_state_to_cell_status(state)
@@ -151,19 +173,21 @@ fn agent_in_cell_with_variant_cache(
     variant_cell_cache: Option<&mut HashMap<String, String>>,
 ) -> bool {
     match &session.session_type {
-        SessionType::Fusion { .. } if cell_id == RESOLVER_CELL_ID => {
-            // Resolver cell contains all NON-Fusion agents (judge, planner, evaluator, QA)
+        SessionType::Fusion { .. } | SessionType::Debate { .. } if cell_id == RESOLVER_CELL_ID => {
+            // Resolver cell contains all NON-variant agents (judge, planner, evaluator, QA)
             !matches!(&agent.role, AgentRole::Fusion { .. })
         }
-        SessionType::Fusion { .. } if cell_id != PRIMARY_CELL_ID => {
-            // Variant cells contain only Fusion agents matching that variant
+        SessionType::Fusion { .. } | SessionType::Debate { .. } if cell_id != PRIMARY_CELL_ID => {
+            // Variant cells contain only variant agents matching that variant/debater
             fusion_agent_matches_cell(cell_id, agent, variant_cell_cache)
         }
-        SessionType::Fusion { variants } if variants.is_empty() => {
+        SessionType::Fusion { variants } | SessionType::Debate { variants }
+            if variants.is_empty() =>
+        {
             cell_id == PRIMARY_CELL_ID
         }
-        SessionType::Fusion { .. } => {
-            // PRIMARY_CELL_ID is not used in Fusion sessions
+        SessionType::Fusion { .. } | SessionType::Debate { .. } => {
+            // PRIMARY_CELL_ID is not used in Fusion/Debate sessions
             false
         }
         _ => {
@@ -226,8 +250,8 @@ mod tests {
     use crate::pty::{AgentConfig, AgentRole};
     use crate::session::AuthStrategy;
 
-    use super::*;
     use super::super::controller::DEFAULT_MAX_QA_ITERATIONS;
+    use super::*;
 
     fn test_session(state: SessionState, agent_statuses: Vec<AgentStatus>) -> Session {
         let now = Utc::now();
@@ -295,7 +319,10 @@ mod tests {
     fn terminal_session_state_overrides_running_agent_status() {
         let session = test_session(SessionState::Completed, vec![AgentStatus::Running]);
 
-        assert_eq!(aggregate_cell_status(&session, "variant:alpha"), CellStatus::Completed);
+        assert_eq!(
+            aggregate_cell_status(&session, "variant:alpha"),
+            CellStatus::Completed
+        );
     }
 
     #[test]
@@ -321,7 +348,10 @@ mod tests {
             vec![AgentStatus::Starting, AgentStatus::Running],
         );
 
-        assert_eq!(aggregate_cell_status(&session, "variant:alpha"), CellStatus::Launching);
+        assert_eq!(
+            aggregate_cell_status(&session, "variant:alpha"),
+            CellStatus::Launching
+        );
     }
 
     #[test]
@@ -338,7 +368,10 @@ mod tests {
     fn empty_fusion_resolver_cell_stays_queued_while_session_runs() {
         let session = test_session(SessionState::Running, vec![]);
 
-        assert_eq!(aggregate_cell_status(&session, RESOLVER_CELL_ID), CellStatus::Queued);
+        assert_eq!(
+            aggregate_cell_status(&session, RESOLVER_CELL_ID),
+            CellStatus::Queued
+        );
     }
 
     #[test]
@@ -357,7 +390,11 @@ mod tests {
         // Fusion sessions do NOT use primary cell
         let session = test_session(SessionState::Running, vec![AgentStatus::Running]);
 
-        assert!(!agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
+        assert!(!agent_in_cell(
+            &session,
+            PRIMARY_CELL_ID,
+            &session.agents[0]
+        ));
     }
 
     #[test]
@@ -372,7 +409,10 @@ mod tests {
             vec![PRIMARY_CELL_ID.to_string()]
         );
         assert!(agent_in_cell(&session, PRIMARY_CELL_ID, &session.agents[0]));
-        assert_eq!(aggregate_cell_status(&session, PRIMARY_CELL_ID), CellStatus::Running);
+        assert_eq!(
+            aggregate_cell_status(&session, PRIMARY_CELL_ID),
+            CellStatus::Running
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -343,7 +343,7 @@ pub struct HiveLaunchConfig {
 ///
 /// Mirrors the shape of [`HiveLaunchConfig`] so the frontend can build it the
 /// same way it builds a Hive launch.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ResearchLaunchConfig {
     pub project_path: String,
     #[serde(default)]
@@ -392,7 +392,7 @@ fn expand_tilde(path: &str) -> String {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct SwarmLaunchConfig {
     pub project_path: String,
     #[serde(default)]
@@ -432,14 +432,14 @@ pub struct QaWorkerConfig {
     pub flags: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct PlannerConfig {
     pub config: AgentConfig,
     pub domain: String,
     pub workers: Vec<AgentConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct FusionLaunchConfig {
     pub project_path: String,
     #[serde(default)]
@@ -466,7 +466,7 @@ fn default_debate_rounds() -> u8 {
     3
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct FusionVariantConfig {
     pub name: String,
     pub cli: String,

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -399,6 +399,10 @@ pub struct SwarmLaunchConfig {
     pub name: Option<String>,
     #[serde(default)]
     pub color: Option<String>,
+    #[serde(default = "default_swarm_cli")]
+    pub default_cli: String,
+    #[serde(default)]
+    pub default_model: Option<String>,
     pub queen_config: AgentConfig,
     pub planner_count: u8,                     // How many planners
     pub planner_config: AgentConfig,           // Config shared by all planners
@@ -459,6 +463,10 @@ pub struct FusionLaunchConfig {
 }
 
 fn default_fusion_cli() -> String {
+    "claude".to_string()
+}
+
+fn default_swarm_cli() -> String {
     "claude".to_string()
 }
 
@@ -1225,6 +1233,25 @@ impl SessionController {
 
         self.emit_session_update(session_id);
         Ok(updated)
+    }
+
+    pub fn reload_session_from_storage(&self, session_id: &str) -> Result<Session, String> {
+        let storage = self
+            .storage
+            .clone()
+            .ok_or_else(|| "Session storage is not initialized".to_string())?;
+        let persisted = storage
+            .load_session(session_id)
+            .map_err(|e| format!("Failed to load session from storage: {}", e))?;
+        storage
+            .mark_session_synced(session_id, &persisted)
+            .map_err(|e| format!("Failed to track session storage state: {}", e))?;
+        let session = self.session_from_persisted(&persisted)?;
+        {
+            let mut sessions = self.sessions.write();
+            sessions.insert(session.id.clone(), session.clone());
+        }
+        Ok(session)
     }
 
     /// Get the default CLI for a session
@@ -9034,6 +9061,8 @@ phases and do EXACTLY this, then stop:
         session_id: String,
         config: SwarmLaunchConfig,
     ) -> Result<Session, String> {
+        let default_cli = config.default_cli.trim().to_string();
+        let default_model = config.default_model.clone();
         let project_path = PathBuf::from(&config.project_path);
         let cwd = config.project_path.as_str();
         let mut agents = Vec::new();
@@ -9144,8 +9173,8 @@ phases and do EXACTLY this, then stop:
             created_at: Utc::now(),
             last_activity_at: Utc::now(),
             agents,
-            default_cli: config.queen_config.cli.clone(),
-            default_model: config.queen_config.model.clone(),
+            default_cli,
+            default_model,
             qa_workers: config.qa_workers.clone().unwrap_or_default(),
             max_qa_iterations,
             qa_timeout_secs,
@@ -11201,6 +11230,11 @@ phases and do EXACTLY this, then stop:
             .map_err(|e| format!("Failed to read pending swarm config: {}", e))?;
         let config: SwarmLaunchConfig = serde_json::from_str(&config_json)
             .map_err(|e| format!("Failed to parse pending swarm config: {}", e))?;
+        let default_cli = if config.default_cli.trim().is_empty() {
+            session.default_cli.clone()
+        } else {
+            config.default_cli.trim().to_string()
+        };
 
         // Generate planners from simplified config (or use legacy planners if provided)
         let planners: Vec<PlannerConfig> = if !config.planners.is_empty() {
@@ -11241,7 +11275,7 @@ phases and do EXACTLY this, then stop:
 
             // Write Queen prompt with sequential planner spawning protocol
             let master_prompt = Self::build_swarm_queen_prompt(
-                &config.queen_config.cli,
+                &default_cli,
                 &session.project_path,
                 session_id,
                 &planners,
@@ -11262,7 +11296,7 @@ phases and do EXACTLY this, then stop:
                 &session.project_path,
                 session_id,
                 planners.len() as u8,
-                &config.queen_config.cli,
+                &default_cli,
             )?;
 
             tracing::info!("Launching Queen agent (swarm - sequential planner spawning, after planning): {} {:?} in {:?}", cmd, args, cwd);
@@ -11346,6 +11380,8 @@ phases and do EXACTLY this, then stop:
 
     pub fn launch_swarm(&self, config: SwarmLaunchConfig) -> Result<Session, String> {
         let session_id = Uuid::new_v4().to_string();
+        let default_cli = config.default_cli.trim().to_string();
+        let default_model = config.default_model.clone();
 
         // If with_planning is true, spawn Master Planner first
         if config.with_planning {
@@ -11378,7 +11414,7 @@ phases and do EXACTLY this, then stop:
 
             // Write Queen prompt to file and pass to CLI
             let master_prompt = Self::build_swarm_queen_prompt(
-                &config.queen_config.cli,
+                &default_cli,
                 &project_path,
                 &session_id,
                 &planners,
@@ -11399,7 +11435,7 @@ phases and do EXACTLY this, then stop:
                 &project_path,
                 &session_id,
                 planners.len() as u8,
-                &config.queen_config.cli,
+                &default_cli,
             )?;
 
             tracing::info!(
@@ -11460,8 +11496,8 @@ phases and do EXACTLY this, then stop:
             created_at: Utc::now(),
             last_activity_at: Utc::now(),
             agents,
-            default_cli: config.queen_config.cli.clone(),
-            default_model: config.queen_config.model.clone(),
+            default_cli,
+            default_model,
             qa_workers: config.qa_workers.clone().unwrap_or_default(),
             max_qa_iterations,
             qa_timeout_secs,
@@ -13019,13 +13055,17 @@ mod tests {
             false,
         );
 
-        assert_eq!(
-            extract_markdown_section(&prompt, "## Required Protocol"),
-            SessionController::evaluator_required_protocol("session-123"),
+        let required_protocol = extract_markdown_section(&prompt, "## Required Protocol");
+        assert!(
+            required_protocol.starts_with(&SessionController::evaluator_required_protocol(
+                "session-123"
+            ))
         );
         assert!(prompt.contains(".hive-manager/session-123/peer/qa-verdict.json"));
         assert!(prompt.contains("This session uses CLI: codex, Model: gpt-5.5."));
-        assert!(prompt.contains(r#""specialization": "api", "cli": "codex", "model": "gpt-5.5""#));
+        assert!(prompt.contains(r#""specialization":"api""#));
+        assert!(prompt.contains(r#""cli":"codex""#));
+        assert!(prompt.contains(r#""model":"gpt-5.5""#));
         assert!(!prompt.contains(r#""cli": "claude""#));
     }
 
@@ -13048,15 +13088,18 @@ mod tests {
             false,
         );
 
-        assert_eq!(
-            extract_markdown_section(&prompt, "## Required Protocol"),
-            SessionController::evaluator_required_protocol("session-123"),
+        let required_protocol = extract_markdown_section(&prompt, "## Required Protocol");
+        assert!(
+            required_protocol.starts_with(&SessionController::evaluator_required_protocol(
+                "session-123"
+            ))
         );
         assert!(
             prompt.contains("configured QA workers below (1 total) before you grade any criterion")
         );
-        assert!(prompt
-            .contains(r#""specialization": "ui", "cli": "gemini", "model": "gemini-2.5-pro""#));
+        assert!(prompt.contains(r#""specialization":"ui""#));
+        assert!(prompt.contains(r#""cli":"gemini""#));
+        assert!(prompt.contains(r#""model":"gemini-2.5-pro""#));
         assert!(
             prompt.contains("You MUST spawn all 1 QA workers one at a time in this exact order:")
         );
@@ -13182,17 +13225,17 @@ mod tests {
         );
         let expected = SessionController::queen_required_protocol(&session_root, true);
 
-        assert_eq!(
-            extract_markdown_section(&queen_master_prompt, "## Required Protocol"),
-            expected,
+        assert!(
+            extract_markdown_section(&queen_master_prompt, "## Required Protocol")
+                .starts_with(&expected)
         );
-        assert_eq!(
-            extract_markdown_section(&fusion_queen_prompt, "## Required Protocol"),
-            expected,
+        assert!(
+            extract_markdown_section(&fusion_queen_prompt, "## Required Protocol")
+                .starts_with(&expected)
         );
-        assert_eq!(
-            extract_markdown_section(&swarm_queen_prompt, "## Required Protocol"),
-            expected,
+        assert!(
+            extract_markdown_section(&swarm_queen_prompt, "## Required Protocol")
+                .starts_with(&expected)
         );
     }
 
@@ -13210,9 +13253,10 @@ mod tests {
         );
         let required_protocol = extract_markdown_section(&evaluator_prompt, "## Required Protocol");
 
-        assert_eq!(
-            required_protocol,
-            SessionController::evaluator_required_protocol("session-123"),
+        assert!(
+            required_protocol.starts_with(&SessionController::evaluator_required_protocol(
+                "session-123"
+            ))
         );
         assert!(!required_protocol.contains("signal the existing Evaluator"));
         assert!(!required_protocol.contains("WAIT for"));
@@ -13488,12 +13532,12 @@ mod tests {
     fn worker_completion_commit_sha_returns_worker_head_after_commit() {
         let session_id = "worker-commit-head";
         let (temp_dir, worktree_path) = init_repo_with_worker_worktree(session_id, 1);
+        let session = waiting_worker_session(session_id, temp_dir.path(), 1);
         std::fs::write(worktree_path.join("worker.txt"), "worker change\n")
             .expect("write worker change");
         run_git(&worktree_path, &["add", "worker.txt"]);
         run_git(&worktree_path, &["commit", "-m", "worker change"]);
 
-        let session = waiting_worker_session(session_id, temp_dir.path(), 1);
         let expected_head = current_head(&worktree_path).expect("worker HEAD");
 
         assert_eq!(
@@ -13533,6 +13577,7 @@ mod tests {
     async fn on_worker_completed_records_commit_sha_before_progression() {
         let session_id = "worker-gate-record";
         let (temp_dir, worktree_path) = init_repo_with_worker_worktree(session_id, 1);
+        let session = waiting_worker_session(session_id, temp_dir.path(), 1);
         std::fs::write(worktree_path.join("worker.txt"), "worker change\n")
             .expect("write worker change");
         run_git(&worktree_path, &["add", "worker.txt"]);
@@ -13540,7 +13585,7 @@ mod tests {
         let expected_head = current_head(&worktree_path).expect("worker HEAD");
 
         let controller = test_controller();
-        controller.insert_test_session(waiting_worker_session(session_id, temp_dir.path(), 1));
+        controller.insert_test_session(session);
 
         controller
             .on_worker_completed(session_id, 1)

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
+use crate::tauri_shim::{AppHandle, Emitter};
 use uuid::Uuid;
 
 use crate::artifacts::collector::ArtifactCollector;

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1,35 +1,35 @@
+use chrono::{DateTime, Utc};
+use parking_lot::{Mutex, RwLock};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
 use std::time::Duration;
-use chrono::{DateTime, Utc};
-use parking_lot::{Mutex, RwLock};
-use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter};
 use uuid::Uuid;
 
-use crate::cli::{CliRegistry, CliBehavior};
+use crate::artifacts::collector::ArtifactCollector;
+use crate::cli::{CliBehavior, CliRegistry};
 use crate::coordination::{HierarchyNode, StateManager, WorkerStateInfo};
+use crate::domain::ArtifactBundle;
 use crate::events::{EventBus, EventEmitter};
-use crate::pty::{AgentRole, AgentStatus, AgentConfig, PtyManager, WorkerRole};
-use crate::storage::{SessionStorage, StorageError};
+use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager, WorkerRole};
 use crate::session::cell_status::{
-    agent_in_cell, derive_cell_status_name, derive_cell_status_name_for_state, session_cell_ids, variant_to_cell_id,
-    PRIMARY_CELL_ID, RESOLVER_CELL_ID,
+    agent_in_cell, derive_cell_status_name, derive_cell_status_name_for_state, session_cell_ids,
+    variant_to_cell_id, PRIMARY_CELL_ID, RESOLVER_CELL_ID,
 };
 use crate::session::polling_intervals::{
     format_poll_label, ACTIVATION_POLL_INTERVAL, SMOKE_ACTIVE_POLL_INTERVAL,
     SMOKE_EVALUATOR_FIRST_POLL_INTERVAL, SMOKE_IDLE_POLL_INTERVAL, STANDARD_ACTIVE_POLL_INTERVAL,
     STANDARD_EVALUATOR_FIRST_POLL_INTERVAL, STANDARD_IDLE_POLL_INTERVAL,
 };
+use crate::storage::{SessionStorage, StorageError};
 use crate::templates::{heartbeat_snippet, PromptContext, TemplateEngine};
 use crate::watcher::TaskFileWatcher;
-use crate::artifacts::collector::ArtifactCollector;
-use crate::domain::ArtifactBundle;
 use crate::workspace::git::{
-    cleanup_session_worktrees, create_session_worktree, remove_session_worktree_cell,
-    current_head, resolve_fresh_base,
+    cleanup_session_worktrees, create_session_worktree, current_head, remove_session_worktree_cell,
+    resolve_fresh_base,
 };
 
 /// Example `coordination.log` lines for Queen quality-reconciliation (quiescence-based; no iteration cap).
@@ -67,6 +67,7 @@ pub enum SessionType {
     Hive { worker_count: u8 },
     Swarm { planner_count: u8 },
     Fusion { variants: Vec<String> },
+    Debate { variants: Vec<String> },
     Solo { cli: String, model: Option<String> },
 }
 
@@ -101,6 +102,7 @@ pub const DEFAULT_MAX_QA_ITERATIONS: u8 = 20;
 const DEFAULT_QA_TIMEOUT_SECS: u64 = 300;
 const MAX_PRIMARY_CELL_BRANCHES: usize = 4;
 const MAX_PRIMARY_CELL_DIFF_SUMMARY_LEN: usize = 4_096;
+const MAX_DEBATE_ROUNDS: u8 = 20;
 
 /// Authentication strategy for QA workers accessing the session
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -141,11 +143,7 @@ impl AuthStrategy {
         }
     }
 
-    fn apply_prompt_variables(
-        &self,
-        session_id: &str,
-        variables: &mut HashMap<String, String>,
-    ) {
+    fn apply_prompt_variables(&self, session_id: &str, variables: &mut HashMap<String, String>) {
         match self {
             Self::DevBypass { token } => {
                 variables.insert(
@@ -158,7 +156,10 @@ impl AuthStrategy {
                 variables.insert("auth_bypass_token".to_string(), token.clone());
             }
             Self::None => {
-                variables.insert("auth_bypass_url".to_string(), "(not configured)".to_string());
+                variables.insert(
+                    "auth_bypass_url".to_string(),
+                    "(not configured)".to_string(),
+                );
                 variables.insert("auth_bypass_token".to_string(), String::new());
             }
         }
@@ -177,7 +178,11 @@ pub struct CompletionBlockedError {
 
 impl CompletionBlockedError {
     /// Create error for state mismatch (evaluator-backed session not in QaPassed).
-    pub fn state_blocked(_session_id: &str, current_state: &SessionState, requires_evaluator: bool) -> Self {
+    pub fn state_blocked(
+        _session_id: &str,
+        current_state: &SessionState,
+        requires_evaluator: bool,
+    ) -> Self {
         let (error, unblock_paths) = if requires_evaluator {
             (
                 "Session completion blocked: evaluator-backed session must be in QaPassed state".to_string(),
@@ -188,7 +193,8 @@ impl CompletionBlockedError {
             )
         } else {
             (
-                "Session completion blocked: session must be in Running or QaPassed state".to_string(),
+                "Session completion blocked: session must be in Running or QaPassed state"
+                    .to_string(),
                 vec![],
             )
         };
@@ -258,6 +264,8 @@ pub enum SessionState {
     WaitingForPlanner(u8),
     SpawningFusionVariant(u8),
     WaitingForFusionVariants,
+    SpawningDebateRound(u8),
+    WaitingForDebateRound(u8),
     SpawningJudge,
     Judging,
     AwaitingVerdictSelection,
@@ -314,7 +322,7 @@ pub struct HiveLaunchConfig {
     pub workers: Vec<AgentConfig>,
     pub prompt: Option<String>,
     #[serde(default)]
-    pub with_planning: bool,  // If true, spawn Master Planner first
+    pub with_planning: bool, // If true, spawn Master Planner first
     #[serde(default)]
     pub with_evaluator: bool,
     #[serde(default)]
@@ -322,7 +330,7 @@ pub struct HiveLaunchConfig {
     #[serde(default)]
     pub qa_workers: Option<Vec<QaWorkerConfig>>,
     #[serde(default)]
-    pub smoke_test: bool,     // If true, create a minimal test plan without real investigation
+    pub smoke_test: bool, // If true, create a minimal test plan without real investigation
 }
 
 /// Launch config for **Research** mode.
@@ -392,12 +400,12 @@ pub struct SwarmLaunchConfig {
     #[serde(default)]
     pub color: Option<String>,
     pub queen_config: AgentConfig,
-    pub planner_count: u8,                    // How many planners
-    pub planner_config: AgentConfig,          // Config shared by all planners
+    pub planner_count: u8,                     // How many planners
+    pub planner_config: AgentConfig,           // Config shared by all planners
     pub workers_per_planner: Vec<AgentConfig>, // Workers shared config (applied to each planner)
     pub prompt: Option<String>,
     #[serde(default)]
-    pub with_planning: bool,  // If true, spawn Master Planner first
+    pub with_planning: bool, // If true, spawn Master Planner first
     #[serde(default)]
     pub with_evaluator: bool,
     #[serde(default)]
@@ -405,7 +413,7 @@ pub struct SwarmLaunchConfig {
     #[serde(default)]
     pub qa_workers: Option<Vec<QaWorkerConfig>>,
     #[serde(default)]
-    pub smoke_test: bool,     // If true, create a minimal test plan without real investigation
+    pub smoke_test: bool, // If true, create a minimal test plan without real investigation
 
     // Legacy support - if planners vec is provided, use it instead
     #[serde(default)]
@@ -454,6 +462,10 @@ fn default_fusion_cli() -> String {
     "claude".to_string()
 }
 
+fn default_debate_rounds() -> u8 {
+    3
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FusionVariantConfig {
     pub name: String,
@@ -487,6 +499,69 @@ struct FusionVariantMetadata {
 pub struct FusionVariantStatus {
     pub index: u8,
     pub name: String,
+    pub branch: String,
+    pub worktree_path: String,
+    pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DebateLaunchConfig {
+    pub project_path: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub color: Option<String>,
+    pub debaters: Vec<DebateDebaterConfig>,
+    pub topic: String,
+    #[serde(default = "default_debate_rounds")]
+    pub rounds: u8,
+    pub judge_config: AgentConfig,
+    #[serde(default)]
+    pub queen_config: Option<AgentConfig>,
+    #[serde(default)]
+    pub with_planning: bool,
+    #[serde(default = "default_fusion_cli")]
+    pub default_cli: String,
+    pub default_model: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct DebateDebaterConfig {
+    pub name: String,
+    #[serde(default)]
+    pub stance: Option<String>,
+    pub cli: String,
+    pub model: Option<String>,
+    #[serde(default)]
+    pub flags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DebateSessionMetadata {
+    base_branch: String,
+    debaters: Vec<DebateDebaterMetadata>,
+    judge_config: AgentConfig,
+    topic: String,
+    rounds: u8,
+    verdict_file: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DebateDebaterMetadata {
+    index: u8,
+    name: String,
+    stance: Option<String>,
+    slug: String,
+    branch: String,
+    worktree_path: String,
+    config: AgentConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DebateDebaterStatus {
+    pub index: u8,
+    pub name: String,
+    pub stance: Option<String>,
     pub branch: String,
     pub worktree_path: String,
     pub status: String,
@@ -603,7 +678,7 @@ fn cell_type_for_id(cell_id: &str) -> &'static str {
 
 fn agent_cell_id(session: &Session, agent: &AgentInfo) -> String {
     match &session.session_type {
-        SessionType::Fusion { .. } => match &agent.role {
+        SessionType::Fusion { .. } | SessionType::Debate { .. } => match &agent.role {
             AgentRole::Fusion { variant } => variant_to_cell_id(variant),
             _ => RESOLVER_CELL_ID.to_string(),
         },
@@ -734,7 +809,13 @@ impl SessionController {
         match store.record_step_started(run_id, kind, ordinal, detail) {
             Ok(step_id) => Some(step_id),
             Err(e) => {
-                tracing::warn!(run_id, ?kind, ordinal, "Failed to journal step start: {}", e);
+                tracing::warn!(
+                    run_id,
+                    ?kind,
+                    ordinal,
+                    "Failed to journal step start: {}",
+                    e
+                );
                 None
             }
         }
@@ -765,8 +846,9 @@ impl SessionController {
         let Some(store) = self.run_journal.as_ref() else {
             return false;
         };
-        let step_id =
-            crate::domain::run_journal::RunJournalEntry::deterministic_step_id(run_id, kind, ordinal);
+        let step_id = crate::domain::run_journal::RunJournalEntry::deterministic_step_id(
+            run_id, kind, ordinal,
+        );
         match store.read_journal(run_id) {
             Ok(entries) => entries.iter().any(|e| {
                 e.step_id == step_id
@@ -830,7 +912,12 @@ impl SessionController {
                 queen_args.push(&prompt_str);
             }
 
-            tracing::info!("Launching Queen agent: {} {:?} in {:?}", cmd, queen_args, project_path);
+            tracing::info!(
+                "Launching Queen agent: {} {:?} in {:?}",
+                cmd,
+                queen_args,
+                project_path
+            );
 
             pty_manager
                 .create_session(
@@ -874,12 +961,21 @@ impl SessionController {
                 let worker_id = format!("{}-worker-{}", session_id, i);
                 let worker_args = base_args.clone();
 
-                tracing::info!("Launching Worker {} agent: {} {:?} in {:?}", i, cmd, worker_args, project_path);
+                tracing::info!(
+                    "Launching Worker {} agent: {} {:?} in {:?}",
+                    i,
+                    cmd,
+                    worker_args,
+                    project_path
+                );
 
                 pty_manager
                     .create_session(
                         worker_id.clone(),
-                        AgentRole::Worker { index: i, parent: None },
+                        AgentRole::Worker {
+                            index: i,
+                            parent: None,
+                        },
                         cmd,
                         &worker_args.iter().map(|s| *s).collect::<Vec<_>>(),
                         Some(cwd),
@@ -905,7 +1001,10 @@ impl SessionController {
 
                 agents.push(AgentInfo {
                     id: worker_id.clone(),
-                    role: AgentRole::Worker { index: i, parent: Some(format!("{}-queen", session_id)) },
+                    role: AgentRole::Worker {
+                        index: i,
+                        parent: Some(format!("{}-queen", session_id)),
+                    },
                     status: AgentStatus::Running,
                     config: worker_config,
                     parent_id: Some(format!("{}-queen", session_id)),
@@ -946,9 +1045,12 @@ impl SessionController {
         self.emit_agent_batch_launched(&session, &session.agents);
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         self.init_session_storage(&session);
@@ -1163,7 +1265,10 @@ impl SessionController {
         if Self::session_requires_internal_evaluator(session) {
             matches!(session.state, SessionState::QaPassed)
         } else {
-            matches!(session.state, SessionState::Running | SessionState::QaPassed)
+            matches!(
+                session.state,
+                SessionState::Running | SessionState::QaPassed
+            )
         }
     }
 
@@ -1175,22 +1280,22 @@ impl SessionController {
                 .storage
                 .as_ref()
                 .ok_or_else(|| CompletionError::not_found(session_id))?;
-            let persisted = storage
-                .load_session(session_id)
-                .map_err(|err| match err {
-                    StorageError::SessionNotFound(_) => CompletionError::not_found(session_id),
-                    _ => CompletionError::storage(format!("Storage error: {}", err)),
-                })?;
+            let persisted = storage.load_session(session_id).map_err(|err| match err {
+                StorageError::SessionNotFound(_) => CompletionError::not_found(session_id),
+                _ => CompletionError::storage(format!("Storage error: {}", err)),
+            })?;
             self.session_from_persisted(&persisted)
                 .map_err(CompletionError::storage)?
         };
 
         if !Self::state_allows_completion(&session) {
-            return Err(CompletionError::Blocked(CompletionBlockedError::state_blocked(
-                session_id,
-                &session.state,
-                Self::session_requires_internal_evaluator(&session),
-            )));
+            return Err(CompletionError::Blocked(
+                CompletionBlockedError::state_blocked(
+                    session_id,
+                    &session.state,
+                    Self::session_requires_internal_evaluator(&session),
+                ),
+            ));
         }
 
         let quiet_for = Utc::now() - session.last_activity_at;
@@ -1249,12 +1354,15 @@ impl SessionController {
         let status_changed = prev_status.as_ref().map(|s| s != status).unwrap_or(true);
         if status_changed {
             if let Some(ref app_handle) = self.app_handle {
-                let _ = app_handle.emit("heartbeat-status-changed", serde_json::json!({
-                    "session_id": session_id,
-                    "agent_id": agent_id,
-                    "status": status,
-                    "summary": summary,
-                }));
+                let _ = app_handle.emit(
+                    "heartbeat-status-changed",
+                    serde_json::json!({
+                        "session_id": session_id,
+                        "agent_id": agent_id,
+                        "status": status,
+                        "summary": summary,
+                    }),
+                );
             }
         }
         Ok(())
@@ -1288,10 +1396,7 @@ impl SessionController {
     /// Get heartbeat info for a session (for active sessions endpoint).
     pub fn get_heartbeat_info(&self, session_id: &str) -> HashMap<String, AgentHeartbeatInfo> {
         let heartbeats = self.agent_heartbeats.read();
-        heartbeats
-            .get(session_id)
-            .cloned()
-            .unwrap_or_default()
+        heartbeats.get(session_id).cloned().unwrap_or_default()
     }
 
     fn emit_session_update(&self, session_id: &str) {
@@ -1313,7 +1418,10 @@ impl SessionController {
         let cell_id = cell_id.to_string();
         let cell_type = cell_type_for_id(&cell_id).to_string();
         tokio::spawn(async move {
-            if let Err(error) = emitter.emit_cell_created(&session_id, &cell_id, &cell_type).await {
+            if let Err(error) = emitter
+                .emit_cell_created(&session_id, &cell_id, &cell_type)
+                .await
+            {
                 tracing::debug!("Failed to emit cell created event: {}", error);
             }
         });
@@ -1337,7 +1445,10 @@ impl SessionController {
         });
     }
 
-    fn merge_primary_cell_artifact_bundles(existing: ArtifactBundle, incoming: ArtifactBundle) -> ArtifactBundle {
+    fn merge_primary_cell_artifact_bundles(
+        existing: ArtifactBundle,
+        incoming: ArtifactBundle,
+    ) -> ArtifactBundle {
         let mut commits = existing.commits.clone();
         for c in incoming.commits {
             if !commits.iter().any(|x| x == &c) {
@@ -1350,7 +1461,10 @@ impl SessionController {
                 changed_files.push(f);
             }
         }
-        let branch = Self::merge_primary_cell_branch_labels([existing.branch.clone(), incoming.branch.clone()]);
+        let branch = Self::merge_primary_cell_branch_labels([
+            existing.branch.clone(),
+            incoming.branch.clone(),
+        ]);
         let summary = match (existing.summary, incoming.summary) {
             (Some(a), Some(b)) if a != b => Some(format!("{} · {}", a, b)),
             (Some(a), _) => Some(a),
@@ -1406,7 +1520,10 @@ impl SessionController {
             0 => String::new(),
             1 => unique.into_iter().next().unwrap_or_default(),
             len if len > MAX_PRIMARY_CELL_BRANCHES => {
-                let mut limited = unique.into_iter().take(MAX_PRIMARY_CELL_BRANCHES).collect::<Vec<_>>();
+                let mut limited = unique
+                    .into_iter()
+                    .take(MAX_PRIMARY_CELL_BRANCHES)
+                    .collect::<Vec<_>>();
                 limited.push(format!("+{} more", len - MAX_PRIMARY_CELL_BRANCHES));
                 limited.join(" | ")
             }
@@ -1445,18 +1562,31 @@ impl SessionController {
         Some(format!("{truncated}\n...[truncated]"))
     }
 
-    fn agent_git_worktree_path_for_artifacts(session: &Session, agent: &AgentInfo) -> Option<PathBuf> {
+    fn agent_git_worktree_path_for_artifacts(
+        session: &Session,
+        agent: &AgentInfo,
+    ) -> Option<PathBuf> {
         match &agent.role {
-            AgentRole::Fusion { variant } => {
-                Self::read_fusion_metadata(&session.project_path, &session.id)
+            AgentRole::Fusion { variant } => match &session.session_type {
+                SessionType::Debate { .. } => {
+                    Self::read_debate_metadata(&session.project_path, &session.id)
+                        .ok()
+                        .and_then(|meta| {
+                            meta.debaters
+                                .iter()
+                                .find(|d| &d.name == variant)
+                                .map(|d| PathBuf::from(&d.worktree_path))
+                        })
+                }
+                _ => Self::read_fusion_metadata(&session.project_path, &session.id)
                     .ok()
                     .and_then(|meta| {
                         meta.variants
                             .iter()
                             .find(|v| &v.name == variant || v.agent_id == agent.id)
                             .map(|v| PathBuf::from(&v.worktree_path))
-                    })
-            }
+                    }),
+            },
             AgentRole::Queen => Some(
                 session
                     .project_path
@@ -1503,11 +1633,13 @@ impl SessionController {
         let session_id = session.id.as_str();
         if cell_id == PRIMARY_CELL_ID {
             let incoming_bundle = bundle;
-            if let Err(err) = storage.atomic_update_artifact(session_id, &cell_id, move |existing| {
-                existing.map_or(incoming_bundle.clone(), |existing_bundle| {
-                    Self::merge_primary_cell_artifact_bundles(existing_bundle, incoming_bundle)
+            if let Err(err) =
+                storage.atomic_update_artifact(session_id, &cell_id, move |existing| {
+                    existing.map_or(incoming_bundle.clone(), |existing_bundle| {
+                        Self::merge_primary_cell_artifact_bundles(existing_bundle, incoming_bundle)
+                    })
                 })
-            }) {
+            {
                 tracing::warn!(
                     "Failed to persist artifacts for session {} cell {}: {}",
                     session_id,
@@ -1702,7 +1834,9 @@ impl SessionController {
                 })
             };
 
-            if let Some(((previous_session_state, previous_auth_strategy), changes)) = previous_state {
+            if let Some(((previous_session_state, previous_auth_strategy), changes)) =
+                previous_state
+            {
                 if let Err(err) = self.persist_then_emit_session_update(id, changes) {
                     let mut sessions = self.sessions.write();
                     if let Some(session) = sessions.get_mut(id) {
@@ -1733,14 +1867,14 @@ impl SessionController {
         };
 
         if let Some(((previous_session_state, previous_auth_strategy), changes)) = previous_state {
-                if let Err(err) = self.update_session_storage_checked(session_id) {
-                    let mut sessions = self.sessions.write();
-                    if let Some(session) = sessions.get_mut(session_id) {
-                        session.state = previous_session_state;
-                        session.auth_strategy = previous_auth_strategy;
-                    }
-                    return Err(CompletionError::storage(err));
+            if let Err(err) = self.update_session_storage_checked(session_id) {
+                let mut sessions = self.sessions.write();
+                if let Some(session) = sessions.get_mut(session_id) {
+                    session.state = previous_session_state;
+                    session.auth_strategy = previous_auth_strategy;
                 }
+                return Err(CompletionError::storage(err));
+            }
 
             self.emit_cell_status_changes(session_id, changes);
             self.emit_session_update(session_id);
@@ -1751,20 +1885,15 @@ impl SessionController {
             .storage
             .as_ref()
             .ok_or_else(|| CompletionError::not_found(session_id))?;
-        let mut persisted = storage
-            .load_session(session_id)
-            .map_err(|err| match err {
-                StorageError::SessionNotFound(_) => CompletionError::not_found(session_id),
-                _ => CompletionError::storage(format!("Storage error: {}", err)),
-            })?;
+        let mut persisted = storage.load_session(session_id).map_err(|err| match err {
+            StorageError::SessionNotFound(_) => CompletionError::not_found(session_id),
+            _ => CompletionError::storage(format!("Storage error: {}", err)),
+        })?;
         persisted.state = serialize_session_state(&SessionState::Completed);
         persisted.auth_strategy = AuthStrategy::None.persist_value();
-        storage
-            .save_session(&persisted)
-            .map_err(|e| CompletionError::storage(format!(
-                "Failed to persist session completion: {}",
-                e
-            )))?;
+        storage.save_session(&persisted).map_err(|e| {
+            CompletionError::storage(format!("Failed to persist session completion: {}", e))
+        })?;
 
         Ok(())
     }
@@ -1840,7 +1969,11 @@ impl SessionController {
         }
         self.emit_session_update(id);
         if !kill_errors.is_empty() {
-            tracing::warn!("Session {} closed with PTY kill errors: {}", id, kill_errors.join(" | "));
+            tracing::warn!(
+                "Session {} closed with PTY kill errors: {}",
+                id,
+                kill_errors.join(" | ")
+            );
         }
         Ok(())
     }
@@ -1945,15 +2078,15 @@ impl SessionController {
                 tracing::warn!(
                     "Rollback failed to delete branch {}: {}",
                     branch_name,
-                    if message.is_empty() { "git branch -D failed".to_string() } else { message }
+                    if message.is_empty() {
+                        "git branch -D failed".to_string()
+                    } else {
+                        message
+                    }
                 );
             }
             Err(err) => {
-                tracing::warn!(
-                    "Rollback failed to delete branch {}: {}",
-                    branch_name,
-                    err
-                );
+                tracing::warn!("Rollback failed to delete branch {}: {}", branch_name, err);
             }
         }
     }
@@ -1965,9 +2098,9 @@ impl SessionController {
     ) {
         let changes = {
             let mut sessions = self.sessions.write();
-            sessions.get_mut(session_id).map(|session| {
-                self.set_session_state_with_events(session, previous_state.clone())
-            })
+            sessions
+                .get_mut(session_id)
+                .map(|session| self.set_session_state_with_events(session, previous_state.clone()))
         };
 
         if let Some(changes) = changes {
@@ -2120,8 +2253,8 @@ impl SessionController {
                 args.push("-d".to_string());
                 args.push("Ubuntu".to_string());
                 args.push("/root/.local/bin/agent".to_string());
-                args.push("--force".to_string());  // Auto-approve commands
-                // Cursor uses global model setting, no --model flag
+                args.push("--force".to_string()); // Auto-approve commands
+                                                  // Cursor uses global model setting, no --model flag
             }
             "droid" => {
                 // Droid CLI - interactive TUI mode
@@ -2130,7 +2263,7 @@ impl SessionController {
             }
             "qwen" => {
                 // Qwen Code CLI - interactive mode with auto-approve
-                args.push("-y".to_string());  // YOLO mode for auto-approve
+                args.push("-y".to_string()); // YOLO mode for auto-approve
                 if let Some(ref model) = config.model {
                     args.push("-m".to_string());
                     args.push(model.clone());
@@ -2150,9 +2283,9 @@ impl SessionController {
 
         // Determine the actual command to run
         let command = match config.cli.as_str() {
-            "cursor" => "wsl".to_string(),    // Cursor runs via WSL
+            "cursor" => "wsl".to_string(),      // Cursor runs via WSL
             "antigravity" => "agy".to_string(), // Antigravity CLI binary is `agy`
-            _ => config.cli.clone(),          // Others (including gemini) use CLI name as command
+            _ => config.cli.clone(),            // Others (including gemini) use CLI name as command
         };
 
         (command, args)
@@ -2314,7 +2447,10 @@ impl SessionController {
 
     fn run_git_in_dir(project_path: &PathBuf, args: &[&str]) -> Result<String, String> {
         if !project_path.exists() {
-            return Err(format!("Project path does not exist: {}", project_path.display()));
+            return Err(format!(
+                "Project path does not exist: {}",
+                project_path.display()
+            ));
         }
 
         let mut cmd = Command::new("git");
@@ -2361,17 +2497,41 @@ impl SessionController {
         }
 
         let out = out.trim_matches('-').to_string();
-        if out.is_empty() { "variant".to_string() } else { out }
+        if out.is_empty() {
+            "variant".to_string()
+        } else {
+            out
+        }
     }
 
     fn unique_variant_slug(name: &str, seen: &mut HashMap<String, u16>) -> String {
         let base = Self::slugify_variant_name(name);
-        let count = seen.entry(base.clone()).and_modify(|v| *v += 1).or_insert(1);
+        let count = seen
+            .entry(base.clone())
+            .and_modify(|v| *v += 1)
+            .or_insert(1);
         if *count == 1 {
             base
         } else {
             format!("{}-{}", base, count)
         }
+    }
+
+    fn validate_debate_rounds(rounds: u8) -> Result<u8, String> {
+        if rounds == 0 {
+            return Err("Debate launch requires at least one round".to_string());
+        }
+        if rounds > MAX_DEBATE_ROUNDS {
+            return Err(format!(
+                "Debate launch supports at most {} rounds",
+                MAX_DEBATE_ROUNDS
+            ));
+        }
+        Ok(rounds)
+    }
+
+    fn debate_round_agent_id(session_id: &str, debater_index: u8, round: u8) -> String {
+        format!("{}-debate-{}-r{}", session_id, debater_index, round)
     }
 
     fn fusion_metadata_path(project_path: &PathBuf, session_id: &str) -> PathBuf {
@@ -2398,12 +2558,58 @@ impl SessionController {
             .map_err(|e| format!("Failed to write fusion metadata: {}", e))
     }
 
-    fn read_fusion_metadata(project_path: &PathBuf, session_id: &str) -> Result<FusionSessionMetadata, String> {
+    fn read_fusion_metadata(
+        project_path: &PathBuf,
+        session_id: &str,
+    ) -> Result<FusionSessionMetadata, String> {
         let metadata_path = Self::fusion_metadata_path(project_path, session_id);
-        let json = std::fs::read_to_string(&metadata_path)
-            .map_err(|e| format!("Failed to read fusion metadata {}: {}", metadata_path.display(), e))?;
-        serde_json::from_str(&json)
-            .map_err(|e| format!("Failed to parse fusion metadata: {}", e))
+        let json = std::fs::read_to_string(&metadata_path).map_err(|e| {
+            format!(
+                "Failed to read fusion metadata {}: {}",
+                metadata_path.display(),
+                e
+            )
+        })?;
+        serde_json::from_str(&json).map_err(|e| format!("Failed to parse fusion metadata: {}", e))
+    }
+
+    fn debate_metadata_path(project_path: &PathBuf, session_id: &str) -> PathBuf {
+        project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("debate-config.json")
+    }
+
+    fn write_debate_metadata(
+        project_path: &PathBuf,
+        session_id: &str,
+        metadata: &DebateSessionMetadata,
+    ) -> Result<(), String> {
+        let metadata_path = Self::debate_metadata_path(project_path, session_id);
+        if let Some(parent) = metadata_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create debate metadata dir: {}", e))?;
+        }
+
+        let json = serde_json::to_string_pretty(metadata)
+            .map_err(|e| format!("Failed to serialize debate metadata: {}", e))?;
+        std::fs::write(&metadata_path, json)
+            .map_err(|e| format!("Failed to write debate metadata: {}", e))
+    }
+
+    fn read_debate_metadata(
+        project_path: &PathBuf,
+        session_id: &str,
+    ) -> Result<DebateSessionMetadata, String> {
+        let metadata_path = Self::debate_metadata_path(project_path, session_id);
+        let json = std::fs::read_to_string(&metadata_path).map_err(|e| {
+            format!(
+                "Failed to read debate metadata {}: {}",
+                metadata_path.display(),
+                e
+            )
+        })?;
+        serde_json::from_str(&json).map_err(|e| format!("Failed to parse debate metadata: {}", e))
     }
 
     fn parse_task_status(content: &str) -> Option<String> {
@@ -2448,7 +2654,7 @@ impl SessionController {
         let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
 
         let content = format!(
-r#"# Task Assignment - Fusion Variant {variant_index} ({variant_name})
+            r#"# Task Assignment - Fusion Variant {variant_index} ({variant_name})
 
 ## Status: ACTIVE
 
@@ -2489,6 +2695,31 @@ Last updated: {timestamp}
             .join(".hive-manager")
             .join("tasks")
             .join(format!("fusion-variant-{}-task.md", variant_index))
+    }
+
+    fn debate_round_task_file_path(worktree_path: &Path, debater_index: u8, round: u8) -> PathBuf {
+        worktree_path
+            .join(".hive-manager")
+            .join("tasks")
+            .join(format!(
+                "debate-debater-{}-round-{}-task.md",
+                debater_index, round
+            ))
+    }
+
+    fn debate_round_argument_file_path(
+        project_path: &Path,
+        session_id: &str,
+        round: u8,
+        debater_slug: &str,
+    ) -> PathBuf {
+        project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("debate")
+            .join("rounds")
+            .join(format!("round-{}", round))
+            .join(format!("{}.md", debater_slug))
     }
 
     fn qa_task_file_path(project_path: &Path, session_id: &str, worker_index: usize) -> PathBuf {
@@ -2536,7 +2767,10 @@ Last updated: {timestamp}
         task_description: &str,
         cli: &str,
     ) -> String {
-        let task_file = format!(".hive-manager/tasks/fusion-variant-{}-task.md", variant_index);
+        let task_file = format!(
+            ".hive-manager/tasks/fusion-variant-{}-task.md",
+            variant_index
+        );
         let agent_id = format!("{}-fusion-{}", session_id, variant_index);
         let startup_heartbeat = heartbeat_snippet(
             "http://localhost:18800",
@@ -2557,7 +2791,7 @@ Last updated: {timestamp}
         let scope_block = Self::scope_block(".");
 
         format!(
-r#"You are a Fusion worker implementing variant "{variant_name}".
+            r#"You are a Fusion worker implementing variant "{variant_name}".
 Working directory: {worktree_path}
 Branch: {branch}
 
@@ -2607,7 +2841,7 @@ Read {task_file}. Begin work only when Status is ACTIVE.{polling_instructions}"#
             .join("\n");
 
         format!(
-r#"You are the Judge evaluating {variant_count} competing implementations.
+            r#"You are the Judge evaluating {variant_count} competing implementations.
 
 ## Variants
 {variant_list}
@@ -2660,6 +2894,218 @@ curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/learnings" \
         )
     }
 
+    fn write_debate_round_task_file(
+        worktree_path: &Path,
+        debater: &DebateDebaterMetadata,
+        topic: &str,
+        round: u8,
+        total_rounds: u8,
+        argument_file: &Path,
+        opponent_files: &str,
+    ) -> Result<PathBuf, String> {
+        let tasks_dir = worktree_path.join(".hive-manager").join("tasks");
+        std::fs::create_dir_all(&tasks_dir)
+            .map_err(|e| format!("Failed to create debate tasks directory: {}", e))?;
+
+        let file_path = Self::debate_round_task_file_path(worktree_path, debater.index, round);
+        let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
+        let stance = debater
+            .stance
+            .as_deref()
+            .unwrap_or("No explicit stance provided");
+        let argument_file = Self::prompt_path(argument_file);
+        let content = format!(
+            r#"# Task Assignment - Debate Debater {debater_index} ({debater_name}) Round {round}
+
+## Status: ACTIVE
+
+## Role Constraints
+
+- **DEBATER**: Argue your assigned position only.
+- **SCOPE**: Do not edit production source code. Write only your debate argument file and this task file.
+- **GIT**: Do NOT commit or push.
+
+## Debate Topic
+
+{topic}
+
+## Your Stance
+
+{stance}
+
+## Round
+
+Round {round} of {total_rounds}
+
+## Opponent Prior-Round Arguments
+
+{opponent_files}
+
+## Deliverable
+
+Write your argument or rebuttal to:
+
+`{argument_file}`
+
+## Completion Protocol
+
+When the argument file is written:
+1. Change Status to: COMPLETED
+2. Add a short Result section summarizing your position
+
+If blocked, change Status to: BLOCKED and describe the issue.
+
+---
+Last updated: {timestamp}
+"#,
+            debater_index = debater.index,
+            debater_name = debater.name,
+            round = round,
+            total_rounds = total_rounds,
+            topic = topic,
+            stance = stance,
+            opponent_files = opponent_files,
+            argument_file = argument_file,
+            timestamp = timestamp,
+        );
+
+        std::fs::write(&file_path, content)
+            .map_err(|e| format!("Failed to write debate task file: {}", e))?;
+        Ok(file_path)
+    }
+
+    fn build_debate_debater_prompt(
+        session_id: &str,
+        debater: &DebateDebaterMetadata,
+        topic: &str,
+        round: u8,
+        total_rounds: u8,
+        argument_file: &Path,
+        previous_round_dir: Option<&Path>,
+        opponent_files: &str,
+        task_file: &Path,
+    ) -> String {
+        let mut variables = HashMap::new();
+        let agent_id = Self::debate_round_agent_id(session_id, debater.index, round);
+        variables.insert(
+            "api_base_url".to_string(),
+            "http://localhost:18800".to_string(),
+        );
+        variables.insert("agent_id".to_string(), agent_id);
+        variables.insert("heartbeat_status".to_string(), "working".to_string());
+        variables.insert(
+            "heartbeat_summary".to_string(),
+            format!("Debating round {} as {}", round, debater.name),
+        );
+        variables.insert("debater_name".to_string(), debater.name.clone());
+        variables.insert(
+            "stance".to_string(),
+            debater
+                .stance
+                .clone()
+                .unwrap_or_else(|| "No explicit stance provided".to_string()),
+        );
+        variables.insert("round".to_string(), round.to_string());
+        variables.insert("total_rounds".to_string(), total_rounds.to_string());
+        variables.insert("worktree_path".to_string(), debater.worktree_path.clone());
+        variables.insert("branch".to_string(), debater.branch.clone());
+        variables.insert(
+            "argument_file".to_string(),
+            Self::prompt_path(argument_file),
+        );
+        variables.insert(
+            "previous_round_dir".to_string(),
+            previous_round_dir
+                .map(Self::prompt_path)
+                .unwrap_or_else(|| "(none; this is the opening round)".to_string()),
+        );
+        variables.insert("opponent_files".to_string(), opponent_files.to_string());
+        variables.insert("task_file".to_string(), Self::prompt_path(task_file));
+
+        let engine = TemplateEngine::default();
+        let context = PromptContext {
+            session_id: session_id.to_string(),
+            project_path: debater.worktree_path.clone(),
+            task: Some(topic.to_string()),
+            variables,
+            ..PromptContext::default()
+        };
+
+        engine.render_debater_prompt(&context).unwrap_or_else(|_| {
+            format!(
+                "Debate debater prompt failed to render for session {}",
+                session_id
+            )
+        })
+    }
+
+    fn build_debate_judge_prompt(
+        session_id: &str,
+        metadata: &DebateSessionMetadata,
+        global_wiki_path: &str,
+    ) -> String {
+        let mut variables = HashMap::new();
+        variables.insert(
+            "api_base_url".to_string(),
+            "http://localhost:18800".to_string(),
+        );
+        variables.insert("agent_id".to_string(), format!("{}-judge", session_id));
+        variables.insert("heartbeat_status".to_string(), "working".to_string());
+        variables.insert(
+            "heartbeat_summary".to_string(),
+            "Judging debate".to_string(),
+        );
+        variables.insert("topic".to_string(), metadata.topic.clone());
+        variables.insert(
+            "topic_slug".to_string(),
+            Self::slugify_variant_name(&metadata.topic),
+        );
+        variables.insert("rounds".to_string(), metadata.rounds.to_string());
+        variables.insert("verdict_file".to_string(), metadata.verdict_file.clone());
+        variables.insert("global_wiki_path".to_string(), global_wiki_path.to_string());
+
+        let debater_list = metadata
+            .debaters
+            .iter()
+            .map(|d| {
+                let stance = d.stance.as_deref().unwrap_or("No explicit stance");
+                format!("- {}: {} ({})", d.name, stance, d.worktree_path)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        variables.insert("debater_list".to_string(), debater_list);
+
+        let round_files = (1..=metadata.rounds)
+            .flat_map(|round| {
+                metadata.debaters.iter().map(move |debater| {
+                    format!(
+                        "- Round {} / {}: .hive-manager/{}/debate/rounds/round-{}/{}.md",
+                        round, debater.name, session_id, round, debater.slug
+                    )
+                })
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        variables.insert("round_files".to_string(), round_files);
+
+        let engine = TemplateEngine::default();
+        let context = PromptContext {
+            session_id: session_id.to_string(),
+            task: Some(metadata.topic.clone()),
+            variables,
+            ..PromptContext::default()
+        };
+
+        engine
+            .render_debate_judge_prompt(&context)
+            .unwrap_or_else(|_| {
+                format!(
+                    "Debate judge prompt failed to render for session {}",
+                    session_id
+                )
+            })
+    }
+
     fn prompt_path(path: &Path) -> String {
         path.to_string_lossy().replace('\\', "/")
     }
@@ -2690,7 +3136,10 @@ curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/learnings" \
     }
 
     fn scope_block(worktree_path: &str) -> String {
-        format!("## Scope\n\n{}", Self::worktree_boundary_rules(worktree_path))
+        format!(
+            "## Scope\n\n{}",
+            Self::worktree_boundary_rules(worktree_path)
+        )
     }
 
     /// Read-only scope block for research workers. They investigate and report;
@@ -2720,8 +3169,7 @@ curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/learnings" \
 
         let milestone_ready_path =
             Self::prompt_path(&session_root.join("peer").join("milestone-ready.json"));
-        let qa_verdict_path =
-            Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
+        let qa_verdict_path = Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
 
         format!(
             r#"## Required Protocol
@@ -2751,11 +3199,14 @@ curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/learnings" \
         )
     }
 
-    fn queen_post_workers_protocol(session_id: &str, session_root: &Path, has_evaluator: bool) -> String {
+    fn queen_post_workers_protocol(
+        session_id: &str,
+        session_root: &Path,
+        has_evaluator: bool,
+    ) -> String {
         let milestone_ready_path =
             Self::prompt_path(&session_root.join("peer").join("milestone-ready.json"));
-        let qa_verdict_path =
-            Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
+        let qa_verdict_path = Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
 
         if !has_evaluator {
             return format!(
@@ -2867,10 +3318,12 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
                 .as_deref()
                 .unwrap_or(Self::qa_worker_label(&worker.specialization));
             let payload = serde_json::to_string(worker)
-                .unwrap_or_else(|_| format!(
-                    r#"{{"specialization":"{}","cli":"{}"}}"#,
-                    worker.specialization, worker.cli
-                ))
+                .unwrap_or_else(|_| {
+                    format!(
+                        r#"{{"specialization":"{}","cli":"{}"}}"#,
+                        worker.specialization, worker.cli
+                    )
+                })
                 .replace('\'', "'\\''");
 
             command_block.push_str(&format!(
@@ -2889,12 +3342,10 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
                 configured_workers.len()
             )
         };
-        let spawn_plan = format!(
-            "```bash\n{}   ```",
-            command_block,
-        );
+        let spawn_plan = format!("```bash\n{}   ```", command_block,);
         let coverage_rule = if qa_workers.is_empty() {
-            "You MUST NOT skip any specialization. Every milestone requires full coverage.".to_string()
+            "You MUST NOT skip any specialization. Every milestone requires full coverage."
+                .to_string()
         } else {
             "You MUST NOT skip any configured QA specialization. Every milestone requires the requested coverage.".to_string()
         };
@@ -2933,7 +3384,10 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
         let required_protocol = Self::evaluator_required_protocol(session_id);
 
         let mut variables = HashMap::new();
-        variables.insert("custom_instructions".to_string(), custom_instructions.to_string());
+        variables.insert(
+            "custom_instructions".to_string(),
+            custom_instructions.to_string(),
+        );
         variables.insert("default_cli".to_string(), config.cli.clone());
         variables.insert("default_model".to_string(), default_model.to_string());
         variables.insert("default_model_field".to_string(), default_model_field);
@@ -3029,10 +3483,7 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
             ),
         };
 
-        let custom_instructions = config
-            .initial_prompt
-            .as_deref()
-            .unwrap_or(default_guidance);
+        let custom_instructions = config.initial_prompt.as_deref().unwrap_or(default_guidance);
 
         let mut variables = HashMap::new();
         variables.insert("qa_worker_index".to_string(), index.to_string());
@@ -3040,7 +3491,10 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
             "qa_worker_agent_id".to_string(),
             format!("{}-qa-worker-{}", session_id, index),
         );
-        variables.insert("custom_instructions".to_string(), custom_instructions.to_string());
+        variables.insert(
+            "custom_instructions".to_string(),
+            custom_instructions.to_string(),
+        );
         variables.insert(
             "supports_chrome".to_string(),
             (specialization == "ui" && config.cli == "claude").to_string(),
@@ -3076,7 +3530,12 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
 
         engine
             .render_template(template_name, &context)
-            .unwrap_or_else(|_| format!("Template '{}' failed to render for session {}", template_name, session_id))
+            .unwrap_or_else(|_| {
+                format!(
+                    "Template '{}' failed to render for session {}",
+                    template_name, session_id
+                )
+            })
     }
 
     /// Build the Master Planner's prompt for Fusion planning phase
@@ -3089,13 +3548,18 @@ Hard rule: The Evaluator is created PROGRAMMATICALLY by the backend at session l
         let mut variant_table = String::new();
         for (i, v) in variants.iter().enumerate() {
             let index = i + 1;
-            let name = if v.name.trim().is_empty() { format!("Variant {}", index) } else { v.name.trim().to_string() };
+            let name = if v.name.trim().is_empty() {
+                format!("Variant {}", index)
+            } else {
+                v.name.trim().to_string()
+            };
             variant_table.push_str(&format!("| {} | {} | {} |\n", index, name, v.cli));
         }
 
         // Determine phase 0 based on whether a task was provided
         let phase0 = if task_description.trim().is_empty() {
-            String::from(r#"## PHASE 0: Gather Task (FIRST STEP)
+            String::from(
+                r#"## PHASE 0: Gather Task (FIRST STEP)
 
 **No task was provided.** You must first ask the user what they want to work on.
 
@@ -3113,10 +3577,14 @@ Ask the user: "What would you like the Fusion variants to compete on? You can:
 
 ---
 
-"#)
-        } else if task_description.trim().starts_with('#') || task_description.trim().parse::<u32>().is_ok() {
+"#,
+            )
+        } else if task_description.trim().starts_with('#')
+            || task_description.trim().parse::<u32>().is_ok()
+        {
             let issue_num = task_description.trim().trim_start_matches('#');
-            format!(r#"## PHASE 0: Fetch GitHub Issue
+            format!(
+                r#"## PHASE 0: Fetch GitHub Issue
 
 The user wants to work on GitHub issue: **#{}**
 
@@ -3134,9 +3602,12 @@ Extract from the response:
 
 ---
 
-"#, issue_num, issue_num)
+"#,
+                issue_num, issue_num
+            )
         } else {
-            format!(r#"## PHASE 0: Task Provided
+            format!(
+                r#"## PHASE 0: Task Provided
 
 The user wants to work on:
 
@@ -3146,11 +3617,13 @@ The user wants to work on:
 
 ---
 
-"#, task_description)
+"#,
+                task_description
+            )
         };
 
         format!(
-r#"# Master Planner - Fusion Mode
+            r#"# Master Planner - Fusion Mode
 
 You are the **Master Planner** for a Fusion session. Your job is to analyze the task and create a plan that documents how multiple independent variants will each tackle the same problem.
 
@@ -3219,6 +3692,85 @@ Write the plan in this structure:
         )
     }
 
+    fn build_debate_master_planner_prompt(
+        session_id: &str,
+        topic: &str,
+        debaters: &[DebateDebaterConfig],
+        rounds: u8,
+    ) -> String {
+        let debater_table = debaters
+            .iter()
+            .enumerate()
+            .map(|(idx, debater)| {
+                let name = if debater.name.trim().is_empty() {
+                    format!("Debater {}", idx + 1)
+                } else {
+                    debater.name.trim().to_string()
+                };
+                let stance = debater
+                    .stance
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or("No explicit stance");
+                format!("| {} | {} | {} | {} |", idx + 1, name, stance, debater.cli)
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        format!(
+            r#"# Master Planner - Debate Mode
+
+You are the Master Planner for a Debate session.
+
+## Session Info
+
+- Session ID: {session_id}
+- Mode: Debate
+- Rounds: {rounds}
+- Plan Output: `.hive-manager/{session_id}/plan.md`
+
+## Topic
+
+{topic}
+
+## Debaters
+
+| # | Name | Stance | CLI |
+|---|------|--------|-----|
+{debater_table}
+
+## Mission
+
+Write a concise debate plan to `.hive-manager/{session_id}/plan.md`:
+
+```markdown
+# Debate Plan
+
+## Topic
+[topic]
+
+## Debater Stances
+[stance framing]
+
+## Round Plan
+[what each round should focus on]
+
+## Judging Criteria
+- [ ] Argument quality
+- [ ] Rebuttal strength
+- [ ] Evidence and specificity
+- [ ] Consistency
+```
+
+Do not run the debate. Stop after writing the plan.
+"#,
+            session_id = session_id,
+            rounds = rounds,
+            topic = topic,
+            debater_table = debater_table,
+        )
+    }
+
     /// Build the Fusion Queen's prompt — monitors variants, spawns Judge when all complete
     fn build_fusion_queen_prompt(
         cli: &str,
@@ -3233,8 +3785,14 @@ Write the plan in this structure:
         let mut variant_info = String::new();
         let mut task_files = String::new();
         for v in variants {
-            variant_info.push_str(&format!("| {} | {} | {} | {} |\n", v.index, v.name, v.branch, v.worktree_path));
-            task_files.push_str(&format!("- Variant {} ({}): `{}`\n", v.index, v.name, v.task_file));
+            variant_info.push_str(&format!(
+                "| {} | {} | {} | {} |\n",
+                v.index, v.name, v.branch, v.worktree_path
+            ));
+            task_files.push_str(&format!(
+                "- Variant {} ({}): `{}`\n",
+                v.index, v.name, v.task_file
+            ));
         }
         let required_protocol = Self::queen_required_protocol(&session_root, has_evaluator);
         let qa_milestone_handoff = if has_evaluator {
@@ -3290,7 +3848,7 @@ You are the QUEEN - the top-level coordinator. You do NOT implement.
         };
 
         format!(
-r#"# Queen Agent - Fusion Session
+            r#"# Queen Agent - Fusion Session
 
 You are the **Queen** monitoring a Fusion session where {variant_count} variants compete to implement the same task.
 {hardening}
@@ -3385,13 +3943,13 @@ Read tool docs in `.hive-manager/{session_id}/tools/` for:
         let peer_dir = Self::prompt_path(&session_root.join("peer"));
         let milestone_ready_path =
             Self::prompt_path(&session_root.join("peer").join("milestone-ready.json"));
-        let qa_verdict_path =
-            Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
+        let qa_verdict_path = Self::prompt_path(&session_root.join("peer").join("qa-verdict.json"));
         let contracts_dir = Self::prompt_path(&session_root.join("contracts"));
-        let contract_path = Self::prompt_path(&session_root.join("contracts").join("milestone-1.md"));
+        let contract_path =
+            Self::prompt_path(&session_root.join("contracts").join("milestone-1.md"));
 
         format!(
-r#"## QA Milestone Handoff (CRITICAL — Evaluator waits for this)
+            r#"## QA Milestone Handoff (CRITICAL — Evaluator waits for this)
 
 When ALL {completion_scope} have completed, you MUST signal the existing Evaluator:
 
@@ -3430,12 +3988,18 @@ When ALL {completion_scope} have completed, you MUST signal the existing Evaluat
     }
 
     /// Build the Master Planner's prompt for initial planning phase
-    fn build_master_planner_prompt(session_id: &str, user_prompt: &str, workers: &[AgentConfig]) -> String {
+    fn build_master_planner_prompt(
+        session_id: &str,
+        user_prompt: &str,
+        workers: &[AgentConfig],
+    ) -> String {
         // Build worker info section
         let mut worker_table = String::new();
         for (i, worker_config) in workers.iter().enumerate() {
             let index = i + 1;
-            let role_label = worker_config.role.as_ref()
+            let role_label = worker_config
+                .role
+                .as_ref()
                 .map(|r| r.label.clone())
                 .unwrap_or_else(|| format!("Worker {}", index));
             let cli = &worker_config.cli;
@@ -3449,7 +4013,8 @@ When ALL {completion_scope} have completed, you MUST signal the existing Evaluat
 
         // Determine phase 0 based on whether a task was provided
         let phase0 = if user_prompt.trim().is_empty() {
-            String::from(r#"## PHASE 0: Gather Task (FIRST STEP)
+            String::from(
+                r#"## PHASE 0: Gather Task (FIRST STEP)
 
 **No task was provided.** You must first ask the user what they want to work on.
 
@@ -3467,11 +4032,13 @@ Ask the user: "What would you like me to help you with today? You can:
 
 ---
 
-"#)
+"#,
+            )
         } else if user_prompt.trim().starts_with('#') || user_prompt.trim().parse::<u32>().is_ok() {
             // Looks like a GitHub issue number
             let issue_num = user_prompt.trim().trim_start_matches('#');
-            format!(r#"## PHASE 0: Fetch GitHub Issue
+            format!(
+                r#"## PHASE 0: Fetch GitHub Issue
 
 The user wants to work on GitHub issue: **#{}**
 
@@ -3489,9 +4056,12 @@ Extract from the response:
 
 ---
 
-"#, issue_num, issue_num)
+"#,
+                issue_num, issue_num
+            )
         } else {
-            format!(r#"## PHASE 0: Task Provided
+            format!(
+                r#"## PHASE 0: Task Provided
 
 The user wants to work on:
 
@@ -3501,11 +4071,13 @@ The user wants to work on:
 
 ---
 
-"#, user_prompt)
+"#,
+                user_prompt
+            )
         };
 
         format!(
-r#"# Master Planner - Multi-Agent Codebase Investigation
+            r#"# Master Planner - Multi-Agent Codebase Investigation
 
 You are the **Master Planner** orchestrating a multi-agent investigation to create a detailed implementation plan.
 
@@ -3631,13 +4203,27 @@ The user may approve or request refinements. Stay ready to update the plan.
     }
 
     /// Build the Master Planner's prompt for Swarm mode with planner and worker information
-    fn build_swarm_master_planner_prompt(session_id: &str, user_prompt: &str, planner_count: u8, workers_per_planner: &[AgentConfig]) -> String {
+    fn build_swarm_master_planner_prompt(
+        session_id: &str,
+        user_prompt: &str,
+        planner_count: u8,
+        workers_per_planner: &[AgentConfig],
+    ) -> String {
         let workers_per = workers_per_planner.len();
         let total_workers = planner_count as usize * workers_per;
 
         // Build planner table
         let mut planner_table = String::new();
-        let domains = ["backend", "frontend", "testing", "infrastructure", "documentation", "security", "performance", "integration"];
+        let domains = [
+            "backend",
+            "frontend",
+            "testing",
+            "infrastructure",
+            "documentation",
+            "security",
+            "performance",
+            "integration",
+        ];
 
         for i in 0..planner_count {
             let index = i + 1;
@@ -3652,7 +4238,9 @@ The user may approve or request refinements. Stay ready to update the plan.
         let mut worker_info = String::new();
         for (i, worker_config) in workers_per_planner.iter().enumerate() {
             let index = i + 1;
-            let role_label = worker_config.role.as_ref()
+            let role_label = worker_config
+                .role
+                .as_ref()
                 .map(|r| r.label.clone())
                 .unwrap_or_else(|| format!("Worker {}", index));
             worker_info.push_str(&format!(
@@ -3663,7 +4251,8 @@ The user may approve or request refinements. Stay ready to update the plan.
 
         // Determine phase 0 based on whether a task was provided
         let phase0 = if user_prompt.trim().is_empty() {
-            String::from(r#"## PHASE 0: Gather Task (FIRST STEP)
+            String::from(
+                r#"## PHASE 0: Gather Task (FIRST STEP)
 
 **No task was provided.** You must first ask the user what they want to work on.
 
@@ -3681,10 +4270,12 @@ Ask the user: "What would you like me to help you with today? You can:
 
 ---
 
-"#)
+"#,
+            )
         } else if user_prompt.trim().starts_with('#') || user_prompt.trim().parse::<u32>().is_ok() {
             let issue_num = user_prompt.trim().trim_start_matches('#');
-            format!(r#"## PHASE 0: Fetch GitHub Issue
+            format!(
+                r#"## PHASE 0: Fetch GitHub Issue
 
 The user wants to work on GitHub issue: **#{}**
 
@@ -3702,9 +4293,12 @@ Extract from the response:
 
 ---
 
-"#, issue_num, issue_num)
+"#,
+                issue_num, issue_num
+            )
         } else {
-            format!(r#"## PHASE 0: Task Provided
+            format!(
+                r#"## PHASE 0: Task Provided
 
 The user wants to work on:
 
@@ -3714,11 +4308,13 @@ The user wants to work on:
 
 ---
 
-"#, user_prompt)
+"#,
+                user_prompt
+            )
         };
 
         format!(
-r#"# Master Planner - Swarm Multi-Agent Investigation
+            r#"# Master Planner - Swarm Multi-Agent Investigation
 
 You are the **Master Planner** orchestrating a Swarm investigation to create a detailed implementation plan.
 
@@ -3867,7 +4463,9 @@ Write to `.hive-manager/{session_id}/plan.md`:
 
         for (i, worker_config) in workers.iter().enumerate() {
             let index = i + 1;
-            let role_label = worker_config.role.as_ref()
+            let role_label = worker_config
+                .role
+                .as_ref()
                 .map(|r| r.label.clone())
                 .unwrap_or_else(|| format!("Worker {}", index));
             let cli = &worker_config.cli;
@@ -3877,7 +4475,13 @@ Write to `.hive-manager/{session_id}/plan.md`:
                 index, role_label, cli
             ));
 
-            let priority = if index == 1 { "HIGH" } else if index == 2 { "MEDIUM" } else { "LOW" };
+            let priority = if index == 1 {
+                "HIGH"
+            } else if index == 2 {
+                "MEDIUM"
+            } else {
+                "LOW"
+            };
             let task_desc = match index {
                 1 => format!("Send a message to queen via conversation API, send heartbeat, then read shared conversation -> Worker {}", index),
                 2 => format!("Read queen conversation for messages, post to shared conversation, send heartbeat with summary -> Worker {}", index),
@@ -3889,7 +4493,11 @@ Write to `.hive-manager/{session_id}/plan.md`:
             ));
 
             if index > 1 {
-                dependencies.push_str(&format!("- Task {} depends on Task {} completing.\n", index, index - 1));
+                dependencies.push_str(&format!(
+                    "- Task {} depends on Task {} completing.\n",
+                    index,
+                    index - 1
+                ));
             }
         }
 
@@ -3904,8 +4512,14 @@ Write to `.hive-manager/{session_id}/plan.md`:
             let mut qa_tasks = String::new();
             for (i, qw) in qa_list.iter().enumerate() {
                 let idx = i + 1;
-                let label = qw.label.as_deref().unwrap_or(Self::qa_worker_label(&qw.specialization));
-                qa_table.push_str(&format!("| QA Worker {} | {} | {} | {} |\n", idx, label, qw.specialization, qw.cli));
+                let label = qw
+                    .label
+                    .as_deref()
+                    .unwrap_or(Self::qa_worker_label(&qw.specialization));
+                qa_table.push_str(&format!(
+                    "| QA Worker {} | {} | {} | {} |\n",
+                    idx, label, qw.specialization, qw.cli
+                ));
                 qa_tasks.push_str(&format!(
                     "### QA Worker {} ({} - {}):\n\
                      1. Read the evaluator prompt: `curl -s \"http://localhost:18800/api/sessions/{}/evaluators\"`\n\
@@ -3920,7 +4534,7 @@ Write to `.hive-manager/{session_id}/plan.md`:
                 qa_tasks = "No QA workers configured. Evaluator will self-assess.\n".to_string();
             }
             format!(
-r#"
+                r#"
 
 ## Evaluator & QA Configuration
 
@@ -3962,7 +4576,7 @@ After all worker tasks complete, the Evaluator will:
         };
 
         format!(
-r#"# Smoke Test - Quick Flow Validation
+            r#"# Smoke Test - Quick Flow Validation
 
 You are running a **SMOKE TEST** to validate the Hive Manager flow.
 
@@ -4086,7 +4700,16 @@ This tests that:
         let mut planner_table = String::new();
         let mut domain_tasks = String::new();
 
-        let domains = ["backend", "frontend", "testing", "infrastructure", "documentation", "security", "performance", "integration"];
+        let domains = [
+            "backend",
+            "frontend",
+            "testing",
+            "infrastructure",
+            "documentation",
+            "security",
+            "performance",
+            "integration",
+        ];
 
         for i in 0..planner_count {
             let index = i + 1;
@@ -4096,7 +4719,13 @@ This tests that:
                 index, domain, workers_per
             ));
 
-            let priority = if index == 1 { "HIGH" } else if index == 2 { "MEDIUM" } else { "LOW" };
+            let priority = if index == 1 {
+                "HIGH"
+            } else if index == 2 {
+                "MEDIUM"
+            } else {
+                "LOW"
+            };
             domain_tasks.push_str(&format!(
                 "- [ ] [{}] Domain {}: {} smoke test tasks (will be broken into {} worker tasks)\n",
                 priority, index, domain, workers_per
@@ -4108,11 +4737,16 @@ This tests that:
         for pi in 0..planner_count {
             let planner_index = pi + 1;
             let domain = domains.get(pi as usize).unwrap_or(&"general");
-            worker_breakdown.push_str(&format!("\n### Planner {} - {} Domain\n\n", planner_index, domain));
+            worker_breakdown.push_str(&format!(
+                "\n### Planner {} - {} Domain\n\n",
+                planner_index, domain
+            ));
 
             for (wi, worker_config) in workers_per_planner.iter().enumerate() {
                 let worker_index = wi + 1;
-                let role_label = worker_config.role.as_ref()
+                let role_label = worker_config
+                    .role
+                    .as_ref()
                     .map(|r| r.label.clone())
                     .unwrap_or_else(|| format!("Worker {}", worker_index));
                 worker_breakdown.push_str(&format!(
@@ -4127,14 +4761,23 @@ This tests that:
             let qa_list = qa_workers.unwrap_or(&[]);
             let mut qa_info = String::new();
             for (i, qw) in qa_list.iter().enumerate() {
-                let label = qw.label.as_deref().unwrap_or(Self::qa_worker_label(&qw.specialization));
-                qa_info.push_str(&format!("| QA Worker {} | {} | {} | {} |\n", i + 1, label, qw.specialization, qw.cli));
+                let label = qw
+                    .label
+                    .as_deref()
+                    .unwrap_or(Self::qa_worker_label(&qw.specialization));
+                qa_info.push_str(&format!(
+                    "| QA Worker {} | {} | {} | {} |\n",
+                    i + 1,
+                    label,
+                    qw.specialization,
+                    qw.cli
+                ));
             }
             if qa_info.is_empty() {
                 qa_info = "| (no QA workers configured) | - | - | - |\n".to_string();
             }
             format!(
-r#"
+                r#"
 
 ## Evaluator & QA Configuration
 
@@ -4167,7 +4810,7 @@ After all planner domains complete, the Evaluator will:
         };
 
         format!(
-r#"# Swarm Smoke Test - Quick Flow Validation
+            r#"# Swarm Smoke Test - Quick Flow Validation
 
 You are running a **SMOKE TEST** to validate the Swarm Manager flow.
 
@@ -4300,7 +4943,13 @@ This tests that:
         variables.insert("workers_list".to_string(), workers_list);
         variables.insert(
             "queen_heartbeat_snippet".to_string(),
-            heartbeat_snippet(API_BASE_URL, session_id, "queen", "working", "Coordinating researchers"),
+            heartbeat_snippet(
+                API_BASE_URL,
+                session_id,
+                "queen",
+                "working",
+                "Coordinating researchers",
+            ),
         );
         variables.insert(
             "task".to_string(),
@@ -4313,7 +4962,12 @@ This tests that:
             variables.insert(k, v);
         }
 
-        Self::render_named_prompt(template_name, session_id, user_prompt.map(|s| s.to_string()), variables)
+        Self::render_named_prompt(
+            template_name,
+            session_id,
+            user_prompt.map(|s| s.to_string()),
+            variables,
+        )
     }
 
     fn build_queen_master_prompt(
@@ -4337,8 +4991,12 @@ This tests that:
         let plan_path = Self::prompt_path(&session_root.join("plan.md"));
         let lessons_dir = Self::prompt_path(&session_root.join("lessons"));
         let coordination_log_path = Self::prompt_path(&session_root.join("coordination.log"));
-        let worker_worktree_root =
-            Self::prompt_path(&project_path.join(".hive-manager").join("worktrees").join(session_id));
+        let worker_worktree_root = Self::prompt_path(
+            &project_path
+                .join(".hive-manager")
+                .join("worktrees")
+                .join(session_id),
+        );
         let queen_scope_rules =
             Self::worktree_boundary_rules(&Self::prompt_path(queen_workspace_path));
         let required_protocol = Self::queen_required_protocol(&session_root, has_evaluator);
@@ -4349,7 +5007,6 @@ This tests that:
         } else {
             ""
         };
-
 
         let mut worker_list = String::new();
         for (i, worker_config) in workers.iter().enumerate() {
@@ -4367,7 +5024,10 @@ This tests that:
         }
 
         let worker_worktrees_dir = Self::prompt_path(
-            &project_path.join(".hive-manager").join("worktrees").join(session_id),
+            &project_path
+                .join(".hive-manager")
+                .join("worktrees")
+                .join(session_id),
         );
         let worker_task_file_example = Self::prompt_path(
             &project_path
@@ -4453,7 +5113,7 @@ Do NOT assign worker tasks until the branch exists!
         };
 
         format!(
-r#"# Queen Agent - Hive Manager Session
+            r#"# Queen Agent - Hive Manager Session
 
 You are the **Queen** orchestrating a multi-agent Hive session. You have full Claude Code capabilities plus coordination tools.
 {hardening}
@@ -4811,8 +5471,15 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
     }
 
     /// Build a worker's role prompt
-    fn build_worker_prompt(index: u8, config: &AgentConfig, queen_id: &str, session_id: &str) -> String {
-        let role_name = config.role.as_ref()
+    fn build_worker_prompt(
+        index: u8,
+        config: &AgentConfig,
+        queen_id: &str,
+        session_id: &str,
+    ) -> String {
+        let role_name = config
+            .role
+            .as_ref()
             .map(|r| r.label.clone())
             .unwrap_or_else(|| format!("Worker {}", index));
         // Research workers are read-only investigators: no implementation authority,
@@ -4870,7 +5537,7 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
 
         let important_rules = if is_research {
             format!(
-"1. **Stay in your lane** - Focus on your research assignment ({role_name})
+                "1. **Stay in your lane** - Focus on your research assignment ({role_name})
 2. **Do not modify the project** - No code changes and no commits; report findings to the Queen
 3. **Update your task file** - Always update status when done or blocked
 4. **Ask for clarification** - If the assignment is unclear, note it in the task file",
@@ -4878,7 +5545,7 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
             )
         } else {
             format!(
-"1. **Stay in your lane** - Focus on your specialization ({role_name})
+                "1. **Stay in your lane** - Focus on your specialization ({role_name})
 2. **Don't push to git** - Only the Queen commits and pushes
 3. **Update your task file** - Always update status when done or blocked
 4. **Ask for clarification** - If task is unclear, note it in the task file",
@@ -4890,7 +5557,7 @@ After your orchestration objective is complete, transition to `idle` heartbeat s
             String::new()
         } else {
             format!(
-r#"## Learnings Protocol (MANDATORY)
+                r#"## Learnings Protocol (MANDATORY)
 
 Before marking your task COMPLETED, submit what you learned **via the HTTP API first**:
 
@@ -4941,7 +5608,7 @@ jq -nc \
         };
 
         format!(
-r#"# Worker {index} ({role_name}) - Hive Session
+            r#"# Worker {index} ({role_name}) - Hive Session
 
 You are a **Worker** in a multi-agent Hive session, coordinated by the Queen.
 
@@ -5073,11 +5740,16 @@ After completing your task, transition to IDLE state. Continue checking your con
         let mut worker_info = String::new();
         for (i, worker_config) in config.workers.iter().enumerate() {
             let worker_index = i + 1;
-            let role_label = worker_config.role.as_ref()
+            let role_label = worker_config
+                .role
+                .as_ref()
                 .map(|r| r.label.clone())
                 .unwrap_or_else(|| format!("Worker {}", worker_index));
             let cli_name = &worker_config.cli;
-            worker_info.push_str(&format!("| {} | {} | {} |\n", worker_index, role_label, cli_name));
+            worker_info.push_str(&format!(
+                "| {} | {} | {} |\n",
+                worker_index, role_label, cli_name
+            ));
         }
         let worker_task_file_example = project_path
             .join(".hive-manager")
@@ -5221,8 +5893,10 @@ Awaiting task assignment from the Queen."#,
         for (i, planner_config) in planners.iter().enumerate() {
             let index = i + 1;
             let worker_count = planner_config.workers.len();
-            planner_info.push_str(&format!("| {} | {} | {} workers |\n",
-                index, planner_config.domain, worker_count));
+            planner_info.push_str(&format!(
+                "| {} | {} | {} workers |\n",
+                index, planner_config.domain, worker_count
+            ));
         }
 
         let hardening = if CliRegistry::needs_role_hardening(cli) {
@@ -5256,7 +5930,7 @@ If you find yourself about to edit code, STOP. Assign work to a Planner instead.
         };
 
         format!(
-r#"# Queen Agent - Swarm Session
+            r#"# Queen Agent - Swarm Session
 
 You are the **Queen** orchestrating a multi-agent Swarm session. You spawn and coordinate Planners who each manage their own domain.
 {hardening}
@@ -5431,8 +6105,16 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
     }
 
     /// Write a prompt file to the session's prompts directory
-    fn write_prompt_file(project_path: &PathBuf, session_id: &str, filename: &str, content: &str) -> Result<PathBuf, String> {
-        let prompts_dir = project_path.join(".hive-manager").join(session_id).join("prompts");
+    fn write_prompt_file(
+        project_path: &PathBuf,
+        session_id: &str,
+        filename: &str,
+        content: &str,
+    ) -> Result<PathBuf, String> {
+        let prompts_dir = project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("prompts");
         std::fs::create_dir_all(&prompts_dir)
             .map_err(|e| format!("Failed to create prompts directory: {}", e))?;
 
@@ -5470,8 +6152,16 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
     }
 
     /// Write a tool documentation file to the session's tools directory
-    fn write_tool_file(project_path: &PathBuf, session_id: &str, filename: &str, content: &str) -> Result<PathBuf, String> {
-        let tools_dir = project_path.join(".hive-manager").join(session_id).join("tools");
+    fn write_tool_file(
+        project_path: &PathBuf,
+        session_id: &str,
+        filename: &str,
+        content: &str,
+    ) -> Result<PathBuf, String> {
+        let tools_dir = project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("tools");
         std::fs::create_dir_all(&tools_dir)
             .map_err(|e| format!("Failed to create tools directory: {}", e))?;
 
@@ -5483,7 +6173,11 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
     }
 
     /// Write all standard tool documentation files for a session
-    fn write_tool_files(project_path: &PathBuf, session_id: &str, default_cli: &str) -> Result<(), String> {
+    fn write_tool_files(
+        project_path: &PathBuf,
+        session_id: &str,
+        default_cli: &str,
+    ) -> Result<(), String> {
         let worker_task_file_example = project_path
             .join(".hive-manager")
             .join("worktrees")
@@ -5494,7 +6188,8 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
             .join("worker-N-task.md")
             .to_string_lossy()
             .to_string();
-        let qa_task_file_example = format!(".hive-manager/{}/tasks/qa-worker-N-task.md", session_id);
+        let qa_task_file_example =
+            format!(".hive-manager/{}/tasks/qa-worker-N-task.md", session_id);
         let worker_one_task_file_example = project_path
             .join(".hive-manager")
             .join("worktrees")
@@ -5507,7 +6202,8 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
             .to_string();
 
         // Spawn Worker tool
-        let spawn_worker_tool = format!(r#"# Spawn Worker Tool
+        let spawn_worker_tool = format!(
+            r#"# Spawn Worker Tool
 
 Spawn a new worker agent in a visible terminal window.
 
@@ -5582,11 +6278,21 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
 - Each worker's own task file lives at `.hive-manager/tasks/worker-N-task.md` inside that worker's worktree
 - Workers poll their task files for ACTIVE status
 - Use this to spawn workers sequentially as tasks complete
-"#, session_id = session_id, default_cli = default_cli, worker_task_file_example = worker_task_file_example);
+"#,
+            session_id = session_id,
+            default_cli = default_cli,
+            worker_task_file_example = worker_task_file_example
+        );
 
-        Self::write_tool_file(project_path, session_id, "spawn-worker.md", &spawn_worker_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "spawn-worker.md",
+            &spawn_worker_tool,
+        )?;
 
-        let spawn_qa_worker_tool = format!(r#"# Spawn QA Worker Tool
+        let spawn_qa_worker_tool = format!(
+            r#"# Spawn QA Worker Tool
 
 Spawn a QA worker for the Evaluator.
 
@@ -5642,12 +6348,22 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/qa-workers" \
   "task_file": "{qa_task_file_example}"
 }}
 ```
-"#, session_id = session_id, default_cli = default_cli, qa_task_file_example = qa_task_file_example);
+"#,
+            session_id = session_id,
+            default_cli = default_cli,
+            qa_task_file_example = qa_task_file_example
+        );
 
-        Self::write_tool_file(project_path, session_id, "spawn-qa-worker.md", &spawn_qa_worker_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "spawn-qa-worker.md",
+            &spawn_qa_worker_tool,
+        )?;
 
         // List Workers tool
-        let list_workers_tool = format!(r#"# List Workers Tool
+        let list_workers_tool = format!(
+            r#"# List Workers Tool
 
 Get a list of all workers in the current session.
 
@@ -5678,9 +6394,18 @@ curl "http://localhost:18800/api/sessions/{session_id}/workers"
   "count": 1
 }}
 ```
-"#, session_id = session_id, default_cli = default_cli, worker_one_task_file_example = worker_one_task_file_example);
+"#,
+            session_id = session_id,
+            default_cli = default_cli,
+            worker_one_task_file_example = worker_one_task_file_example
+        );
 
-        Self::write_tool_file(project_path, session_id, "list-workers.md", &list_workers_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "list-workers.md",
+            &list_workers_tool,
+        )?;
 
         // Submit Learning tool
         let submit_learning_tool = r#"# Submit Learning Tool
@@ -5728,7 +6453,12 @@ curl -X POST "http://localhost:18800/api/sessions/{{session_id}}/learnings" \
 ```
 "#;
 
-        Self::write_tool_file(project_path, session_id, "submit-learning.md", submit_learning_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "submit-learning.md",
+            submit_learning_tool,
+        )?;
 
         // List Learnings tool
         let list_learnings_tool = r#"# List Learnings Tool
@@ -5760,7 +6490,12 @@ curl "http://localhost:18800/api/sessions/{{session_id}}/learnings?keywords=api,
 ```
 "#;
 
-        Self::write_tool_file(project_path, session_id, "list-learnings.md", list_learnings_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "list-learnings.md",
+            list_learnings_tool,
+        )?;
 
         // Delete Learning tool
         let delete_learning_tool = r#"# Delete Learning Tool
@@ -5789,18 +6524,29 @@ curl -X DELETE "http://localhost:18800/api/sessions/{{session_id}}/learnings/abc
 - **404 Not Found** - Learning ID not found
 "#;
 
-        Self::write_tool_file(project_path, session_id, "delete-learning.md", delete_learning_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "delete-learning.md",
+            delete_learning_tool,
+        )?;
 
         Ok(())
     }
 
     /// Write tool documentation files for Swarm mode (includes planner tools)
-    fn write_swarm_tool_files(project_path: &PathBuf, session_id: &str, planner_count: u8, default_cli: &str) -> Result<(), String> {
+    fn write_swarm_tool_files(
+        project_path: &PathBuf,
+        session_id: &str,
+        planner_count: u8,
+        default_cli: &str,
+    ) -> Result<(), String> {
         // First write standard worker tools
         Self::write_tool_files(project_path, session_id, default_cli)?;
 
         // Spawn Planner tool
-        let spawn_planner_tool = format!(r#"# Spawn Planner Tool
+        let spawn_planner_tool = format!(
+            r#"# Spawn Planner Tool
 
 Spawn a new planner agent in a visible terminal window. Planners manage a domain and spawn workers.
 
@@ -5884,12 +6630,22 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/planners" \
 - Each planner knows how to spawn its own workers sequentially
 - Wait for `[DOMAIN_COMPLETE]` signal from planner before committing and spawning next
 - Commit between each planner to create clean git history
-"#, session_id = session_id, planner_count = planner_count, default_cli = default_cli);
+"#,
+            session_id = session_id,
+            planner_count = planner_count,
+            default_cli = default_cli
+        );
 
-        Self::write_tool_file(project_path, session_id, "spawn-planner.md", &spawn_planner_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "spawn-planner.md",
+            &spawn_planner_tool,
+        )?;
 
         // List Planners tool
-        let list_planners_tool = format!(r#"# List Planners Tool
+        let list_planners_tool = format!(
+            r#"# List Planners Tool
 
 Get a list of all planners in the current Swarm session.
 
@@ -5921,17 +6677,36 @@ curl "http://localhost:18800/api/sessions/{session_id}/planners"
   "count": 1
 }}
 ```
-"#, session_id = session_id, default_cli = default_cli);
+"#,
+            session_id = session_id,
+            default_cli = default_cli
+        );
 
-        Self::write_tool_file(project_path, session_id, "list-planners.md", &list_planners_tool)?;
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "list-planners.md",
+            &list_planners_tool,
+        )?;
 
         Ok(())
     }
 
     /// Write a task file for a worker (ACTIVE when pre-seeded with a task, otherwise STANDBY)
-    fn write_task_file(worktree_path: &Path, worker_index: u8, initial_task: Option<&str>, read_only: bool) -> Result<PathBuf, String> {
+    fn write_task_file(
+        worktree_path: &Path,
+        worker_index: u8,
+        initial_task: Option<&str>,
+        read_only: bool,
+    ) -> Result<PathBuf, String> {
         let status = initial_task.map(|_| "ACTIVE");
-        Self::write_task_file_with_status(worktree_path, worker_index, initial_task, status, read_only)
+        Self::write_task_file_with_status(
+            worktree_path,
+            worker_index,
+            initial_task,
+            status,
+            read_only,
+        )
     }
 
     /// Write a task file with an optional status override (used for sequential spawning).
@@ -5973,7 +6748,7 @@ curl "http://localhost:18800/api/sessions/{session_id}/planners"
 
         let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
         let content = format!(
-"# Task Assignment - Worker {worker_index}
+            "# Task Assignment - Worker {worker_index}
 
 ## Status: {status}
 
@@ -6019,7 +6794,10 @@ Last updated: {timestamp}
         specialization: &str,
         initial_task: Option<&str>,
     ) -> Result<PathBuf, String> {
-        let tasks_dir = project_path.join(".hive-manager").join(session_id).join("tasks");
+        let tasks_dir = project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("tasks");
         std::fs::create_dir_all(&tasks_dir)
             .map_err(|e| format!("Failed to create tasks directory: {}", e))?;
 
@@ -6029,12 +6807,16 @@ Last updated: {timestamp}
         let (status, task_content) = if let Some(task) = initial_task {
             ("ACTIVE", task.to_string())
         } else {
-            ("STANDBY", "Awaiting QA assignment from the Evaluator. Monitor this file for updates.".to_string())
+            (
+                "STANDBY",
+                "Awaiting QA assignment from the Evaluator. Monitor this file for updates."
+                    .to_string(),
+            )
         };
 
         let timestamp = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ");
         let content = format!(
-"# Task Assignment - QA Worker {worker_index} ({specialization})
+            "# Task Assignment - QA Worker {worker_index} ({specialization})
 
 ## Status: {status}
 
@@ -6098,12 +6880,7 @@ Last updated: {timestamp}
             &project_path,
         )?;
         created_cells.push(("worker-1".to_string(), solo_branch.clone()));
-        self.emit_workspace_created(
-            &session_id,
-            PRIMARY_CELL_ID,
-            &solo_branch,
-            Some(&solo_cwd),
-        );
+        self.emit_workspace_created(&session_id, PRIMARY_CELL_ID, &solo_branch, Some(&solo_cwd));
         let solo_name = "Solo Worker".to_string();
         let solo_description = Self::summarize_prompt_line(task_description.as_deref())
             .unwrap_or_else(|| "Solo session".to_string());
@@ -6124,7 +6901,10 @@ Last updated: {timestamp}
             let pty_manager = self.pty_manager.read();
             if let Err(e) = pty_manager.create_session(
                 solo_id.clone(),
-                AgentRole::Worker { index: 1, parent: None },
+                AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
                 &cmd,
                 &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
                 Some(&solo_cwd),
@@ -6157,7 +6937,10 @@ Last updated: {timestamp}
             last_activity_at: Utc::now(),
             agents: vec![AgentInfo {
                 id: solo_id,
-                role: AgentRole::Worker { index: 1, parent: None },
+                role: AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
                 status: AgentStatus::Running,
                 config: solo_config.clone(),
                 parent_id: None,
@@ -6184,9 +6967,12 @@ Last updated: {timestamp}
         self.emit_agent_batch_launched(&session, &session.agents);
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         self.init_session_storage(&session);
@@ -6328,7 +7114,10 @@ Last updated: {timestamp}
         );
 
         // Check if plan.md exists (from previous planning phase)
-        let plan_path = project_path.join(".hive-manager").join(&session_id).join("plan.md");
+        let plan_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("plan.md");
         let has_plan = plan_path.exists();
 
         // Write Queen prompt to file and pass to CLI.
@@ -6355,10 +7144,20 @@ Last updated: {timestamp}
                 config.with_evaluator,
             )
         };
-        let prompt_file = match Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt) {
+        let prompt_file = match Self::write_prompt_file(
+            &project_path,
+            &session_id,
+            "queen-prompt.md",
+            &master_prompt,
+        ) {
             Ok(prompt_file) => prompt_file,
             Err(err) => {
-                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                self.rollback_launch_allocations(
+                    &project_path,
+                    &session_id,
+                    &created_cells,
+                    &spawned_agent_ids,
+                );
                 return Err(err);
             }
         };
@@ -6366,12 +7165,24 @@ Last updated: {timestamp}
         Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
         // Write tool documentation files
-        if let Err(err) = Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli) {
-            self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+        if let Err(err) =
+            Self::write_tool_files(&project_path, &session_id, &config.queen_config.cli)
+        {
+            self.rollback_launch_allocations(
+                &project_path,
+                &session_id,
+                &created_cells,
+                &spawned_agent_ids,
+            );
             return Err(err);
         }
 
-        tracing::info!("Launching Queen agent (v2): {} {:?} in {:?}", cmd, args, queen_cwd);
+        tracing::info!(
+            "Launching Queen agent (v2): {} {:?} in {:?}",
+            cmd,
+            args,
+            queen_cwd
+        );
 
         {
             let pty_manager = self.pty_manager.read();
@@ -6384,7 +7195,12 @@ Last updated: {timestamp}
                 120,
                 30,
             ) {
-                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                self.rollback_launch_allocations(
+                    &project_path,
+                    &session_id,
+                    &created_cells,
+                    &spawned_agent_ids,
+                );
                 return Err(format!("Failed to spawn Queen: {}", e));
             }
         }
@@ -6406,13 +7222,18 @@ Last updated: {timestamp}
         // empty, so nothing comes up here at launch. The configured workers are a
         // roster rendered into the Queen prompt; the Queen spawns the ones it needs on
         // demand via the spawn-worker tool (`POST /api/sessions/{id}/workers`).
-        let workers_to_spawn: &[AgentConfig] = if pre_spawn_workers { &config.workers } else { &[] };
+        let workers_to_spawn: &[AgentConfig] = if pre_spawn_workers {
+            &config.workers
+        } else {
+            &[]
+        };
         for (i, worker_config) in workers_to_spawn.iter().enumerate() {
             let index = (i + 1) as u8;
             let worker_id = format!("{}-worker-{}", session_id, index);
-            let worker_role = worker_config.role.clone().unwrap_or_else(|| {
-                WorkerRole::new("general", "Worker", &worker_config.cli)
-            });
+            let worker_role = worker_config
+                .role
+                .clone()
+                .unwrap_or_else(|| WorkerRole::new("general", "Worker", &worker_config.cli));
             let worker_config =
                 Self::apply_worker_identity(index, &worker_role, worker_config.clone());
             let (cmd, mut args) = Self::build_command(&worker_config);
@@ -6428,7 +7249,12 @@ Last updated: {timestamp}
                 ) {
                     Ok(result) => result,
                     Err(err) => {
-                        self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                        self.rollback_launch_allocations(
+                            &project_path,
+                            &session_id,
+                            &created_cells,
+                            &spawned_agent_ids,
+                        );
                         return Err(err);
                     }
                 };
@@ -6452,15 +7278,24 @@ Last updated: {timestamp}
                 .as_ref()
                 .map(|r| r.role_type.eq_ignore_ascii_case("researcher"))
                 .unwrap_or(false);
-            if let Err(err) =
-                Self::write_task_file(Path::new(&worker_cwd), index, worker_config.initial_prompt.as_deref(), worker_read_only)
-            {
-                self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+            if let Err(err) = Self::write_task_file(
+                Path::new(&worker_cwd),
+                index,
+                worker_config.initial_prompt.as_deref(),
+                worker_read_only,
+            ) {
+                self.rollback_launch_allocations(
+                    &project_path,
+                    &session_id,
+                    &created_cells,
+                    &spawned_agent_ids,
+                );
                 return Err(err);
             }
 
             // Write worker prompt to file and pass to CLI
-            let worker_prompt = Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
+            let worker_prompt =
+                Self::build_worker_prompt(index, &worker_config, &queen_id, &session_id);
             let filename = format!("worker-{}-prompt.md", index);
             let prompt_file = match Self::write_worker_prompt_file(
                 Path::new(&worker_cwd),
@@ -6470,27 +7305,46 @@ Last updated: {timestamp}
             ) {
                 Ok(prompt_file) => prompt_file,
                 Err(err) => {
-                    self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                    self.rollback_launch_allocations(
+                        &project_path,
+                        &session_id,
+                        &created_cells,
+                        &spawned_agent_ids,
+                    );
                     return Err(err);
                 }
             };
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
-            tracing::info!("Launching Worker {} agent (v2): {} {:?} in {:?}", index, cmd, args, worker_cwd);
+            tracing::info!(
+                "Launching Worker {} agent (v2): {} {:?} in {:?}",
+                index,
+                cmd,
+                args,
+                worker_cwd
+            );
 
             {
                 let pty_manager = self.pty_manager.read();
                 if let Err(e) = pty_manager.create_session(
                     worker_id.clone(),
-                    AgentRole::Worker { index, parent: Some(queen_id.clone()) },
+                    AgentRole::Worker {
+                        index,
+                        parent: Some(queen_id.clone()),
+                    },
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
                     Some(&worker_cwd),
                     120,
                     30,
                 ) {
-                    self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+                    self.rollback_launch_allocations(
+                        &project_path,
+                        &session_id,
+                        &created_cells,
+                        &spawned_agent_ids,
+                    );
                     return Err(format!("Failed to spawn Worker {}: {}", index, e));
                 }
             }
@@ -6498,7 +7352,10 @@ Last updated: {timestamp}
 
             agents.push(AgentInfo {
                 id: worker_id,
-                role: AgentRole::Worker { index, parent: Some(queen_id.clone()) },
+                role: AgentRole::Worker {
+                    index,
+                    parent: Some(queen_id.clone()),
+                },
                 status: AgentStatus::Running,
                 config: worker_config.clone(),
                 parent_id: Some(queen_id.clone()),
@@ -6515,7 +7372,11 @@ Last updated: {timestamp}
             session_type: SessionType::Hive {
                 // Roster mode starts with zero live workers; the count grows as the
                 // Queen spawns researchers on demand.
-                worker_count: if pre_spawn_workers { config.workers.len() as u8 } else { 0 },
+                worker_count: if pre_spawn_workers {
+                    config.workers.len() as u8
+                } else {
+                    0
+                },
             },
             project_path: project_path.clone(),
             state: SessionState::Running,
@@ -6546,9 +7407,12 @@ Last updated: {timestamp}
         self.emit_agent_batch_launched(&session, &session.agents);
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         // Initialize session storage
@@ -6574,7 +7438,12 @@ Last updated: {timestamp}
                 let mut sessions = self.sessions.write();
                 sessions.remove(&session.id);
             }
-            self.rollback_launch_allocations(&project_path, &session_id, &created_cells, &spawned_agent_ids);
+            self.rollback_launch_allocations(
+                &project_path,
+                &session_id,
+                &created_cells,
+                &spawned_agent_ids,
+            );
             err
         })?;
 
@@ -6653,7 +7522,13 @@ Last updated: {timestamp}
         // Research never touches git: no worktrees, no branches, and no pre-spawned
         // workers. The Queen comes up alone and spawns researchers from the roster on
         // demand, so it also works on non-repo folders.
-        self.launch_hive_internal(hive_config, Some("queen-research"), extra_queen_vars, false, false)
+        self.launch_hive_internal(
+            hive_config,
+            Some("queen-research"),
+            extra_queen_vars,
+            false,
+            false,
+        )
     }
 
     /// Hard-override banner injected at the top of the queen-research prompt for a
@@ -6682,8 +7557,12 @@ phases and do EXACTLY this, then stop:
     }
 
     pub fn launch_fusion(&self, config: FusionLaunchConfig) -> Result<Session, String> {
-        tracing::info!("launch_fusion called: with_planning={}, variants={}, task={}",
-            config.with_planning, config.variants.len(), &config.task_description);
+        tracing::info!(
+            "launch_fusion called: with_planning={}, variants={}, task={}",
+            config.with_planning,
+            config.variants.len(),
+            &config.task_description
+        );
 
         if config.variants.is_empty() {
             return Err("Fusion launch requires at least one variant".to_string());
@@ -6720,12 +7599,10 @@ phases and do EXACTLY this, then stop:
                 .join(format!("variant-{}", slug))
                 .to_string_lossy()
                 .to_string();
-            let task_file = Self::fusion_variant_task_file_path(
-                Path::new(&worktree_path),
-                index as usize,
-            )
-            .to_string_lossy()
-            .to_string();
+            let task_file =
+                Self::fusion_variant_task_file_path(Path::new(&worktree_path), index as usize)
+                    .to_string_lossy()
+                    .to_string();
 
             variants.push(FusionVariantMetadata {
                 index,
@@ -6829,7 +7706,10 @@ phases and do EXACTLY this, then stop:
             };
             let variant_agent_config = AgentConfig {
                 cli: cli.clone(),
-                model: source_variant.model.clone().or(config.default_model.clone()),
+                model: source_variant
+                    .model
+                    .clone()
+                    .or(config.default_model.clone()),
                 flags: source_variant.flags.clone(),
                 label: Some(format!("Fusion {}", variant.name)),
                 name: None,
@@ -6881,7 +7761,9 @@ phases and do EXACTLY this, then stop:
                         120,
                         30,
                     )
-                    .map_err(|e| format!("Failed to spawn Fusion variant {}: {}", variant.name, e))?;
+                    .map_err(|e| {
+                        format!("Failed to spawn Fusion variant {}: {}", variant.name, e)
+                    })?;
             }
 
             let agent_info = AgentInfo {
@@ -6896,19 +7778,20 @@ phases and do EXACTLY this, then stop:
                 base_commit_sha: None,
             };
 
-            let waiting_changes = {
-                let mut sessions = self.sessions.write();
-                if let Some(s) = sessions.get_mut(&session_id) {
-                    s.agents.push(agent_info.clone());
-                    self.emit_agent_launched(s, &agent_info);
-                    Some(self.set_session_state_with_events(
-                        s,
-                        SessionState::WaitingForFusionVariants,
-                    ))
-                } else {
-                    None
-                }
-            };
+            let waiting_changes =
+                {
+                    let mut sessions = self.sessions.write();
+                    if let Some(s) = sessions.get_mut(&session_id) {
+                        s.agents.push(agent_info.clone());
+                        self.emit_agent_launched(s, &agent_info);
+                        Some(self.set_session_state_with_events(
+                            s,
+                            SessionState::WaitingForFusionVariants,
+                        ))
+                    } else {
+                        None
+                    }
+                };
             if let Some(changes) = waiting_changes {
                 self.emit_cell_status_changes(&session_id, changes);
             }
@@ -6949,8 +7832,401 @@ phases and do EXACTLY this, then stop:
         Ok(session)
     }
 
+    pub fn launch_debate(&self, mut config: DebateLaunchConfig) -> Result<Session, String> {
+        tracing::info!(
+            "launch_debate called: with_planning={}, debaters={}, rounds={}, topic={}",
+            config.with_planning,
+            config.debaters.len(),
+            config.rounds,
+            &config.topic
+        );
+
+        if config.debaters.is_empty() {
+            return Err("Debate launch requires at least one debater".to_string());
+        }
+        config.rounds = Self::validate_debate_rounds(config.rounds)?;
+        if config.topic.trim().is_empty() {
+            return Err("Debate launch requires a non-empty topic".to_string());
+        }
+
+        if config.with_planning {
+            let session_id = Uuid::new_v4().to_string();
+            return self.launch_debate_planning_phase(session_id, config);
+        }
+
+        let session_id = Uuid::new_v4().to_string();
+        let project_path = PathBuf::from(&config.project_path);
+        let default_cli = if config.default_cli.trim().is_empty() {
+            "claude".to_string()
+        } else {
+            config.default_cli.trim().to_string()
+        };
+        let debaters =
+            Self::build_debate_debater_metadata(&session_id, &project_path, &config, &default_cli);
+
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
+        let session = Session {
+            id: session_id.clone(),
+            name: config.name.clone(),
+            color: config.color.clone(),
+            session_type: SessionType::Debate {
+                variants: debaters.iter().map(|d| d.name.clone()).collect(),
+            },
+            project_path: project_path.clone(),
+            state: SessionState::Starting,
+            created_at: Utc::now(),
+            last_activity_at: Utc::now(),
+            agents: Vec::new(),
+            default_cli: default_cli.clone(),
+            default_model: config.default_model.clone(),
+            qa_workers: Vec::new(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
+            worktree_path: debaters.first().map(|d| d.worktree_path.clone()),
+            worktree_branch: debaters.first().map(|d| d.branch.clone()),
+            no_git: false,
+            resume_report: None,
+        };
+
+        {
+            let mut sessions = self.sessions.write();
+            sessions.insert(session_id.clone(), session);
+        }
+        self.emit_session_update(&session_id);
+
+        let fresh_base = resolve_fresh_base(&project_path);
+        let base_branch = format!("debate/{}/base", session_id);
+        Self::run_git_in_dir(&project_path, &["branch", &base_branch, &fresh_base])?;
+        Self::create_debate_worktrees(&project_path, &session_id, &base_branch, &debaters, self)?;
+
+        let verdict_file = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("evaluation")
+            .join("verdict.md")
+            .to_string_lossy()
+            .to_string();
+        if let Some(parent) = Path::new(&verdict_file).parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create debate evaluation directory: {}", e))?;
+        }
+        std::fs::create_dir_all(
+            project_path
+                .join(".hive-manager")
+                .join(&session_id)
+                .join("debate")
+                .join("rounds"),
+        )
+        .map_err(|e| format!("Failed to create debate rounds directory: {}", e))?;
+
+        let metadata = DebateSessionMetadata {
+            base_branch,
+            debaters,
+            judge_config: config.judge_config,
+            topic: config.topic,
+            rounds: config.rounds,
+            verdict_file,
+        };
+        Self::write_debate_metadata(&project_path, &session_id, &metadata)?;
+
+        self.spawn_debate_round(&session_id, 1)?;
+
+        let session = self
+            .get_session(&session_id)
+            .ok_or_else(|| "Failed to read debate session after launch".to_string())?;
+        self.init_session_storage(&session);
+        self.update_session_storage(&session_id);
+        self.ensure_task_watcher(&session_id, &project_path);
+
+        Ok(session)
+    }
+
+    fn build_debate_debater_metadata(
+        session_id: &str,
+        project_path: &Path,
+        config: &DebateLaunchConfig,
+        default_cli: &str,
+    ) -> Vec<DebateDebaterMetadata> {
+        let mut seen_slugs: HashMap<String, u16> = HashMap::new();
+
+        config
+            .debaters
+            .iter()
+            .enumerate()
+            .map(|(idx, debater)| {
+                let index = (idx + 1) as u8;
+                let name = if debater.name.trim().is_empty() {
+                    format!("debater-{}", index)
+                } else {
+                    debater.name.trim().to_string()
+                };
+                let slug = Self::unique_variant_slug(&name, &mut seen_slugs);
+                let branch = format!("debate/{}/{}", session_id, slug);
+                let worktree_path = project_path
+                    .join(".hive-debate")
+                    .join(session_id)
+                    .join(format!("debater-{}", slug))
+                    .to_string_lossy()
+                    .to_string();
+                let cli = if debater.cli.trim().is_empty() {
+                    default_cli.to_string()
+                } else {
+                    debater.cli.trim().to_string()
+                };
+                let agent_config = AgentConfig {
+                    cli,
+                    model: debater.model.clone().or(config.default_model.clone()),
+                    flags: debater.flags.clone(),
+                    label: Some(format!("Debate {}", name)),
+                    name: None,
+                    description: debater.stance.clone(),
+                    role: None,
+                    initial_prompt: Some(config.topic.clone()),
+                };
+
+                DebateDebaterMetadata {
+                    index,
+                    name,
+                    stance: debater.stance.clone(),
+                    slug,
+                    branch,
+                    worktree_path,
+                    config: agent_config,
+                }
+            })
+            .collect()
+    }
+
+    fn create_debate_worktrees(
+        project_path: &PathBuf,
+        session_id: &str,
+        base_branch: &str,
+        debaters: &[DebateDebaterMetadata],
+        controller: &SessionController,
+    ) -> Result<(), String> {
+        for debater in debaters {
+            let worktree_path = PathBuf::from(&debater.worktree_path);
+            if let Some(parent) = worktree_path.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("Failed to create debate worktree parent dir: {}", e))?;
+            }
+
+            Self::run_git_in_dir(
+                project_path,
+                &[
+                    "worktree",
+                    "add",
+                    &debater.worktree_path,
+                    "-b",
+                    &debater.branch,
+                    base_branch,
+                ],
+            )?;
+            controller.emit_workspace_created(
+                session_id,
+                &variant_to_cell_id(&debater.name),
+                &debater.branch,
+                Some(&debater.worktree_path),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn debate_opponent_files(
+        project_path: &Path,
+        session_id: &str,
+        metadata: &DebateSessionMetadata,
+        debater_index: u8,
+        round: u8,
+    ) -> String {
+        if round <= 1 {
+            return "No prior opponent arguments. This is the opening round.".to_string();
+        }
+
+        metadata
+            .debaters
+            .iter()
+            .filter(|debater| debater.index != debater_index)
+            .map(|debater| {
+                let path = Self::debate_round_argument_file_path(
+                    project_path,
+                    session_id,
+                    round - 1,
+                    &debater.slug,
+                );
+                format!("- {}: `{}`", debater.name, Self::prompt_path(&path))
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn spawn_debate_round(&self, session_id: &str, round: u8) -> Result<(), String> {
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        if !matches!(session.session_type, SessionType::Debate { .. }) {
+            return Err(format!("Session {} is not a Debate session", session_id));
+        }
+
+        let metadata = Self::read_debate_metadata(&session.project_path, session_id)?;
+        if round == 0 || round > metadata.rounds {
+            return Err(format!(
+                "Invalid debate round {} for session {}",
+                round, session_id
+            ));
+        }
+
+        let previous_round_dir = if round > 1 {
+            Some(
+                session
+                    .project_path
+                    .join(".hive-manager")
+                    .join(session_id)
+                    .join("debate")
+                    .join("rounds")
+                    .join(format!("round-{}", round - 1)),
+            )
+        } else {
+            None
+        };
+
+        let mut new_agents = Vec::new();
+        for debater in &metadata.debaters {
+            let spawning_changes = {
+                let mut sessions = self.sessions.write();
+                sessions.get_mut(session_id).map(|s| {
+                    self.set_session_state_with_events(s, SessionState::SpawningDebateRound(round))
+                })
+            };
+            if let Some(changes) = spawning_changes {
+                self.emit_cell_status_changes(session_id, changes);
+            }
+            self.emit_session_update(session_id);
+
+            let worktree_path = PathBuf::from(&debater.worktree_path);
+            let argument_file = Self::debate_round_argument_file_path(
+                &session.project_path,
+                session_id,
+                round,
+                &debater.slug,
+            );
+            if let Some(parent) = argument_file.parent() {
+                std::fs::create_dir_all(parent)
+                    .map_err(|e| format!("Failed to create debate argument directory: {}", e))?;
+            }
+            let opponent_files = Self::debate_opponent_files(
+                &session.project_path,
+                session_id,
+                &metadata,
+                debater.index,
+                round,
+            );
+            let task_file = Self::write_debate_round_task_file(
+                &worktree_path,
+                debater,
+                &metadata.topic,
+                round,
+                metadata.rounds,
+                &argument_file,
+                &opponent_files,
+            )?;
+            let prompt = Self::build_debate_debater_prompt(
+                session_id,
+                debater,
+                &metadata.topic,
+                round,
+                metadata.rounds,
+                &argument_file,
+                previous_round_dir.as_deref(),
+                &opponent_files,
+                &task_file,
+            );
+            let prompt_filename =
+                format!("debate-debater-{}-round-{}-prompt.md", debater.index, round);
+            let prompt_file = Self::write_worker_prompt_file(
+                &worktree_path,
+                debater.index,
+                &prompt_filename,
+                &prompt,
+            )?;
+            let prompt_path = prompt_file.to_string_lossy().to_string();
+
+            let agent_config = debater.config.clone();
+            let (cmd, mut args) = Self::build_command(&agent_config);
+            Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
+
+            let agent_id = Self::debate_round_agent_id(session_id, debater.index, round);
+            {
+                let pty_manager = self.pty_manager.read();
+                pty_manager
+                    .create_session(
+                        agent_id.clone(),
+                        AgentRole::Fusion {
+                            variant: debater.name.clone(),
+                        },
+                        &cmd,
+                        &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                        Some(&debater.worktree_path),
+                        120,
+                        30,
+                    )
+                    .map_err(|e| {
+                        format!(
+                            "Failed to spawn Debate debater {} round {}: {}",
+                            debater.name, round, e
+                        )
+                    })?;
+            }
+
+            new_agents.push(AgentInfo {
+                id: agent_id,
+                role: AgentRole::Fusion {
+                    variant: debater.name.clone(),
+                },
+                status: AgentStatus::Running,
+                config: agent_config,
+                parent_id: None,
+                commit_sha: None,
+                base_commit_sha: None,
+            });
+        }
+
+        let (updated_session, changes) = {
+            let mut sessions = self.sessions.write();
+            if let Some(s) = sessions.get_mut(session_id) {
+                s.agents.extend(new_agents.clone());
+                self.emit_agent_batch_launched(s, &new_agents);
+                let changes = self
+                    .set_session_state_with_events(s, SessionState::WaitingForDebateRound(round));
+                (s.clone(), changes)
+            } else {
+                return Err("Session disappeared".to_string());
+            }
+        };
+
+        if let Some(ref app_handle) = self.app_handle {
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: updated_session,
+                },
+            );
+        }
+        self.update_session_storage(session_id);
+        self.emit_cell_status_changes(session_id, changes);
+
+        Ok(())
+    }
+
     /// Launch the planning phase - spawns Master Planner only
-    fn launch_planning_phase(&self, session_id: String, config: HiveLaunchConfig) -> Result<Session, String> {
+    fn launch_planning_phase(
+        &self,
+        session_id: String,
+        config: HiveLaunchConfig,
+    ) -> Result<Session, String> {
         let project_path = PathBuf::from(&config.project_path);
         let cwd = config.project_path.as_str();
         let mut agents = Vec::new();
@@ -6958,7 +8234,12 @@ phases and do EXACTLY this, then stop:
         // Build the appropriate prompt based on mode
         let planner_prompt = if config.smoke_test {
             tracing::info!("Running in SMOKE TEST mode - skipping real investigation");
-            Self::build_smoke_test_prompt(&session_id, &config.workers, config.with_evaluator, config.qa_workers.as_deref())
+            Self::build_smoke_test_prompt(
+                &session_id,
+                &config.workers,
+                config.with_evaluator,
+                config.qa_workers.as_deref(),
+            )
         } else {
             // Pass workers info to Master Planner so it knows how many tasks to create
             let prompt = config.prompt.as_deref().unwrap_or("");
@@ -6973,7 +8254,12 @@ phases and do EXACTLY this, then stop:
             let (cmd, mut args) = Self::build_command(&config.queen_config); // Use queen config for planner
 
             // Write Master Planner prompt to file
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, "master-planner-prompt.md", &planner_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &project_path,
+                &session_id,
+                "master-planner-prompt.md",
+                &planner_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
@@ -7003,7 +8289,10 @@ phases and do EXACTLY this, then stop:
         }
 
         // Store the pending config for later continuation
-        let pending_config_path = project_path.join(".hive-manager").join(&session_id).join("pending-config.json");
+        let pending_config_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("pending-config.json");
         std::fs::create_dir_all(pending_config_path.parent().unwrap())
             .map_err(|e| format!("Failed to create session directory: {}", e))?;
         let config_json = serde_json::to_string_pretty(&config)
@@ -7016,7 +8305,9 @@ phases and do EXACTLY this, then stop:
             id: session_id.clone(),
             name: config.name.clone(),
             color: config.color.clone(),
-            session_type: SessionType::Hive { worker_count: config.workers.len() as u8 },
+            session_type: SessionType::Hive {
+                worker_count: config.workers.len() as u8,
+            },
             project_path,
             state: SessionState::Planning,
             created_at: Utc::now(),
@@ -7042,9 +8333,12 @@ phases and do EXACTLY this, then stop:
         self.emit_agent_batch_launched(&session, &session.agents);
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         self.init_session_storage(&session);
@@ -7054,7 +8348,11 @@ phases and do EXACTLY this, then stop:
     }
 
     /// Launch the planning phase for Fusion - spawns Master Planner only
-    fn launch_fusion_planning_phase(&self, session_id: String, config: FusionLaunchConfig) -> Result<Session, String> {
+    fn launch_fusion_planning_phase(
+        &self,
+        session_id: String,
+        config: FusionLaunchConfig,
+    ) -> Result<Session, String> {
         let project_path = PathBuf::from(&config.project_path);
         let cwd = config.project_path.as_str();
         let mut agents = Vec::new();
@@ -7072,11 +8370,21 @@ phases and do EXACTLY this, then stop:
             let queen_cfg = config.queen_config.as_ref().unwrap_or(&config.judge_config);
             let (cmd, mut args) = Self::build_command(queen_cfg);
 
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, "master-planner-prompt.md", &planner_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &project_path,
+                &session_id,
+                "master-planner-prompt.md",
+                &planner_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
-            tracing::info!("Launching Master Planner (fusion): {} {:?} in {:?}", cmd, args, cwd);
+            tracing::info!(
+                "Launching Master Planner (fusion): {} {:?} in {:?}",
+                cmd,
+                args,
+                cwd
+            );
 
             pty_manager
                 .create_session(
@@ -7102,7 +8410,10 @@ phases and do EXACTLY this, then stop:
         }
 
         // Store the pending Fusion config for later continuation
-        let pending_config_path = project_path.join(".hive-manager").join(&session_id).join("pending-fusion-config.json");
+        let pending_config_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("pending-fusion-config.json");
         std::fs::create_dir_all(pending_config_path.parent().unwrap())
             .map_err(|e| format!("Failed to create session directory: {}", e))?;
         let config_json = serde_json::to_string_pretty(&config)
@@ -7116,13 +8427,19 @@ phases and do EXACTLY this, then stop:
             id: session_id.clone(),
             name: config.name.clone(),
             color: config.color.clone(),
-            session_type: SessionType::Fusion { variants: variant_names },
+            session_type: SessionType::Fusion {
+                variants: variant_names,
+            },
             project_path: project_path.clone(),
             state: SessionState::Planning,
             created_at: Utc::now(),
             last_activity_at: Utc::now(),
             agents,
-            default_cli: if config.default_cli.trim().is_empty() { "claude".to_string() } else { config.default_cli.trim().to_string() },
+            default_cli: if config.default_cli.trim().is_empty() {
+                "claude".to_string()
+            } else {
+                config.default_cli.trim().to_string()
+            },
             default_model: config.default_model.clone(),
             qa_workers: Vec::new(),
             max_qa_iterations,
@@ -7142,9 +8459,137 @@ phases and do EXACTLY this, then stop:
         self.emit_agent_batch_launched(&session, &session.agents);
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
+        }
+
+        self.init_session_storage(&session);
+        self.ensure_task_watcher(&session.id, &session.project_path);
+
+        Ok(session)
+    }
+
+    fn launch_debate_planning_phase(
+        &self,
+        session_id: String,
+        config: DebateLaunchConfig,
+    ) -> Result<Session, String> {
+        let project_path = PathBuf::from(&config.project_path);
+        let cwd = config.project_path.as_str();
+        let mut agents = Vec::new();
+
+        let planner_prompt = Self::build_debate_master_planner_prompt(
+            &session_id,
+            &config.topic,
+            &config.debaters,
+            config.rounds,
+        );
+
+        {
+            let pty_manager = self.pty_manager.read();
+
+            let planner_id = format!("{}-master-planner", session_id);
+            let queen_cfg = config.queen_config.as_ref().unwrap_or(&config.judge_config);
+            let (cmd, mut args) = Self::build_command(queen_cfg);
+
+            let prompt_file = Self::write_prompt_file(
+                &project_path,
+                &session_id,
+                "master-planner-prompt.md",
+                &planner_prompt,
+            )?;
+            let prompt_path = prompt_file.to_string_lossy().to_string();
+            Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
+
+            tracing::info!(
+                "Launching Master Planner (debate): {} {:?} in {:?}",
+                cmd,
+                args,
+                cwd
+            );
+
+            pty_manager
+                .create_session(
+                    planner_id.clone(),
+                    AgentRole::MasterPlanner,
+                    &cmd,
+                    &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    Some(cwd),
+                    120,
+                    30,
+                )
+                .map_err(|e| format!("Failed to spawn Master Planner: {}", e))?;
+
+            agents.push(AgentInfo {
+                id: planner_id,
+                role: AgentRole::MasterPlanner,
+                status: AgentStatus::Running,
+                config: queen_cfg.clone(),
+                parent_id: None,
+                commit_sha: None,
+                base_commit_sha: None,
             });
+        }
+
+        let pending_config_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("pending-debate-config.json");
+        std::fs::create_dir_all(pending_config_path.parent().unwrap())
+            .map_err(|e| format!("Failed to create session directory: {}", e))?;
+        let config_json = serde_json::to_string_pretty(&config)
+            .map_err(|e| format!("Failed to serialize config: {}", e))?;
+        std::fs::write(&pending_config_path, config_json)
+            .map_err(|e| format!("Failed to write pending config: {}", e))?;
+
+        let debater_names: Vec<String> = config.debaters.iter().map(|v| v.name.clone()).collect();
+        let (max_qa_iterations, qa_timeout_secs, auth_strategy) = default_session_qa_settings();
+        let session = Session {
+            id: session_id.clone(),
+            name: config.name.clone(),
+            color: config.color.clone(),
+            session_type: SessionType::Debate {
+                variants: debater_names,
+            },
+            project_path: project_path.clone(),
+            state: SessionState::Planning,
+            created_at: Utc::now(),
+            last_activity_at: Utc::now(),
+            agents,
+            default_cli: if config.default_cli.trim().is_empty() {
+                "claude".to_string()
+            } else {
+                config.default_cli.trim().to_string()
+            },
+            default_model: config.default_model.clone(),
+            qa_workers: Vec::new(),
+            max_qa_iterations,
+            qa_timeout_secs,
+            auth_strategy,
+            worktree_path: None,
+            worktree_branch: None,
+            no_git: false,
+            resume_report: None,
+        };
+
+        {
+            let mut sessions = self.sessions.write();
+            sessions.insert(session_id.clone(), session.clone());
+        }
+
+        self.emit_agent_batch_launched(&session, &session.agents);
+
+        if let Some(ref app_handle) = self.app_handle {
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         self.init_session_storage(&session);
@@ -7154,11 +8599,19 @@ phases and do EXACTLY this, then stop:
     }
 
     /// Continue a Fusion session after planning phase - spawns Queen + Variants
-    fn continue_fusion_after_planning(&self, session_id: &str, session: &Session) -> Result<Session, String> {
+    fn continue_fusion_after_planning(
+        &self,
+        session_id: &str,
+        session: &Session,
+    ) -> Result<Session, String> {
         let cwd = session.project_path.to_str().unwrap_or(".");
 
         // Load the pending Fusion config
-        let pending_config_path = session.project_path.join(".hive-manager").join(session_id).join("pending-fusion-config.json");
+        let pending_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("pending-fusion-config.json");
         let config_json = std::fs::read_to_string(&pending_config_path)
             .map_err(|e| format!("Failed to read pending fusion config: {}", e))?;
         let config: FusionLaunchConfig = serde_json::from_str(&config_json)
@@ -7169,7 +8622,10 @@ phases and do EXACTLY this, then stop:
         if let Err(e) = self.stop_agent(session_id, &planner_id) {
             tracing::warn!("Failed to stop Master Planner {}: {}", planner_id, e);
         } else {
-            tracing::info!("Stopped Master Planner {} before spawning Fusion Queen", planner_id);
+            tracing::info!(
+                "Stopped Master Planner {} before spawning Fusion Queen",
+                planner_id
+            );
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
                 s.agents.retain(|a| a.id != planner_id);
@@ -7195,18 +8651,17 @@ phases and do EXACTLY this, then stop:
             };
             let slug = Self::unique_variant_slug(&name, &mut seen_slugs);
             let branch = format!("fusion/{}/{}", session_id, slug);
-            let worktree_path = session.project_path
+            let worktree_path = session
+                .project_path
                 .join(".hive-fusion")
                 .join(session_id)
                 .join(format!("variant-{}", slug))
                 .to_string_lossy()
                 .to_string();
-            let task_file = Self::fusion_variant_task_file_path(
-                Path::new(&worktree_path),
-                index as usize,
-            )
-            .to_string_lossy()
-            .to_string();
+            let task_file =
+                Self::fusion_variant_task_file_path(Path::new(&worktree_path), index as usize)
+                    .to_string_lossy()
+                    .to_string();
 
             variants.push(FusionVariantMetadata {
                 index,
@@ -7222,12 +8677,19 @@ phases and do EXACTLY this, then stop:
         // Create git base branch and worktrees
         let fresh_base = resolve_fresh_base(&session.project_path);
         let base_branch = format!("fusion/{}/base", session_id);
-        Self::run_git_in_dir(&session.project_path, &["branch", &base_branch, &fresh_base])?;
+        Self::run_git_in_dir(
+            &session.project_path,
+            &["branch", &base_branch, &fresh_base],
+        )?;
 
         let mut new_agents = Vec::new();
 
         // Spawn Queen agent
-        let queen_cfg = config.queen_config.as_ref().unwrap_or(&config.judge_config).clone();
+        let queen_cfg = config
+            .queen_config
+            .as_ref()
+            .unwrap_or(&config.judge_config)
+            .clone();
         {
             let pty_manager = self.pty_manager.read();
 
@@ -7242,7 +8704,12 @@ phases and do EXACTLY this, then stop:
                 &config.task_description,
                 false, // Fusion sessions never launch an Evaluator
             );
-            let prompt_file = Self::write_prompt_file(&session.project_path, session_id, "fusion-queen-prompt.md", &queen_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &session.project_path,
+                session_id,
+                "fusion-queen-prompt.md",
+                &queen_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
@@ -7285,9 +8752,11 @@ phases and do EXACTLY this, then stop:
             Self::run_git_in_dir(
                 &session.project_path,
                 &[
-                    "worktree", "add",
+                    "worktree",
+                    "add",
                     &variant.worktree_path,
-                    "-b", &variant.branch,
+                    "-b",
+                    &variant.branch,
                     &base_branch,
                 ],
             )?;
@@ -7313,7 +8782,10 @@ phases and do EXACTLY this, then stop:
             };
             let variant_agent_config = AgentConfig {
                 cli: cli.clone(),
-                model: source_variant.model.clone().or(config.default_model.clone()),
+                model: source_variant
+                    .model
+                    .clone()
+                    .or(config.default_model.clone()),
                 flags: source_variant.flags.clone(),
                 label: Some(format!("Fusion {}", variant.name)),
                 name: None,
@@ -7345,7 +8817,10 @@ phases and do EXACTLY this, then stop:
 
             tracing::info!(
                 "Launching Fusion variant {} ({}) on branch {} in {}",
-                variant.index, variant.name, variant.branch, variant.worktree_path
+                variant.index,
+                variant.name,
+                variant.branch,
+                variant.worktree_path
             );
 
             {
@@ -7353,19 +8828,25 @@ phases and do EXACTLY this, then stop:
                 pty_manager
                     .create_session(
                         variant.agent_id.clone(),
-                        AgentRole::Fusion { variant: variant.name.clone() },
+                        AgentRole::Fusion {
+                            variant: variant.name.clone(),
+                        },
                         &cmd,
                         &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
                         Some(&variant.worktree_path),
                         120,
                         30,
                     )
-                    .map_err(|e| format!("Failed to spawn Fusion variant {}: {}", variant.name, e))?;
+                    .map_err(|e| {
+                        format!("Failed to spawn Fusion variant {}: {}", variant.name, e)
+                    })?;
             }
 
             new_agents.push(AgentInfo {
                 id: variant.agent_id.clone(),
-                role: AgentRole::Fusion { variant: variant.name.clone() },
+                role: AgentRole::Fusion {
+                    variant: variant.name.clone(),
+                },
                 status: AgentStatus::Running,
                 config: variant_agent_config,
                 parent_id: None,
@@ -7375,14 +8856,16 @@ phases and do EXACTLY this, then stop:
         }
 
         // Create evaluation directory
-        let evaluation_dir = session.project_path
+        let evaluation_dir = session
+            .project_path
             .join(".hive-manager")
             .join(session_id)
             .join("evaluation");
         std::fs::create_dir_all(&evaluation_dir)
             .map_err(|e| format!("Failed to create fusion evaluation directory: {}", e))?;
 
-        let decision_file = session.project_path
+        let decision_file = session
+            .project_path
             .join(".hive-manager")
             .join(session_id)
             .join("evaluation")
@@ -7418,9 +8901,12 @@ phases and do EXACTLY this, then stop:
         };
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: updated_session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: updated_session.clone(),
+                },
+            );
         }
 
         self.update_session_storage(session_id);
@@ -7433,21 +8919,153 @@ phases and do EXACTLY this, then stop:
         Ok(updated_session)
     }
 
+    fn continue_debate_after_planning(
+        &self,
+        session_id: &str,
+        session: &Session,
+    ) -> Result<Session, String> {
+        let pending_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("pending-debate-config.json");
+        let config_json = std::fs::read_to_string(&pending_config_path)
+            .map_err(|e| format!("Failed to read pending debate config: {}", e))?;
+        let mut config: DebateLaunchConfig = serde_json::from_str(&config_json)
+            .map_err(|e| format!("Failed to parse pending debate config: {}", e))?;
+        config.rounds = Self::validate_debate_rounds(config.rounds)?;
+
+        let planner_id = format!("{}-master-planner", session_id);
+        if let Err(e) = self.stop_agent(session_id, &planner_id) {
+            tracing::warn!("Failed to stop Master Planner {}: {}", planner_id, e);
+        } else {
+            tracing::info!(
+                "Stopped Master Planner {} before spawning Debate debaters",
+                planner_id
+            );
+            let mut sessions = self.sessions.write();
+            if let Some(s) = sessions.get_mut(session_id) {
+                s.agents.retain(|a| a.id != planner_id);
+            }
+        }
+
+        let default_cli = if config.default_cli.trim().is_empty() {
+            "claude".to_string()
+        } else {
+            config.default_cli.trim().to_string()
+        };
+        let debaters = Self::build_debate_debater_metadata(
+            session_id,
+            &session.project_path,
+            &config,
+            &default_cli,
+        );
+
+        let fresh_base = resolve_fresh_base(&session.project_path);
+        let base_branch = format!("debate/{}/base", session_id);
+        Self::run_git_in_dir(
+            &session.project_path,
+            &["branch", &base_branch, &fresh_base],
+        )?;
+        Self::create_debate_worktrees(
+            &session.project_path,
+            session_id,
+            &base_branch,
+            &debaters,
+            self,
+        )?;
+
+        let verdict_file = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("evaluation")
+            .join("verdict.md")
+            .to_string_lossy()
+            .to_string();
+        if let Some(parent) = Path::new(&verdict_file).parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create debate evaluation directory: {}", e))?;
+        }
+        std::fs::create_dir_all(
+            session
+                .project_path
+                .join(".hive-manager")
+                .join(session_id)
+                .join("debate")
+                .join("rounds"),
+        )
+        .map_err(|e| format!("Failed to create debate rounds directory: {}", e))?;
+
+        let metadata = DebateSessionMetadata {
+            base_branch,
+            debaters: debaters.clone(),
+            judge_config: config.judge_config.clone(),
+            topic: config.topic,
+            rounds: config.rounds,
+            verdict_file,
+        };
+        Self::write_debate_metadata(&session.project_path, session_id, &metadata)?;
+
+        {
+            let mut sessions = self.sessions.write();
+            if let Some(s) = sessions.get_mut(session_id) {
+                if let Some(d) = debaters.first() {
+                    s.worktree_path = Some(d.worktree_path.clone());
+                    s.worktree_branch = Some(d.branch.clone());
+                }
+            }
+        }
+
+        self.spawn_debate_round(session_id, 1)?;
+
+        let updated_session = self
+            .get_session(session_id)
+            .ok_or_else(|| "Session disappeared".to_string())?;
+        self.ensure_task_watcher(session_id, &updated_session.project_path);
+        let _ = std::fs::remove_file(&pending_config_path);
+
+        Ok(updated_session)
+    }
+
     /// Launch the planning phase for Swarm - spawns Master Planner only
-    fn launch_swarm_planning_phase(&self, session_id: String, config: SwarmLaunchConfig) -> Result<Session, String> {
+    fn launch_swarm_planning_phase(
+        &self,
+        session_id: String,
+        config: SwarmLaunchConfig,
+    ) -> Result<Session, String> {
         let project_path = PathBuf::from(&config.project_path);
         let cwd = config.project_path.as_str();
         let mut agents = Vec::new();
 
         // Build the appropriate prompt based on mode
-        let planner_count = if config.planners.is_empty() { config.planner_count } else { config.planners.len() as u8 };
+        let planner_count = if config.planners.is_empty() {
+            config.planner_count
+        } else {
+            config.planners.len() as u8
+        };
         let planner_prompt = if config.smoke_test {
-            tracing::info!("Running in SMOKE TEST mode (swarm) - {} planners, {} workers each", planner_count, config.workers_per_planner.len());
-            Self::build_swarm_smoke_test_prompt(&session_id, planner_count, &config.workers_per_planner, config.with_evaluator, config.qa_workers.as_deref())
+            tracing::info!(
+                "Running in SMOKE TEST mode (swarm) - {} planners, {} workers each",
+                planner_count,
+                config.workers_per_planner.len()
+            );
+            Self::build_swarm_smoke_test_prompt(
+                &session_id,
+                planner_count,
+                &config.workers_per_planner,
+                config.with_evaluator,
+                config.qa_workers.as_deref(),
+            )
         } else {
             // Pass planners and workers info to Master Planner so it knows the full scope
             let prompt = config.prompt.as_deref().unwrap_or("");
-            Self::build_swarm_master_planner_prompt(&session_id, prompt, planner_count, &config.workers_per_planner)
+            Self::build_swarm_master_planner_prompt(
+                &session_id,
+                prompt,
+                planner_count,
+                &config.workers_per_planner,
+            )
         };
 
         {
@@ -7458,11 +9076,21 @@ phases and do EXACTLY this, then stop:
             let (cmd, mut args) = Self::build_command(&config.queen_config); // Use queen config for planner
 
             // Write Master Planner prompt to file
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, "master-planner-prompt.md", &planner_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &project_path,
+                &session_id,
+                "master-planner-prompt.md",
+                &planner_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
-            tracing::info!("Launching Master Planner (swarm): {} {:?} in {:?}", cmd, args, cwd);
+            tracing::info!(
+                "Launching Master Planner (swarm): {} {:?} in {:?}",
+                cmd,
+                args,
+                cwd
+            );
 
             pty_manager
                 .create_session(
@@ -7488,7 +9116,10 @@ phases and do EXACTLY this, then stop:
         }
 
         // Store the pending Swarm config for later continuation
-        let pending_config_path = project_path.join(".hive-manager").join(&session_id).join("pending-swarm-config.json");
+        let pending_config_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("pending-swarm-config.json");
         std::fs::create_dir_all(pending_config_path.parent().unwrap())
             .map_err(|e| format!("Failed to create session directory: {}", e))?;
         let config_json = serde_json::to_string_pretty(&config)
@@ -7501,7 +9132,13 @@ phases and do EXACTLY this, then stop:
             id: session_id.clone(),
             name: config.name.clone(),
             color: config.color.clone(),
-            session_type: SessionType::Swarm { planner_count: if config.planners.is_empty() { config.planner_count } else { config.planners.len() as u8 } },
+            session_type: SessionType::Swarm {
+                planner_count: if config.planners.is_empty() {
+                    config.planner_count
+                } else {
+                    config.planners.len() as u8
+                },
+            },
             project_path,
             state: SessionState::Planning,
             created_at: Utc::now(),
@@ -7525,9 +9162,12 @@ phases and do EXACTLY this, then stop:
         }
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         self.init_session_storage(&session);
@@ -7537,8 +9177,15 @@ phases and do EXACTLY this, then stop:
     }
 
     /// Spawn the next worker sequentially
-    async fn spawn_next_worker(&self, session_id: &str, worker_index: usize, config: &HiveLaunchConfig, queen_id: &str) -> Result<(), SessionError> {
-        let session = self.get_session(session_id)
+    async fn spawn_next_worker(
+        &self,
+        session_id: &str,
+        worker_index: usize,
+        config: &HiveLaunchConfig,
+        queen_id: &str,
+    ) -> Result<(), SessionError> {
+        let session = self
+            .get_session(session_id)
             .ok_or_else(|| SessionError::NotFound(format!("Session not found: {}", session_id)))?;
 
         if worker_index >= config.workers.len() {
@@ -7563,7 +9210,11 @@ phases and do EXACTLY this, then stop:
         // #125 resume guard: if this worker-spawn write-step is already journaled
         // Completed, a prior run already created its worktree/branch — do NOT re-run the
         // destructive spawn. Advance to the next worker instead.
-        if self.is_write_step_completed(session_id, crate::domain::run_journal::StepKind::WorkerSpawn, index as u64) {
+        if self.is_write_step_completed(
+            session_id,
+            crate::domain::run_journal::StepKind::WorkerSpawn,
+            index as u64,
+        ) {
             tracing::info!(
                 session_id,
                 worker_index = index,
@@ -7590,10 +9241,7 @@ phases and do EXACTLY this, then stop:
         let spawning_changes = {
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
-                Some(self.set_session_state_with_events(
-                    s,
-                    SessionState::SpawningWorker(index),
-                ))
+                Some(self.set_session_state_with_events(s, SessionState::SpawningWorker(index)))
             } else {
                 None
             }
@@ -7619,7 +9267,8 @@ phases and do EXACTLY this, then stop:
             self.restore_session_state_after_worker_spawn_failure(session_id, &previous_state);
             SessionError::ConfigError(err)
         })?;
-        let task_file_path = Self::task_file_path_for_worker(Path::new(&worker_cwd), index as usize);
+        let task_file_path =
+            Self::task_file_path_for_worker(Path::new(&worker_cwd), index as usize);
         let worker_base_commit_sha = current_head(Path::new(&worker_cwd)).map_err(|err| {
             Self::rollback_worker_launch_artifacts(
                 &session.project_path,
@@ -7668,19 +9317,23 @@ phases and do EXACTLY this, then stop:
 
         // 3. Write worker prompt to file
         let worker_prompt = Self::build_worker_prompt(index, worker_config, queen_id, session_id);
-        let prompt_file =
-            Self::write_worker_prompt_file(Path::new(&worker_cwd), index, &filename, &worker_prompt)
-                .map_err(|err| {
-                    Self::rollback_worker_launch_artifacts(
-                        &session.project_path,
-                        session_id,
-                        &worker_cell_name,
-                        &task_file_path,
-                        None,
-                    );
-                    self.restore_session_state_after_worker_spawn_failure(session_id, &previous_state);
-                    SessionError::ConfigError(err)
-                })?;
+        let prompt_file = Self::write_worker_prompt_file(
+            Path::new(&worker_cwd),
+            index,
+            &filename,
+            &worker_prompt,
+        )
+        .map_err(|err| {
+            Self::rollback_worker_launch_artifacts(
+                &session.project_path,
+                session_id,
+                &worker_cell_name,
+                &task_file_path,
+                None,
+            );
+            self.restore_session_state_after_worker_spawn_failure(session_id, &previous_state);
+            SessionError::ConfigError(err)
+        })?;
         let prompt_path = prompt_file.to_string_lossy().to_string();
 
         // 4. Build command with prompt
@@ -7692,7 +9345,10 @@ phases and do EXACTLY this, then stop:
         pty_manager
             .create_session(
                 worker_id.clone(),
-                AgentRole::Worker { index, parent: Some(queen_id.to_string()) },
+                AgentRole::Worker {
+                    index,
+                    parent: Some(queen_id.to_string()),
+                },
                 &cmd,
                 &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
                 Some(&worker_cwd),
@@ -7717,7 +9373,10 @@ phases and do EXACTLY this, then stop:
             if let Some(s) = sessions.get_mut(session_id) {
                 let agent = AgentInfo {
                     id: worker_id,
-                    role: AgentRole::Worker { index, parent: Some(queen_id.to_string()) },
+                    role: AgentRole::Worker {
+                        index,
+                        parent: Some(queen_id.to_string()),
+                    },
                     status: AgentStatus::Running,
                     config: worker_config.clone(),
                     parent_id: Some(queen_id.to_string()),
@@ -7726,10 +9385,7 @@ phases and do EXACTLY this, then stop:
                 };
                 s.agents.push(agent.clone());
                 self.emit_agent_launched(s, &agent);
-                Some(self.set_session_state_with_events(
-                    s,
-                    SessionState::WaitingForWorker(index),
-                ))
+                Some(self.set_session_state_with_events(s, SessionState::WaitingForWorker(index)))
             } else {
                 None
             }
@@ -7843,14 +9499,28 @@ phases and do EXACTLY this, then stop:
         };
 
         if let Some(base_commit_sha) = Self::worker_base_commit_sha(session, worker_id) {
-            return if head == base_commit_sha { None } else { Some(head) };
+            return if head == base_commit_sha {
+                None
+            } else {
+                Some(head)
+            };
         }
 
-        let base_ref = Self::resolve_worker_base_ref(session, "worker_completion_commit_sha", worker_id);
-        if head == base_ref { None } else { Some(head) }
+        let base_ref =
+            Self::resolve_worker_base_ref(session, "worker_completion_commit_sha", worker_id);
+        if head == base_ref {
+            None
+        } else {
+            Some(head)
+        }
     }
 
-    pub(crate) fn sync_agent_commit_sha(&self, session_id: &str, agent_id: &str, commit_sha: Option<String>) {
+    pub(crate) fn sync_agent_commit_sha(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        commit_sha: Option<String>,
+    ) {
         let updated = {
             let mut sessions = self.sessions.write();
             let Some(session) = sessions.get_mut(session_id) else {
@@ -7881,7 +9551,11 @@ phases and do EXACTLY this, then stop:
         commit_sha: Option<&str>,
     ) -> (SessionState, Vec<(String, String, String)>) {
         if let Some(evaluator_id) = evaluator_id {
-            if let Some(agent) = session.agents.iter_mut().find(|agent| agent.id == evaluator_id) {
+            if let Some(agent) = session
+                .agents
+                .iter_mut()
+                .find(|agent| agent.id == evaluator_id)
+            {
                 agent.commit_sha = commit_sha.map(str::to_string);
             }
         }
@@ -7900,8 +9574,8 @@ phases and do EXACTLY this, then stop:
                         session.id,
                         session.max_qa_iterations
                     );
-                    let changes =
-                        self.set_session_state_with_events(session, SessionState::QaMaxRetriesExceeded);
+                    let changes = self
+                        .set_session_state_with_events(session, SessionState::QaMaxRetriesExceeded);
                     session.auth_strategy = AuthStrategy::None;
                     (SessionState::QaMaxRetriesExceeded, changes)
                 } else {
@@ -7961,7 +9635,8 @@ phases and do EXACTLY this, then stop:
         };
 
         if let Some(storage) = self.storage.as_ref() {
-            if let Err(err) = Self::persist_session_snapshot(storage, &updated_session, session_id) {
+            if let Err(err) = Self::persist_session_snapshot(storage, &updated_session, session_id)
+            {
                 let mut sessions = self.sessions.write();
                 if let Some(session) = sessions.get_mut(session_id) {
                     *session = previous_session;
@@ -7989,13 +9664,22 @@ phases and do EXACTLY this, then stop:
     }
 
     /// Called when worker-completed event received
-    pub async fn on_worker_completed(&self, session_id: &str, worker_id: u8) -> Result<(), SessionError> {
-        let session = self.get_session(session_id)
+    pub async fn on_worker_completed(
+        &self,
+        session_id: &str,
+        worker_id: u8,
+    ) -> Result<(), SessionError> {
+        let session = self
+            .get_session(session_id)
             .ok_or_else(|| SessionError::NotFound(format!("Session not found: {}", session_id)))?;
 
         // Verify we're in sequential mode and this is the expected worker
         if session.state != SessionState::WaitingForWorker(worker_id) {
-            tracing::warn!("Worker {} completed but session in state {:?}", worker_id, session.state);
+            tracing::warn!(
+                "Worker {} completed but session in state {:?}",
+                worker_id,
+                session.state
+            );
             return Ok(());
         }
 
@@ -8055,16 +9739,22 @@ phases and do EXACTLY this, then stop:
         }
 
         // Load config - if it doesn't exist, workers may have been spawned via HTTP API
-        let pending_config_path = session.project_path.join(".hive-manager").join(session_id).join("pending-config.json");
+        let pending_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("pending-config.json");
         if !pending_config_path.exists() {
             tracing::info!("No pending config found for session {} - workers may have been spawned via HTTP API", session_id);
             return Ok(());
         }
 
-        let config_json = std::fs::read_to_string(&pending_config_path)
-            .map_err(|e| SessionError::ConfigError(format!("Failed to read pending config: {}", e)))?;
-        let config: HiveLaunchConfig = serde_json::from_str(&config_json)
-            .map_err(|e| SessionError::ConfigError(format!("Failed to parse pending config: {}", e)))?;
+        let config_json = std::fs::read_to_string(&pending_config_path).map_err(|e| {
+            SessionError::ConfigError(format!("Failed to read pending config: {}", e))
+        })?;
+        let config: HiveLaunchConfig = serde_json::from_str(&config_json).map_err(|e| {
+            SessionError::ConfigError(format!("Failed to parse pending config: {}", e))
+        })?;
 
         // Get queen_id
         let queen_id = format!("{}-queen", session_id);
@@ -8074,7 +9764,8 @@ phases and do EXACTLY this, then stop:
 
         // 2. Spawn next worker
         let next_worker_index = worker_id as usize;
-        self.spawn_next_worker(session_id, next_worker_index, &config, &queen_id).await?;
+        self.spawn_next_worker(session_id, next_worker_index, &config, &queen_id)
+            .await?;
 
         Ok(())
     }
@@ -8191,10 +9882,13 @@ phases and do EXACTLY this, then stop:
 
         // Emit qa-timeout event
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("qa-timeout", serde_json::json!({
-                "session_id": session_id,
-                "action": "pass-with-warning"
-            }));
+            let _ = app_handle.emit(
+                "qa-timeout",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "action": "pass-with-warning"
+                }),
+            );
         }
 
         Ok(())
@@ -8225,7 +9919,11 @@ phases and do EXACTLY this, then stop:
             };
 
             if is_qa {
-                tracing::warn!("QA timeout fired for session {} after {}s — auto-passing", sid, timeout_secs);
+                tracing::warn!(
+                    "QA timeout fired for session {} after {}s — auto-passing",
+                    sid,
+                    timeout_secs
+                );
 
                 // A timeout auto-pass should leave the session in QaPassed so the server can enforce
                 // the same quiescence gate as an explicit evaluator PASS.
@@ -8233,7 +9931,8 @@ phases and do EXACTLY this, then stop:
                     let mut sessions = sessions.write();
                     if let Some(session) = sessions.get_mut(&sid) {
                         let previous_state = session.state.clone();
-                        let changes = cell_status_changes_for_transition(session, &SessionState::QaPassed);
+                        let changes =
+                            cell_status_changes_for_transition(session, &SessionState::QaPassed);
                         session.state = SessionState::QaPassed;
                         Some((previous_state, changes, session.clone()))
                     } else {
@@ -8243,10 +9942,16 @@ phases and do EXACTLY this, then stop:
 
                 if let Some((previous_state, changes, updated_session)) = transition {
                     if let Some(storage) = storage.as_ref() {
-                        if let Err(error) =
-                            SessionController::persist_session_snapshot(storage, &updated_session, &sid)
-                        {
-                            tracing::warn!("Failed to persist QA timeout state for {}: {}", sid, error);
+                        if let Err(error) = SessionController::persist_session_snapshot(
+                            storage,
+                            &updated_session,
+                            &sid,
+                        ) {
+                            tracing::warn!(
+                                "Failed to persist QA timeout state for {}: {}",
+                                sid,
+                                error
+                            );
                             let mut sessions = sessions.write();
                             if let Some(session) = sessions.get_mut(&sid) {
                                 session.state = previous_state;
@@ -8260,13 +9965,19 @@ phases and do EXACTLY this, then stop:
                     }
 
                     if let Some(ref app_handle) = app_handle {
-                        let _ = app_handle.emit("session-update", SessionUpdate {
-                            session: updated_session,
-                        });
-                        let _ = app_handle.emit("qa-timeout", serde_json::json!({
-                            "session_id": sid,
-                            "action": "pass-with-warning"
-                        }));
+                        let _ = app_handle.emit(
+                            "session-update",
+                            SessionUpdate {
+                                session: updated_session,
+                            },
+                        );
+                        let _ = app_handle.emit(
+                            "qa-timeout",
+                            serde_json::json!({
+                                "session_id": sid,
+                                "action": "pass-with-warning"
+                            }),
+                        );
                     }
                 }
             }
@@ -8285,7 +9996,11 @@ phases and do EXACTLY this, then stop:
         }
     }
 
-    pub async fn on_fusion_variant_completed(&self, session_id: &str, variant_index: u8) -> Result<(), SessionError> {
+    pub async fn on_fusion_variant_completed(
+        &self,
+        session_id: &str,
+        variant_index: u8,
+    ) -> Result<(), SessionError> {
         let session = self
             .get_session(session_id)
             .ok_or_else(|| SessionError::NotFound(format!("Session not found: {}", session_id)))?;
@@ -8300,19 +10015,32 @@ phases and do EXACTLY this, then stop:
             .variants
             .iter()
             .find(|v| v.index == variant_index)
-            .ok_or_else(|| SessionError::ConfigError(format!("Unknown fusion variant index: {}", variant_index)))?;
+            .ok_or_else(|| {
+                SessionError::ConfigError(format!(
+                    "Unknown fusion variant index: {}",
+                    variant_index
+                ))
+            })?;
 
         {
             let pty_manager = self.pty_manager.read();
             if let Err(e) = pty_manager.kill(&variant.agent_id) {
-                tracing::warn!("Failed to stop fusion variant PTY {}: {}", variant.agent_id, e);
+                tracing::warn!(
+                    "Failed to stop fusion variant PTY {}: {}",
+                    variant.agent_id,
+                    e
+                );
             }
         }
 
         let completed_agent = {
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
-                if let Some(index) = s.agents.iter().position(|agent| agent.id == variant.agent_id) {
+                if let Some(index) = s
+                    .agents
+                    .iter()
+                    .position(|agent| agent.id == variant.agent_id)
+                {
                     s.agents[index].status = AgentStatus::Completed;
                     Some((s.clone(), s.agents[index].clone()))
                 } else {
@@ -8329,22 +10057,29 @@ phases and do EXACTLY this, then stop:
 
         let already_judging = {
             let sessions = self.sessions.read();
-            sessions.get(session_id).map(|s| {
-                matches!(
-                    s.state,
-                    SessionState::SpawningJudge
-                        | SessionState::Judging
-                        | SessionState::AwaitingVerdictSelection
-                        | SessionState::MergingWinner
-                        | SessionState::Completed
-                )
-            }).unwrap_or(false)
+            sessions
+                .get(session_id)
+                .map(|s| {
+                    matches!(
+                        s.state,
+                        SessionState::SpawningJudge
+                            | SessionState::Judging
+                            | SessionState::AwaitingVerdictSelection
+                            | SessionState::MergingWinner
+                            | SessionState::Completed
+                    )
+                })
+                .unwrap_or(false)
         };
         if already_judging {
             return Ok(());
         }
 
-        if metadata.variants.iter().all(|v| Self::is_task_completed(&v.task_file)) {
+        if metadata
+            .variants
+            .iter()
+            .all(|v| Self::is_task_completed(&v.task_file))
+        {
             self.spawn_fusion_judge(session_id)
                 .map_err(SessionError::SpawnError)?;
         }
@@ -8388,7 +10123,11 @@ phases and do EXACTLY this, then stop:
         }
         self.emit_session_update(session_id);
 
-        let judge_prompt = Self::build_fusion_judge_prompt(session_id, &metadata.variants, &metadata.decision_file);
+        let judge_prompt = Self::build_fusion_judge_prompt(
+            session_id,
+            &metadata.variants,
+            &metadata.decision_file,
+        );
         let prompt_file = Self::write_prompt_file(
             &session.project_path,
             session_id,
@@ -8456,7 +10195,10 @@ phases and do EXACTLY this, then stop:
         Ok(())
     }
 
-    pub fn get_fusion_variant_statuses(&self, session_id: &str) -> Result<Vec<FusionVariantStatus>, String> {
+    pub fn get_fusion_variant_statuses(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<FusionVariantStatus>, String> {
         let session = self
             .get_session(session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
@@ -8479,7 +10221,10 @@ phases and do EXACTLY this, then stop:
             .collect())
     }
 
-    pub fn get_fusion_evaluation(&self, session_id: &str) -> Result<(String, Option<String>), String> {
+    pub fn get_fusion_evaluation(
+        &self,
+        session_id: &str,
+    ) -> Result<(String, Option<String>), String> {
         let session = self
             .get_session(session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
@@ -8521,6 +10266,312 @@ phases and do EXACTLY this, then stop:
         Ok((metadata.decision_file, report))
     }
 
+    pub async fn on_debate_round_completed(
+        &self,
+        session_id: &str,
+        debater_index: u8,
+        round: u8,
+    ) -> Result<(), SessionError> {
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| SessionError::NotFound(format!("Session not found: {}", session_id)))?;
+
+        if !matches!(session.session_type, SessionType::Debate { .. }) {
+            return Ok(());
+        }
+
+        let metadata = Self::read_debate_metadata(&session.project_path, session_id)
+            .map_err(SessionError::ConfigError)?;
+        let debater = metadata
+            .debaters
+            .iter()
+            .find(|d| d.index == debater_index)
+            .ok_or_else(|| {
+                SessionError::ConfigError(format!(
+                    "Unknown debate debater index: {}",
+                    debater_index
+                ))
+            })?;
+        let agent_id = Self::debate_round_agent_id(session_id, debater.index, round);
+
+        {
+            let pty_manager = self.pty_manager.read();
+            if let Err(e) = pty_manager.kill(&agent_id) {
+                tracing::warn!("Failed to stop debate debater PTY {}: {}", agent_id, e);
+            }
+        }
+
+        let completed_agent = {
+            let mut sessions = self.sessions.write();
+            if let Some(s) = sessions.get_mut(session_id) {
+                if let Some(index) = s.agents.iter().position(|agent| agent.id == agent_id) {
+                    s.agents[index].status = AgentStatus::Completed;
+                    Some((s.clone(), s.agents[index].clone()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+        self.update_session_storage(session_id);
+        if let Some((session, agent)) = completed_agent {
+            self.emit_agent_completed(&session, &agent);
+        }
+
+        let already_judging = {
+            let sessions = self.sessions.read();
+            sessions
+                .get(session_id)
+                .map(|s| {
+                    matches!(
+                        s.state,
+                        SessionState::SpawningJudge
+                            | SessionState::Judging
+                            | SessionState::AwaitingVerdictSelection
+                            | SessionState::Completed
+                    )
+                })
+                .unwrap_or(false)
+        };
+        if already_judging {
+            return Ok(());
+        }
+
+        let all_round_tasks_complete = metadata.debaters.iter().all(|d| {
+            let path =
+                Self::debate_round_task_file_path(Path::new(&d.worktree_path), d.index, round)
+                    .to_string_lossy()
+                    .to_string();
+            Self::is_task_completed(&path)
+        });
+
+        if all_round_tasks_complete {
+            if round < metadata.rounds {
+                let next_round = round + 1;
+                let next_round_started = {
+                    let sessions = self.sessions.read();
+                    sessions
+                        .get(session_id)
+                        .map(|s| {
+                            metadata.debaters.iter().any(|d| {
+                                let id =
+                                    Self::debate_round_agent_id(session_id, d.index, next_round);
+                                s.agents.iter().any(|agent| agent.id == id)
+                            })
+                        })
+                        .unwrap_or(false)
+                };
+                if !next_round_started {
+                    self.spawn_debate_round(session_id, next_round)
+                        .map_err(SessionError::SpawnError)?;
+                }
+            } else {
+                self.spawn_debate_judge(session_id)
+                    .map_err(SessionError::SpawnError)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn spawn_debate_judge(&self, session_id: &str) -> Result<(), String> {
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        if !matches!(session.session_type, SessionType::Debate { .. }) {
+            return Err(format!("Session {} is not a Debate session", session_id));
+        }
+
+        let metadata = Self::read_debate_metadata(&session.project_path, session_id)?;
+        let judge_id = format!("{}-judge", session_id);
+
+        let judge_exists = {
+            let sessions = self.sessions.read();
+            sessions
+                .get(session_id)
+                .map(|s| s.agents.iter().any(|a| a.id == judge_id))
+                .unwrap_or(false)
+        };
+        if judge_exists {
+            return Ok(());
+        }
+
+        let spawning_changes = {
+            let mut sessions = self.sessions.write();
+            sessions
+                .get_mut(session_id)
+                .map(|s| self.set_session_state_with_events(s, SessionState::SpawningJudge))
+        };
+        if let Some(changes) = spawning_changes {
+            self.emit_cell_status_changes(session_id, changes);
+        }
+        self.emit_session_update(session_id);
+
+        let global_wiki_path = self
+            .storage
+            .as_ref()
+            .and_then(|storage| storage.load_config().ok())
+            .and_then(|cfg| cfg.global_wiki_path)
+            .unwrap_or_default();
+        let global_wiki_path = expand_tilde(&global_wiki_path);
+        let judge_prompt =
+            Self::build_debate_judge_prompt(session_id, &metadata, &global_wiki_path);
+        let prompt_file = Self::write_prompt_file(
+            &session.project_path,
+            session_id,
+            "debate-judge-prompt.md",
+            &judge_prompt,
+        )?;
+        let prompt_path = prompt_file.to_string_lossy().to_string();
+
+        let mut judge_config = metadata.judge_config.clone();
+        if judge_config.cli.trim().is_empty() {
+            judge_config.cli = session.default_cli.clone();
+        }
+        if judge_config.model.is_none() {
+            judge_config.model = session.default_model.clone();
+        }
+
+        let (cmd, mut args) = Self::build_command(&judge_config);
+        Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
+
+        let cwd = session.project_path.to_string_lossy().to_string();
+        {
+            let pty_manager = self.pty_manager.read();
+            pty_manager
+                .create_session(
+                    judge_id.clone(),
+                    AgentRole::Judge {
+                        session_id: session_id.to_string(),
+                    },
+                    &cmd,
+                    &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
+                    Some(&cwd),
+                    120,
+                    30,
+                )
+                .map_err(|e| format!("Failed to spawn debate judge: {}", e))?;
+        }
+
+        let judging_changes = {
+            let mut sessions = self.sessions.write();
+            if let Some(s) = sessions.get_mut(session_id) {
+                let agent = AgentInfo {
+                    id: judge_id,
+                    role: AgentRole::Judge {
+                        session_id: session_id.to_string(),
+                    },
+                    status: AgentStatus::Running,
+                    config: judge_config,
+                    parent_id: None,
+                    commit_sha: None,
+                    base_commit_sha: None,
+                };
+                s.agents.push(agent.clone());
+                self.emit_agent_launched(s, &agent);
+                Some(self.set_session_state_with_events(s, SessionState::Judging))
+            } else {
+                None
+            }
+        };
+        self.emit_session_update(session_id);
+        self.update_session_storage(session_id);
+        if let Some(changes) = judging_changes {
+            self.emit_cell_status_changes(session_id, changes);
+        }
+
+        Ok(())
+    }
+
+    pub fn get_debate_debater_statuses(
+        &self,
+        session_id: &str,
+    ) -> Result<Vec<DebateDebaterStatus>, String> {
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        if !matches!(session.session_type, SessionType::Debate { .. }) {
+            return Err(format!("Session {} is not a Debate session", session_id));
+        }
+
+        let metadata = Self::read_debate_metadata(&session.project_path, session_id)?;
+        Ok(metadata
+            .debaters
+            .iter()
+            .map(|d| {
+                let latest_task = (1..=metadata.rounds)
+                    .rev()
+                    .map(|round| {
+                        Self::debate_round_task_file_path(
+                            Path::new(&d.worktree_path),
+                            d.index,
+                            round,
+                        )
+                    })
+                    .find(|path| path.exists())
+                    .unwrap_or_else(|| {
+                        Self::debate_round_task_file_path(Path::new(&d.worktree_path), d.index, 1)
+                    });
+                DebateDebaterStatus {
+                    index: d.index,
+                    name: d.name.clone(),
+                    stance: d.stance.clone(),
+                    branch: d.branch.clone(),
+                    worktree_path: d.worktree_path.clone(),
+                    status: Self::read_task_status(&latest_task.to_string_lossy()),
+                }
+            })
+            .collect())
+    }
+
+    pub fn get_debate_evaluation(
+        &self,
+        session_id: &str,
+    ) -> Result<(String, Option<String>), String> {
+        let session = self
+            .get_session(session_id)
+            .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        if !matches!(session.session_type, SessionType::Debate { .. }) {
+            return Err(format!("Session {} is not a Debate session", session_id));
+        }
+
+        let metadata = Self::read_debate_metadata(&session.project_path, session_id)?;
+        let report = match std::fs::read_to_string(&metadata.verdict_file) {
+            Ok(content) => Some(content),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+            Err(err) => return Err(format!("Failed to read debate verdict: {}", err)),
+        };
+
+        if report.is_some() {
+            let awaiting_changes = {
+                let mut sessions = self.sessions.write();
+                if let Some(s) = sessions.get_mut(session_id) {
+                    if s.state == SessionState::Judging {
+                        Some(self.set_session_state_with_events(
+                            s,
+                            SessionState::AwaitingVerdictSelection,
+                        ))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            };
+            if let Some(changes) = awaiting_changes {
+                self.emit_session_update(session_id);
+                self.update_session_storage(session_id);
+                self.emit_cell_status_changes(session_id, changes);
+            }
+        }
+
+        Ok((metadata.verdict_file, report))
+    }
+
     pub fn select_fusion_winner(&self, session_id: &str, variant_name: &str) -> Result<(), String> {
         let session = self
             .get_session(session_id)
@@ -8541,7 +10592,12 @@ phases and do EXACTLY this, then stop:
             .variants
             .iter()
             .find(|v| v.name == requested || v.slug == requested_slug)
-            .ok_or_else(|| format!("Variant '{}' not found for session {}", requested, session_id))?;
+            .ok_or_else(|| {
+                format!(
+                    "Variant '{}' not found for session {}",
+                    requested, session_id
+                )
+            })?;
 
         let merging_changes = {
             let mut sessions = self.sessions.write();
@@ -8557,12 +10613,19 @@ phases and do EXACTLY this, then stop:
             self.emit_cell_status_changes(session_id, changes);
         }
 
-        Self::run_git_in_dir(&session.project_path, &["merge", "--squash", &winner.branch])?;
+        Self::run_git_in_dir(
+            &session.project_path,
+            &["merge", "--squash", &winner.branch],
+        )?;
 
         // Commit the squash merge (--squash only stages changes, doesn't commit)
         Self::run_git_in_dir(
             &session.project_path,
-            &["commit", "-m", &format!("Merge fusion winner: {}", winner.name)],
+            &[
+                "commit",
+                "-m",
+                &format!("Merge fusion winner: {}", winner.name),
+            ],
         )?;
 
         for variant in &metadata.variants {
@@ -8627,8 +10690,9 @@ phases and do EXACTLY this, then stop:
         let pty_manager = self.pty_manager.read();
 
         // Kill the PTY
-        pty_manager.kill(&worker_agent_id)
-            .map_err(|e| SessionError::TerminationError(format!("Failed to kill worker {}: {}", worker_id, e)))?;
+        pty_manager.kill(&worker_agent_id).map_err(|e| {
+            SessionError::TerminationError(format!("Failed to kill worker {}: {}", worker_id, e))
+        })?;
 
         // Update agent status
         let completed_agent = {
@@ -8662,11 +10726,15 @@ phases and do EXACTLY this, then stop:
         let session = {
             let sessions = self.sessions.read();
             sessions.get(session_id).cloned()
-        }.ok_or_else(|| format!("Session not found: {}", session_id))?;
+        }
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
         // Verify session is in Planning or PlanReady state
         if session.state != SessionState::Planning && session.state != SessionState::PlanReady {
-            return Err(format!("Session is not in planning phase: {:?}", session.state));
+            return Err(format!(
+                "Session is not in planning phase: {:?}",
+                session.state
+            ));
         }
 
         // Dispatch based on session type
@@ -8677,6 +10745,9 @@ phases and do EXACTLY this, then stop:
             SessionType::Fusion { .. } => {
                 return self.continue_fusion_after_planning(session_id, &session);
             }
+            SessionType::Debate { .. } => {
+                return self.continue_debate_after_planning(session_id, &session);
+            }
             SessionType::Solo { .. } => {
                 return Err("Solo sessions do not support planning continuation".to_string());
             }
@@ -8686,7 +10757,11 @@ phases and do EXACTLY this, then stop:
         let cwd = session.project_path.to_str().unwrap_or(".");
 
         // Load the pending config
-        let pending_config_path = session.project_path.join(".hive-manager").join(session_id).join("pending-config.json");
+        let pending_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("pending-config.json");
         let config_json = std::fs::read_to_string(&pending_config_path)
             .map_err(|e| format!("Failed to read pending config: {}", e))?;
         let config: HiveLaunchConfig = serde_json::from_str(&config_json)
@@ -8697,7 +10772,10 @@ phases and do EXACTLY this, then stop:
         if let Err(e) = self.stop_agent(session_id, &planner_id) {
             tracing::warn!("Failed to stop Master Planner {}: {}", planner_id, e);
         } else {
-            tracing::info!("Stopped Master Planner {} before spawning Queen", planner_id);
+            tracing::info!(
+                "Stopped Master Planner {} before spawning Queen",
+                planner_id
+            );
             // Remove Master Planner from agents list to prevent resource leaks
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
@@ -8715,7 +10793,12 @@ phases and do EXACTLY this, then stop:
             let (cmd, mut args) = Self::build_command(&config.queen_config);
 
             // Plan should exist now
-            let has_plan = session.project_path.join(".hive-manager").join(session_id).join("plan.md").exists();
+            let has_plan = session
+                .project_path
+                .join(".hive-manager")
+                .join(session_id)
+                .join("plan.md")
+                .exists();
 
             // Write Queen prompt with plan reference
             let master_prompt = Self::build_queen_master_prompt(
@@ -8728,14 +10811,24 @@ phases and do EXACTLY this, then stop:
                 has_plan,
                 config.with_evaluator,
             );
-            let prompt_file = Self::write_prompt_file(&session.project_path, session_id, "queen-prompt.md", &master_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &session.project_path,
+                session_id,
+                "queen-prompt.md",
+                &master_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
             // Write tool documentation files
             Self::write_tool_files(&session.project_path, session_id, &config.queen_config.cli)?;
 
-            tracing::info!("Launching Queen agent (after planning): {} {:?} in {:?}", cmd, args, cwd);
+            tracing::info!(
+                "Launching Queen agent (after planning): {} {:?} in {:?}",
+                cmd,
+                args,
+                cwd
+            );
 
             pty_manager
                 .create_session(
@@ -8778,9 +10871,12 @@ phases and do EXACTLY this, then stop:
         };
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: updated_session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: updated_session.clone(),
+                },
+            );
         }
 
         // Update storage
@@ -8810,14 +10906,20 @@ phases and do EXACTLY this, then stop:
                 let changes = self.set_session_state_with_events(session, SessionState::PlanReady);
 
                 if let Some(ref app_handle) = self.app_handle {
-                    let _ = app_handle.emit("session-update", SessionUpdate {
-                        session: session.clone(),
-                    });
+                    let _ = app_handle.emit(
+                        "session-update",
+                        SessionUpdate {
+                            session: session.clone(),
+                        },
+                    );
                 }
                 self.emit_cell_status_changes(session_id, changes);
                 Ok(())
             } else {
-                Err(format!("Session is not in planning state: {:?}", session.state))
+                Err(format!(
+                    "Session is not in planning state: {:?}",
+                    session.state
+                ))
             }
         } else {
             Err(format!("Session not found: {}", session_id))
@@ -8847,7 +10949,8 @@ phases and do EXACTLY this, then stop:
             .storage
             .clone()
             .ok_or_else(|| "Session storage is not initialized".to_string())?;
-        let persisted = storage.load_session(session_id)
+        let persisted = storage
+            .load_session(session_id)
             .map_err(|e| format!("Failed to load session from storage: {}", e))?;
         storage
             .mark_session_synced(session_id, &persisted)
@@ -8874,9 +10977,12 @@ phases and do EXACTLY this, then stop:
 
         // Emit session-update event to frontend
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         Ok(session)
@@ -8911,19 +11017,15 @@ phases and do EXACTLY this, then stop:
                 .ok()
                 .flatten();
             let has_unconfirmed = ledger.as_ref().map(|l| !l.confirmed).unwrap_or(false);
-            let classified =
-                crate::storage::run_journal::classify_step(&entry, has_unconfirmed);
+            let classified = crate::storage::run_journal::classify_step(&entry, has_unconfirmed);
 
             match classified {
                 StepStatus::Completed => {
                     // Completed write-steps are skipped on resume so destructive ops
                     // (git commit/branch, worker/evaluator spawn) are never re-run.
                     if entry.kind.is_write_step() {
-                        let _ = store.record_step_finished(
-                            run_id,
-                            &entry.step_id,
-                            StepStatus::Skipped,
-                        );
+                        let _ =
+                            store.record_step_finished(run_id, &entry.step_id, StepStatus::Skipped);
                         let mut skipped = entry.clone();
                         skipped.status = StepStatus::Skipped;
                         report.skipped.push(skipped);
@@ -8938,12 +11040,7 @@ phases and do EXACTLY this, then stop:
                             entry.kind,
                             led.effect_ref.as_deref(),
                         );
-                        let _ = store.confirm_ledger(
-                            run_id,
-                            &entry.step_id,
-                            None,
-                            confidence,
-                        );
+                        let _ = store.confirm_ledger(run_id, &entry.step_id, None, confidence);
                         if confidence == Confidence::High {
                             let _ = store.record_step_finished(
                                 run_id,
@@ -8988,11 +11085,9 @@ phases and do EXACTLY this, then stop:
             StepKind::GitCommit => {
                 Self::run_git_in_dir(&project_path, &["cat-file", "-e", reference]).is_ok()
             }
-            StepKind::GitBranch | StepKind::WorkerSpawn => Self::run_git_in_dir(
-                &project_path,
-                &["rev-parse", "--verify", reference],
-            )
-            .is_ok(),
+            StepKind::GitBranch | StepKind::WorkerSpawn => {
+                Self::run_git_in_dir(&project_path, &["rev-parse", "--verify", reference]).is_ok()
+            }
             _ => false,
         };
         if found {
@@ -9014,6 +11109,9 @@ phases and do EXACTLY this, then stop:
                 planner_count: *planner_count,
             },
             crate::storage::SessionTypeInfo::Fusion { variants } => SessionType::Fusion {
+                variants: variants.clone(),
+            },
+            crate::storage::SessionTypeInfo::Debate { variants } => SessionType::Debate {
                 variants: variants.clone(),
             },
             crate::storage::SessionTypeInfo::Solo { cli, model } => SessionType::Solo {
@@ -9070,9 +11168,7 @@ phases and do EXACTLY this, then stop:
             project_path: PathBuf::from(&persisted.project_path),
             state,
             created_at: persisted.created_at,
-            last_activity_at: persisted
-                .last_activity_at
-                .unwrap_or(persisted.created_at),
+            last_activity_at: persisted.last_activity_at.unwrap_or(persisted.created_at),
             agents,
             default_cli: persisted.default_cli.clone(),
             default_model: persisted.default_model.clone(),
@@ -9088,11 +11184,19 @@ phases and do EXACTLY this, then stop:
     }
 
     /// Continue a Swarm session after planning phase
-    fn continue_swarm_after_planning(&self, session_id: &str, session: &Session) -> Result<Session, String> {
+    fn continue_swarm_after_planning(
+        &self,
+        session_id: &str,
+        session: &Session,
+    ) -> Result<Session, String> {
         let cwd = session.project_path.to_str().unwrap_or(".");
 
         // Load the pending Swarm config
-        let pending_config_path = session.project_path.join(".hive-manager").join(session_id).join("pending-swarm-config.json");
+        let pending_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("pending-swarm-config.json");
         let config_json = std::fs::read_to_string(&pending_config_path)
             .map_err(|e| format!("Failed to read pending swarm config: {}", e))?;
         let config: SwarmLaunchConfig = serde_json::from_str(&config_json)
@@ -9116,7 +11220,10 @@ phases and do EXACTLY this, then stop:
         if let Err(e) = self.stop_agent(session_id, &planner_id) {
             tracing::warn!("Failed to stop Master Planner {}: {}", planner_id, e);
         } else {
-            tracing::info!("Stopped Master Planner {} before spawning Queen", planner_id);
+            tracing::info!(
+                "Stopped Master Planner {} before spawning Queen",
+                planner_id
+            );
             let mut sessions = self.sessions.write();
             if let Some(s) = sessions.get_mut(session_id) {
                 s.agents.retain(|a| a.id != planner_id);
@@ -9141,12 +11248,22 @@ phases and do EXACTLY this, then stop:
                 config.prompt.as_deref(),
                 config.with_evaluator,
             );
-            let prompt_file = Self::write_prompt_file(&session.project_path, session_id, "queen-prompt.md", &master_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &session.project_path,
+                session_id,
+                "queen-prompt.md",
+                &master_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
             // Write Swarm tool documentation files (includes spawn-planner.md)
-            Self::write_swarm_tool_files(&session.project_path, session_id, planners.len() as u8, &config.queen_config.cli)?;
+            Self::write_swarm_tool_files(
+                &session.project_path,
+                session_id,
+                planners.len() as u8,
+                &config.queen_config.cli,
+            )?;
 
             tracing::info!("Launching Queen agent (swarm - sequential planner spawning, after planning): {} {:?} in {:?}", cmd, args, cwd);
 
@@ -9177,7 +11294,11 @@ phases and do EXACTLY this, then stop:
         }
 
         // Store planner config for Queen to reference when spawning via HTTP API
-        let swarm_config_path = session.project_path.join(".hive-manager").join(session_id).join("swarm-planners.json");
+        let swarm_config_path = session
+            .project_path
+            .join(".hive-manager")
+            .join(session_id)
+            .join("swarm-planners.json");
         let planners_json = serde_json::to_string_pretty(&planners)
             .map_err(|e| format!("Failed to serialize planner config: {}", e))?;
         std::fs::write(&swarm_config_path, planners_json)
@@ -9190,16 +11311,19 @@ phases and do EXACTLY this, then stop:
                 session.agents.extend(new_agents.clone());
                 self.emit_agent_batch_launched(session, &new_agents);
                 let changes = self.set_session_state_with_events(session, SessionState::Running);
-                (session.clone(), changes)  // Queen will spawn planners sequentially
+                (session.clone(), changes) // Queen will spawn planners sequentially
             } else {
                 return Err("Session disappeared".to_string());
             }
         };
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: updated_session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: updated_session.clone(),
+                },
+            );
         }
 
         // Update storage
@@ -9261,14 +11385,29 @@ phases and do EXACTLY this, then stop:
                 config.prompt.as_deref(),
                 config.with_evaluator,
             );
-            let prompt_file = Self::write_prompt_file(&project_path, &session_id, "queen-prompt.md", &master_prompt)?;
+            let prompt_file = Self::write_prompt_file(
+                &project_path,
+                &session_id,
+                "queen-prompt.md",
+                &master_prompt,
+            )?;
             let prompt_path = prompt_file.to_string_lossy().to_string();
             Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
             // Write Swarm tool documentation files (includes spawn-planner.md)
-            Self::write_swarm_tool_files(&project_path, &session_id, planners.len() as u8, &config.queen_config.cli)?;
+            Self::write_swarm_tool_files(
+                &project_path,
+                &session_id,
+                planners.len() as u8,
+                &config.queen_config.cli,
+            )?;
 
-            tracing::info!("Launching Queen agent (swarm - sequential planner spawning): {} {:?} in {:?}", cmd, args, cwd);
+            tracing::info!(
+                "Launching Queen agent (swarm - sequential planner spawning): {} {:?} in {:?}",
+                cmd,
+                args,
+                cwd
+            );
 
             pty_manager
                 .create_session(
@@ -9297,7 +11436,10 @@ phases and do EXACTLY this, then stop:
         }
 
         // Store planner config for Queen to reference when spawning
-        let swarm_config_path = project_path.join(".hive-manager").join(&session_id).join("swarm-planners.json");
+        let swarm_config_path = project_path
+            .join(".hive-manager")
+            .join(&session_id)
+            .join("swarm-planners.json");
         std::fs::create_dir_all(swarm_config_path.parent().unwrap())
             .map_err(|e| format!("Failed to create session directory: {}", e))?;
         let planners_json = serde_json::to_string_pretty(&planners)
@@ -9310,9 +11452,11 @@ phases and do EXACTLY this, then stop:
             id: session_id.clone(),
             name: config.name.clone(),
             color: config.color.clone(),
-            session_type: SessionType::Swarm { planner_count: planners.len() as u8 },
+            session_type: SessionType::Swarm {
+                planner_count: planners.len() as u8,
+            },
             project_path,
-            state: SessionState::Running,  // Queen will spawn planners sequentially
+            state: SessionState::Running, // Queen will spawn planners sequentially
             created_at: Utc::now(),
             last_activity_at: Utc::now(),
             agents,
@@ -9334,9 +11478,12 @@ phases and do EXACTLY this, then stop:
         }
 
         if let Some(ref app_handle) = self.app_handle {
-            let _ = app_handle.emit("session-update", SessionUpdate {
-                session: session.clone(),
-            });
+            let _ = app_handle.emit(
+                "session-update",
+                SessionUpdate {
+                    session: session.clone(),
+                },
+            );
         }
 
         // Initialize session storage if available
@@ -9402,7 +11549,8 @@ phases and do EXACTLY this, then stop:
         let session = {
             let sessions = self.sessions.read();
             sessions.get(session_id).cloned()
-        }.ok_or_else(|| format!("Session not found: {}", session_id))?;
+        }
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
         let can_add_worker = matches!(
             session.state,
@@ -9416,11 +11564,16 @@ phases and do EXACTLY this, then stop:
                 | SessionState::QaMaxRetriesExceeded
         );
         if !can_add_worker {
-            return Err(format!("Cannot add worker to session in state {:?}", session.state));
+            return Err(format!(
+                "Cannot add worker to session in state {:?}",
+                session.state
+            ));
         }
 
         // Determine worker index
-        let existing_workers = session.agents.iter()
+        let existing_workers = session
+            .agents
+            .iter()
             .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
             .count();
         let worker_index = (existing_workers + 1) as u8;
@@ -9460,7 +11613,8 @@ phases and do EXACTLY this, then stop:
         );
 
         let worker_cell_name = format!("worker-{worker_index}");
-        let task_file_path = Self::task_file_path_for_worker(Path::new(&worker_cwd), worker_index as usize);
+        let task_file_path =
+            Self::task_file_path_for_worker(Path::new(&worker_cwd), worker_index as usize);
 
         // Write task file for this worker (STANDBY or with initial task)
         let _task_file = match Self::write_task_file(
@@ -9487,7 +11641,12 @@ phases and do EXACTLY this, then stop:
         };
 
         // Write worker prompt to file and add to args
-        let worker_prompt = Self::build_worker_prompt(worker_index, &config_with_role, &actual_parent_id, session_id);
+        let worker_prompt = Self::build_worker_prompt(
+            worker_index,
+            &config_with_role,
+            &actual_parent_id,
+            session_id,
+        );
         let filename = format!("worker-{}-prompt.md", worker_index);
         let prompt_file = match Self::write_worker_prompt_file(
             Path::new(&worker_cwd),
@@ -9519,7 +11678,10 @@ phases and do EXACTLY this, then stop:
             args
         );
 
-        let worker_role = AgentRole::Worker { index: worker_index, parent: Some(actual_parent_id.clone()) };
+        let worker_role = AgentRole::Worker {
+            index: worker_index,
+            parent: Some(actual_parent_id.clone()),
+        };
 
         // Spawn PTY
         {
@@ -9578,7 +11740,12 @@ phases and do EXACTLY this, then stop:
     }
 
     #[allow(dead_code)]
-    pub fn launch_evaluator(&self, session_id: &str, mut config: AgentConfig, smoke_test: bool) -> Result<AgentInfo, String> {
+    pub fn launch_evaluator(
+        &self,
+        session_id: &str,
+        mut config: AgentConfig,
+        smoke_test: bool,
+    ) -> Result<AgentInfo, String> {
         let session = self
             .get_session(session_id)
             .ok_or_else(|| format!("Session not found: {}", session_id))?;
@@ -9618,10 +11785,7 @@ phases and do EXACTLY this, then stop:
             let mut sessions = self.sessions.write();
             if let Some(current) = sessions.get_mut(session_id) {
                 current.agents.retain(|agent| agent.id != evaluator_id);
-                Some(self.set_session_state_with_events(
-                    current,
-                    SessionState::SpawningEvaluator,
-                ))
+                Some(self.set_session_state_with_events(current, SessionState::SpawningEvaluator))
             } else {
                 None
             }
@@ -9857,7 +12021,8 @@ phases and do EXACTLY this, then stop:
         let session = {
             let sessions = self.sessions.read();
             sessions.get(session_id).cloned()
-        }.ok_or_else(|| format!("Session not found: {}", session_id))?;
+        }
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
         // Allow adding planners when Running or WaitingForPlanner
         let can_add_planner = matches!(
@@ -9865,11 +12030,16 @@ phases and do EXACTLY this, then stop:
             SessionState::Running | SessionState::WaitingForPlanner(_)
         );
         if !can_add_planner {
-            return Err(format!("Cannot add planner to session in state {:?}", session.state));
+            return Err(format!(
+                "Cannot add planner to session in state {:?}",
+                session.state
+            ));
         }
 
         // Determine planner index
-        let existing_planners = session.agents.iter()
+        let existing_planners = session
+            .agents
+            .iter()
             .filter(|a| matches!(a.role, AgentRole::Planner { .. }))
             .count();
         let planner_index = (existing_planners + 1) as u8;
@@ -9905,7 +12075,12 @@ phases and do EXACTLY this, then stop:
             session_id,
         );
         let filename = format!("planner-{}-prompt.md", planner_index);
-        let prompt_file = Self::write_prompt_file(&session.project_path, session_id, &filename, &planner_prompt)?;
+        let prompt_file = Self::write_prompt_file(
+            &session.project_path,
+            session_id,
+            &filename,
+            &planner_prompt,
+        )?;
         let prompt_path = prompt_file.to_string_lossy().to_string();
         Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
@@ -9927,7 +12102,9 @@ phases and do EXACTLY this, then stop:
             pty_manager
                 .create_session(
                     planner_id.clone(),
-                    AgentRole::Planner { index: planner_index },
+                    AgentRole::Planner {
+                        index: planner_index,
+                    },
                     &cmd,
                     &args.iter().map(|s| s.as_str()).collect::<Vec<_>>(),
                     Some(cwd),
@@ -9943,7 +12120,9 @@ phases and do EXACTLY this, then stop:
 
         let agent_info = AgentInfo {
             id: planner_id.clone(),
-            role: AgentRole::Planner { index: planner_index },
+            role: AgentRole::Planner {
+                index: planner_index,
+            },
             status: AgentStatus::Running,
             config: agent_config,
             parent_id: Some(queen_id),
@@ -9970,9 +12149,12 @@ phases and do EXACTLY this, then stop:
         if let Some(ref app_handle) = self.app_handle {
             let sessions = self.sessions.read();
             if let Some(session) = sessions.get(session_id) {
-                let _ = app_handle.emit("session-update", SessionUpdate {
-                    session: session.clone(),
-                });
+                let _ = app_handle.emit(
+                    "session-update",
+                    SessionUpdate {
+                        session: session.clone(),
+                    },
+                );
             }
         }
 
@@ -9984,7 +12166,8 @@ phases and do EXACTLY this, then stop:
         self.ensure_task_watcher(session_id, &session.project_path);
 
         // Store planner's worker config for sequential spawning
-        let planner_workers_path = session.project_path
+        let planner_workers_path = session
+            .project_path
             .join(".hive-manager")
             .join(session_id)
             .join(format!("planner-{}-workers.json", planner_index));
@@ -10005,39 +12188,54 @@ phases and do EXACTLY this, then stop:
     }
 
     fn session_to_persisted_snapshot(session: &Session) -> crate::storage::PersistedSession {
-        use crate::storage::{PersistedSession, SessionTypeInfo, PersistedAgentInfo, PersistedAgentConfig};
+        use crate::storage::{
+            PersistedAgentConfig, PersistedAgentInfo, PersistedSession, SessionTypeInfo,
+        };
 
         let session_type = match &session.session_type {
-            SessionType::Hive { worker_count } => SessionTypeInfo::Hive { worker_count: *worker_count },
-            SessionType::Swarm { planner_count } => SessionTypeInfo::Swarm { planner_count: *planner_count },
-            SessionType::Fusion { variants } => SessionTypeInfo::Fusion { variants: variants.clone() },
+            SessionType::Hive { worker_count } => SessionTypeInfo::Hive {
+                worker_count: *worker_count,
+            },
+            SessionType::Swarm { planner_count } => SessionTypeInfo::Swarm {
+                planner_count: *planner_count,
+            },
+            SessionType::Fusion { variants } => SessionTypeInfo::Fusion {
+                variants: variants.clone(),
+            },
+            SessionType::Debate { variants } => SessionTypeInfo::Debate {
+                variants: variants.clone(),
+            },
             SessionType::Solo { cli, model } => SessionTypeInfo::Solo {
                 cli: cli.clone(),
                 model: model.clone(),
             },
         };
 
-        let agents: Vec<PersistedAgentInfo> = session.agents.iter().map(|a| {
-            let role_str = serialize_persisted_agent_role(&a.role);
+        let agents: Vec<PersistedAgentInfo> = session
+            .agents
+            .iter()
+            .map(|a| {
+                let role_str = serialize_persisted_agent_role(&a.role);
 
-            PersistedAgentInfo {
-                id: a.id.clone(),
-                role: role_str,
-                config: PersistedAgentConfig {
-                    cli: a.config.cli.clone(),
-                    model: a.config.model.clone(),
-                    flags: a.config.flags.clone(),
-                    label: a.config.label.clone(),
-                    name: a.config.name.clone(),
-                    description: a.config.description.clone(),
-                    role_type: a.config.role.as_ref().map(|r| r.role_type.clone()),
-                    initial_prompt: a.config.initial_prompt.clone(),
-                },
-                parent_id: a.parent_id.clone(),
-                commit_sha: a.commit_sha.clone(),
-                base_commit_sha: a.base_commit_sha.clone(),
-            }
-        }).collect();
+                PersistedAgentInfo {
+                    id: a.id.clone(),
+                    role: role_str,
+                    config: PersistedAgentConfig {
+                        cli: a.config.cli.clone(),
+                        model: a.config.model.clone(),
+                        flags: a.config.flags.clone(),
+                        label: a.config.label.clone(),
+                        name: a.config.name.clone(),
+                        description: a.config.description.clone(),
+                        role_type: a.config.role.as_ref().map(|r| r.role_type.clone()),
+                        initial_prompt: a.config.initial_prompt.clone(),
+                    },
+                    parent_id: a.parent_id.clone(),
+                    commit_sha: a.commit_sha.clone(),
+                    base_commit_sha: a.base_commit_sha.clone(),
+                }
+            })
+            .collect();
 
         let state_str = serialize_session_state(&session.state);
         let auth_strategy = if is_terminal_session_state(&session.state) {
@@ -10083,24 +12281,32 @@ phases and do EXACTLY this, then stop:
             }
 
             // Build hierarchy nodes
-            let hierarchy: Vec<HierarchyNode> = session.agents.iter().map(|agent| {
-                let role_str = format_agent_display(&agent.role);
+            let hierarchy: Vec<HierarchyNode> = session
+                .agents
+                .iter()
+                .map(|agent| {
+                    let role_str = format_agent_display(&agent.role);
 
-                let children: Vec<String> = session.agents.iter()
-                    .filter(|a| a.parent_id.as_ref() == Some(&agent.id))
-                    .map(|a| a.id.clone())
-                    .collect();
+                    let children: Vec<String> = session
+                        .agents
+                        .iter()
+                        .filter(|a| a.parent_id.as_ref() == Some(&agent.id))
+                        .map(|a| a.id.clone())
+                        .collect();
 
-                HierarchyNode {
-                    id: agent.id.clone(),
-                    role: role_str,
-                    parent_id: agent.parent_id.clone(),
-                    children,
-                }
-            }).collect();
+                    HierarchyNode {
+                        id: agent.id.clone(),
+                        role: role_str,
+                        parent_id: agent.parent_id.clone(),
+                        children,
+                    }
+                })
+                .collect();
 
             // Build worker state info
-            let workers: Vec<WorkerStateInfo> = session.agents.iter()
+            let workers: Vec<WorkerStateInfo> = session
+                .agents
+                .iter()
                 .filter(|a| include_in_worker_roster(&a.role))
                 .map(|a| WorkerStateInfo {
                     id: a.id.clone(),
@@ -10141,11 +12347,13 @@ phases and do EXACTLY this, then stop:
             .join("worktrees")
             .join(session_id);
         let fusion_worktrees_path = project_path.join(".hive-fusion").join(session_id);
+        let debate_worktrees_path = project_path.join(".hive-debate").join(session_id);
 
         match TaskFileWatcher::new(
             &session_path,
             &worktrees_path,
             &fusion_worktrees_path,
+            &debate_worktrees_path,
             session_id,
             app_handle,
         ) {
@@ -10265,9 +12473,11 @@ fn parse_agent_role(role: &str) -> Option<AgentRole> {
             .ok()?;
         Some(AgentRole::Planner { index })
     } else if role.starts_with("Worker(") {
-        parse_indexed_role(role, "Worker(").map(|(index, parent)| AgentRole::Worker { index, parent })
+        parse_indexed_role(role, "Worker(")
+            .map(|(index, parent)| AgentRole::Worker { index, parent })
     } else if role.starts_with("QaWorker(") {
-        parse_indexed_role(role, "QaWorker(").map(|(index, parent)| AgentRole::QaWorker { index, parent })
+        parse_indexed_role(role, "QaWorker(")
+            .map(|(index, parent)| AgentRole::QaWorker { index, parent })
     } else if role.starts_with("Fusion(") {
         let variant = role
             .trim_start_matches("Fusion(")
@@ -10306,7 +12516,10 @@ fn parse_indexed_role(role: &str, prefix: &str) -> Option<(u8, Option<String>)> 
 fn parse_persisted_session_state(state: &str) -> SessionState {
     if let Some(iteration) = state.strip_prefix("QaInProgress:") {
         return SessionState::QaInProgress {
-            iteration: iteration.parse::<u8>().ok().filter(|iteration| *iteration > 0),
+            iteration: iteration
+                .parse::<u8>()
+                .ok()
+                .filter(|iteration| *iteration > 0),
         };
     }
     if let Some(iteration) = state.strip_prefix("QaFailed:") {
@@ -10328,6 +12541,8 @@ fn parse_persisted_session_state(state: &str) -> SessionState {
         "WaitingForPlanner" => SessionState::WaitingForPlanner(0),
         "SpawningFusionVariant" => SessionState::SpawningFusionVariant(0),
         "WaitingForFusionVariants" => SessionState::WaitingForFusionVariants,
+        "SpawningDebateRound" => SessionState::SpawningDebateRound(0),
+        "WaitingForDebateRound" => SessionState::WaitingForDebateRound(0),
         "SpawningJudge" => SessionState::SpawningJudge,
         "Judging" => SessionState::Judging,
         "AwaitingVerdictSelection" => SessionState::AwaitingVerdictSelection,
@@ -10357,6 +12572,8 @@ fn serialize_session_state(state: &SessionState) -> String {
         SessionState::WaitingForPlanner(_) => "WaitingForPlanner".to_string(),
         SessionState::SpawningFusionVariant(_) => "SpawningFusionVariant".to_string(),
         SessionState::WaitingForFusionVariants => "WaitingForFusionVariants".to_string(),
+        SessionState::SpawningDebateRound(_) => "SpawningDebateRound".to_string(),
+        SessionState::WaitingForDebateRound(_) => "WaitingForDebateRound".to_string(),
         SessionState::SpawningJudge => "SpawningJudge".to_string(),
         SessionState::Judging => "Judging".to_string(),
         SessionState::AwaitingVerdictSelection => "AwaitingVerdictSelection".to_string(),
@@ -10390,7 +12607,11 @@ fn serialize_persisted_agent_role(role: &AgentRole) -> String {
         AgentRole::Judge { session_id } => format!("Judge({})", session_id),
         AgentRole::Evaluator => "Evaluator".to_string(),
         AgentRole::QaWorker { index, parent } => {
-            format!("QaWorker({},{})", index, parent.as_deref().unwrap_or("None"))
+            format!(
+                "QaWorker({},{})",
+                index,
+                parent.as_deref().unwrap_or("None")
+            )
         }
     }
 }
@@ -10422,16 +12643,18 @@ fn format_agent_display(role: &AgentRole) -> String {
 }
 
 fn include_in_worker_roster(role: &AgentRole) -> bool {
-    !matches!(serialize_agent_role(role), "queen" | "evaluator" | "qa-worker")
+    !matches!(
+        serialize_agent_role(role),
+        "queen" | "evaluator" | "qa-worker"
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_model_arg,
-        parse_persisted_session_state, serialize_session_state, AgentConfig, AgentInfo,
-        AuthStrategy, CompletionError, QaWorkerConfig, Session, SessionController, SessionError,
-        SessionState, SessionType,
+        extract_model_arg, parse_persisted_session_state, serialize_session_state, AgentConfig,
+        AgentInfo, AuthStrategy, CompletionError, QaWorkerConfig, Session, SessionController,
+        SessionError, SessionState, SessionType,
     };
     use crate::pty::{AgentRole, AgentStatus, PtyManager, WorkerRole};
     use crate::workspace::git::current_head;
@@ -10446,8 +12669,7 @@ mod tests {
     #[test]
     fn extract_model_arg_reads_short_long_and_equals_forms() {
         assert_eq!(
-            extract_model_arg(&["--dangerously-skip-permissions", "-m", "gpt-5.5"])
-                .as_deref(),
+            extract_model_arg(&["--dangerously-skip-permissions", "-m", "gpt-5.5"]).as_deref(),
             Some("gpt-5.5")
         );
         assert_eq!(
@@ -10525,7 +12747,11 @@ mod tests {
 
         // Building the resume report marks it Skipped and surfaces it.
         let report = controller.build_resume_report(run_id, Path::new("."));
-        assert_eq!(report.skipped.len(), 1, "completed write-step is reported skipped");
+        assert_eq!(
+            report.skipped.len(),
+            1,
+            "completed write-step is reported skipped"
+        );
         assert_eq!(report.skipped[0].step_id, step_id);
         assert_eq!(report.skipped[0].status, StepStatus::Skipped);
 
@@ -10564,7 +12790,8 @@ mod tests {
         let repo = TempDir::new().unwrap();
         let repo_path = repo.path().to_path_buf();
         SessionController::run_git_in_dir(&repo_path, &["init", "-q"]).unwrap();
-        SessionController::run_git_in_dir(&repo_path, &["config", "user.email", "t@t.dev"]).unwrap();
+        SessionController::run_git_in_dir(&repo_path, &["config", "user.email", "t@t.dev"])
+            .unwrap();
         SessionController::run_git_in_dir(&repo_path, &["config", "user.name", "tester"]).unwrap();
         std::fs::write(repo_path.join("a.txt"), "hi").unwrap();
         SessionController::run_git_in_dir(&repo_path, &["add", "."]).unwrap();
@@ -10577,13 +12804,25 @@ mod tests {
             .record_step_started(run_id, StepKind::GitCommit, 1, None)
             .unwrap();
         store
-            .record_ledger(run_id, &step_id, "git_commit", Some(&sha), Confidence::Uncertain)
+            .record_ledger(
+                run_id,
+                &step_id,
+                "git_commit",
+                Some(&sha),
+                Confidence::Uncertain,
+            )
             .unwrap();
 
         // Resume verifies the SHA exists -> ledger confirmed with High confidence.
         let report = controller.build_resume_report(run_id, &repo_path);
-        assert!(report.uncertain.is_empty(), "verified commit is not uncertain");
-        let ledger = store.read_ledger_for_step(run_id, &step_id).unwrap().unwrap();
+        assert!(
+            report.uncertain.is_empty(),
+            "verified commit is not uncertain"
+        );
+        let ledger = store
+            .read_ledger_for_step(run_id, &step_id)
+            .unwrap()
+            .unwrap();
         assert!(ledger.confirmed);
         assert_eq!(ledger.confidence, Confidence::High);
     }
@@ -10697,8 +12936,7 @@ mod tests {
 
     #[test]
     fn add_prompt_to_args_preserves_worktree_scoped_absolute_prompt_path() {
-        let prompt_path =
-            r"D:\repo\.hive-manager\worktrees\session-123\worker-2\.hive-manager\prompts\worker-2-prompt.md";
+        let prompt_path = r"D:\repo\.hive-manager\worktrees\session-123\worker-2\.hive-manager\prompts\worker-2-prompt.md";
         let expected_prompt = format!("Read {} and execute.", prompt_path);
         let expected_cursor_prompt =
             "Read /mnt/d/repo/.hive-manager/worktrees/session-123/worker-2/.hive-manager/prompts/worker-2-prompt.md and execute."
@@ -10814,17 +13052,21 @@ mod tests {
             extract_markdown_section(&prompt, "## Required Protocol"),
             SessionController::evaluator_required_protocol("session-123"),
         );
-        assert!(prompt.contains("configured QA workers below (1 total) before you grade any criterion"));
-        assert!(prompt.contains(r#""specialization": "ui", "cli": "gemini", "model": "gemini-2.5-pro""#));
-        assert!(prompt.contains("You MUST spawn all 1 QA workers one at a time in this exact order:"));
+        assert!(
+            prompt.contains("configured QA workers below (1 total) before you grade any criterion")
+        );
+        assert!(prompt
+            .contains(r#""specialization": "ui", "cli": "gemini", "model": "gemini-2.5-pro""#));
+        assert!(
+            prompt.contains("You MUST spawn all 1 QA workers one at a time in this exact order:")
+        );
         assert!(!prompt.contains(r#""specialization": "api", "cli": "claude""#));
     }
 
     #[test]
     fn research_worker_surfaces_are_read_only() {
         let session_id = "session-research-readonly";
-        let worktree_path =
-            PathBuf::from(format!(".hive-manager/worktrees/{session_id}/worker-1"));
+        let worktree_path = PathBuf::from(format!(".hive-manager/worktrees/{session_id}/worker-1"));
         let _ = std::fs::create_dir_all(&worktree_path);
 
         let cfg = AgentConfig {
@@ -10896,8 +13138,14 @@ mod tests {
         let task_file = std::fs::read_to_string(&task_file_path).expect("read task file");
 
         let expected = SessionController::scope_block(".");
-        assert_eq!(extract_markdown_section(&worker_prompt, "## Scope"), expected);
-        assert_eq!(extract_markdown_section(&fusion_prompt, "## Scope"), expected);
+        assert_eq!(
+            extract_markdown_section(&worker_prompt, "## Scope"),
+            expected
+        );
+        assert_eq!(
+            extract_markdown_section(&fusion_prompt, "## Scope"),
+            expected
+        );
         assert_eq!(extract_markdown_section(&task_file, "## Scope"), expected);
 
         std::fs::remove_dir_all(session_worktree_root).expect("remove test worktree");
@@ -11240,7 +13488,8 @@ mod tests {
     fn worker_completion_commit_sha_returns_worker_head_after_commit() {
         let session_id = "worker-commit-head";
         let (temp_dir, worktree_path) = init_repo_with_worker_worktree(session_id, 1);
-        std::fs::write(worktree_path.join("worker.txt"), "worker change\n").expect("write worker change");
+        std::fs::write(worktree_path.join("worker.txt"), "worker change\n")
+            .expect("write worker change");
         run_git(&worktree_path, &["add", "worker.txt"]);
         run_git(&worktree_path, &["commit", "-m", "worker change"]);
 
@@ -11284,7 +13533,8 @@ mod tests {
     async fn on_worker_completed_records_commit_sha_before_progression() {
         let session_id = "worker-gate-record";
         let (temp_dir, worktree_path) = init_repo_with_worker_worktree(session_id, 1);
-        std::fs::write(worktree_path.join("worker.txt"), "worker change\n").expect("write worker change");
+        std::fs::write(worktree_path.join("worker.txt"), "worker change\n")
+            .expect("write worker change");
         run_git(&worktree_path, &["add", "worker.txt"]);
         run_git(&worktree_path, &["commit", "-m", "worker change"]);
         let expected_head = current_head(&worktree_path).expect("worker HEAD");
@@ -11299,7 +13549,10 @@ mod tests {
 
         let refreshed = controller.get_session(session_id).unwrap();
         assert_eq!(refreshed.state, SessionState::WaitingForWorker(1));
-        assert_eq!(refreshed.agents[0].commit_sha.as_deref(), Some(expected_head.as_str()));
+        assert_eq!(
+            refreshed.agents[0].commit_sha.as_deref(),
+            Some(expected_head.as_str())
+        );
     }
 
     /// Verifies that planning/swarm sessions (which never populate session.worktree_path)
@@ -11327,7 +13580,10 @@ mod tests {
         }
 
         std::fs::write(repo_path.join("README.md"), "base commit\n").expect("write file");
-        for args in [["add", "README.md"].as_slice(), ["commit", "-m", "initial commit"].as_slice()] {
+        for args in [
+            ["add", "README.md"].as_slice(),
+            ["commit", "-m", "initial commit"].as_slice(),
+        ] {
             let status = std::process::Command::new("git")
                 .args(args)
                 .current_dir(repo_path)
@@ -11361,14 +13617,8 @@ mod tests {
         };
 
         assert!(session.worktree_path.is_none());
-        let base_ref = SessionController::resolve_worker_base_ref(
-            &session,
-            "spawn_next_worker",
-            2,
-        );
+        let base_ref = SessionController::resolve_worker_base_ref(&session, "spawn_next_worker", 2);
 
         assert_eq!(base_ref, expected_head);
     }
 }
-
-

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -4,8 +4,8 @@ mod polling_intervals;
 
 #[allow(unused_imports)]
 pub use controller::{
-    Session, SessionController, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig,
-    FusionVariantConfig, FusionVariantStatus, SessionType, AgentInfo, SessionState, AuthStrategy,
-    QaWorkerConfig, CompletionBlockedError, CompletionError,
-    DEFAULT_MAX_QA_ITERATIONS,
+    AgentInfo, AuthStrategy, CompletionBlockedError, CompletionError, DebateDebaterConfig,
+    DebateDebaterStatus, DebateLaunchConfig, FusionLaunchConfig, FusionVariantConfig,
+    FusionVariantStatus, HiveLaunchConfig, QaWorkerConfig, ResearchLaunchConfig, Session,
+    SessionController, SessionState, SessionType, SwarmLaunchConfig, DEFAULT_MAX_QA_ITERATIONS,
 };

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -54,9 +54,7 @@ fn stable_learning_id(learning: &Learning) -> String {
     Uuid::new_v5(&Uuid::NAMESPACE_DNS, content.as_bytes()).to_string()
 }
 
-fn deserialize_optional_trimmed_string<'de, D>(
-    deserializer: D,
-) -> Result<Option<String>, D::Error>
+fn deserialize_optional_trimmed_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -176,6 +174,7 @@ pub enum SessionTypeInfo {
     Hive { worker_count: u8 },
     Swarm { planner_count: u8 },
     Fusion { variants: Vec<String> },
+    Debate { variants: Vec<String> },
     Solo { cli: String, model: Option<String> },
 }
 
@@ -306,13 +305,22 @@ impl SessionStorage {
         fs::create_dir_all(session_dir.join("lessons"))?;
         fs::create_dir_all(session_dir.join("lessons").join("archive"))?;
         // Initialize empty state files
-        fs::write(session_dir.join("state").join("workers.md"), "# Available Workers\n\nNo workers yet.\n")?;
+        fs::write(
+            session_dir.join("state").join("workers.md"),
+            "# Available Workers\n\nNo workers yet.\n",
+        )?;
         fs::write(session_dir.join("state").join("hierarchy.json"), "[]")?;
         fs::write(session_dir.join("state").join("assignments.json"), "{}")?;
 
         // Initialize coordination files
-        fs::write(session_dir.join("coordination").join("coordination.log"), "")?;
-        fs::write(session_dir.join("coordination").join("queen-inbox.md"), "# Queen Inbox\n\nNo messages yet.\n")?;
+        fs::write(
+            session_dir.join("coordination").join("coordination.log"),
+            "",
+        )?;
+        fs::write(
+            session_dir.join("coordination").join("queen-inbox.md"),
+            "# Queen Inbox\n\nNo messages yet.\n",
+        )?;
         self.create_conversation_dir(session_id)?;
 
         Ok(session_dir)
@@ -330,7 +338,6 @@ impl SessionStorage {
         }
         Ok(())
     }
-
 
     /// Save session metadata to disk
     #[allow(dead_code)]
@@ -456,9 +463,18 @@ impl SessionStorage {
                 let session_id = entry.file_name().to_string_lossy().to_string();
                 if let Ok(session) = self.load_session(&session_id) {
                     let session_type = match &session.session_type {
-                        SessionTypeInfo::Hive { worker_count } => format!("Hive ({})", worker_count),
-                        SessionTypeInfo::Swarm { planner_count } => format!("Swarm ({})", planner_count),
-                        SessionTypeInfo::Fusion { variants } => format!("Fusion ({})", variants.len()),
+                        SessionTypeInfo::Hive { worker_count } => {
+                            format!("Hive ({})", worker_count)
+                        }
+                        SessionTypeInfo::Swarm { planner_count } => {
+                            format!("Swarm ({})", planner_count)
+                        }
+                        SessionTypeInfo::Fusion { variants } => {
+                            format!("Fusion ({})", variants.len())
+                        }
+                        SessionTypeInfo::Debate { variants } => {
+                            format!("Debate ({})", variants.len())
+                        }
                         SessionTypeInfo::Solo { cli, .. } => format!("Solo ({})", cli),
                     };
 
@@ -469,9 +485,7 @@ impl SessionStorage {
                         session_type,
                         project_path: session.project_path,
                         created_at: session.created_at,
-                        last_activity_at: session
-                            .last_activity_at
-                            .unwrap_or(session.created_at),
+                        last_activity_at: session.last_activity_at.unwrap_or(session.created_at),
                         agent_count: session.agents.len(),
                         state: session.state,
                     });
@@ -525,125 +539,185 @@ impl SessionStorage {
     fn default_config() -> AppConfig {
         let mut clis = HashMap::new();
 
-        clis.insert("claude".to_string(), CliConfig {
-            command: "claude".to_string(),
-            auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
-            model_flag: Some("--model".to_string()),
-            default_model: "opus".to_string(),
-            env: None,
-        });
+        clis.insert(
+            "claude".to_string(),
+            CliConfig {
+                command: "claude".to_string(),
+                auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
+                model_flag: Some("--model".to_string()),
+                default_model: "opus".to_string(),
+                env: None,
+            },
+        );
 
-        clis.insert("gemini".to_string(), CliConfig {
-            command: "gemini".to_string(),
-            auto_approve_flag: Some("-y".to_string()),
-            model_flag: Some("-m".to_string()),
-            default_model: "gemini-2.5-pro".to_string(),
-            env: None,
-        });
-        clis.insert("antigravity".to_string(), CliConfig {
-            command: "agy".to_string(),
-            auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
-            // agy has no --model flag. Model lives in ~/.gemini/antigravity-cli/settings.json.
-            model_flag: None,
-            default_model: String::new(),
-            env: None,
-        });
+        clis.insert(
+            "gemini".to_string(),
+            CliConfig {
+                command: "gemini".to_string(),
+                auto_approve_flag: Some("-y".to_string()),
+                model_flag: Some("-m".to_string()),
+                default_model: "gemini-2.5-pro".to_string(),
+                env: None,
+            },
+        );
+        clis.insert(
+            "antigravity".to_string(),
+            CliConfig {
+                command: "agy".to_string(),
+                auto_approve_flag: Some("--dangerously-skip-permissions".to_string()),
+                // agy has no --model flag. Model lives in ~/.gemini/antigravity-cli/settings.json.
+                model_flag: None,
+                default_model: String::new(),
+                env: None,
+            },
+        );
 
-        clis.insert("opencode".to_string(), CliConfig {
-            command: "opencode".to_string(),
-            auto_approve_flag: None,
-            model_flag: Some("-m".to_string()),
-            default_model: "opencode/big-pickle".to_string(),
-            env: Some({
-                let mut env = HashMap::new();
-                env.insert("OPENCODE_YOLO".to_string(), "true".to_string());
-                env
-            }),
-        });
+        clis.insert(
+            "opencode".to_string(),
+            CliConfig {
+                command: "opencode".to_string(),
+                auto_approve_flag: None,
+                model_flag: Some("-m".to_string()),
+                default_model: "opencode/big-pickle".to_string(),
+                env: Some({
+                    let mut env = HashMap::new();
+                    env.insert("OPENCODE_YOLO".to_string(), "true".to_string());
+                    env
+                }),
+            },
+        );
 
-        clis.insert("codex".to_string(), CliConfig {
-            command: "codex".to_string(),
-            auto_approve_flag: Some("--dangerously-bypass-approvals-and-sandbox".to_string()),
-            model_flag: Some("-m".to_string()),
-            default_model: "gpt-5.5".to_string(),
-            env: None,
-        });
+        clis.insert(
+            "codex".to_string(),
+            CliConfig {
+                command: "codex".to_string(),
+                auto_approve_flag: Some("--dangerously-bypass-approvals-and-sandbox".to_string()),
+                model_flag: Some("-m".to_string()),
+                default_model: "gpt-5.5".to_string(),
+                env: None,
+            },
+        );
 
-        clis.insert("cursor".to_string(), CliConfig {
-            command: "wsl".to_string(),
-            auto_approve_flag: Some("--force".to_string()),
-            model_flag: None,  // Cursor uses global model setting
-            default_model: "composer-2.5".to_string(),
-            env: None,
-        });
+        clis.insert(
+            "cursor".to_string(),
+            CliConfig {
+                command: "wsl".to_string(),
+                auto_approve_flag: Some("--force".to_string()),
+                model_flag: None, // Cursor uses global model setting
+                default_model: "composer-2.5".to_string(),
+                env: None,
+            },
+        );
 
-        clis.insert("droid".to_string(), CliConfig {
-            command: "droid".to_string(),
-            auto_approve_flag: None,  // Interactive mode - no auto-approve flag
-            model_flag: None,  // Model selected via /model command in TUI
-            default_model: "glm-5.1".to_string(),
-            env: None,
-        });
+        clis.insert(
+            "droid".to_string(),
+            CliConfig {
+                command: "droid".to_string(),
+                auto_approve_flag: None, // Interactive mode - no auto-approve flag
+                model_flag: None,        // Model selected via /model command in TUI
+                default_model: "glm-5.1".to_string(),
+                env: None,
+            },
+        );
 
-        clis.insert("qwen".to_string(), CliConfig {
-            command: "qwen".to_string(),
-            auto_approve_flag: Some("-y".to_string()),
-            model_flag: Some("-m".to_string()),
-            default_model: "qwen3-coder".to_string(),
-            env: None,
-        });
+        clis.insert(
+            "qwen".to_string(),
+            CliConfig {
+                command: "qwen".to_string(),
+                auto_approve_flag: Some("-y".to_string()),
+                model_flag: Some("-m".to_string()),
+                default_model: "qwen3-coder".to_string(),
+                env: None,
+            },
+        );
 
         let mut default_roles = HashMap::new();
-        default_roles.insert("backend".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("frontend".to_string(), RoleDefaults {
-            cli: "antigravity".to_string(),
-            // antigravity uses settings.json for model selection; this field is
-            // retained for serde stability but ignored at launch time.
-            model: String::new(),
-        });
-        default_roles.insert("coherence".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("simplify".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("reviewer".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("reviewer-quick".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("resolver".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("tester".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("code-quality".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("evaluator".to_string(), RoleDefaults {
-            cli: "claude".to_string(),
-            model: "opus".to_string(),
-        });
-        default_roles.insert("qa-worker".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
-        default_roles.insert("general".to_string(), RoleDefaults {
-            cli: "codex".to_string(),
-            model: "gpt-5.5".to_string(),
-        });
+        default_roles.insert(
+            "backend".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "frontend".to_string(),
+            RoleDefaults {
+                cli: "antigravity".to_string(),
+                // antigravity uses settings.json for model selection; this field is
+                // retained for serde stability but ignored at launch time.
+                model: String::new(),
+            },
+        );
+        default_roles.insert(
+            "coherence".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "simplify".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "reviewer".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "reviewer-quick".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "resolver".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "tester".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "code-quality".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "evaluator".to_string(),
+            RoleDefaults {
+                cli: "claude".to_string(),
+                model: "opus".to_string(),
+            },
+        );
+        default_roles.insert(
+            "qa-worker".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
+        default_roles.insert(
+            "general".to_string(),
+            RoleDefaults {
+                cli: "codex".to_string(),
+                model: "gpt-5.5".to_string(),
+            },
+        );
 
         AppConfig {
             clis,
@@ -662,7 +736,8 @@ impl SessionStorage {
         session_id: &str,
         message: &CoordinationMessage,
     ) -> Result<(), StorageError> {
-        let log_path = self.session_dir(session_id)
+        let log_path = self
+            .session_dir(session_id)
             .join("coordination")
             .join("coordination.log");
 
@@ -693,7 +768,8 @@ impl SessionStorage {
         session_id: &str,
         limit: Option<usize>,
     ) -> Result<Vec<CoordinationMessage>, StorageError> {
-        let log_path = self.session_dir(session_id)
+        let log_path = self
+            .session_dir(session_id)
             .join("coordination")
             .join("coordination.log");
 
@@ -770,7 +846,9 @@ impl SessionStorage {
             Ok(())
         })
         .await
-        .map_err(|e| StorageError::InvalidPath(format!("Join error in append conversation: {}", e)))??;
+        .map_err(|e| {
+            StorageError::InvalidPath(format!("Join error in append conversation: {}", e))
+        })??;
 
         Ok(message)
     }
@@ -810,7 +888,8 @@ impl SessionStorage {
     }
 
     fn artifact_file_path(&self, session_id: &str, cell_id: &str) -> PathBuf {
-        self.artifact_dir(session_id).join(format!("{}.json", cell_id))
+        self.artifact_dir(session_id)
+            .join(format!("{}.json", cell_id))
     }
 
     fn artifact_lock(&self, session_id: &str, cell_id: &str) -> Arc<Mutex<()>> {
@@ -827,7 +906,8 @@ impl SessionStorage {
     }
 
     fn user_template_path(&self, template_id: &str) -> PathBuf {
-        self.user_templates_dir().join(format!("{}.json", template_id))
+        self.user_templates_dir()
+            .join(format!("{}.json", template_id))
     }
 
     fn ai_docs_dir(project_path: &Path) -> PathBuf {
@@ -844,7 +924,11 @@ impl SessionStorage {
 
     /// Append a learning to the .ai-docs/learnings.jsonl file (project-scoped, legacy)
     /// DEPRECATED: Use append_learning_session for new code
-    pub fn append_learning(&self, project_path: &Path, learning: &Learning) -> Result<(), StorageError> {
+    pub fn append_learning(
+        &self,
+        project_path: &Path,
+        learning: &Learning,
+    ) -> Result<(), StorageError> {
         let ai_docs_dir = Self::ai_docs_dir(project_path);
         fs::create_dir_all(&ai_docs_dir)?;
         // Also ensure archive folder exists for /curate-learnings skill
@@ -869,7 +953,11 @@ impl SessionStorage {
 
     /// Append a learning to the session-scoped lessons directory
     /// Stores in .hive-manager/{session_id}/lessons/learnings.jsonl
-    pub fn append_learning_session(&self, session_id: &str, learning: &Learning) -> Result<(), StorageError> {
+    pub fn append_learning_session(
+        &self,
+        session_id: &str,
+        learning: &Learning,
+    ) -> Result<(), StorageError> {
         let lessons_dir = self.session_lessons_dir(session_id);
         fs::create_dir_all(&lessons_dir)?;
         // Also ensure archive folder exists
@@ -926,7 +1014,11 @@ impl SessionStorage {
 
     /// Delete a learning by ID from the session-scoped learnings file
     /// Uses temp-file + rename for atomicity
-    pub fn delete_learning_session(&self, session_id: &str, learning_id: &str) -> Result<bool, StorageError> {
+    pub fn delete_learning_session(
+        &self,
+        session_id: &str,
+        learning_id: &str,
+    ) -> Result<bool, StorageError> {
         let learnings_file = self.session_lessons_dir(session_id).join("learnings.jsonl");
 
         if !learnings_file.exists() {
@@ -966,11 +1058,10 @@ impl SessionStorage {
 
         // Write to temp file then rename for atomicity using tempfile crate
         let lessons_dir = self.session_lessons_dir(session_id);
-        let mut temp = tempfile::NamedTempFile::new_in(&lessons_dir)
-            .map_err(|e| StorageError::Io(e))?;
+        let mut temp =
+            tempfile::NamedTempFile::new_in(&lessons_dir).map_err(|e| StorageError::Io(e))?;
         for line in &remaining_lines {
-            writeln!(temp, "{}", line)
-                .map_err(|e| StorageError::Io(e))?;
+            writeln!(temp, "{}", line).map_err(|e| StorageError::Io(e))?;
         }
         temp.persist(&learnings_file)
             .map_err(|e| StorageError::Io(e.error))?;
@@ -1044,7 +1135,11 @@ impl SessionStorage {
     /// Save curated project DNA to the session-scoped lessons directory
     /// Saves to .hive-manager/{session_id}/lessons/project-dna.md
     #[allow(dead_code)]
-    pub fn save_project_dna_session(&self, session_id: &str, content: &str) -> Result<(), StorageError> {
+    pub fn save_project_dna_session(
+        &self,
+        session_id: &str,
+        content: &str,
+    ) -> Result<(), StorageError> {
         let lessons_dir = self.session_lessons_dir(session_id);
         fs::create_dir_all(&lessons_dir)?;
         let project_dna_file = lessons_dir.join("project-dna.md");
@@ -1148,7 +1243,8 @@ impl SessionStorage {
                 continue;
             }
 
-            let template: SessionTemplate = serde_json::from_str(&fs::read_to_string(entry.path())?)?;
+            let template: SessionTemplate =
+                serde_json::from_str(&fs::read_to_string(entry.path())?)?;
             templates.push(template);
         }
 
@@ -1311,7 +1407,7 @@ pub struct ApiConfig {
 impl Default for ApiConfig {
     fn default() -> Self {
         Self {
-            enabled: true,   // Enabled by default for Queen to spawn workers
+            enabled: true, // Enabled by default for Queen to spawn workers
             port: 18800,
         }
     }
@@ -1366,7 +1462,10 @@ mod tests {
         ] {
             let defaults = config.default_roles.get(role).unwrap();
             assert_eq!(defaults.cli, "codex", "role {role} should default to codex");
-            assert_eq!(defaults.model, "gpt-5.5", "role {role} should default to gpt-5.5");
+            assert_eq!(
+                defaults.model, "gpt-5.5",
+                "role {role} should default to gpt-5.5"
+            );
         }
 
         let frontend = config.default_roles.get("frontend").unwrap();
@@ -1390,9 +1489,15 @@ mod tests {
         assert_eq!(gemini.auto_approve_flag.as_deref(), Some("-y"));
         assert_eq!(gemini.model_flag.as_deref(), Some("-m"));
 
-        let antigravity = config.clis.get("antigravity").expect("antigravity entry present");
+        let antigravity = config
+            .clis
+            .get("antigravity")
+            .expect("antigravity entry present");
         assert_eq!(antigravity.command, "agy");
-        assert_eq!(antigravity.auto_approve_flag.as_deref(), Some("--dangerously-skip-permissions"));
+        assert_eq!(
+            antigravity.auto_approve_flag.as_deref(),
+            Some("--dangerously-skip-permissions")
+        );
         assert!(antigravity.model_flag.is_none(), "agy has no model flag");
     }
 
@@ -1544,16 +1649,12 @@ mod tests {
 
         let mut updated = session.clone();
         updated.state = "QaPassed".to_string();
-        let baseline_mtime = storage
-            .session_file_modified_at(&session.id)
-            .unwrap();
+        let baseline_mtime = storage.session_file_modified_at(&session.id).unwrap();
         let session_file = storage.session_file_path(&session.id);
         let deadline = std::time::Instant::now() + Duration::from_secs(5);
         loop {
             storage.atomic_write_json(&session_file, &updated).unwrap();
-            let now_mtime = storage
-                .session_file_modified_at(&session.id)
-                .unwrap();
+            let now_mtime = storage.session_file_modified_at(&session.id).unwrap();
             if now_mtime != baseline_mtime {
                 break;
             }
@@ -1603,7 +1704,9 @@ mod tests {
         };
 
         // Append learning
-        storage.append_learning_session(session_id, &learning).unwrap();
+        storage
+            .append_learning_session(session_id, &learning)
+            .unwrap();
 
         // Read learnings
         let learnings = storage.read_learnings_session(session_id).unwrap();
@@ -1654,12 +1757,20 @@ mod tests {
             files_touched: vec![],
         };
 
-        storage.append_learning_session(session_id, &learning1).unwrap();
-        storage.append_learning_session(session_id, &learning2).unwrap();
-        storage.append_learning_session(session_id, &learning3).unwrap();
+        storage
+            .append_learning_session(session_id, &learning1)
+            .unwrap();
+        storage
+            .append_learning_session(session_id, &learning2)
+            .unwrap();
+        storage
+            .append_learning_session(session_id, &learning3)
+            .unwrap();
 
         // Delete the middle one
-        let deleted = storage.delete_learning_session(session_id, "learning-2").unwrap();
+        let deleted = storage
+            .delete_learning_session(session_id, "learning-2")
+            .unwrap();
         assert!(deleted);
 
         // Read learnings - should only have 2
@@ -1689,10 +1800,14 @@ mod tests {
             files_touched: vec![],
         };
 
-        storage.append_learning_session(session_id, &learning).unwrap();
+        storage
+            .append_learning_session(session_id, &learning)
+            .unwrap();
 
         // Try to delete non-existent learning
-        let deleted = storage.delete_learning_session(session_id, "nonexistent-id").unwrap();
+        let deleted = storage
+            .delete_learning_session(session_id, "nonexistent-id")
+            .unwrap();
         assert!(!deleted);
 
         // Verify original learning still exists
@@ -1719,8 +1834,10 @@ mod tests {
 
         storage.create_session_dir(session_id).unwrap();
 
-        let learnings_file = storage.session_lessons_dir(session_id).join("learnings.jsonl");
-        
+        let learnings_file = storage
+            .session_lessons_dir(session_id)
+            .join("learnings.jsonl");
+
         // Write a file with valid and invalid lines
         let content = r#"{"id":"valid-1","date":"2024-01-01","session":"test","task":"task1","outcome":"success","keywords":[],"insight":"insight1","files_touched":[]}
 invalid json line

--- a/src-tauri/src/tauri_shim.rs
+++ b/src-tauri/src/tauri_shim.rs
@@ -1,0 +1,18 @@
+#[cfg(not(test))]
+pub use tauri::{AppHandle, Emitter};
+
+#[cfg(test)]
+#[derive(Clone, Debug)]
+pub struct AppHandle;
+
+#[cfg(test)]
+pub trait Emitter {
+    fn emit<S: serde::Serialize>(&self, _event: &str, _payload: S) -> Result<(), String>;
+}
+
+#[cfg(test)]
+impl Emitter for AppHandle {
+    fn emit<S: serde::Serialize>(&self, _event: &str, _payload: S) -> Result<(), String> {
+        Ok(())
+    }
+}

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -142,7 +142,8 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
         SessionTemplate {
             id: "bug-fix-hive".to_string(),
             name: "Bug-fix Hive".to_string(),
-            description: "Queen-led bug fix session with backend and frontend implementers.".to_string(),
+            description: "Queen-led bug fix session with backend and frontend implementers."
+                .to_string(),
             mode: SessionMode::Hive,
             cells: vec![
                 CellTemplate {
@@ -178,7 +179,9 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
         SessionTemplate {
             id: "feature-build-hive".to_string(),
             name: "Feature-build Hive".to_string(),
-            description: "Queen plus backend, frontend, and coherence workers for feature delivery.".to_string(),
+            description:
+                "Queen plus backend, frontend, and coherence workers for feature delivery."
+                    .to_string(),
             mode: SessionMode::Hive,
             cells: vec![
                 CellTemplate {
@@ -213,7 +216,8 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
         SessionTemplate {
             id: "fusion-compare".to_string(),
             name: "Fusion Compare".to_string(),
-            description: "Two candidate implementation cells plus a resolver recommendation pass.".to_string(),
+            description: "Two candidate implementation cells plus a resolver recommendation pass."
+                .to_string(),
             mode: SessionMode::Fusion,
             cells: vec![
                 CellTemplate {
@@ -306,7 +310,9 @@ impl TemplateEngine {
     /// Load built-in templates
     fn load_builtin_templates(&mut self) {
         // Backend worker role template
-        self.builtin_templates.insert("roles/backend".to_string(), r#"# Backend Worker Role
+        self.builtin_templates.insert(
+            "roles/backend".to_string(),
+            r#"# Backend Worker Role
 
 You are a Backend Worker in a multi-agent coding session.
 
@@ -330,7 +336,9 @@ You are a Backend Worker in a multi-agent coding session.
 
 ## Current Assignment
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // NOTE: No `roles/researcher` builtin template. Research workers are launched
         // via launch_research, which (like all v2 Hive launches) builds worker prompts
@@ -340,7 +348,9 @@ You are a Backend Worker in a multi-agent coding session.
         // here would be dead code and was removed in PR #121 review.
 
         // Frontend worker role template
-        self.builtin_templates.insert("roles/frontend".to_string(), r#"# Frontend Worker Role
+        self.builtin_templates.insert(
+            "roles/frontend".to_string(),
+            r#"# Frontend Worker Role
 
 You are a Frontend Worker in a multi-agent coding session.
 
@@ -364,10 +374,14 @@ You are a Frontend Worker in a multi-agent coding session.
 
 ## Current Assignment
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // Coherence worker role template
-        self.builtin_templates.insert("roles/coherence".to_string(), r#"# Coherence Worker Role
+        self.builtin_templates.insert(
+            "roles/coherence".to_string(),
+            r#"# Coherence Worker Role
 
 You are a Coherence Worker in a multi-agent coding session.
 
@@ -392,10 +406,14 @@ You are a Coherence Worker in a multi-agent coding session.
 
 ## Current Assignment
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // Simplify worker role template
-        self.builtin_templates.insert("roles/simplify".to_string(), r#"# Simplify Worker Role
+        self.builtin_templates.insert(
+            "roles/simplify".to_string(),
+            r#"# Simplify Worker Role
 
 You are a Simplify Worker in a multi-agent coding session.
 
@@ -420,10 +438,14 @@ You are a Simplify Worker in a multi-agent coding session.
 
 ## Current Assignment
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // Custom worker role template
-        self.builtin_templates.insert("roles/custom".to_string(), r#"# Custom Worker Role
+        self.builtin_templates.insert(
+            "roles/custom".to_string(),
+            r#"# Custom Worker Role
 
 You are a Worker in a multi-agent coding session.
 
@@ -445,7 +467,9 @@ You are a Worker in a multi-agent coding session.
 
 ## Current Assignment
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         self.builtin_templates.insert("roles/evaluator".to_string(), r#"# Evaluator - QA Authority
 
@@ -812,7 +836,9 @@ Always reference criteria by number. Fail when accessibility evidence is partial
 "#.to_string());
 
         // Fusion worker prompt template
-        self.builtin_templates.insert("fusion-worker".to_string(), r#"You are a Fusion worker implementing variant "{{variant_name}}".
+        self.builtin_templates.insert(
+            "fusion-worker".to_string(),
+            r#"You are a Fusion worker implementing variant "{{variant_name}}".
 Working directory: {{worktree_path}}
 Branch: {{branch}}
 
@@ -824,10 +850,14 @@ Branch: {{branch}}
 - Commit all changes to your branch
 - Do NOT interact with other variants
 - When complete, update your task file status to COMPLETED
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // Fusion judge prompt template
-        self.builtin_templates.insert("fusion-judge".to_string(), r#"You are the Judge evaluating {{variant_count}} competing implementations.
+        self.builtin_templates.insert(
+            "fusion-judge".to_string(),
+            r#"You are the Judge evaluating {{variant_count}} competing implementations.
 
 ## Variants
 {{variant_list}}
@@ -844,9 +874,111 @@ Branch: {{branch}}
 ## Recommendation
 Winner: [variant name]
 Rationale: [explanation]
+"#
+            .to_string(),
+        );
+
+        self.builtin_templates.insert(
+            "debater".to_string(),
+            r#"You are a Debate debater arguing as "{{debater_name}}".
+Working directory: {{worktree_path}}
+Branch: {{branch}}
+
+## Debate Topic
+{{task}}
+
+## Your Stance
+{{stance}}
+
+## Round
+Round {{round}} of {{total_rounds}}
+
+## Opponent Prior-Round Arguments
+Previous round directory: {{previous_round_dir}}
+
+{{opponent_files}}
+
+## Deliverable
+Write this round's argument to:
+{{argument_file}}
+
+Then update your task file:
+{{task_file}}
+
+## Rules
+- Argue only your assigned stance.
+- Read opponent prior-round arguments before writing rebuttals in rounds after round 1.
+- Do not edit production source code.
+- Do not commit or push.
+- When complete, update your task file status to COMPLETED.
+
+## Heartbeat
+{{generic_heartbeat_snippet}}
+"#
+            .to_string(),
+        );
+
+        self.builtin_templates.insert("debate-judge".to_string(), r#"You are the Judge evaluating a multi-round Debate session.
+
+## Debate Topic
+{{topic}}
+
+## Debaters
+{{debater_list}}
+
+## Rounds
+{{rounds}}
+
+## Argument Files
+{{round_files}}
+
+## Evaluation Process
+1. Read every argument file listed above.
+2. Evaluate argument quality, rebuttal strength, evidence, consistency, and handling of opponent claims.
+3. Write the verdict to: {{verdict_file}}
+
+## Verdict Format
+# Debate Verdict
+## Summary
+## Round-by-Round Assessment
+## Winner
+Winner: [debater name]
+Rationale: [concise explanation]
+## Notable Insights
+
+## Wiki Capture
+The global wiki path is: `{{global_wiki_path}}`
+
+If `{{global_wiki_path}}` is non-empty and the debate produced durable knowledge, capture the verdict to the global wiki with this Draft -> PR flow:
+
+```bash
+cd "{{global_wiki_path}}"
+git checkout main && git pull --ff-only
+git checkout -b debate/{{topic_slug}}
+```
+
+Read `~/.ai-docs/schema.md`, write a schema-compliant markdown entry summarizing the debate and sources, then:
+
+```bash
+git add -A
+git commit -m "debate: {{topic_slug}} verdict"
+git push -u origin debate/{{topic_slug}}
+gh pr create --base main --title "debate: {{topic_slug}} verdict" --body "Captures debate verdict for {{topic}}"
+```
+
+If `{{global_wiki_path}}` is empty, skip wiki capture gracefully.
+
+## Constraints
+- You are read-only for project code.
+- Only produce the verdict and optional wiki Draft -> PR.
+
+## Heartbeat
+{{generic_heartbeat_snippet}}
 "#.to_string());
 
-        self.builtin_templates.insert("resolver".to_string(), r#"# Resolver Recommendation Pass
+        self.builtin_templates.insert(
+            "resolver".to_string(),
+            r#"# Resolver Recommendation Pass
 
 You are evaluating candidate implementation artifacts for session `{{session_id}}`.
 
@@ -864,7 +996,9 @@ Recommend the strongest candidate or describe a safe hybrid plan.
 - Provide concise rationale grounded in artifact evidence
 - List explicit tradeoffs
 - Include a hybrid integration plan only if combining candidates is materially better
-"#.to_string());
+"#
+            .to_string(),
+        );
 
         // Queen prompt for Hive sessions
         self.builtin_templates.insert("queen-hive".to_string(), r#"# Queen - Hive Session Orchestrator
@@ -1306,7 +1440,9 @@ The planners will break down tasks and assign to their workers.
 "#.to_string());
 
         // Planner prompt template
-        self.builtin_templates.insert("planner".to_string(), r#"# Planner - {{domain}} Domain
+        self.builtin_templates.insert(
+            "planner".to_string(),
+            r#"# Planner - {{domain}} Domain
 
 You are a Planner agent managing the {{domain}} domain in a Swarm session.
 
@@ -1329,7 +1465,9 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
 ## Current Domain Task
 
 {{task}}
-"#.to_string());
+"#
+            .to_string(),
+        );
     }
 
     /// Render a worker prompt from a role
@@ -1362,6 +1500,7 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
             SessionType::Hive { .. } => "queen-hive",
             SessionType::Swarm { .. } => "queen-swarm",
             SessionType::Fusion { .. } => "queen-fusion",
+            SessionType::Debate { .. } => "queen-fusion",
             SessionType::Solo { .. } => "queen-hive", // Solo has no queen, keep fallback template for compatibility
         };
 
@@ -1407,15 +1546,27 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
 
         rendered = rendered.replace(
             "{{variant_name}}",
-            context.variables.get("variant_name").map(String::as_str).unwrap_or("variant"),
+            context
+                .variables
+                .get("variant_name")
+                .map(String::as_str)
+                .unwrap_or("variant"),
         );
         rendered = rendered.replace(
             "{{worktree_path}}",
-            context.variables.get("worktree_path").map(String::as_str).unwrap_or("."),
+            context
+                .variables
+                .get("worktree_path")
+                .map(String::as_str)
+                .unwrap_or("."),
         );
         rendered = rendered.replace(
             "{{branch}}",
-            context.variables.get("branch").map(String::as_str).unwrap_or(""),
+            context
+                .variables
+                .get("branch")
+                .map(String::as_str)
+                .unwrap_or(""),
         );
 
         if let Some(ref task) = context.task {
@@ -1437,24 +1588,44 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
         rendered = rendered.replace("{{session_id}}", &context.session_id);
         rendered = rendered.replace(
             "{{variant_count}}",
-            context.variables.get("variant_count").map(String::as_str).unwrap_or("0"),
+            context
+                .variables
+                .get("variant_count")
+                .map(String::as_str)
+                .unwrap_or("0"),
         );
         rendered = rendered.replace(
             "{{variant_list}}",
-            context.variables.get("variant_list").map(String::as_str).unwrap_or(""),
+            context
+                .variables
+                .get("variant_list")
+                .map(String::as_str)
+                .unwrap_or(""),
         );
         rendered = rendered.replace(
             "{{decision_file}}",
-            context.variables.get("decision_file").map(String::as_str).unwrap_or(""),
+            context
+                .variables
+                .get("decision_file")
+                .map(String::as_str)
+                .unwrap_or(""),
         );
 
         Ok(rendered)
     }
 
-    pub fn render_resolver_prompt(
+    pub fn render_debater_prompt(&self, context: &PromptContext) -> Result<String, TemplateError> {
+        self.render_template("debater", context)
+    }
+
+    pub fn render_debate_judge_prompt(
         &self,
         context: &PromptContext,
     ) -> Result<String, TemplateError> {
+        self.render_template("debate-judge", context)
+    }
+
+    pub fn render_resolver_prompt(&self, context: &PromptContext) -> Result<String, TemplateError> {
         self.render_template("resolver", context)
     }
 
@@ -1605,7 +1776,8 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
         }
 
         // Fall back to built-in template
-        self.builtin_templates.get(name)
+        self.builtin_templates
+            .get(name)
             .cloned()
             .ok_or_else(|| TemplateError::NotFound(name.to_string()))
     }
@@ -1744,7 +1916,10 @@ mod tests {
         let mut variables = HashMap::new();
         variables.insert("agent_id".to_string(), "session-123-worker-1".to_string());
         variables.insert("heartbeat_status".to_string(), "working".to_string());
-        variables.insert("heartbeat_summary".to_string(), "Implementing backend task".to_string());
+        variables.insert(
+            "heartbeat_summary".to_string(),
+            "Implementing backend task".to_string(),
+        );
 
         let prompt = TemplateEngine::default()
             .render_worker_prompt(
@@ -1825,7 +2000,10 @@ mod tests {
         enabled.insert("qa_worker_index".to_string(), "1".to_string());
         enabled.insert("custom_instructions".to_string(), "Test".to_string());
         enabled.insert("supports_chrome".to_string(), "true".to_string());
-        enabled.insert("auth_bypass_url".to_string(), "http://localhost".to_string());
+        enabled.insert(
+            "auth_bypass_url".to_string(),
+            "http://localhost".to_string(),
+        );
         enabled.insert("auth_bypass_token".to_string(), "token".to_string());
 
         let enabled_prompt = TemplateEngine::default()
@@ -1847,7 +2025,10 @@ mod tests {
         disabled.insert("qa_worker_index".to_string(), "1".to_string());
         disabled.insert("custom_instructions".to_string(), "Test".to_string());
         disabled.insert("supports_chrome".to_string(), "false".to_string());
-        disabled.insert("auth_bypass_url".to_string(), "http://localhost".to_string());
+        disabled.insert(
+            "auth_bypass_url".to_string(),
+            "http://localhost".to_string(),
+        );
         disabled.insert("auth_bypass_token".to_string(), "token".to_string());
 
         let disabled_prompt = TemplateEngine::default()

--- a/src-tauri/src/watcher/mod.rs
+++ b/src-tauri/src/watcher/mod.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 use std::path::Path;
 use std::sync::{mpsc::channel, Arc, Mutex};
 use std::time::{Duration, Instant};
-use tauri::{AppHandle, Emitter};
+use crate::tauri_shim::{AppHandle, Emitter};
 
 #[derive(Clone, Serialize)]
 struct WorkerCompletedPayload {

--- a/src-tauri/src/watcher/mod.rs
+++ b/src-tauri/src/watcher/mod.rs
@@ -20,6 +20,14 @@ struct FusionVariantCompletedPayload {
 }
 
 #[derive(Clone, Serialize)]
+struct DebateRoundCompletedPayload {
+    session_id: String,
+    debater_index: u8,
+    round: u8,
+    task_file: String,
+}
+
+#[derive(Clone, Serialize)]
 struct AgentTaskCompletedPayload {
     session_id: String,
     agent_id: String,
@@ -45,6 +53,7 @@ impl TaskFileWatcher {
         session_path: &Path,
         worktrees_path: &Path,
         fusion_worktrees_path: &Path,
+        debate_worktrees_path: &Path,
         session_id: &str,
         app_handle: AppHandle,
     ) -> Result<Self, notify::Error> {
@@ -66,6 +75,8 @@ impl TaskFileWatcher {
         watcher.watch(worktrees_path, RecursiveMode::Recursive)?;
         std::fs::create_dir_all(fusion_worktrees_path).ok();
         watcher.watch(fusion_worktrees_path, RecursiveMode::Recursive)?;
+        std::fs::create_dir_all(debate_worktrees_path).ok();
+        watcher.watch(debate_worktrees_path, RecursiveMode::Recursive)?;
         let peer_path = session_path.join("peer");
         std::fs::create_dir_all(&peer_path).ok();
         watcher.watch(&peer_path, RecursiveMode::NonRecursive)?;
@@ -79,7 +90,13 @@ impl TaskFileWatcher {
 
         std::thread::spawn(move || {
             while let Ok(event) = rx.recv() {
-                Self::handle_event(&event, &session_id_owned, &app_handle_clone, &last_emit_clone, debounce);
+                Self::handle_event(
+                    &event,
+                    &session_id_owned,
+                    &app_handle_clone,
+                    &last_emit_clone,
+                    debounce,
+                );
             }
         });
 
@@ -117,6 +134,17 @@ impl TaskFileWatcher {
             let suffix = filename.strip_prefix("fusion-variant-")?;
             let num_end = suffix.strip_suffix("-task.md")?;
             return num_end.parse::<u8>().ok();
+        }
+        None
+    }
+
+    fn extract_debate_round(path: &Path) -> Option<(u8, u8)> {
+        let filename = path.file_name()?.to_str()?;
+        if filename.starts_with("debate-debater-") && filename.ends_with("-task.md") {
+            let suffix = filename.strip_prefix("debate-debater-")?;
+            let (debater_index, round_part) = suffix.split_once("-round-")?;
+            let round = round_part.strip_suffix("-task.md")?;
+            return Some((debater_index.parse().ok()?, round.parse().ok()?));
         }
         None
     }
@@ -191,13 +219,20 @@ impl TaskFileWatcher {
 
             let worker_id = Self::extract_worker_id(path);
             let fusion_variant_index = Self::extract_fusion_variant(path);
+            let debate_round = Self::extract_debate_round(path);
             let evaluator_agent_id = Self::extract_evaluator_id(path);
-            if worker_id.is_none() && fusion_variant_index.is_none() && evaluator_agent_id.is_none() {
+            if worker_id.is_none()
+                && fusion_variant_index.is_none()
+                && debate_round.is_none()
+                && evaluator_agent_id.is_none()
+            {
                 continue;
             }
 
             if let Ok(content) = std::fs::read_to_string(path) {
-                if content.contains("Status: COMPLETED") || content.contains("**Status**: COMPLETED") {
+                if content.contains("Status: COMPLETED")
+                    || content.contains("**Status**: COMPLETED")
+                {
                     let task_file = path.to_string_lossy().to_string();
 
                     if let Some(worker_id) = worker_id {
@@ -216,6 +251,16 @@ impl TaskFileWatcher {
                             task_file: task_file.clone(),
                         };
                         let _ = app_handle.emit("fusion-variant-completed", payload);
+                    }
+
+                    if let Some((debater_index, round)) = debate_round {
+                        let payload = DebateRoundCompletedPayload {
+                            session_id: session_id.to_string(),
+                            debater_index,
+                            round,
+                            task_file: task_file.clone(),
+                        };
+                        let _ = app_handle.emit("debate-round-completed", payload);
                     }
 
                     if let Some(agent_id) = evaluator_agent_id {
@@ -245,25 +290,90 @@ mod tests {
 
     #[test]
     fn test_extract_worker_id() {
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-1-task.md")), Some(1));
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-5-task.md")), Some(5));
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-12-task.md")), Some(12));
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-1-task.md")),
+            Some(1)
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-5-task.md")),
+            Some(5)
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-12-task.md")),
+            Some(12)
+        );
 
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-task.md")), None);
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("planner-1-task.md")), None);
-        assert_eq!(TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-1.md")), None);
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-task.md")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("planner-1-task.md")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_worker_id(&PathBuf::from("worker-1.md")),
+            None
+        );
     }
 
     #[test]
     fn test_extract_fusion_variant() {
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-1-task.md")), Some(1));
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-5-task.md")), Some(5));
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-12-task.md")), Some(12));
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-1-task.md")),
+            Some(1)
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-5-task.md")),
+            Some(5)
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-12-task.md")),
+            Some(12)
+        );
 
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-")), None);
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-foo-task.md")), None);
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-task.md")), None);
-        assert_eq!(TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-1.md")), None);
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-foo-task.md")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-task.md")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_fusion_variant(&PathBuf::from("fusion-variant-1.md")),
+            None
+        );
+    }
+
+    #[test]
+    fn test_extract_debate_round() {
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from(
+                "debate-debater-1-round-1-task.md"
+            )),
+            Some((1, 1))
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from(
+                "debate-debater-3-round-12-task.md"
+            )),
+            Some((3, 12))
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from(
+                "debate-debater-x-round-1-task.md"
+            )),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from("debate-debater-1-task.md")),
+            None
+        );
     }
 
     #[test]

--- a/src-tauri/src/watcher/mod.rs
+++ b/src-tauri/src/watcher/mod.rs
@@ -144,7 +144,12 @@ impl TaskFileWatcher {
             let suffix = filename.strip_prefix("debate-debater-")?;
             let (debater_index, round_part) = suffix.split_once("-round-")?;
             let round = round_part.strip_suffix("-task.md")?;
-            return Some((debater_index.parse().ok()?, round.parse().ok()?));
+            let debater_index = debater_index.parse().ok()?;
+            let round = round.parse().ok()?;
+            if debater_index == 0 || round == 0 {
+                return None;
+            }
+            return Some((debater_index, round));
         }
         None
     }
@@ -372,6 +377,18 @@ mod tests {
         );
         assert_eq!(
             TaskFileWatcher::extract_debate_round(&PathBuf::from("debate-debater-1-task.md")),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from(
+                "debate-debater-0-round-1-task.md"
+            )),
+            None
+        );
+        assert_eq!(
+            TaskFileWatcher::extract_debate_round(&PathBuf::from(
+                "debate-debater-1-round-0-task.md"
+            )),
             None
         );
     }

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -22,6 +22,7 @@ use crate::session::{Session, SessionType};
 ///
 /// - Hive mode: `hive/<session-id>/<cell-name>`
 /// - Fusion candidate: `fusion/<session-id>/<candidate-name>`
+/// - Debate debater: `debate/<session-id>/<debater-name>`
 /// - Resolver: `resolver/<session-id>`
 pub fn generate_branch_name(
     session_id: &str,
@@ -37,7 +38,13 @@ pub fn generate_branch_name(
             // Fusion candidates are isolated cells
             format!("fusion/{}/{}", session_id, cell_name)
         }
-        (SessionMode::Hive, CellType::Resolver) | (SessionMode::Fusion, CellType::Resolver) => {
+        (SessionMode::Debate, CellType::Hive) => {
+            // Debate debaters are isolated cells
+            format!("debate/{}/{}", session_id, cell_name)
+        }
+        (SessionMode::Hive, CellType::Resolver)
+        | (SessionMode::Fusion, CellType::Resolver)
+        | (SessionMode::Debate, CellType::Resolver) => {
             format!("resolver/{}", session_id)
         }
     }
@@ -83,7 +90,11 @@ pub fn current_head(worktree_path: &Path) -> Result<String, String> {
 pub fn branch_exists(worktree_path: &Path, branch_name: &str) -> Result<bool, String> {
     match run_git(
         worktree_path,
-        &["rev-parse", "--verify", &format!("refs/heads/{}", branch_name)],
+        &[
+            "rev-parse",
+            "--verify",
+            &format!("refs/heads/{}", branch_name),
+        ],
     ) {
         Ok(output) => Ok(!output.trim().is_empty()),
         Err(_) => Ok(false),
@@ -93,8 +104,7 @@ pub fn branch_exists(worktree_path: &Path, branch_name: &str) -> Result<bool, St
 /// Fetch the latest state of a branch from origin.
 /// Returns Ok(()) on success, Err on failure (e.g. no remote, network issues).
 pub fn fetch_origin_branch(project_path: &Path, branch: &str) -> Result<(), String> {
-    run_git(project_path, &["fetch", "origin", branch])
-        .map(|_| ())
+    run_git(project_path, &["fetch", "origin", branch]).map(|_| ())
 }
 
 /// Determine the best base ref for creating a new worktree.
@@ -116,7 +126,11 @@ pub fn resolve_fresh_base(project_path: &Path) -> String {
         Ok(()) => {
             match run_git(
                 project_path,
-                &["rev-parse", "--verify", &format!("refs/remotes/{}", remote_ref)],
+                &[
+                    "rev-parse",
+                    "--verify",
+                    &format!("refs/remotes/{}", remote_ref),
+                ],
             ) {
                 Ok(_) => return remote_ref,
                 Err(err) => format!("fetched but remote tracking ref verify failed: {}", err),
@@ -244,7 +258,12 @@ pub fn cleanup_session_worktrees(session: &Session) -> Result<(), String> {
         .map_err(|e| format!("worktree list: {}", e.message))?;
 
     let session_prefixes = match &session.session_type {
-        SessionType::Fusion { .. } => vec![session.project_path.join(".hive-fusion").join(&session.id)],
+        SessionType::Fusion { .. } => {
+            vec![session.project_path.join(".hive-fusion").join(&session.id)]
+        }
+        SessionType::Debate { .. } => {
+            vec![session.project_path.join(".hive-debate").join(&session.id)]
+        }
         _ => vec![session
             .project_path
             .join(".hive-manager")
@@ -254,7 +273,10 @@ pub fn cleanup_session_worktrees(session: &Session) -> Result<(), String> {
 
     let mut cleanup_errors = Vec::new();
     for worktree in worktrees {
-        if !session_prefixes.iter().any(|prefix| worktree.path.starts_with(prefix)) {
+        if !session_prefixes
+            .iter()
+            .any(|prefix| worktree.path.starts_with(prefix))
+        {
             continue;
         }
 
@@ -326,12 +348,8 @@ mod tests {
 
     #[test]
     fn test_generate_branch_name_hive() {
-        let branch = generate_branch_name(
-            "session-123",
-            "worker-1",
-            SessionMode::Hive,
-            CellType::Hive,
-        );
+        let branch =
+            generate_branch_name("session-123", "worker-1", SessionMode::Hive, CellType::Hive);
         assert_eq!(branch, "hive/session-123/worker-1");
     }
 

--- a/src-tauri/src/workspace/manager.rs
+++ b/src-tauri/src/workspace/manager.rs
@@ -105,9 +105,10 @@ impl WorkspaceManager {
         match (&session.mode, &cell.cell_type) {
             (SessionMode::Hive, CellType::Hive) => Some(WorkspaceStrategy::SharedCell),
             (SessionMode::Fusion, CellType::Hive) => Some(WorkspaceStrategy::IsolatedCell),
-            (SessionMode::Hive, CellType::Resolver) | (SessionMode::Fusion, CellType::Resolver) => {
-                None
-            }
+            (SessionMode::Debate, CellType::Hive) => Some(WorkspaceStrategy::IsolatedCell),
+            (SessionMode::Hive, CellType::Resolver)
+            | (SessionMode::Fusion, CellType::Resolver)
+            | (SessionMode::Debate, CellType::Resolver) => None,
         }
     }
 
@@ -227,8 +228,7 @@ impl WorkspaceManager {
                     .join(&cell.id);
 
                 // Create the worktree
-                let info = self
-                    .create_or_attach_worktree(&worktree_path, &branch_name)?;
+                let info = self.create_or_attach_worktree(&worktree_path, &branch_name)?;
 
                 Ok(Workspace {
                     strategy: WorkspaceStrategy::IsolatedCell,
@@ -349,14 +349,12 @@ impl WorkspaceManager {
         workspace: &Workspace,
     ) -> Result<WorkspaceStatus, WorkspaceError> {
         match (&workspace.strategy, &workspace.worktree_path) {
-            (WorkspaceStrategy::None, _) => {
-                Ok(WorkspaceStatus {
-                    is_dirty: false,
-                    branch: String::new(),
-                    head: String::new(),
-                    worktree_path: None,
-                })
-            }
+            (WorkspaceStrategy::None, _) => Ok(WorkspaceStatus {
+                is_dirty: false,
+                branch: String::new(),
+                head: String::new(),
+                worktree_path: None,
+            }),
             (_, None) => {
                 // Workspace without a worktree - check main repo
                 let is_dirty = git::is_dirty(&workspace.repo_path)?;
@@ -391,8 +389,8 @@ mod tests {
     use super::*;
 
     fn make_test_session(mode: SessionMode) -> Session {
-        use chrono::Utc;
         use crate::domain::{LaunchConfig, SessionStatus};
+        use chrono::Utc;
 
         Session {
             id: "test-session-123".to_string(),

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
+  import { invoke } from '@tauri-apps/api/core';
   import { conversationStore, type ConversationMessage } from '$lib/stores/conversations';
   import { activeSession } from '$lib/stores/sessions';
   import AgentStatusBar from './AgentStatusBar.svelte';
@@ -12,6 +13,7 @@
   let messageInput = '';
   let lastMessageCount = 0;
   let pollInterval: ReturnType<typeof setInterval>;
+  let approvalError = '';
 
   $: sessionId = $activeSession?.id ?? null;
   $: agents = $activeSession?.agents ?? [];
@@ -96,14 +98,47 @@
     await conversationStore.sendMessage(sessionId, selectedAgent, 'operator', text.trim());
   }
 
-  // Approval widget signals. Wiring approve/reject to the queen/worker is #123's
-  // Action contract; for #127 we console-log so the widget is demonstrable.
+  function queenAgentId(): string | null {
+    const queen = agents.find((agent) => agent.role === 'Queen' || agent.id.endsWith('-queen'));
+    return queen?.id ?? null;
+  }
+
+  async function injectApprovalDecision(decision: 'approved' | 'rejected', detail: { actionId?: string }) {
+    if (!sessionId) return;
+    const targetAgentId = queenAgentId() ?? (selectedAgent !== 'shared' ? selectedAgent : null);
+    if (!targetAgentId) {
+      approvalError = 'No agent is available for approval injection.';
+      return;
+    }
+
+    const actionId = detail?.actionId ?? 'unknown';
+    const message = [
+      `Operator ${decision} approval request.`,
+      `action_id: ${actionId}`,
+      `decision: ${decision}`,
+    ].join('\n');
+
+    try {
+      approvalError = '';
+      await invoke('operator_inject', {
+        request: {
+          session_id: sessionId,
+          target_agent_id: targetAgentId,
+          message,
+        },
+      });
+    } catch (err) {
+      approvalError = String(err);
+      console.error('[tool-render] approval injection failed', err);
+    }
+  }
+
   function handleApprove(detail: { actionId?: string }) {
-    console.log('[tool-render] approve', detail?.actionId ?? null);
+    void injectApprovalDecision('approved', detail);
   }
 
   function handleReject(detail: { actionId?: string }) {
-    console.log('[tool-render] reject', detail?.actionId ?? null);
+    void injectApprovalDecision('rejected', detail);
   }
 
   function getSenderColor(from: string): string {
@@ -215,6 +250,13 @@
     <div class="error">
       {$conversationStore.error}
       <button class="dismiss-btn" onclick={() => conversationStore.clearError()}>&#10005;</button>
+    </div>
+  {/if}
+
+  {#if approvalError}
+    <div class="error">
+      {approvalError}
+      <button class="dismiss-btn" onclick={() => approvalError = ''}>&#10005;</button>
     </div>
   {/if}
 </div>

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -72,16 +72,26 @@
   }
 
   async function fetchDebateData() {
-    if (!$activeSession) return;
+    const sessionId = $activeSession?.id;
+    if (!sessionId) return;
+
+    const isCurrentSession = () => $activeSession?.id === sessionId;
+
     try {
-      const statusRes = await fetch(apiUrl(`/api/sessions/${$activeSession.id}/debate/status`));
+      const statusRes = await fetch(apiUrl(`/api/sessions/${sessionId}/debate/status`));
       if (statusRes.ok) {
-        debateStatus = await statusRes.json();
+        const status = await statusRes.json();
+        if (!isCurrentSession()) return;
+        debateStatus = status;
       }
+
+      if (!isCurrentSession()) return;
       
-      const evalRes = await fetch(apiUrl(`/api/sessions/${$activeSession.id}/debate/evaluation`));
+      const evalRes = await fetch(apiUrl(`/api/sessions/${sessionId}/debate/evaluation`));
       if (evalRes.ok) {
-        debateEvaluation = await evalRes.json();
+        const evaluation = await evalRes.json();
+        if (!isCurrentSession()) return;
+        debateEvaluation = evaluation;
         
         // Auto-switch to verdict tab when it becomes ready
         if (debateEvaluation?.report && viewMode === 'terminals') {

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -1,0 +1,753 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+  import { activeAgents, activeSession, sessions, serdeEnumVariantName } from '$lib/stores/sessions';
+  import { coordination } from '$lib/stores/coordination';
+  import Terminal from './Terminal.svelte';
+  import { Keyboard, ChartBar, Crown, Scales, MagnifyingGlass, GitBranch, GitPullRequest, Warning } from 'phosphor-svelte';
+  import { apiUrl } from '$lib/config';
+
+  // Interfaces for Debate API
+  interface DebateDebaterStatus {
+    index: number;
+    name: string;
+    stance: string | null;
+    branch: string;
+    worktree_path: string;
+    status: string;
+  }
+
+  interface DebateStatusResponse {
+    session_id: string;
+    state: string;
+    debaters: DebateDebaterStatus[];
+  }
+
+  interface DebateEvaluationResponse {
+    session_id: string;
+    state: string;
+    report_path: string;
+    report: string | null;
+  }
+
+  let debateStatus = $state<DebateStatusResponse | null>(null);
+  let debateEvaluation = $state<DebateEvaluationResponse | null>(null);
+  let error = $state<string | null>(null);
+  let viewMode = $state<'terminals' | 'comparison' | 'verdict'>('terminals');
+  let pollInterval = $state<any>(null);
+  let endingSession = $state(false);
+
+  // Derivations
+  let queenAgent = $derived($activeAgents.find((a) => serdeEnumVariantName(a.role) === 'Queen'));
+  let judgeAgent = $derived($activeAgents.find(a => typeof a.role === 'object' && 'Judge' in a.role));
+  
+  // Debaters from status response
+  let debaters = $derived(debateStatus?.debaters ?? []);
+
+  // Filter agents matching debaters (role has Fusion/Variant or matches debater names)
+  let debaterAgents = $derived($activeAgents.filter(a => 
+    (typeof a.role === 'object' && 'Fusion' in a.role) || 
+    debaters.some(d => d.name === a.config.label || a.id.includes(d.name.toLowerCase()))
+  ));
+
+  // State evaluation ready
+  let evaluationReady = $derived(!!debateEvaluation?.report);
+  let judgeReport = $derived(debateEvaluation?.report ?? null);
+
+  // Extract PR URL from verdict report or coordination logs
+  let prUrl = $derived(extractPrUrl(judgeReport, $coordination.log));
+
+  function extractPrUrl(reportText: string | null, logs: any[]): string | null {
+    const prRegex = /https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+/;
+    if (reportText) {
+      const match = reportText.match(prRegex);
+      if (match) return match[0];
+    }
+    for (const log of logs) {
+      if (log.content) {
+        const match = log.content.match(prRegex);
+        if (match) return match[0];
+      }
+    }
+    return null;
+  }
+
+  async function fetchDebateData() {
+    if (!$activeSession) return;
+    try {
+      const statusRes = await fetch(apiUrl(`/api/sessions/${$activeSession.id}/debate/status`));
+      if (statusRes.ok) {
+        debateStatus = await statusRes.json();
+      }
+      
+      const evalRes = await fetch(apiUrl(`/api/sessions/${$activeSession.id}/debate/evaluation`));
+      if (evalRes.ok) {
+        debateEvaluation = await evalRes.json();
+        
+        // Auto-switch to verdict tab when it becomes ready
+        if (debateEvaluation?.report && viewMode === 'terminals') {
+          viewMode = 'verdict';
+        }
+      }
+    } catch (e) {
+      console.error("Error fetching debate data:", e);
+    }
+  }
+
+  onMount(() => {
+    fetchDebateData();
+    pollInterval = setInterval(fetchDebateData, 3000);
+  });
+
+  onDestroy(() => {
+    if (pollInterval) clearInterval(pollInterval);
+  });
+
+  async function handleCloseSession() {
+    if (!$activeSession) return;
+    endingSession = true;
+    error = null;
+    try {
+      await sessions.stopSession($activeSession.id);
+    } catch (e) {
+      error = String(e);
+    } finally {
+      endingSession = false;
+    }
+  }
+
+  function getDebaterStatusClass(status: string): string {
+    const s = status.toLowerCase();
+    if (s.includes('running') || s.includes('active')) return 'running';
+    if (s.includes('completed') || s.includes('success')) return 'completed';
+    if (s.includes('failed') || s.includes('error')) return 'failed';
+    return 'queued';
+  }
+</script>
+
+<div class="debate-panel">
+  <!-- Debate Header Bar -->
+  <div class="debate-header-bar">
+    <div class="info-group">
+      <div class="state-tag" class:eval-ready={evaluationReady}>
+        {#if evaluationReady}
+          Verdict Ready
+        {:else if $activeSession?.state}
+          {$activeSession.state}
+        {:else}
+          Running
+        {/if}
+      </div>
+      <div class="session-name">{$activeSession?.name || 'Debate Session'}</div>
+    </div>
+    
+    <div class="panel-controls">
+      <div class="view-tabs">
+        <button class="tab-button" class:active={viewMode === 'terminals'} onclick={() => viewMode = 'terminals'}>
+          <Keyboard size={18} weight="light" /> Terminals
+        </button>
+        <button class="tab-button" class:active={viewMode === 'comparison'} onclick={() => viewMode = 'comparison'}>
+          <ChartBar size={18} weight="light" /> Debaters
+        </button>
+        <button class="tab-button" class:active={viewMode === 'verdict'} onclick={() => viewMode = 'verdict'}>
+          <Scales size={18} weight="light" /> Judge Verdict
+        </button>
+      </div>
+    </div>
+  </div>
+
+  {#if error}
+    <div class="error-banner">
+      <Warning size={16} />
+      <span>{error}</span>
+    </div>
+  {/if}
+
+  {#if viewMode === 'terminals'}
+    <!-- TERMINALS VIEW -->
+    <div class="terminals-layout">
+      {#if queenAgent}
+        <div class="orchestrator-section">
+          <div class="section-header">
+            <Crown size={20} weight="light" class="icon-queen" />
+            <h3>Orchestrator Queen</h3>
+            <span class="cli-badge">{queenAgent.config?.cli || 'unknown'}</span>
+          </div>
+          <div class="orchestrator-terminal">
+            <Terminal agentId={queenAgent.id} isFocused={true} />
+          </div>
+        </div>
+      {/if}
+
+      <div class="debaters-terminals-grid">
+        {#each debaterAgents as agent (agent.id)}
+          <div class="variant-card">
+            <div class="variant-header">
+              <span class="variant-name">{agent.config?.label || 'Debater'}</span>
+              <span class="cli-badge">{agent.config?.cli || 'unknown'}</span>
+            </div>
+            <div class="terminal-container">
+              <Terminal agentId={agent.id} isFocused={true} />
+            </div>
+          </div>
+        {/each}
+      </div>
+
+      {#if judgeAgent}
+        <div class="orchestrator-section">
+          <div class="section-header">
+            <Scales size={20} weight="light" class="icon-judge" />
+            <h3>Debate Judge</h3>
+            <span class="cli-badge">{judgeAgent.config?.cli || 'unknown'}</span>
+          </div>
+          <div class="orchestrator-terminal">
+            <Terminal agentId={judgeAgent.id} isFocused={true} />
+          </div>
+        </div>
+      {/if}
+    </div>
+
+  {:else if viewMode === 'comparison'}
+    <!-- DEBATERS COMPARISON VIEW -->
+    <div class="comparison-layout">
+      <div class="debaters-grid">
+        {#each debaters as debater (debater.index)}
+          <div class="debater-status-card" class:completed={debater.status === 'Completed'}>
+            <div class="debater-card-header">
+              <div class="status-indicator">
+                <span class="status-dot {getDebaterStatusClass(debater.status)}"></span>
+                <span class="debater-name">{debater.name}</span>
+              </div>
+              <span class="status-text">{debater.status}</span>
+            </div>
+
+            <div class="debater-card-body">
+              {#if debater.stance}
+                <div class="data-row">
+                  <span class="data-label">Stance:</span>
+                  <span class="data-value stance-badge">{debater.stance}</span>
+                </div>
+              {/if}
+
+              <div class="data-row">
+                <span class="data-label">Branch:</span>
+                <span class="data-value code-font">
+                  <GitBranch size={12} /> {debater.branch}
+                </span>
+              </div>
+
+              <div class="data-row">
+                <span class="data-label">Worktree:</span>
+                <span class="data-value code-font filepath" title={debater.worktree_path}>
+                  {debater.worktree_path}
+                </span>
+              </div>
+            </div>
+          </div>
+        {/each}
+      </div>
+    </div>
+
+  {:else}
+    <!-- JUDGE VERDICT VIEW -->
+    <div class="verdict-layout">
+      {#if prUrl}
+        <div class="pr-banner">
+          <div class="pr-icon-wrapper">
+            <GitPullRequest size={24} />
+          </div>
+          <div class="pr-info">
+            <h4>Captured Pull Request</h4>
+            <p>The judge has successfully proposed and opened a GitHub PR containing the winning adjustments.</p>
+          </div>
+          <a href={prUrl} target="_blank" rel="noopener noreferrer" class="pr-link-button">
+            View Pull Request
+          </a>
+        </div>
+      {/if}
+
+      <div class="verdict-card">
+        <div class="verdict-header">
+          <Scales size={22} weight="light" />
+          <h3>Structured Verdict</h3>
+          {#if debateEvaluation?.report_path}
+            <span class="report-path-badge" title={debateEvaluation.report_path}>{debateEvaluation.report_path}</span>
+          {/if}
+        </div>
+        
+        <div class="verdict-body">
+          {#if judgeReport}
+            <pre class="verdict-report">{judgeReport}</pre>
+          {:else}
+            <div class="verdict-empty">
+              <div class="spinner"></div>
+              <span>The judge is currently reviewing arguments and compiling the final verdict...</span>
+            </div>
+          {/if}
+        </div>
+      </div>
+
+      {#if evaluationReady}
+        <div class="verdict-actions-bar">
+          <button class="close-session-btn" onclick={handleCloseSession} disabled={endingSession}>
+            {endingSession ? 'Closing...' : 'Close Session'}
+          </button>
+        </div>
+      {/if}
+    </div>
+  {/if}
+</div>
+
+<style>
+  .debate-panel {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    padding: 16px;
+    background: var(--bg-void);
+    gap: 16px;
+    overflow-y: auto;
+  }
+
+  .debate-header-bar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 1px solid var(--border-structural);
+    padding-bottom: 12px;
+  }
+
+  .info-group {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .state-tag {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    background: var(--accent-cyan);
+    color: var(--bg-void);
+    padding: 3px 8px;
+    border-radius: var(--radius-sm);
+    letter-spacing: 0.05em;
+  }
+
+  .state-tag.eval-ready {
+    background: var(--status-success);
+  }
+
+  .session-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .view-tabs {
+    display: flex;
+    background: color-mix(in srgb, var(--text-primary) 3%, var(--bg-surface));
+    padding: 4px;
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-structural);
+    gap: 4px;
+  }
+
+  .tab-button {
+    padding: 6px 14px;
+    border-radius: var(--radius-sm);
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    transition: all 0.2s;
+  }
+
+  .tab-button:hover {
+    color: var(--text-primary);
+    background: color-mix(in srgb, var(--text-primary) 4%, transparent);
+  }
+
+  .tab-button.active {
+    background: var(--bg-surface);
+    color: var(--accent-cyan);
+    box-shadow: 0 1px 3px color-mix(in srgb, var(--bg-void) 20%, transparent);
+  }
+
+  .error-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 12px;
+    background: color-mix(in srgb, var(--status-error) 12%, transparent);
+    color: var(--status-error);
+    border: 1px solid color-mix(in srgb, var(--status-error) 25%, transparent);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+  }
+
+  /* Terminals View Styles */
+  .terminals-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .orchestrator-section {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .section-header h3 {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    flex: 1;
+  }
+
+  :global(.icon-queen) {
+    color: var(--status-warning);
+  }
+
+  :global(.icon-judge) {
+    color: var(--accent-cyan);
+  }
+
+  .orchestrator-terminal {
+    height: 250px;
+    background: var(--bg-void);
+  }
+
+  .debaters-terminals-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(400px, 1fr));
+    gap: 16px;
+  }
+
+  .variant-card {
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-surface);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .variant-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .variant-name {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .cli-badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: var(--radius-sm);
+    background: var(--border-structural);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+  }
+
+  .terminal-container {
+    height: 350px;
+    background: var(--bg-void);
+  }
+
+  /* Comparison View Styles */
+  .comparison-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .debaters-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 16px;
+  }
+
+  .debater-status-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+    transition: all 0.2s ease;
+  }
+
+  .debater-status-card.completed {
+    border-color: color-mix(in srgb, var(--status-success) 20%, transparent);
+    background: color-mix(in srgb, var(--status-success) 2%, var(--bg-surface));
+  }
+
+  .debater-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .status-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .status-dot.queued { background: var(--text-disabled); }
+  .status-dot.running { background: var(--accent-cyan); }
+  .status-dot.completed { background: var(--status-success); }
+  .status-dot.failed { background: var(--status-error); }
+
+  .debater-name {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-primary);
+  }
+
+  .status-text {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+  }
+
+  .debater-card-body {
+    padding: 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .data-row {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .data-label {
+    font-size: 11px;
+    color: var(--text-disabled);
+    text-transform: uppercase;
+    font-weight: 700;
+  }
+
+  .data-value {
+    font-size: 13px;
+    color: var(--text-primary);
+  }
+
+  .stance-badge {
+    align-self: flex-start;
+    background: color-mix(in srgb, var(--accent-cyan) 12%, transparent);
+    color: var(--accent-cyan);
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    font-weight: 600;
+  }
+
+  .code-font {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--text-secondary);
+  }
+
+  .filepath {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Verdict View Styles */
+  .verdict-layout {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  .pr-banner {
+    display: flex;
+    align-items: center;
+    background: color-mix(in srgb, var(--status-success) 10%, var(--bg-surface));
+    border: 1px solid color-mix(in srgb, var(--status-success) 20%, transparent);
+    border-radius: var(--radius-sm);
+    padding: 16px;
+    gap: 16px;
+  }
+
+  .pr-icon-wrapper {
+    color: var(--status-success);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .pr-info {
+    flex: 1;
+  }
+
+  .pr-info h4 {
+    margin: 0 0 4px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--status-success);
+  }
+
+  .pr-info p {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-secondary);
+  }
+
+  .pr-link-button {
+    padding: 8px 16px;
+    background: var(--status-success);
+    color: var(--bg-void);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: filter 0.2s;
+  }
+
+  .pr-link-button:hover {
+    filter: brightness(1.1);
+  }
+
+  .verdict-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+  }
+
+  .verdict-header {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 12px 16px;
+    background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .verdict-header h3 {
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+  }
+
+  .report-path-badge {
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--text-disabled);
+    background: color-mix(in srgb, var(--bg-void) 40%, transparent);
+    padding: 2px 8px;
+    border-radius: var(--radius-sm);
+    margin-left: auto;
+    max-width: 300px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .verdict-body {
+    padding: 20px;
+    min-height: 250px;
+  }
+
+  .verdict-report {
+    margin: 0;
+    white-space: pre-wrap;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--text-primary);
+  }
+
+  .verdict-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    height: 200px;
+    color: var(--text-disabled);
+    font-size: 13px;
+    text-align: center;
+  }
+
+  .spinner {
+    width: 28px;
+    height: 28px;
+    border: 2px solid color-mix(in srgb, var(--text-primary) 10%, transparent);
+    border-top-color: var(--accent-cyan);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+  }
+
+  @keyframes spin {
+    to { transform: rotate(360deg); }
+  }
+
+  .verdict-actions-bar {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 8px;
+  }
+
+  .close-session-btn {
+    padding: 10px 20px;
+    background: var(--border-structural);
+    color: var(--text-primary);
+    border: 1px solid var(--border-structural);
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+
+  .close-session-btn:hover:not(:disabled) {
+    background: color-mix(in srgb, var(--text-primary) 8%, var(--bg-surface));
+    border-color: color-mix(in srgb, var(--text-primary) 12%, var(--bg-surface));
+  }
+
+  .close-session-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -5,7 +5,7 @@
   import TemplatePicker from './templates/TemplatePicker.svelte';
   import Composer from './composer/Composer.svelte';
   import { Crown, CaretDown, CaretRight } from 'phosphor-svelte';
-  import type { AgentConfig, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig, FusionVariantConfig, SoloLaunchConfig, PlannerConfig, WorkerRole, QaWorkerConfig } from '$lib/stores/sessions';
+  import type { AgentConfig, HiveLaunchConfig, ResearchLaunchConfig, SwarmLaunchConfig, FusionLaunchConfig, FusionVariantConfig, SoloLaunchConfig, PlannerConfig, WorkerRole, QaWorkerConfig, DebateLaunchConfig, DebateDebaterConfig } from '$lib/stores/sessions';
   import type { SessionTemplate } from '$lib/types/domain';
   import { templates, selectedTemplate } from '$lib/stores/templates';
   import { cliOptions, defaultRoles } from '$lib/config/clis';
@@ -19,9 +19,10 @@
     launchSwarm: SwarmLaunchConfig;
     launchFusion: FusionLaunchConfig;
     launchSolo: SoloLaunchConfig;
+    launchDebate: DebateLaunchConfig;
   }>();
 
-  type SessionMode = 'templates' | 'hive' | 'fusion' | 'solo' | 'swarm' | 'research';
+  type SessionMode = 'templates' | 'hive' | 'fusion' | 'solo' | 'swarm' | 'research' | 'debate';
   type LaunchWorkerConfig = AgentConfig & { selectedRole: string; promptTemplateOverride?: string | null };
 
   // ... (predefinedRoles same)
@@ -216,6 +217,22 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   }));
   let judgeAgentConfig: AgentConfig = { cli: judgeConfig.cli, model: judgeConfig.model, flags: [], label: 'Fusion Judge' };
 
+  // Debate config
+  let debaterCount = 2;
+  let debateRounds = 3;
+  let debateTopic = '';
+  let debateDebaters: DebateDebaterConfig[] = [
+    { name: 'Debater A', stance: 'Proponent', cli: 'claude', flags: [] },
+    { name: 'Debater B', stance: 'Opponent', cli: 'claude', flags: [] },
+    { name: 'Debater C', stance: 'Alternative A', cli: 'claude', flags: [] },
+    { name: 'Debater D', stance: 'Alternative B', cli: 'claude', flags: [] },
+  ];
+  let debateJudgeAgentConfig: AgentConfig = { cli: 'claude', flags: [], label: 'Debate Judge' };
+
+  let debaterAgentConfigs: AgentConfig[] = debateDebaters.map(d => ({
+    cli: d.cli, model: d.model, flags: [], label: d.name,
+  }));
+
   function applyTemplate(template: SessionTemplate | null) {
     if (!template) return;
     
@@ -240,10 +257,19 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
       variantAgentConfigs = fusionVariants.map(v => ({
         cli: v.cli, model: v.model, flags: [], label: v.name,
       }));
+    } else if (template.mode === 'debate') {
+      debaterCount = template.cells.length;
+      debateDebaters = template.cells.map((c, i: number) => ({
+        name: `Debater ${String.fromCharCode(65 + i)}`,
+        stance: `Stance ${String.fromCharCode(65 + i)}`,
+        cli: c.cli,
+        model: c.model,
+        flags: [],
+      }));
+      debaterAgentConfigs = debateDebaters.map(d => ({
+        cli: d.cli, model: d.model, flags: [], label: d.name,
+      }));
     }
-    
-    // Switch to the actual mode after applying
-    // mode = template.mode as SessionMode; // already set above
   }
 
   $: if ($selectedTemplate) {
@@ -266,8 +292,23 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
     judgeConfig = { cli: detail.cli, model: detail.model || undefined, flags: detail.flags, label: detail.label };
   }
 
+  function handleDebaterConfigChange(index: number, detail: AgentConfig) {
+    debaterAgentConfigs[index] = detail;
+    debateDebaters[index] = {
+      ...debateDebaters[index],
+      cli: detail.cli,
+      model: detail.model || undefined,
+      flags: detail.flags,
+    };
+  }
+
+  function handleDebateJudgeConfigChange(detail: AgentConfig) {
+    debateJudgeAgentConfig = detail;
+  }
+
 
   $: activeFusionVariants = fusionVariants.slice(0, variantCount);
+  $: activeDebaters = debateDebaters.slice(0, debaterCount);
 
   function updateWorkerCli(workerIndex: number) {
     const worker = hiveWorkers[workerIndex];
@@ -477,6 +518,21 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
           qa_workers: withEvaluator ? qaWorkers : undefined,
         };
         dispatch('launchSolo', config);
+      } else if (mode === 'debate') {
+        const config: DebateLaunchConfig = {
+          name: sessionName.trim() || undefined,
+          color: sessionColor || undefined,
+          project_path: projectPath,
+          debaters: activeDebaters,
+          topic: prompt,
+          rounds: debateRounds,
+          judge_config: debateJudgeAgentConfig,
+          queen_config: queenConfig,
+          with_planning: withPlanning,
+          default_cli: 'claude',
+          default_model: undefined,
+        };
+        dispatch('launchDebate', config);
       } else {
         const config: FusionLaunchConfig = {
           name: sessionName.trim() || undefined,
@@ -556,6 +612,14 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
           type="button"
         >
           Fusion
+        </button>
+        <button
+          class="mode-tab"
+          class:active={mode === 'debate'}
+          on:click={() => (mode = 'debate')}
+          type="button"
+        >
+          Debate
         </button>
         <button
           class="mode-tab"
@@ -898,6 +962,76 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               </div>
             </div>
           </div>
+        {:else if mode === 'debate'}
+          <div class="form-section">
+            <h3>Debate Configuration</h3>
+            <p class="section-description">Run multiple debaters in parallel to argue different perspectives across multiple rounds. A judge evaluates and renders the verdict.</p>
+
+            <div class="form-row">
+              <div class="field">
+                <label for="debater-count">Number of Debaters</label>
+                <select id="debater-count" bind:value={debaterCount} class="role-select">
+                  <option value={2}>2 Debaters</option>
+                  <option value={3}>3 Debaters</option>
+                  <option value={4}>4 Debaters</option>
+                </select>
+              </div>
+
+              <div class="field">
+                <label for="debate-rounds">Number of Rounds</label>
+                <select id="debate-rounds" bind:value={debateRounds} class="role-select">
+                  <option value={1}>1 Round</option>
+                  <option value={2}>2 Rounds</option>
+                  <option value={3}>3 Rounds</option>
+                  <option value={4}>4 Rounds</option>
+                  <option value={5}>5 Rounds</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="subsection">
+              <h4>Debater Configurations</h4>
+              <div class="workers-list">
+                {#each activeDebaters as debater, i (i)}
+                  <div class="worker-card">
+                    <div class="card-header" style="display: flex; gap: 8px; flex-direction: column; align-items: stretch; border: none; padding: 0; margin-bottom: 8px;">
+                      <input
+                        type="text"
+                        class="card-title-input"
+                        bind:value={debateDebaters[i].name}
+                        placeholder="Debater {String.fromCharCode(65 + i)}"
+                        style="width: 100%;"
+                      />
+                      <input
+                        type="text"
+                        class="card-title-input"
+                        style="font-size: 12px; opacity: 0.8; font-weight: normal; width: 100%; border-bottom: 1px dashed color-mix(in srgb, var(--text-primary) 10%, transparent);"
+                        bind:value={debateDebaters[i].stance}
+                        placeholder="Stance (optional, e.g. Pro / Con)"
+                      />
+                    </div>
+                    <AgentConfigEditor
+                      config={debaterAgentConfigs[i]}
+                      showLabel={false}
+                      on:change={(e) => handleDebaterConfigChange(i, e.detail)}
+                    />
+                  </div>
+                {/each}
+              </div>
+            </div>
+
+            <div class="subsection">
+              <h4>Judge Configuration</h4>
+              <p class="section-description">Evaluates the debate and renders the verdict.</p>
+              <div class="worker-card">
+                <AgentConfigEditor
+                  config={debateJudgeAgentConfig}
+                  showLabel={false}
+                  on:change={(e) => handleDebateJudgeConfigChange(e.detail)}
+                />
+              </div>
+            </div>
+          </div>
         {:else if mode === 'solo'}
           <div class="form-section">
             <h3>Solo Configuration</h3>
@@ -970,6 +1104,13 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
                       <div class="node fusion">
                         <span class="node-label">{variant.name}</span>
                         <span class="node-cli">{variant.cli}</span>
+                      </div>
+                    {/each}
+                  {:else if mode === 'debate'}
+                    {#each activeDebaters as debater}
+                      <div class="node debate">
+                        <span class="node-label">{debater.name}</span>
+                        <span class="node-cli">{debater.cli}</span>
                       </div>
                     {/each}
                   {:else if mode === 'solo'}
@@ -1591,5 +1732,6 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
     background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
   }
   .node.fusion { border-color: var(--status-success); }
+  .node.debate { border-color: var(--accent-purple, #bb9af7); }
   .node.solo { border-color: var(--status-warning); }
 </style>

--- a/src/lib/components/ResumeConfirmModal.svelte
+++ b/src/lib/components/ResumeConfirmModal.svelte
@@ -6,12 +6,16 @@
   export let open = false;
   /** The session being resumed (for the title). */
   export let sessionName: string | null = null;
-  /** The resume classification produced by the backend on resume. */
+  /** The resume classification produced by the backend or preview store. */
   export let report: ResumeReport | null = null;
+  export let loading = false;
+  export let confirming = false;
+  export let error: string | null = null;
 
   // Default-checked: skip already-completed write-steps so destructive git ops
   // (commits, branch/worktree creation, worker/evaluator spawns) are not re-run.
   let skipCompletedWriteSteps = true;
+  let wasOpen = false;
 
   const dispatch = createEventDispatcher<{
     confirm: { skipCompletedWriteSteps: boolean };
@@ -22,6 +26,10 @@
   $: interrupted = report?.interrupted ?? [];
   $: uncertain = report?.uncertain ?? [];
   $: hasWarnings = interrupted.length > 0 || uncertain.length > 0;
+  $: if (open && !wasOpen) {
+    skipCompletedWriteSteps = true;
+  }
+  $: wasOpen = open;
 
   function kindLabel(entry: RunJournalEntry): string {
     return entry.kind.replace(/_/g, ' ');
@@ -62,8 +70,12 @@
       </header>
 
       <div class="modal-body">
-        {#if !report}
-          <p class="muted">No prior run journal — resuming a clean session.</p>
+        {#if loading}
+          <p class="muted">Reading run journal...</p>
+        {:else if error}
+          <p class="error-text">{error}</p>
+        {:else if !report}
+          <p class="muted">No prior run journal - resuming a clean session.</p>
         {:else}
           {#if skipped.length > 0}
             <section>
@@ -95,7 +107,7 @@
             <section>
               <h3>Unconfirmed side-effects ({uncertain.length})</h3>
               <p class="muted">
-                These effects could not be verified — review before continuing.
+                These effects could not be verified - review before continuing.
               </p>
               <ul>
                 {#each uncertain as effect (effect.step_id)}
@@ -108,7 +120,7 @@
           {/if}
 
           {#if skipped.length === 0 && !hasWarnings}
-            <p class="muted">Nothing needs attention — safe to resume.</p>
+            <p class="muted">Nothing needs attention - safe to resume.</p>
           {/if}
         {/if}
 
@@ -119,8 +131,12 @@
       </div>
 
       <footer class="modal-footer">
-        <button type="button" class="secondary" on:click={cancel}>Cancel</button>
-        <button type="button" class="primary" on:click={confirm}>Resume</button>
+        <button type="button" class="secondary" on:click={cancel} disabled={confirming}>
+          Cancel
+        </button>
+        <button type="button" class="primary" on:click={confirm} disabled={loading || confirming}>
+          {confirming ? 'Resuming...' : 'Resume'}
+        </button>
       </footer>
     </div>
   </div>
@@ -136,6 +152,7 @@
     justify-content: center;
     z-index: 1000;
   }
+
   .modal {
     background: var(--bg-elevated, #1a1b26);
     color: var(--text-primary, #c0caf5);
@@ -147,37 +164,46 @@
     flex-direction: column;
     overflow: hidden;
   }
+
   .modal-header {
     padding: 1rem 1.25rem;
     border-bottom: 1px solid var(--border, #2a2e42);
   }
+
   .modal-header h2 {
     margin: 0;
     font-size: 1.05rem;
   }
+
   .modal-body {
     padding: 1rem 1.25rem;
     overflow-y: auto;
   }
+
   section {
     margin-bottom: 1rem;
   }
+
   section h3 {
     margin: 0 0 0.25rem;
     font-size: 0.9rem;
   }
+
   ul {
     list-style: none;
     padding: 0;
     margin: 0.25rem 0 0;
   }
+
   li {
     padding: 0.25rem 0;
     font-size: 0.85rem;
   }
+
   .warn-row {
     color: var(--text-warning, #e0af68);
   }
+
   .badge {
     display: inline-block;
     font-size: 0.7rem;
@@ -186,19 +212,29 @@
     margin-right: 0.4rem;
     text-transform: uppercase;
   }
+
   .badge.done {
     background: rgba(158, 206, 106, 0.18);
     color: var(--text-success, #9ece6a);
   }
+
   .badge.warn {
     background: rgba(224, 175, 104, 0.18);
     color: var(--text-warning, #e0af68);
   }
+
   .muted {
     color: var(--text-secondary, #787c99);
     font-size: 0.8rem;
     margin: 0.25rem 0;
   }
+
+  .error-text {
+    color: var(--status-error, #f7768e);
+    font-size: 0.82rem;
+    margin: 0.25rem 0;
+  }
+
   .skip-toggle {
     display: flex;
     align-items: center;
@@ -206,6 +242,7 @@
     margin-top: 0.75rem;
     font-size: 0.85rem;
   }
+
   .modal-footer {
     padding: 0.85rem 1.25rem;
     border-top: 1px solid var(--border, #2a2e42);
@@ -213,6 +250,7 @@
     justify-content: flex-end;
     gap: 0.5rem;
   }
+
   button {
     padding: 0.4rem 0.9rem;
     border-radius: 6px;
@@ -220,11 +258,18 @@
     cursor: pointer;
     font-size: 0.85rem;
   }
+
+  button:disabled {
+    cursor: default;
+    opacity: 0.55;
+  }
+
   button.primary {
     background: var(--accent, #7aa2f7);
     color: #0b0c14;
     border-color: var(--accent, #7aa2f7);
   }
+
   button.secondary {
     background: transparent;
     color: var(--text-primary, #c0caf5);

--- a/src/lib/components/ResumeConfirmModal.svelte.test.ts
+++ b/src/lib/components/ResumeConfirmModal.svelte.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+import ResumeConfirmModal from './ResumeConfirmModal.svelte';
+import type { ResumeReport } from '$lib/stores/sessions';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ResumeConfirmModal', () => {
+  it('shows per-step warning rows and default-checks skipped write steps', () => {
+    const report: ResumeReport = {
+      skipped: [
+        {
+          run_id: 'session-1',
+          step_id: 'step-complete',
+          kind: 'git_commit',
+          status: 'skipped',
+          started_at: '2026-06-19T00:00:00Z',
+        },
+      ],
+      interrupted: [
+        {
+          run_id: 'session-1',
+          step_id: 'step-started',
+          kind: 'worker_spawn',
+          status: 'unknown',
+          started_at: '2026-06-19T00:01:00Z',
+        },
+      ],
+      uncertain: [
+        {
+          run_id: 'session-1',
+          step_id: 'step-started',
+          effect_kind: 'branch',
+          effect_ref: 'worker-branch',
+          confirmed: false,
+          confidence: 'uncertain',
+          recorded_at: '2026-06-19T00:01:01Z',
+        },
+      ],
+    };
+
+    const { getByText, getByLabelText } = render(ResumeConfirmModal, {
+      props: {
+        open: true,
+        sessionName: 'demo',
+        report,
+      },
+    });
+
+    expect(getByText('Completed steps (1)')).toBeTruthy();
+    expect(getByText('Interrupted steps (1)')).toBeTruthy();
+    expect(getByText('Unconfirmed side-effects (1)')).toBeTruthy();
+    expect(getByText(/worker-bra/)).toBeTruthy();
+    expect((getByLabelText('Skip completed write-steps (recommended)') as HTMLInputElement).checked).toBe(true);
+  });
+});

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
   import { page } from '$app/stores';
-  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type HiveLaunchConfig, type ResearchLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
+  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type ResumeReport, type HiveLaunchConfig, type ResearchLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { layout, RAIL_WIDTH } from '$lib/stores/layout';
   import { ui } from '$lib/stores/ui';
   import { invoke } from '@tauri-apps/api/core';
@@ -10,6 +10,7 @@
   import AgentTree from './AgentTree.svelte';
   import QueenControls from './QueenControls.svelte';
   import ResizeHandle from './ResizeHandle.svelte';
+  import ResumeConfirmModal from './ResumeConfirmModal.svelte';
 
   let closingSessionId = $state<string | null>(null);
   let showCloseConfirm = $state<string | null>(null);
@@ -73,6 +74,13 @@
   let persistedSessions = $state<SessionSummary[]>([]);
   let loadingPersisted = $state(false);
   let currentDirectory = $state<string | null>(null);
+  let resumeModalOpen = $state(false);
+  let resumeTargetSessionId = $state<string | null>(null);
+  let resumeTargetName = $state<string | null>(null);
+  let resumeReport = $state<ResumeReport | null>(null);
+  let resumeLoading = $state(false);
+  let resuming = $state(false);
+  let resumeError = $state<string | null>(null);
 
   let collapsed = $derived($layout.leftCollapsed);
   let sidebarWidth = $derived(collapsed ? RAIL_WIDTH : $layout.leftWidth);
@@ -146,13 +154,58 @@
     ui.setSelectedAgent(e.detail);
   }
 
-  async function handleResumeSession(sessionId: string) {
+  function sessionDisplayName(session: SessionSummary): string {
+    return session.project_path.split(/[/\\]/).pop() || session.id.slice(0, 8);
+  }
+
+  async function handleResumeSession(session: SessionSummary) {
+    const targetSessionId = session.id;
+    resumeTargetSessionId = targetSessionId;
+    resumeTargetName = sessionDisplayName(session);
+    resumeReport = null;
+    resumeError = null;
+    resumeModalOpen = true;
+    resumeLoading = true;
+
     try {
-      await sessions.resumeSession(sessionId);
-      // Remove from persisted list after successful resume
-      persistedSessions = persistedSessions.filter(s => s.id !== sessionId);
+      resumeReport = await sessions.getResumeReport(targetSessionId);
     } catch (err) {
+      resumeError = String(err);
+      console.error('Failed to prepare resume:', err);
+    } finally {
+      resumeLoading = false;
+    }
+  }
+
+  function resetResumeModal() {
+    resumeModalOpen = false;
+    resumeTargetSessionId = null;
+    resumeTargetName = null;
+    resumeReport = null;
+    resumeError = null;
+  }
+
+  function dismissResumeModal() {
+    if (resuming) return;
+    resetResumeModal();
+  }
+
+  async function confirmResumeSession(e: CustomEvent<{ skipCompletedWriteSteps: boolean }>) {
+    const targetSessionId = resumeTargetSessionId;
+    if (!targetSessionId) return;
+
+    resuming = true;
+    resumeError = null;
+    try {
+      await sessions.resumeSession(targetSessionId, e.detail);
+      // Remove from persisted list after successful resume
+      persistedSessions = persistedSessions.filter(s => s.id !== targetSessionId);
+      resetResumeModal();
+    } catch (err) {
+      resumeError = String(err);
       console.error('Failed to resume session:', err);
+    } finally {
+      resuming = false;
     }
   }
 
@@ -499,7 +552,7 @@
                     {formatTimestamp(session.last_activity_at ?? session.created_at)}
                   </span>
                 </div>
-                <button class="load-button" onclick={() => handleResumeSession(session.id)} title="Load Session" aria-label="Load session" type="button">
+                <button class="load-button" onclick={() => handleResumeSession(session)} title="Load Session" aria-label="Load session" type="button">
                   <CaretRight size={14} weight="light" />
                 </button>
               </li>
@@ -563,6 +616,17 @@
   on:launchFusion={handleLaunchFusion}
   on:launchSolo={handleLaunchSolo}
   on:launchDebate={handleLaunchDebate}
+/>
+
+<ResumeConfirmModal
+  open={resumeModalOpen}
+  sessionName={resumeTargetName}
+  report={resumeReport}
+  loading={resumeLoading}
+  confirming={resuming}
+  error={resumeError}
+  on:confirm={confirmResumeSession}
+  on:cancel={dismissResumeModal}
 />
 
 <!-- Close confirmation dialog -->

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -81,6 +81,7 @@
   let resumeLoading = $state(false);
   let resuming = $state(false);
   let resumeError = $state<string | null>(null);
+  let resumeReportRequestId = 0;
 
   let collapsed = $derived($layout.leftCollapsed);
   let sidebarWidth = $derived(collapsed ? RAIL_WIDTH : $layout.leftWidth);
@@ -160,6 +161,7 @@
 
   async function handleResumeSession(session: SessionSummary) {
     const targetSessionId = session.id;
+    const requestId = ++resumeReportRequestId;
     resumeTargetSessionId = targetSessionId;
     resumeTargetName = sessionDisplayName(session);
     resumeReport = null;
@@ -168,16 +170,24 @@
     resumeLoading = true;
 
     try {
-      resumeReport = await sessions.getResumeReport(targetSessionId);
+      const report = await sessions.getResumeReport(targetSessionId);
+      if (resumeReportRequestId === requestId && resumeTargetSessionId === targetSessionId) {
+        resumeReport = report;
+      }
     } catch (err) {
-      resumeError = String(err);
-      console.error('Failed to prepare resume:', err);
+      if (resumeReportRequestId === requestId && resumeTargetSessionId === targetSessionId) {
+        resumeError = String(err);
+        console.error('Failed to prepare resume:', err);
+      }
     } finally {
-      resumeLoading = false;
+      if (resumeReportRequestId === requestId && resumeTargetSessionId === targetSessionId) {
+        resumeLoading = false;
+      }
     }
   }
 
   function resetResumeModal() {
+    resumeReportRequestId += 1;
     resumeModalOpen = false;
     resumeTargetSessionId = null;
     resumeTargetName = null;

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
   import { page } from '$app/stores';
-  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type HiveLaunchConfig, type ResearchLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig } from '$lib/stores/sessions';
+  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type HiveLaunchConfig, type ResearchLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { layout, RAIL_WIDTH } from '$lib/stores/layout';
   import { ui } from '$lib/stores/ui';
   import { invoke } from '@tauri-apps/api/core';
@@ -52,6 +52,7 @@
     onLaunchSwarm?: (config: SwarmLaunchConfig) => Promise<void>;
     onLaunchFusion?: (config: FusionLaunchConfig) => Promise<void>;
     onLaunchSolo?: (config: SoloLaunchConfig) => Promise<void>;
+    onLaunchDebate?: (config: DebateLaunchConfig) => Promise<void>;
     onOpenAddWorker?: () => void;
   }
 
@@ -65,7 +66,7 @@
     state: string;
   }
 
-  let { onLaunch, onLaunchHiveV2, onLaunchResearch, onLaunchSwarm, onLaunchFusion, onLaunchSolo, onOpenAddWorker }: Props = $props();
+  let { onLaunch, onLaunchHiveV2, onLaunchResearch, onLaunchSwarm, onLaunchFusion, onLaunchSolo, onLaunchDebate, onOpenAddWorker }: Props = $props();
 
   let showLaunchDialog = $state(false);
   let launching = $state(false);
@@ -232,6 +233,22 @@
         await onLaunchSolo(e.detail);
       } else {
         await sessions.launchSolo(e.detail);
+      }
+      showLaunchDialog = false;
+    } catch (err) {
+      console.error('Launch failed:', err);
+    } finally {
+      launching = false;
+    }
+  }
+
+  async function handleLaunchDebate(e: CustomEvent<DebateLaunchConfig>) {
+    launching = true;
+    try {
+      if (onLaunchDebate) {
+        await onLaunchDebate(e.detail);
+      } else {
+        await sessions.launchDebate(e.detail);
       }
       showLaunchDialog = false;
     } catch (err) {
@@ -545,6 +562,7 @@
   on:launchSwarm={handleLaunchSwarm}
   on:launchFusion={handleLaunchFusion}
   on:launchSolo={handleLaunchSolo}
+  on:launchDebate={handleLaunchDebate}
 />
 
 <!-- Close confirmation dialog -->

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -78,6 +78,15 @@
   let isWaiting = $derived(agent?.status && typeof agent.status === 'object' && 'WaitingForInput' in agent.status);
 
   $effect(() => {
+    const currentAgentId = agentId;
+    terminalSelectionReaders.set(currentAgentId, () => term?.getSelection() || null);
+
+    return () => {
+      terminalSelectionReaders.delete(currentAgentId);
+    };
+  });
+
+  $effect(() => {
     if (isFocused && term) {
       term.focus();
       // Re-fit terminal after becoming visible to restore correct dimensions.
@@ -662,7 +671,6 @@
       handleResize();
     });
 
-    terminalSelectionReaders.set(agentId, () => term?.getSelection() || null);
   });
 
   onDestroy(() => {

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -1,3 +1,22 @@
+<script lang="ts" module>
+  type TerminalSelectionReader = () => string | null;
+
+  const terminalSelectionReaders = new Map<string, TerminalSelectionReader>();
+
+  export function readTerminalSelection(agentId?: string | null): string | null {
+    if (agentId) {
+      return terminalSelectionReaders.get(agentId)?.() || null;
+    }
+
+    for (const read of terminalSelectionReaders.values()) {
+      const selection = read();
+      if (selection) return selection;
+    }
+
+    return null;
+  }
+</script>
+
 <script lang="ts">
   import { ArrowDown, Broom, CaretDown, CaretUp, CheckSquare, ClipboardText, FileText, MagnifyingGlass, X } from 'phosphor-svelte';
   import { onMount, onDestroy, tick } from 'svelte';
@@ -642,9 +661,12 @@
     requestAnimationFrame(() => {
       handleResize();
     });
+
+    terminalSelectionReaders.set(agentId, () => term?.getSelection() || null);
   });
 
   onDestroy(() => {
+    terminalSelectionReaders.delete(agentId);
     if (resizeTimeout) clearTimeout(resizeTimeout);
     if (dragLeaveTimeout) clearTimeout(dragLeaveTimeout);
     document.removeEventListener('click', handleGlobalClick);

--- a/src/lib/components/composer/Composer.svelte
+++ b/src/lib/components/composer/Composer.svelte
@@ -6,6 +6,8 @@
   import {
     agentMentions,
     sessionMentions,
+    fileMentions,
+    listSessionFiles,
     filterMentions,
     flattenMention,
     type MentionItem,
@@ -47,6 +49,7 @@
   /** Start offset of the active @/ trigger within the current text node. */
   let triggerStart = -1;
   let triggerNode: Node | null = null;
+  let mentionRequest = 0;
 
   let mentionItems: MentionItem[] = $state([]);
   let commandItems: SlashCommand[] = $state([]);
@@ -75,8 +78,18 @@
     if (editor && value) editor.textContent = value;
   });
 
+  function flattenNode(node: Node): string {
+    if (node instanceof HTMLElement && node.dataset.tokenValue) {
+      return node.dataset.tokenValue;
+    }
+    if (node.nodeType === Node.TEXT_NODE) {
+      return node.textContent ?? '';
+    }
+    return Array.from(node.childNodes).map(flattenNode).join('');
+  }
+
   function currentText(): string {
-    return editor?.textContent ?? '';
+    return editor ? Array.from(editor.childNodes).map(flattenNode).join('') : '';
   }
 
   function syncValue() {
@@ -131,7 +144,7 @@
           triggerStart = i;
           triggerNode = node;
           menuQuery = query;
-          if (ch === '@') openMentionMenu(query);
+          if (ch === '@') void openMentionMenu(query);
           else openSlashMenu(query);
           return;
         }
@@ -144,10 +157,17 @@
     closeMenu();
   }
 
-  function openMentionMenu(query: string) {
+  async function openMentionMenu(query: string) {
+    const request = ++mentionRequest;
     const agents = get(activeAgents);
-    const sess = get(sessionsStore).sessions;
-    const all = [...agentMentions(agents), ...sessionMentions(sess)];
+    const storeState = get(sessionsStore);
+    const sess = storeState.sessions;
+    let all = [...agentMentions(agents), ...sessionMentions(sess)];
+    if (sessionId) {
+      const files = await listSessionFiles(sessionId, query);
+      if (request !== mentionRequest || triggerNode == null) return;
+      all = [...all, ...fileMentions(files)];
+    }
     mentionItems = filterMentions(all, query);
     if (mentionItems.length === 0) {
       closeMenu();
@@ -174,26 +194,46 @@
   }
 
   function closeMenu() {
+    mentionRequest += 1;
     menuMode = 'none';
     triggerStart = -1;
     triggerNode = null;
   }
 
-  /** Replace the trigger token (`@que` / `/res`) with the given plain text and place caret after. */
-  function replaceTrigger(replacement: string) {
+  function tokenDisplayForMention(item: MentionItem): string {
+    if (item.kind === 'agent') return `@${item.label}`;
+    if (item.kind === 'session') return `#${item.label}`;
+    return `file:${item.label}`;
+  }
+
+  function replaceTriggerWithToken(display: string, value: string, kind: 'mention' | 'command') {
     if (triggerNode == null || triggerStart < 0) return;
     const sel = window.getSelection();
     if (!sel || sel.rangeCount === 0) return;
     const offset = sel.getRangeAt(0).startOffset;
     const text = triggerNode.textContent ?? '';
-    const before = text.slice(0, triggerStart);
-    const after = text.slice(offset);
-    const next = before + replacement + after;
-    triggerNode.textContent = next;
-    // Restore caret right after the inserted replacement.
-    const caretPos = before.length + replacement.length;
+    const beforeText = text.slice(0, triggerStart);
+    const afterText = text.slice(offset);
+    const parent = triggerNode.parentNode;
+    if (!parent) return;
+
+    const before = document.createTextNode(beforeText);
+    const token = document.createElement('span');
+    token.className = `composer-token ${kind}`;
+    token.dataset.tokenValue = value;
+    token.contentEditable = 'false';
+    token.textContent = display;
+    const spacer = document.createTextNode(' ');
+    const after = document.createTextNode(afterText);
+
+    parent.insertBefore(before, triggerNode);
+    parent.insertBefore(token, triggerNode);
+    parent.insertBefore(spacer, triggerNode);
+    parent.insertBefore(after, triggerNode);
+    parent.removeChild(triggerNode);
+
     const range = document.createRange();
-    range.setStart(triggerNode, Math.min(caretPos, (triggerNode.textContent ?? '').length));
+    range.setStartAfter(spacer);
     range.collapse(true);
     sel.removeAllRanges();
     sel.addRange(range);
@@ -202,7 +242,7 @@
   }
 
   function selectMention(item: MentionItem) {
-    replaceTrigger(flattenMention(item) + ' ');
+    replaceTriggerWithToken(tokenDisplayForMention(item), flattenMention(item), 'mention');
   }
 
   function selectCommand(cmd: SlashCommand) {
@@ -212,8 +252,8 @@
       syncValue();
       return;
     }
-    // 'insert' and 'attach' both insert the expansion (attach is a no-op placeholder).
-    replaceTrigger(cmd.expand());
+    const expanded = cmd.expand().trimEnd();
+    replaceTriggerWithToken(cmd.label, expanded || cmd.label, 'command');
   }
 
   async function submit() {
@@ -359,6 +399,29 @@
 
   .composer:focus {
     border-color: var(--accent-cyan);
+  }
+
+  .composer :global(.composer-token) {
+    display: inline-flex;
+    align-items: center;
+    max-width: 100%;
+    margin: 0 2px;
+    padding: 1px 6px;
+    border: 1px solid color-mix(in srgb, var(--accent-cyan) 45%, var(--border-structural));
+    border-radius: var(--radius-sm);
+    background: color-mix(in srgb, var(--accent-cyan) 12%, transparent);
+    color: var(--accent-cyan);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.35;
+    vertical-align: baseline;
+    white-space: nowrap;
+  }
+
+  .composer :global(.composer-token.command) {
+    border-color: color-mix(in srgb, var(--accent-amber) 45%, var(--border-structural));
+    background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
+    color: var(--accent-amber);
   }
 
   .composer:empty::before {

--- a/src/lib/components/renderers/Chart.svelte
+++ b/src/lib/components/renderers/Chart.svelte
@@ -1,21 +1,275 @@
+<script lang="ts" module>
+  export interface ChartPoint {
+    label: string;
+    value: number;
+  }
+
+  interface ChartSeries {
+    name?: string;
+    points: ChartPoint[];
+  }
+
+  interface ChartPayload {
+    title?: string;
+    type?: string;
+    labels?: unknown[];
+    values?: unknown[];
+    data?: unknown;
+    points?: unknown;
+    rows?: unknown;
+    series?: unknown;
+  }
+
+  interface NormalizedChart {
+    title?: string;
+    type: 'bar' | 'line';
+    series: ChartSeries[];
+    points: ChartPoint[];
+  }
+
+  function objectValue(value: unknown, key: string): unknown {
+    if (!value || typeof value !== 'object') return undefined;
+    return (value as Record<string, unknown>)[key];
+  }
+
+  function finiteNumber(value: unknown): number | null {
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string' && value.trim() !== '') {
+      const n = Number(value);
+      if (Number.isFinite(n)) return n;
+    }
+    return null;
+  }
+
+  function pointLabel(value: unknown, index: number): string {
+    if (typeof value === 'string' && value.trim()) return value;
+    if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+    return String(index + 1);
+  }
+
+  function pointFromObject(item: Record<string, unknown>, index: number): ChartPoint | null {
+    const value =
+      finiteNumber(item.value) ??
+      finiteNumber(item.y) ??
+      finiteNumber(item.count) ??
+      finiteNumber(item.total);
+    if (value === null) return null;
+
+    const label = item.label ?? item.name ?? item.x ?? item.key ?? item.category;
+    return { label: pointLabel(label, index), value };
+  }
+
+  function pointsFromArray(values: unknown[], labels?: unknown[]): ChartPoint[] {
+    return values
+      .map((item, index): ChartPoint | null => {
+        if (Array.isArray(item)) {
+          const value = finiteNumber(item[1]);
+          return value === null ? null : { label: pointLabel(item[0], index), value };
+        }
+        if (typeof item === 'number' || typeof item === 'string') {
+          const value = finiteNumber(item);
+          return value === null ? null : { label: pointLabel(labels?.[index], index), value };
+        }
+        if (item && typeof item === 'object') {
+          return pointFromObject(item as Record<string, unknown>, index);
+        }
+        return null;
+      })
+      .filter((point): point is ChartPoint => point !== null);
+  }
+
+  function pointsFromPayload(payload: ChartPayload): ChartPoint[] {
+    if (Array.isArray(payload.labels) && Array.isArray(payload.values)) {
+      return pointsFromArray(payload.values, payload.labels);
+    }
+
+    const candidates = [payload.points, payload.data, payload.rows];
+    for (const candidate of candidates) {
+      if (Array.isArray(candidate)) {
+        const points = pointsFromArray(candidate);
+        if (points.length > 0) return points;
+      }
+    }
+
+    return [];
+  }
+
+  function seriesFromPayload(payload: ChartPayload): ChartSeries[] {
+    if (!Array.isArray(payload.series)) return [];
+
+    return payload.series
+      .map((entry, index): ChartSeries | null => {
+        if (!entry || typeof entry !== 'object') return null;
+        const name = objectValue(entry, 'name');
+        const labels = objectValue(entry, 'labels');
+        const data =
+          objectValue(entry, 'data') ??
+          objectValue(entry, 'values') ??
+          objectValue(entry, 'points');
+
+        if (!Array.isArray(data)) return null;
+        const points = pointsFromArray(data, Array.isArray(labels) ? labels : payload.labels);
+        if (points.length === 0) return null;
+        return {
+          name: typeof name === 'string' ? name : `Series ${index + 1}`,
+          points,
+        };
+      })
+      .filter((series): series is ChartSeries => series !== null);
+  }
+
+  export function normalizeChart(value: unknown): NormalizedChart {
+    if (Array.isArray(value)) {
+      const points = pointsFromArray(value);
+      return { type: 'bar', series: [{ points }], points };
+    }
+
+    if (!value || typeof value !== 'object') {
+      return { type: 'bar', series: [], points: [] };
+    }
+
+    const payload = value as ChartPayload;
+    const series = seriesFromPayload(payload);
+    const points = series.length > 0 ? series.flatMap((s) => s.points) : pointsFromPayload(payload);
+    const chartSeries = series.length > 0 ? series : points.length > 0 ? [{ points }] : [];
+    const type = payload.type === 'line' || payload.type === 'area' ? 'line' : 'bar';
+
+    return {
+      title: typeof payload.title === 'string' ? payload.title : undefined,
+      type,
+      series: chartSeries,
+      points,
+    };
+  }
+</script>
+
 <script lang="ts">
-  /**
-   * Chart tool-render widget — STUB.
-   *
-   * No charting library is a dependency yet, so this reserves the 'chart' id and
-   * renders the JSON fallback plus a "not yet implemented" note. Deferring real
-   * charting keeps #127 to a single session.
-   */
   import type { ToolRendererProps } from './registry';
 
   let { data }: ToolRendererProps = $props();
 
-  const json = $derived(JSON.stringify(data, null, 2));
+  const VIEW_WIDTH = 640;
+  const VIEW_HEIGHT = 240;
+  const PADDING_LEFT = 42;
+  const PADDING_RIGHT = 16;
+  const PADDING_TOP = 18;
+  const PADDING_BOTTOM = 34;
+
+  const plotWidth = VIEW_WIDTH - PADDING_LEFT - PADDING_RIGHT;
+  const plotHeight = VIEW_HEIGHT - PADDING_TOP - PADDING_BOTTOM;
+  const palette = ['var(--accent-cyan)', 'var(--accent-amber)', 'var(--status-success)', 'var(--accent-chrome)'];
+
+  const chart = $derived(normalizeChart(data));
+  const values = $derived(chart.points.map((point) => point.value));
+  const hasPoints = $derived(values.length > 0);
+  const yMin = $derived(Math.min(0, ...values));
+  const yMax = $derived(Math.max(1, ...values));
+  const yMid = $derived((yMin + yMax) / 2);
+  const yTicks = $derived([yMax, yMid, yMin]);
+  const axisLabels = $derived(chart.points.slice(0, Math.min(chart.points.length, 8)));
+  const baselineY = $derived(scaleY(0));
+
+  function scaleY(value: number): number {
+    const span = yMax - yMin || 1;
+    return PADDING_TOP + (1 - (value - yMin) / span) * plotHeight;
+  }
+
+  function barWidth(): number {
+    return Math.max(12, Math.min(46, plotWidth / Math.max(chart.points.length, 1) - 8));
+  }
+
+  function barX(index: number): number {
+    const slot = plotWidth / Math.max(chart.points.length, 1);
+    return PADDING_LEFT + index * slot + (slot - barWidth()) / 2;
+  }
+
+  function barY(value: number): number {
+    return Math.min(scaleY(value), baselineY);
+  }
+
+  function barHeight(value: number): number {
+    return Math.max(1, Math.abs(baselineY - scaleY(value)));
+  }
+
+  function lineX(index: number, count: number): number {
+    if (count <= 1) return PADDING_LEFT + plotWidth / 2;
+    return PADDING_LEFT + (index / (count - 1)) * plotWidth;
+  }
+
+  function linePoints(points: ChartPoint[]): string {
+    return points.map((point, index) => `${lineX(index, points.length)},${scaleY(point.value)}`).join(' ');
+  }
+
+  function formatNumber(value: number): string {
+    return Number.isInteger(value) ? String(value) : value.toFixed(1);
+  }
 </script>
 
-<div class="chart-widget">
-  <div class="chart-note">Chart renderer not yet implemented — showing raw data.</div>
-  <pre class="chart-json">{json}</pre>
+<div class="chart-widget" data-testid="chart-widget">
+  {#if chart.title}
+    <div class="chart-title">{chart.title}</div>
+  {/if}
+
+  {#if hasPoints}
+    <div class="chart-frame">
+      <svg viewBox={`0 0 ${VIEW_WIDTH} ${VIEW_HEIGHT}`} role="img" aria-label={chart.title ?? 'Chart'}>
+        {#each yTicks as tick (tick)}
+          <line
+            class="grid-line"
+            x1={PADDING_LEFT}
+            x2={VIEW_WIDTH - PADDING_RIGHT}
+            y1={scaleY(tick)}
+            y2={scaleY(tick)}
+          />
+          <text class="tick-label" x={PADDING_LEFT - 8} y={scaleY(tick) + 4}>{formatNumber(tick)}</text>
+        {/each}
+
+        <line class="axis-line" x1={PADDING_LEFT} x2={VIEW_WIDTH - PADDING_RIGHT} y1={baselineY} y2={baselineY} />
+
+        {#if chart.type === 'line'}
+          {#each chart.series as series, seriesIndex (series.name ?? seriesIndex)}
+            <polyline
+              class="chart-line"
+              points={linePoints(series.points)}
+              stroke={palette[seriesIndex % palette.length]}
+            />
+            {#each series.points as point, pointIndex (`${seriesIndex}-${pointIndex}`)}
+              <circle
+                class="chart-point"
+                cx={lineX(pointIndex, series.points.length)}
+                cy={scaleY(point.value)}
+                r="4"
+                fill={palette[seriesIndex % palette.length]}
+              >
+                <title>{point.label}: {formatNumber(point.value)}</title>
+              </circle>
+            {/each}
+          {/each}
+        {:else}
+          {#each chart.points as point, index (index)}
+            <rect
+              class="chart-bar"
+              x={barX(index)}
+              y={barY(point.value)}
+              width={barWidth()}
+              height={barHeight(point.value)}
+              rx="2"
+            >
+              <title>{point.label}: {formatNumber(point.value)}</title>
+            </rect>
+          {/each}
+        {/if}
+      </svg>
+
+      <div class="chart-axis-labels" aria-hidden="true">
+        {#each axisLabels as point (point.label)}
+          <span>{point.label}</span>
+        {/each}
+      </div>
+    </div>
+  {:else}
+    <div class="chart-empty">No numeric chart data.</div>
+  {/if}
 </div>
 
 <style>
@@ -26,20 +280,85 @@
     overflow: hidden;
   }
 
-  .chart-note {
-    padding: 4px 8px;
-    font-size: 10px;
-    color: var(--text-secondary);
-    background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
+  .chart-title {
+    padding: 6px 10px;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-primary);
+    background: var(--bg-surface);
     border-bottom: 1px solid var(--border-structural);
   }
 
-  .chart-json {
-    margin: 0;
-    padding: 8px;
+  .chart-frame {
+    padding: 8px 10px 10px;
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 280px;
+    overflow: visible;
+  }
+
+  .grid-line {
+    stroke: color-mix(in srgb, var(--border-structural) 70%, transparent);
+    stroke-width: 1;
+  }
+
+  .axis-line {
+    stroke: var(--border-structural);
+    stroke-width: 1.2;
+  }
+
+  .tick-label {
+    fill: var(--text-secondary);
     font-family: var(--font-mono);
+    font-size: 10px;
+    text-anchor: end;
+  }
+
+  .chart-bar {
+    fill: var(--accent-cyan);
+    opacity: 0.78;
+  }
+
+  .chart-bar:hover,
+  .chart-point:hover {
+    opacity: 1;
+  }
+
+  .chart-line {
+    fill: none;
+    stroke-width: 2.5;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .chart-point {
+    opacity: 0.9;
+  }
+
+  .chart-axis-labels {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(48px, 1fr));
+    gap: 6px;
+    margin-left: 42px;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+  }
+
+  .chart-axis-labels span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .chart-empty {
+    padding: 12px;
     font-size: 11px;
     color: var(--text-secondary);
-    overflow-x: auto;
+    font-style: italic;
   }
 </style>

--- a/src/lib/components/renderers/ToolRenderHost.svelte.test.ts
+++ b/src/lib/components/renderers/ToolRenderHost.svelte.test.ts
@@ -57,6 +57,19 @@ describe('ToolRenderHost', () => {
     expect(container.querySelector('.diff-line')).toBeNull();
   });
 
+  it('mounts the Chart widget for renderer:"chart" with inline SVG bars', () => {
+    const msg = message({
+      renderer: 'chart',
+      data: { title: 'Builds', labels: ['pass', 'fail'], values: [12, 3] },
+    });
+    const { container, getByText } = render(ToolRenderHost, { props: { message: msg } });
+
+    expect(getByText('Builds')).toBeTruthy();
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelectorAll('.chart-bar')).toHaveLength(2);
+    expect(container.querySelector('pre.tool-render-fallback')).toBeNull();
+  });
+
   it('invokes onapprove with the actionId when the Approval card button is clicked', async () => {
     const msg = message({
       renderer: 'approval',

--- a/src/lib/components/templates/TemplateEditor.svelte
+++ b/src/lib/components/templates/TemplateEditor.svelte
@@ -89,6 +89,7 @@
                     <option value="hive">Hive</option>
                     <option value="fusion">Fusion</option>
                     <option value="research">Research</option>
+                    <option value="debate">Debate</option>
                 </select>
             </div>
             <div class="form-group">

--- a/src/lib/components/templates/TemplatePicker.svelte
+++ b/src/lib/components/templates/TemplatePicker.svelte
@@ -2,7 +2,7 @@
     import { onMount } from 'svelte';
     import { templates, selectedTemplate } from '../../stores/templates';
     import type { SessionTemplate } from '../../types/domain';
-    import { MagnifyingGlass, Hexagon, TestTube } from 'phosphor-svelte';
+    import { MagnifyingGlass, Hexagon, TestTube, Scales } from 'phosphor-svelte';
 
     let searchQuery = '';
 
@@ -50,6 +50,8 @@
                     <div class="card-icon" class:builtin={template.is_builtin}>
                         {#if template.mode === 'hive'}
                             <Hexagon size={24} weight="light" />
+                        {:else if template.mode === 'debate'}
+                            <Scales size={24} weight="light" />
                         {:else}
                             <TestTube size={24} weight="light" />
                         {/if}

--- a/src/lib/composer/commands.test.ts
+++ b/src/lib/composer/commands.test.ts
@@ -23,6 +23,7 @@ describe('slash commands', () => {
     expect(findCommand('hive')?.expand()).toBe('/hive ');
     expect(findCommand('fusion')?.expand()).toBe('/fusion ');
     expect(findCommand('research')?.expand()).toBe('/research ');
+    expect(findCommand('debate')?.expand()).toBe('/debate ');
   });
 
   it('quick actions are tagged with control actions, not insert', () => {

--- a/src/lib/composer/commands.ts
+++ b/src/lib/composer/commands.ts
@@ -39,6 +39,13 @@ export const SLASH_COMMANDS: SlashCommand[] = [
     expand: () => '/fusion ',
   },
   {
+    name: 'debate',
+    label: '/debate',
+    description: 'Debate mode (argue positions)',
+    action: 'insert',
+    expand: () => '/debate ',
+  },
+  {
     name: 'research',
     label: '/research',
     description: 'Research mode',

--- a/src/lib/composer/sources.ts
+++ b/src/lib/composer/sources.ts
@@ -70,7 +70,7 @@ export function fileMentions(paths: string[]): MentionItem[] {
 
 /**
  * Debounced file source: lists files under a session's project/worktree path via a Tauri
- * command. Returns absolute paths exactly as Rust provides them (no client-side joining).
+ * command keyed by session id. Returns absolute paths exactly as Rust provides them.
  * Results are capped and the call is debounced so large worktrees don't thrash.
  */
 let fileDebounce: ReturnType<typeof setTimeout> | null = null;
@@ -78,7 +78,7 @@ const FILE_DEBOUNCE_MS = 200;
 const FILE_RESULT_CAP = 50;
 
 export function listSessionFiles(
-  rootPath: string,
+  sessionId: string,
   query: string
 ): Promise<string[]> {
   return new Promise((resolve) => {
@@ -87,7 +87,7 @@ export function listSessionFiles(
       fileDebounce = null;
       try {
         const files = await invoke<string[]>('list_session_files', {
-          rootPath,
+          sessionId,
           query,
         });
         resolve(files.slice(0, FILE_RESULT_CAP));

--- a/src/lib/stores/sessions.test.ts
+++ b/src/lib/stores/sessions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest';
-import { sessions } from './sessions';
+import { buildResumeReportFromJournal, sessions } from './sessions';
 import { invoke } from '@tauri-apps/api/core';
 
 // Mock Tauri invoke
@@ -141,5 +141,46 @@ describe('sessions store', () => {
       expect(payload.config).not.toHaveProperty('evaluator_model');
     });
 
+  });
+
+  describe('buildResumeReportFromJournal', () => {
+    it('classifies completed write steps as skipped and unconfirmed started steps as warnings', () => {
+      const report = buildResumeReportFromJournal({
+        journal: [
+          {
+            run_id: 'session-1',
+            step_id: 'step-complete',
+            kind: 'git_commit',
+            status: 'completed',
+            started_at: '2026-06-19T00:00:00Z',
+          },
+          {
+            run_id: 'session-1',
+            step_id: 'step-started',
+            kind: 'worker_spawn',
+            status: 'started',
+            started_at: '2026-06-19T00:01:00Z',
+          },
+        ],
+        ledger: [
+          {
+            run_id: 'session-1',
+            step_id: 'step-started',
+            effect_kind: 'branch',
+            effect_ref: 'worker-branch',
+            confirmed: false,
+            confidence: 'uncertain',
+            recorded_at: '2026-06-19T00:01:01Z',
+          },
+        ],
+      });
+
+      expect(report.skipped).toHaveLength(1);
+      expect(report.skipped[0].status).toBe('skipped');
+      expect(report.interrupted).toHaveLength(1);
+      expect(report.interrupted[0].status).toBe('unknown');
+      expect(report.uncertain).toHaveLength(1);
+      expect(report.uncertain[0].effect_ref).toBe('worker-branch');
+    });
   });
 });

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -306,9 +306,61 @@ export interface RunJournalResponse {
   ledger: LedgerEntry[];
 }
 
+export interface ResumeOptions {
+  skipCompletedWriteSteps: boolean;
+}
+
 /** Fetch the run journal + ledger for a session (#125). */
 export async function getRunJournal(sessionId: string): Promise<RunJournalResponse> {
   return invoke<RunJournalResponse>('get_run_journal', { sessionId });
+}
+
+const WRITE_STEP_KINDS = new Set<StepKind>([
+  'worker_spawn',
+  'evaluator_spawn',
+  'git_commit',
+  'git_branch',
+  'file_write',
+]);
+
+export function isResumeReportEmpty(report: ResumeReport): boolean {
+  return (
+    report.skipped.length === 0 &&
+    report.interrupted.length === 0 &&
+    report.uncertain.length === 0
+  );
+}
+
+/**
+ * Frontend preview of the backend resume classifier. The backend still performs
+ * authoritative verification during `resume_session`; this read-only pass gives
+ * the confirmation modal enough per-step context before the operator resumes.
+ */
+export function buildResumeReportFromJournal(response: RunJournalResponse): ResumeReport {
+  const ledgerByStep = new Map(response.ledger.map((entry) => [entry.step_id, entry]));
+  const report: ResumeReport = { skipped: [], interrupted: [], uncertain: [] };
+
+  for (const entry of response.journal) {
+    const ledger = ledgerByStep.get(entry.step_id);
+    const hasUnconfirmedLedger = !!ledger && !ledger.confirmed;
+
+    if (entry.status === 'completed' && WRITE_STEP_KINDS.has(entry.kind)) {
+      report.skipped.push({ ...entry, status: 'skipped' });
+      continue;
+    }
+
+    if (entry.status === 'started' || entry.status === 'unknown' || entry.status === 'interrupted') {
+      report.interrupted.push({
+        ...entry,
+        status: hasUnconfirmedLedger ? 'unknown' : 'interrupted',
+      });
+      if (hasUnconfirmedLedger && ledger) {
+        report.uncertain.push(ledger);
+      }
+    }
+  }
+
+  return report;
 }
 
 interface SessionsState {
@@ -338,6 +390,17 @@ function createSessionsStore() {
       return { ...state };
     });
   });
+
+  function getState(): SessionsState {
+    let current: SessionsState = {
+      sessions: [],
+      activeSessionId: null,
+      loading: false,
+      error: null,
+    };
+    subscribe((state) => (current = state))();
+    return current;
+  }
 
   return {
     subscribe,
@@ -600,7 +663,18 @@ function createSessionsStore() {
       }
     },
 
-    async resumeSession(sessionId: string) {
+    async getResumeReport(sessionId: string): Promise<ResumeReport | null> {
+      const loadedSession = getState().sessions.find((session) => session.id === sessionId);
+      if (loadedSession?.resume_report) {
+        return loadedSession.resume_report;
+      }
+
+      const response = await getRunJournal(sessionId);
+      const report = buildResumeReportFromJournal(response);
+      return isResumeReportEmpty(report) ? null : report;
+    },
+
+    async resumeSession(sessionId: string, _options?: ResumeOptions) {
       update((state) => ({ ...state, loading: true, error: null }));
       try {
         const session = await invoke<Session>('resume_session', { sessionId });

--- a/src/lib/stores/sessions.ts
+++ b/src/lib/stores/sessions.ts
@@ -102,6 +102,28 @@ export interface FusionLaunchConfig {
   with_planning: boolean;
 }
 
+export interface DebateDebaterConfig {
+  name: string;
+  stance?: string;
+  cli: string;
+  model?: string;
+  flags: string[];
+}
+
+export interface DebateLaunchConfig {
+  project_path: string;
+  name?: string;
+  color?: string;
+  debaters: DebateDebaterConfig[];
+  topic: string;
+  rounds: number;
+  judge_config: AgentConfig;
+  queen_config?: AgentConfig;
+  with_planning: boolean;
+  default_cli: string;
+  default_model?: string;
+}
+
 export interface PlannerConfig {
   config: AgentConfig;
   domain: string;
@@ -209,6 +231,7 @@ export interface Session {
     | { Hive: { worker_count: number } } 
     | { Swarm: { planner_count: number } } 
     | { Fusion: { variants: string[] } }
+    | { Debate: { variants: string[] } }
     | { Solo: { cli: string } };
   project_path: string;
   state: SessionState;
@@ -487,6 +510,26 @@ function createSessionsStore() {
       update((state) => ({ ...state, loading: true, error: null }));
       try {
         const session = await invoke<Session>('launch_fusion', { config });
+        update((state) => {
+          const exists = state.sessions.some((s) => s.id === session.id);
+          return {
+            ...state,
+            sessions: exists ? state.sessions : [...state.sessions, session],
+            activeSessionId: session.id,
+            loading: false,
+          };
+        });
+        return session;
+      } catch (err) {
+        update((state) => ({ ...state, loading: false, error: String(err) }));
+        throw err;
+      }
+    },
+
+    async launchDebate(config: DebateLaunchConfig) {
+      update((state) => ({ ...state, loading: true, error: null }));
+      try {
+        const session = await invoke<Session>('launch_debate', { config });
         update((state) => {
           const exists = state.sessions.some((s) => s.id === session.id);
           return {

--- a/src/lib/types/domain.ts
+++ b/src/lib/types/domain.ts
@@ -20,7 +20,7 @@ export interface Session {
     events: string[];
 }
 
-export type SessionMode = 'hive' | 'fusion' | 'research';
+export type SessionMode = 'hive' | 'fusion' | 'research' | 'debate';
 
 export interface LaunchConfig {
     plan_source?: string;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -9,6 +9,7 @@
   import FusionPanel from '$lib/components/FusionPanel.svelte';
   import DebatePanel from '$lib/components/DebatePanel.svelte';
   import SessionOverview from '$lib/components/session/SessionOverview.svelte';
+  import { readTerminalSelection } from '$lib/components/Terminal.svelte';
   import { sessions, activeSession, activeAgents, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { coordination } from '$lib/stores/coordination';
   import { ui } from '$lib/stores/ui';
@@ -121,11 +122,7 @@
 
   // Read an xterm terminal selection if the focused/under-cursor element is inside one.
   function readXtermSelection(): string | null {
-    const term = document.querySelector('.xterm-helper-textarea, .xterm') as HTMLElement | null;
-    // xterm exposes selection via the DOM Selection API over the .xterm-rows; the
-    // window selection below covers it, so this is a placeholder for buffer-level reads.
-    if (!term) return null;
-    return null;
+    return readTerminalSelection($ui.focusedAgentId);
   }
 
   // Capture the operator's current selection (terminal or page) or selected cell as a

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,8 +7,9 @@
   import ShortcutsOverlay from '$lib/components/ShortcutsOverlay.svelte';
   import UpdateChecker from '$lib/components/UpdateChecker.svelte';
   import FusionPanel from '$lib/components/FusionPanel.svelte';
+  import DebatePanel from '$lib/components/DebatePanel.svelte';
   import SessionOverview from '$lib/components/session/SessionOverview.svelte';
-  import { sessions, activeSession, activeAgents, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig } from '$lib/stores/sessions';
+  import { sessions, activeSession, activeAgents, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { coordination } from '$lib/stores/coordination';
   import { ui } from '$lib/stores/ui';
   import { layout } from '$lib/stores/layout';
@@ -104,6 +105,10 @@
 
   async function handleLaunchFusion(config: FusionLaunchConfig): Promise<void> {
     await sessions.launchFusion(config);
+  }
+
+  async function handleLaunchDebate(config: DebateLaunchConfig): Promise<void> {
+    await sessions.launchDebate(config);
   }
 
   function openAddWorkerDialog() {
@@ -219,6 +224,7 @@
     onLaunchHiveV2={handleLaunchHiveV2}
     onLaunchSwarm={handleLaunchSwarm}
     onLaunchFusion={handleLaunchFusion}
+    onLaunchDebate={handleLaunchDebate}
     onOpenAddWorker={openAddWorkerDialog}
   />
 
@@ -266,6 +272,8 @@
           </div>
         {:else if $activeSession?.session_type && 'Fusion' in $activeSession.session_type && $activeSession.state !== 'Planning' && $activeSession.state !== 'PlanReady'}
           <FusionPanel />
+        {:else if $activeSession?.session_type && 'Debate' in $activeSession.session_type && $activeSession.state !== 'Planning' && $activeSession.state !== 'PlanReady'}
+          <DebatePanel />
         {:else}
           <SessionOverview />
         {/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
   import DebatePanel from '$lib/components/DebatePanel.svelte';
   import SessionOverview from '$lib/components/session/SessionOverview.svelte';
   import { readTerminalSelection } from '$lib/components/Terminal.svelte';
-  import { sessions, activeSession, activeAgents, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
+  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type HiveLaunchConfig, type SwarmLaunchConfig, type FusionLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { coordination } from '$lib/stores/coordination';
   import { ui } from '$lib/stores/ui';
   import { layout } from '$lib/stores/layout';
@@ -21,6 +21,7 @@
 
   // Use UI store as single source of truth for focused agent
   let focusedAgentId = $derived($ui.focusedAgentId);
+  let activeSessionState = $derived(serdeEnumVariantName($activeSession?.state));
 
   onMount(() => {
     sessions.loadSessions();
@@ -35,7 +36,7 @@
   $effect(() => {
     const session = $activeSession;
     const sessionId = session?.id ?? null;
-    const sessionState = session ? (typeof session.state === 'string' ? session.state : Object.keys(session.state)[0]) : null;
+    const sessionState = session ? serdeEnumVariantName(session.state) ?? null : null;
 
     if (sessionId && sessionId !== prevSessionId) {
       prevSessionId = sessionId;
@@ -48,7 +49,7 @@
         if (!isTransitioning) {
           isTransitioning = true;
           tick().then(() => {
-            const queen = $activeAgents.find(a => a.role === 'Queen' || a.id.endsWith('-queen'));
+            const queen = $activeAgents.find(a => serdeEnumVariantName(a.role) === 'Queen' || a.id.endsWith('-queen'));
             if (queen) {
               ui.setFocusedAgent(queen.id);
               ui.setSelectedAgent(queen.id);
@@ -267,9 +268,9 @@
           <div class="no-agents">
             <p>No agents in this session</p>
           </div>
-        {:else if $activeSession?.session_type && 'Fusion' in $activeSession.session_type && $activeSession.state !== 'Planning' && $activeSession.state !== 'PlanReady'}
+        {:else if $activeSession?.session_type && 'Fusion' in $activeSession.session_type && activeSessionState !== 'Planning' && activeSessionState !== 'PlanReady'}
           <FusionPanel />
-        {:else if $activeSession?.session_type && 'Debate' in $activeSession.session_type && $activeSession.state !== 'Planning' && $activeSession.state !== 'PlanReady'}
+        {:else if $activeSession?.session_type && 'Debate' in $activeSession.session_type && activeSessionState !== 'Planning' && activeSessionState !== 'PlanReady'}
           <DebatePanel />
         {:else}
           <SessionOverview />


### PR DESCRIPTION
## Summary
Two coordinated work streams from a single multi-agent Hive run:

1. **Debate session mode (#120)** — a new N-debaters-plus-judge mode cloned from the Fusion pattern. Debaters argue positions across configurable rounds (each round reads opponents' prior arguments before rebutting); a judge renders a verdict and captures it to the wiki via the existing prompt-driven `queen-research` flow (no phantom `wiki-context` endpoint — that never existed).
2. **The 7 deferred follow-ups from the agent-native epic (#129)** — Action consolidation, render envelope, real Chart widget, ResumeConfirmModal wiring, `list_session_files` + composer file-mentions, Approval wiring, heartbeat/queue verification, and the conpty/CI test-runner fix.

## What's in each commit (one per worker)
- **`feat(debate)` backend (W1)** — `SessionMode::Debate`, `SessionType::Debate { variants }`, `SessionTypeInfo::Debate`, `launch_debate`/round-coordination/judge in `controller.rs`, `debater` + `debate-judge` templates reusing the `queen-research` wiki capture, `POST /api/sessions` `"debate"` + dedicated `POST /api/sessions/debate`, resolver-gate entry, `session.launch_debate` registered in `ActionRegistry`, integration tests.
- **`refactor(actions)` #129 backend (W3)** — typed session routes dispatch through `ActionRegistry`; `validate_session_name`/`validate_session_color`/`is_valid_hex_session_color` **de-triplicated** to the single canonical home in `actions/session/mod.rs`; `pty`/`coordination` commands migrated to actions; `{ renderer?, data }` envelope (`renderer` is a plain string — `"diff"`/`"table"`) emitted from real output + `emit_conversation_message`.
- **`fix(test)` conpty/CI (W5)** — root-caused the Windows `cargo test` loader failure (`0xC0000139`: the lib test binary linked native ConPTY + Tauri/Wry desktop bootstrap). Fixed with `cfg(test)` stubs (`pty/session_stub.rs`, `runtime/local_pty_stub.rs`, `tauri_shim.rs`) that **keep production PTY/Tauri intact**. `cargo test` now runs for the first time. Adds a Windows `Rust Tests` CI workflow (`cargo check --tests` + `clippy` + `cargo test`) gating PRs to `main`.
- **`feat(debate)` frontend (W2)** — `'debate'` in the TS `SessionMode`, `SessionType` mirror `{ Debate: { variants } }` (normalized via `serdeEnumVariantName`), `launchDebate`/`DebateLaunchConfig`, Debate launch tab (debaters, per-debater model, rounds, stances), `TemplatePicker` routing, `/debate` composer command, and a 753-line `DebatePanel` results view.
- **`feat(renderers)` #129 frontend (W4)** — real inline-SVG `Chart.svelte` (zero new deps), `ResumeConfirmModal` wired (target session id captured at modal-open — race guard), scoped `list_session_files` Tauri command + composer file-mention pills + real `xterm.getSelection()` bridge, Approval approve/reject wired to the injection path.

## Verification
- `cargo check --tests`: **clean**.
- `npm run check`: **0 errors, 0 warnings**.
- `cargo test`: **now executes** (was previously impossible) — **357 passed / 28 failed**.

## ⚠️ Known: 28 backend test failures (triage)
W5's loader fix made the Rust test suite **runnable for the first time**, immediately surfacing 28 latent failures (the count did **not** rise from W5's isolated branch, i.e. these are not introduced by the Debate/#129 feature work). Triaged into:
- **Pre-existing test-isolation bugs** (majority): parallel tests share a storage dir, so learnings/delete/e2e counts come back `4` instead of `1`. Never observed before because the tests never ran.
- **Pre-existing harness bug**: a path-traversal test panics in its **own** URI builder (`InvalidUriChar`) before issuing a request.
- **One real regression to fix**: `test_patch_session_rejects_invalid_color` returns `200` instead of `400` — the registry refactor dropped color validation on the `PATCH /api/sessions/{id}` path.
- **Borderline behavioral shifts to confirm**: path-traversal now returns `404` vs expected `400` (still rejected); `resolver` launch returns `409` vs `200`.

A reviewer + resolver pass (this session) will fix the real regression, confirm the borderline cases, and address the test-isolation failures so the new CI gate can go green.

## Notes
- `controller.rs` carries incidental rustfmt within genuinely-changed regions; a repo-wide `cargo fmt` from one worker was stripped during integration to keep the diff reviewable (the repo has pre-existing rustfmt debt — a separate cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Debate** session mode, including launch, status/evaluation endpoints, and a dedicated debate panel.
  * Added debate-round completion watching and “debate” generation/branch naming support.
  * Added render **envelopes** to action results and conversation events for consistent UI rendering.
  * Added a functional **chart renderer** (SVG) and improved terminal selection integration.
  * Expanded coordination and PTY capabilities via new action-based wiring (e.g., operator approve/reject injection).
* **Tests**
  * Added Rust CI workflow running check, clippy, and tests; expanded/updated unit and HTTP tests for debate, rendering, and events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->