### PR TITLE
feat: add Knowledge Atlas and reliable completion handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A local, operator-controlled meta-harness for AI coding sessions. Launch, supervise, and compare coordinated CLI agents (Claude, Codex, Gemini, Antigravity, and others) without handing topology decisions to an opaque control plane.
 
-![Hive Manager](https://img.shields.io/badge/version-0.34.0-blue)
+![Hive Manager](https://img.shields.io/badge/version-0.35.1-blue)
 ![Platform](https://img.shields.io/badge/platform-Windows-lightgrey)
 ![License](https://img.shields.io/badge/license-MIT-green)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-manager",
-  "version": "0.32.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-manager",
-      "version": "0.32.0",
+      "version": "0.35.1",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.35.0"
+version = "0.35.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/coordination/queue_manager.rs
+++ b/src-tauri/src/coordination/queue_manager.rs
@@ -114,7 +114,8 @@ impl QueueManager {
     }
 
     /// Record a heartbeat against the queue row, advancing continuation / no-progress
-    /// counters. Returns `true` if a row was updated.
+    /// counters. A completed heartbeat atomically finalizes the row and emits the matching
+    /// lifecycle event. Returns `true` if a row was updated.
     pub async fn record_heartbeat(
         &self,
         session_id: &str,
@@ -122,7 +123,19 @@ impl QueueManager {
         status: &str,
     ) -> Result<bool, StorageError> {
         let now = Self::now_ms();
-        self.repo.record_heartbeat(session_id, worker_id, status, now)
+        let updated = self
+            .repo
+            .record_heartbeat(session_id, worker_id, status, now)?;
+        if updated && status == "completed" {
+            self.emit(
+                session_id,
+                worker_id,
+                EventType::WorkerFinalized,
+                Severity::Info,
+            )
+            .await;
+        }
+        Ok(updated)
     }
 
     /// Maintenance: flip stale `running` rows back to `queued`. Emits `WorkerReclaimed`

--- a/src-tauri/src/http/handlers/knowledge.rs
+++ b/src-tauri/src/http/handlers/knowledge.rs
@@ -116,6 +116,7 @@ pub(crate) struct KnowledgePageResponse {
     pub truncated: bool,
 }
 
+/// Optional bounds and session context for a Knowledge Atlas graph request.
 #[derive(Debug, Default, Deserialize)]
 pub struct KnowledgeGraphQuery {
     #[serde(default, alias = "maxNodes")]
@@ -124,6 +125,7 @@ pub struct KnowledgeGraphQuery {
     pub session_id: Option<String>,
 }
 
+/// Stable page identifier and optional session context for a preview request.
 #[derive(Debug, Deserialize)]
 pub struct KnowledgePageQuery {
     pub id: String,
@@ -325,6 +327,7 @@ fn resolve_project_root_from_sessions<'a>(
         .ok_or_else(|| ApiError::not_found("Session not found"))
 }
 
+/// Build a bounded graph from the global wiki and the session project's allowlisted documents.
 pub(crate) fn scan_knowledge(
     wiki_root: &Path,
     project_root: Option<&Path>,
@@ -403,6 +406,7 @@ pub(crate) fn scan_knowledge(
     response
 }
 
+/// Resolve an allowlisted page ID and return its bounded Markdown preview.
 pub(crate) fn preview_knowledge_page(
     wiki_root: &Path,
     project_root: Option<&Path>,
@@ -555,6 +559,13 @@ fn enumerate_sources(wiki_root: &Path, project_root: Option<&Path>) -> SourceEnu
         }
     }
 
+    // Session-scoped project context is the most relevant part of the graph. Keep the exact
+    // project allowlist ahead of the global corpus so it cannot be displaced when the caller's
+    // node cap is smaller than (or already saturated by) the wiki.
+    enumeration
+        .sources
+        .sort_by_key(|source| source.folder != KnowledgeFolder::Project);
+
     enumeration
 }
 
@@ -659,10 +670,10 @@ fn has_markdown_extension(path: &Path) -> bool {
 }
 
 fn read_source(source: &SourceFile) -> SourceRead {
-    let Ok(metadata) = fs::symlink_metadata(&source.path) else {
+    let Ok(source_metadata) = fs::symlink_metadata(&source.path) else {
         return SourceRead::Unavailable;
     };
-    if !metadata.is_file() || metadata.file_type().is_symlink() {
+    if !source_metadata.is_file() || source_metadata.file_type().is_symlink() {
         return SourceRead::Unavailable;
     }
     let Ok(canonical_path) = fs::canonicalize(&source.path) else {
@@ -671,16 +682,20 @@ fn read_source(source: &SourceFile) -> SourceRead {
     if !canonical_path.starts_with(&source.root) {
         return SourceRead::Unavailable;
     }
-
-    let Ok(mut file) = File::open(&canonical_path) else {
+    let Ok(target_metadata) = fs::symlink_metadata(&canonical_path) else {
         return SourceRead::Unavailable;
     };
-    let Ok(open_metadata) = file.metadata() else {
-        return SourceRead::Unavailable;
-    };
-    if !open_metadata.is_file() {
+    if !target_metadata.is_file()
+        || target_metadata.file_type().is_symlink()
+        || !validated_path_matches(&source_metadata, &target_metadata)
+    {
         return SourceRead::Unavailable;
     }
+
+    let Some((mut file, open_metadata)) = open_file_if_unchanged(&canonical_path, &target_metadata)
+    else {
+        return SourceRead::Unavailable;
+    };
     if open_metadata.len() > MAX_FILE_BYTES as u64 {
         return SourceRead::TooLarge;
     }
@@ -756,6 +771,115 @@ fn read_source(source: &SourceFile) -> SourceRead {
         body: body.to_string(),
         truncated: title_truncated || last_updated_truncated || edge_hints_truncated,
     })
+}
+
+/// Open `path` only when the resulting handle still identifies the file validated by the caller.
+/// Unix compares device/inode identity; Windows resolves the live handle's final path. Validating
+/// the handle, rather than re-checking the pathname, closes the replacement or symlink-swap window
+/// between canonicalization and `File::open`.
+fn open_file_if_unchanged(
+    path: &Path,
+    expected_metadata: &fs::Metadata,
+) -> Option<(File, fs::Metadata)> {
+    let file = File::open(path).ok()?;
+    let opened_metadata = file.metadata().ok()?;
+    if !opened_metadata.is_file()
+        || !opened_file_matches(path, expected_metadata, &file, &opened_metadata)
+    {
+        return None;
+    }
+    Some((file, opened_metadata))
+}
+
+#[cfg(unix)]
+fn validated_path_matches(source: &fs::Metadata, target: &fs::Metadata) -> bool {
+    same_unix_file_identity(source, target)
+}
+
+#[cfg(windows)]
+fn validated_path_matches(_source: &fs::Metadata, _target: &fs::Metadata) -> bool {
+    // Windows verifies the final path of the opened handle below, which also detects a swapped
+    // parent-directory reparse point.
+    true
+}
+
+#[cfg(not(any(unix, windows)))]
+fn validated_path_matches(_source: &fs::Metadata, _target: &fs::Metadata) -> bool {
+    false
+}
+
+#[cfg(unix)]
+fn opened_file_matches(
+    _path: &Path,
+    expected: &fs::Metadata,
+    _file: &File,
+    opened: &fs::Metadata,
+) -> bool {
+    same_unix_file_identity(expected, opened)
+}
+
+#[cfg(unix)]
+fn same_unix_file_identity(expected: &fs::Metadata, opened: &fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    expected.dev() == opened.dev() && expected.ino() == opened.ino()
+}
+
+#[cfg(windows)]
+fn opened_file_matches(
+    path: &Path,
+    _expected: &fs::Metadata,
+    file: &File,
+    _opened: &fs::Metadata,
+) -> bool {
+    final_path_for_open_file(file).is_some_and(|opened_path| opened_path == path)
+}
+
+#[cfg(windows)]
+fn final_path_for_open_file(file: &File) -> Option<PathBuf> {
+    use std::os::windows::ffi::OsStringExt;
+    use std::os::windows::io::AsRawHandle;
+
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn GetFinalPathNameByHandleW(
+            file: *mut std::ffi::c_void,
+            file_path: *mut u16,
+            file_path_len: u32,
+            flags: u32,
+        ) -> u32;
+    }
+
+    let handle = file.as_raw_handle();
+    // SAFETY: `handle` belongs to the live `File`; a null buffer with length zero only queries the
+    // required UTF-16 buffer length and does not transfer ownership.
+    let required = unsafe { GetFinalPathNameByHandleW(handle, std::ptr::null_mut(), 0, 0) };
+    if required == 0 {
+        return None;
+    }
+    let mut buffer = vec![0u16; required as usize + 1];
+    // SAFETY: `buffer` is writable for the advertised length and the file handle remains live for
+    // the duration of the call.
+    let written = unsafe {
+        GetFinalPathNameByHandleW(handle, buffer.as_mut_ptr(), buffer.len() as u32, 0)
+    };
+    if written == 0 || written as usize >= buffer.len() {
+        return None;
+    }
+    buffer.truncate(written as usize);
+    Some(PathBuf::from(OsString::from_wide(&buffer)))
+}
+
+#[cfg(not(any(unix, windows)))]
+fn opened_file_matches(
+    _path: &Path,
+    _expected: &fs::Metadata,
+    _file: &File,
+    _opened: &fs::Metadata,
+) -> bool {
+    // File identity APIs are platform-specific. Refuse to read rather than weakening the
+    // containment guarantee on an unsupported target.
+    false
 }
 
 fn node_id_for(source: &SourceFile) -> Option<String> {
@@ -1239,6 +1363,80 @@ mod tests {
                 .title,
             "Source #153"
         );
+    }
+
+    #[test]
+    fn project_nodes_are_reserved_ahead_of_a_saturated_global_corpus() {
+        let wiki = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        for index in 0..MAX_NODES {
+            write_page(
+                wiki.path(),
+                &format!("patterns/global-{index:03}.md"),
+                &format!("# Global {index}\n"),
+            );
+        }
+        write_page(
+            project.path(),
+            ".ai-docs/project-dna.md",
+            "# Project DNA\n",
+        );
+        write_page(
+            project.path(),
+            ".ai-docs/bug-patterns.md",
+            "# Bug Patterns\n",
+        );
+
+        let graph = scan_knowledge(wiki.path(), Some(project.path()), MAX_NODES);
+        let node_ids: Vec<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+
+        assert_eq!(graph.nodes.len(), MAX_NODES);
+        assert_eq!(
+            &node_ids[..PROJECT_FILES.len()],
+            &["project/project-dna", "project/bug-patterns"]
+        );
+        assert!(graph.truncated);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_file_must_match_the_previously_validated_identity() {
+        let root = TempDir::new().unwrap();
+        let path = root.path().join("page.md");
+        let original_path = root.path().join("original.md");
+        fs::write(&path, "# Expected\n").unwrap();
+        let expected_metadata = fs::symlink_metadata(&path).unwrap();
+
+        let (original_handle, _) = open_file_if_unchanged(&path, &expected_metadata).unwrap();
+        drop(original_handle);
+
+        // Keep the original file alive so its OS identity cannot be recycled, then replace its
+        // pathname exactly as a validation-to-open race would.
+        fs::rename(&path, &original_path).unwrap();
+        fs::write(&path, "# Replacement\n").unwrap();
+
+        assert!(open_file_if_unchanged(&path, &expected_metadata).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn opened_handle_must_resolve_to_the_validated_windows_path() {
+        let root = TempDir::new().unwrap();
+        let expected_path = root.path().join("expected.md");
+        let other_path = root.path().join("other.md");
+        fs::write(&expected_path, "# Expected\n").unwrap();
+        fs::write(&other_path, "# Other\n").unwrap();
+        let expected_path = fs::canonicalize(expected_path).unwrap();
+        let expected_metadata = fs::symlink_metadata(&expected_path).unwrap();
+        let other_file = File::open(other_path).unwrap();
+        let other_metadata = other_file.metadata().unwrap();
+
+        assert!(!opened_file_matches(
+            &expected_path,
+            &expected_metadata,
+            &other_file,
+            &other_metadata,
+        ));
     }
 
     #[test]

--- a/src-tauri/src/http/handlers/knowledge.rs
+++ b/src-tauri/src/http/handlers/knowledge.rs
@@ -1,0 +1,1582 @@
+use axum::{
+    extract::{Query, State},
+    Json,
+};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fs::{self, File};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, OnceLock};
+use tokio::sync::Semaphore;
+
+use super::validate_session_id;
+use crate::http::error::ApiError;
+use crate::http::state::AppState;
+
+const WIKI_FOLDERS: [KnowledgeFolder; 3] = [
+    KnowledgeFolder::Patterns,
+    KnowledgeFolder::Practices,
+    KnowledgeFolder::Research,
+];
+const PROJECT_FILES: [&str; 2] = ["project-dna.md", "bug-patterns.md"];
+const DEFAULT_WIKI_ROOT: &str = "~/.ai-docs/wiki";
+
+pub(crate) const MAX_NODES: usize = 400;
+pub(crate) const MAX_EDGES: usize = 1_500;
+pub(crate) const MAX_FILE_BYTES: usize = 256 * 1024;
+const MAX_PREVIEW_BYTES: usize = 20 * 1024;
+const MAX_TITLE_BYTES: usize = 512;
+const MAX_LAST_UPDATED_BYTES: usize = 128;
+const MAX_EDGE_HINT_BYTES: usize = 512;
+const MAX_DISCOVERED_FILES: usize = MAX_NODES * 3;
+const MAX_RAW_EDGES: usize = MAX_EDGES * 8;
+const MAX_SCAN_ENTRIES: usize = 10_000;
+const MAX_DIRECTORY_DEPTH: usize = 32;
+const MAX_GRAPH_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
+const GRAPH_RESPONSE_OVERHEAD_RESERVE: usize = 64 * 1024;
+const MAX_GRAPH_ITEM_BYTES: usize = MAX_GRAPH_RESPONSE_BYTES - GRAPH_RESPONSE_OVERHEAD_RESERVE;
+const MAX_CONCURRENT_SCANS: usize = 2;
+
+static KNOWLEDGE_SCAN_LIMITER: OnceLock<Semaphore> = OnceLock::new();
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum KnowledgeFolder {
+    Patterns,
+    Practices,
+    Research,
+    Project,
+}
+
+impl KnowledgeFolder {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Patterns => "patterns",
+            Self::Practices => "practices",
+            Self::Research => "research",
+            Self::Project => "project",
+        }
+    }
+
+    fn from_id_prefix(prefix: &str) -> Option<Self> {
+        WIKI_FOLDERS
+            .into_iter()
+            .chain(std::iter::once(Self::Project))
+            .find(|folder| folder.as_str() == prefix)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum KnowledgeEdgeKind {
+    CrossRef,
+    Wikilink,
+    Global,
+    Related,
+    From,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct KnowledgeNode {
+    pub id: String,
+    pub title: String,
+    pub folder: KnowledgeFolder,
+    /// Folder-relative path only. Absolute filesystem paths never cross the API boundary.
+    pub path: String,
+    pub last_updated: String,
+    pub in_degree: usize,
+    pub out_degree: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct KnowledgeEdge {
+    pub source: String,
+    pub target: String,
+    pub kind: KnowledgeEdgeKind,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub(crate) struct KnowledgeGraphResponse {
+    pub nodes: Vec<KnowledgeNode>,
+    pub edges: Vec<KnowledgeEdge>,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct KnowledgePageResponse {
+    pub id: String,
+    pub title: String,
+    pub folder: KnowledgeFolder,
+    pub path: String,
+    pub content: String,
+    pub last_updated: String,
+    pub truncated: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct KnowledgeGraphQuery {
+    #[serde(default, alias = "maxNodes")]
+    pub max_nodes: Option<usize>,
+    #[serde(default, alias = "sessionId")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct KnowledgePageQuery {
+    pub id: String,
+    #[serde(default, alias = "sessionId")]
+    pub session_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SourceFile {
+    folder: KnowledgeFolder,
+    path: PathBuf,
+    /// Canonical root for this folder; used both to form relative IDs and to re-check containment.
+    root: PathBuf,
+}
+
+#[derive(Debug, Default)]
+struct SourceEnumeration {
+    sources: Vec<SourceFile>,
+    truncated: bool,
+}
+
+#[derive(Debug)]
+struct ParsedSource {
+    node: KnowledgeNode,
+    raw_edges: Vec<RawEdge>,
+    body: String,
+    truncated: bool,
+}
+
+#[derive(Debug)]
+struct RawEdge {
+    source: String,
+    target_hint: String,
+    kind: KnowledgeEdgeKind,
+}
+
+enum SourceRead {
+    Parsed(ParsedSource),
+    TooLarge,
+    Unavailable,
+}
+
+#[derive(Default)]
+struct NodeLookup {
+    by_id: HashMap<String, Vec<String>>,
+    by_basename: HashMap<String, Vec<String>>,
+    by_title: HashMap<String, Vec<String>>,
+}
+
+/// GET /api/knowledge/graph?session_id=<optional-live-session-id>
+///
+/// Read-only and fail-soft: filesystem failures produce a partial or empty graph, never a 500.
+/// Project-local nodes are included only when the caller supplies a live session id.
+pub async fn get_knowledge_graph(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<KnowledgeGraphQuery>,
+) -> Result<Json<KnowledgeGraphResponse>, ApiError> {
+    if query.max_nodes == Some(0) {
+        return Err(ApiError::bad_request("max_nodes must be greater than zero"));
+    }
+    let max_nodes = query.max_nodes.unwrap_or(MAX_NODES).min(MAX_NODES);
+    let wiki_root = resolve_wiki_root(&state).await;
+    let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
+    let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
+        return Ok(Json(KnowledgeGraphResponse::default()));
+    };
+
+    let graph = tokio::task::spawn_blocking(move || {
+        scan_knowledge(&wiki_root, project_root.as_deref(), max_nodes)
+    })
+    .await
+    .unwrap_or_default();
+
+    Ok(Json(graph))
+}
+
+/// GET /api/knowledge/page?id=patterns/example&session_id=<optional-live-session-id>
+///
+/// The request supplies an allow-listed node ID, never a filesystem path. Malformed IDs are
+/// rejected before any filesystem work; a safe but unknown ID returns 404 without echoing a path.
+pub async fn get_knowledge_page(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<KnowledgePageQuery>,
+) -> Result<Json<KnowledgePageResponse>, ApiError> {
+    validate_knowledge_id(&query.id)?;
+    let wiki_root = resolve_wiki_root(&state).await;
+    let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
+    let id = query.id;
+    let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
+        return Err(ApiError::not_found("Knowledge page not found"));
+    };
+
+    let page = tokio::task::spawn_blocking(move || {
+        preview_knowledge_page(&wiki_root, project_root.as_deref(), &id)
+    })
+    .await
+    .ok()
+    .flatten();
+
+    page.map(Json)
+        .ok_or_else(|| ApiError::not_found("Knowledge page not found"))
+}
+
+async fn resolve_wiki_root(state: &AppState) -> PathBuf {
+    let configured = state.config.read().await.global_wiki_path.clone();
+    let env_root = std::env::var_os("HIVE_WIKI_ROOT").filter(|value| !value.is_empty());
+    resolve_wiki_root_from(env_root, configured.as_deref(), user_home().as_deref())
+}
+
+fn resolve_wiki_root_from(
+    env_root: Option<OsString>,
+    configured: Option<&str>,
+    home: Option<&Path>,
+) -> PathBuf {
+    let selected = env_root
+        .map(PathBuf::from)
+        .or_else(|| {
+            configured
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_WIKI_ROOT));
+    expand_tilde_path(&selected, home)
+}
+
+fn user_home() -> Option<PathBuf> {
+    let preferred = if cfg!(windows) { "USERPROFILE" } else { "HOME" };
+    let fallback = if cfg!(windows) { "HOME" } else { "USERPROFILE" };
+    std::env::var_os(preferred)
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os(fallback).filter(|value| !value.is_empty()))
+        .map(PathBuf::from)
+}
+
+fn expand_tilde_path(path: &Path, home: Option<&Path>) -> PathBuf {
+    let Some(raw) = path.to_str() else {
+        return path.to_path_buf();
+    };
+    let Some(rest) = raw.strip_prefix('~') else {
+        return path.to_path_buf();
+    };
+    if !rest.is_empty() && !rest.starts_with('/') && !rest.starts_with('\\') {
+        return path.to_path_buf();
+    }
+    let Some(home) = home else {
+        return path.to_path_buf();
+    };
+    let rest = rest.trim_start_matches(['/', '\\']);
+    if rest.is_empty() {
+        home.to_path_buf()
+    } else {
+        home.join(rest)
+    }
+}
+
+fn knowledge_scan_limiter() -> &'static Semaphore {
+    KNOWLEDGE_SCAN_LIMITER.get_or_init(|| Semaphore::new(MAX_CONCURRENT_SCANS))
+}
+
+/// Project-local knowledge is opt-in and bound to one exact live session. Requests without a
+/// session id deliberately expose only the global allow-listed wiki, so adding or switching other
+/// sessions cannot change which `project/*` page a previously loaded graph id resolves to.
+fn resolve_project_root(
+    state: &AppState,
+    session_id: Option<&str>,
+) -> Result<Option<PathBuf>, ApiError> {
+    let sessions = if session_id.is_some() {
+        state.session_controller.read().list_sessions()
+    } else {
+        Vec::new()
+    };
+    resolve_project_root_from_sessions(
+        session_id,
+        sessions
+            .iter()
+            .map(|session| (session.id.as_str(), session.project_path.as_path())),
+    )
+}
+
+fn resolve_project_root_from_sessions<'a>(
+    session_id: Option<&str>,
+    sessions: impl IntoIterator<Item = (&'a str, &'a Path)>,
+) -> Result<Option<PathBuf>, ApiError> {
+    let Some(session_id) = session_id else {
+        return Ok(None);
+    };
+    if session_id.is_empty() || session_id.len() > 128 {
+        return Err(ApiError::bad_request("Invalid session ID"));
+    }
+    validate_session_id(session_id)?;
+
+    sessions
+        .into_iter()
+        .find_map(|(candidate_id, project_root)| {
+            (candidate_id == session_id).then(|| project_root.to_path_buf())
+        })
+        .map(Some)
+        .ok_or_else(|| ApiError::not_found("Session not found"))
+}
+
+pub(crate) fn scan_knowledge(
+    wiki_root: &Path,
+    project_root: Option<&Path>,
+    max_nodes: usize,
+) -> KnowledgeGraphResponse {
+    let node_cap = max_nodes.clamp(1, MAX_NODES);
+    let enumeration = enumerate_sources(wiki_root, project_root);
+    let mut truncated = enumeration.truncated;
+    let mut nodes = Vec::new();
+    let mut raw_edges = Vec::new();
+    let mut seen_ids = HashSet::new();
+    let mut graph_item_bytes = 0usize;
+
+    for source in enumeration.sources {
+        if nodes.len() >= node_cap {
+            truncated = true;
+            break;
+        }
+        match read_source(&source) {
+            SourceRead::Parsed(parsed) => {
+                if seen_ids.contains(&parsed.node.id) {
+                    continue;
+                }
+                let node_bytes = serialized_item_bytes(&parsed.node);
+                if graph_item_bytes.saturating_add(node_bytes) > MAX_GRAPH_ITEM_BYTES {
+                    truncated = true;
+                    break;
+                }
+                graph_item_bytes += node_bytes;
+                seen_ids.insert(parsed.node.id.clone());
+                truncated |= parsed.truncated;
+                nodes.push(parsed.node);
+                for edge in parsed.raw_edges {
+                    if raw_edges.len() >= MAX_RAW_EDGES {
+                        truncated = true;
+                        break;
+                    }
+                    raw_edges.push(edge);
+                }
+            }
+            SourceRead::TooLarge => truncated = true,
+            SourceRead::Unavailable => {}
+        }
+    }
+
+    let lookup = NodeLookup::from_nodes(&nodes);
+    let edge_byte_budget = MAX_GRAPH_ITEM_BYTES.saturating_sub(graph_item_bytes);
+    let (edges, edges_truncated) = build_edges(raw_edges, &lookup, edge_byte_budget);
+    truncated |= edges_truncated;
+
+    let node_positions: HashMap<String, usize> = nodes
+        .iter()
+        .enumerate()
+        .map(|(index, node)| (node.id.clone(), index))
+        .collect();
+    for edge in &edges {
+        if let Some(index) = node_positions.get(&edge.source) {
+            nodes[*index].out_degree += 1;
+        }
+        if let Some(index) = node_positions.get(&edge.target) {
+            nodes[*index].in_degree += 1;
+        }
+    }
+
+    let response = KnowledgeGraphResponse {
+        nodes,
+        edges,
+        truncated,
+    };
+    debug_assert!(
+        serde_json::to_vec(&response)
+            .map(|serialized| serialized.len() <= MAX_GRAPH_RESPONSE_BYTES)
+            .unwrap_or(false),
+        "knowledge graph response exceeded its serialized size cap"
+    );
+    response
+}
+
+pub(crate) fn preview_knowledge_page(
+    wiki_root: &Path,
+    project_root: Option<&Path>,
+    id: &str,
+) -> Option<KnowledgePageResponse> {
+    if validate_knowledge_id(id).is_err() {
+        return None;
+    }
+
+    let source = enumerate_sources(wiki_root, project_root)
+        .sources
+        .into_iter()
+        .find(|source| node_id_for(source).as_deref() == Some(id))?;
+    let SourceRead::Parsed(parsed) = read_source(&source) else {
+        return None;
+    };
+    let metadata_truncated = parsed.truncated;
+    let (content, content_truncated) = truncate_utf8(parsed.body, MAX_PREVIEW_BYTES);
+
+    Some(KnowledgePageResponse {
+        id: parsed.node.id,
+        title: parsed.node.title,
+        folder: parsed.node.folder,
+        path: parsed.node.path,
+        content,
+        last_updated: parsed.node.last_updated,
+        truncated: metadata_truncated || content_truncated,
+    })
+}
+
+fn serialized_item_bytes<T: Serialize>(value: &T) -> usize {
+    // Include an array separator. The fixed response wrapper and degree growth are covered by
+    // GRAPH_RESPONSE_OVERHEAD_RESERVE.
+    serde_json::to_vec(value)
+        .map(|serialized| serialized.len().saturating_add(1))
+        .unwrap_or(MAX_GRAPH_ITEM_BYTES.saturating_add(1))
+}
+
+fn validate_knowledge_id(id: &str) -> Result<(), ApiError> {
+    if id.is_empty() || id.len() > 512 || id.contains('\0') {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    }
+    if id.starts_with('/')
+        || id.starts_with('\\')
+        || id.contains('\\')
+        || id.get(1..2) == Some(":")
+    {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    }
+
+    let components: Vec<&str> = id.split('/').collect();
+    let Some(folder) = components
+        .first()
+        .and_then(|prefix| KnowledgeFolder::from_id_prefix(prefix))
+    else {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    };
+    if components.len() < 2
+        || components
+            .iter()
+            .any(|component| component.is_empty() || *component == "." || *component == "..")
+    {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    }
+    if folder == KnowledgeFolder::Project
+        && !matches!(id, "project/project-dna" | "project/bug-patterns")
+    {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    }
+    Ok(())
+}
+
+fn enumerate_sources(wiki_root: &Path, project_root: Option<&Path>) -> SourceEnumeration {
+    let mut enumeration = SourceEnumeration::default();
+    let mut entries_seen = 0;
+    let canonical_wiki_root = fs::canonicalize(wiki_root).ok();
+
+    for folder in WIKI_FOLDERS {
+        let subtree = wiki_root.join(folder.as_str());
+        let Ok(metadata) = fs::symlink_metadata(&subtree) else {
+            continue;
+        };
+        if !metadata.is_dir() || metadata.file_type().is_symlink() {
+            continue;
+        }
+        let Ok(canonical_root) = fs::canonicalize(&subtree) else {
+            continue;
+        };
+        if canonical_wiki_root
+            .as_ref()
+            .is_some_and(|root| !canonical_root.starts_with(root))
+        {
+            continue;
+        }
+
+        let remaining = MAX_DISCOVERED_FILES.saturating_sub(enumeration.sources.len());
+        if remaining == 0 {
+            enumeration.truncated = true;
+            break;
+        }
+        let mut found = Vec::new();
+        collect_markdown_files(
+            &canonical_root,
+            &canonical_root,
+            0,
+            remaining,
+            &mut entries_seen,
+            &mut found,
+            &mut enumeration.truncated,
+        );
+        enumeration
+            .sources
+            .extend(found.into_iter().map(|path| SourceFile {
+                folder,
+                path,
+                root: canonical_root.clone(),
+            }));
+    }
+
+    if let Some(project_root) = project_root {
+        let ai_docs = project_root.join(".ai-docs");
+        let Ok(ai_docs_metadata) = fs::symlink_metadata(&ai_docs) else {
+            return enumeration;
+        };
+        if !ai_docs_metadata.is_dir() || ai_docs_metadata.file_type().is_symlink() {
+            return enumeration;
+        }
+        let canonical_ai_docs = fs::canonicalize(&ai_docs).ok();
+        for name in PROJECT_FILES {
+            let path = ai_docs.join(name);
+            let Ok(metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if !metadata.is_file() || metadata.file_type().is_symlink() {
+                continue;
+            }
+            let (Some(root), Ok(canonical_path)) =
+                (canonical_ai_docs.as_ref(), fs::canonicalize(&path))
+            else {
+                continue;
+            };
+            if !canonical_path.starts_with(root) {
+                continue;
+            }
+            enumeration.sources.push(SourceFile {
+                folder: KnowledgeFolder::Project,
+                path: canonical_path,
+                root: root.clone(),
+            });
+        }
+    }
+
+    enumeration
+}
+
+#[allow(clippy::too_many_arguments)]
+fn collect_markdown_files(
+    canonical_root: &Path,
+    directory: &Path,
+    depth: usize,
+    file_limit: usize,
+    entries_seen: &mut usize,
+    output: &mut Vec<PathBuf>,
+    truncated: &mut bool,
+) {
+    if depth > MAX_DIRECTORY_DEPTH {
+        *truncated = true;
+        return;
+    }
+    if *entries_seen >= MAX_SCAN_ENTRIES || output.len() >= file_limit {
+        *truncated = true;
+        return;
+    }
+    let Ok(read_dir) = fs::read_dir(directory) else {
+        return;
+    };
+    // Bound collection itself before sorting. `ReadDir` is lazy, but collecting it wholesale would
+    // otherwise let one enormous directory bypass MAX_SCAN_ENTRIES before the loop below runs.
+    let remaining_entries = MAX_SCAN_ENTRIES.saturating_sub(*entries_seen);
+    let mut enumerated: Vec<_> = read_dir
+        .take(remaining_entries.saturating_add(1))
+        .collect();
+    if enumerated.len() > remaining_entries {
+        enumerated.truncate(remaining_entries);
+        *truncated = true;
+    }
+    // Count raw iterator results, including errors, so repeated ReadDir failures cannot evade the
+    // global traversal-work ceiling.
+    *entries_seen += enumerated.len();
+    let mut entries: Vec<_> = enumerated.into_iter().filter_map(Result::ok).collect();
+    entries.sort_by_key(|entry| entry.file_name());
+
+    for entry in entries {
+        if output.len() >= file_limit {
+            *truncated = true;
+            return;
+        }
+
+        let name = entry.file_name();
+        if name.to_string_lossy().starts_with('.') || is_forbidden_name(&name.to_string_lossy()) {
+            continue;
+        }
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            continue;
+        }
+        let Ok(canonical_path) = fs::canonicalize(entry.path()) else {
+            continue;
+        };
+        if !canonical_path.starts_with(canonical_root) {
+            continue;
+        }
+
+        if file_type.is_dir() {
+            collect_markdown_files(
+                canonical_root,
+                &canonical_path,
+                depth + 1,
+                file_limit,
+                entries_seen,
+                output,
+                truncated,
+            );
+            if output.len() >= file_limit {
+                *truncated = true;
+                return;
+            }
+        } else if file_type.is_file() && has_markdown_extension(&canonical_path) {
+            output.push(canonical_path);
+        }
+    }
+}
+
+fn is_forbidden_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.as_str(),
+        "agent-os.db"
+            | "agent-os.db-shm"
+            | "agent-os.db-wal"
+            | ".env"
+            | "learnings.jsonl"
+            | "log.md"
+            | "index.md"
+    ) || (lower.starts_with("log-archive") && lower.ends_with(".md"))
+}
+
+fn has_markdown_extension(path: &Path) -> bool {
+    path.extension()
+        .and_then(|extension| extension.to_str())
+        .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+}
+
+fn read_source(source: &SourceFile) -> SourceRead {
+    let Ok(metadata) = fs::symlink_metadata(&source.path) else {
+        return SourceRead::Unavailable;
+    };
+    if !metadata.is_file() || metadata.file_type().is_symlink() {
+        return SourceRead::Unavailable;
+    }
+    let Ok(canonical_path) = fs::canonicalize(&source.path) else {
+        return SourceRead::Unavailable;
+    };
+    if !canonical_path.starts_with(&source.root) {
+        return SourceRead::Unavailable;
+    }
+
+    let Ok(mut file) = File::open(&canonical_path) else {
+        return SourceRead::Unavailable;
+    };
+    let Ok(open_metadata) = file.metadata() else {
+        return SourceRead::Unavailable;
+    };
+    if !open_metadata.is_file() {
+        return SourceRead::Unavailable;
+    }
+    if open_metadata.len() > MAX_FILE_BYTES as u64 {
+        return SourceRead::TooLarge;
+    }
+
+    let mut bytes = Vec::with_capacity(open_metadata.len() as usize);
+    if file
+        .by_ref()
+        .take((MAX_FILE_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .is_err()
+    {
+        return SourceRead::Unavailable;
+    }
+    if bytes.len() > MAX_FILE_BYTES {
+        return SourceRead::TooLarge;
+    }
+    let Ok(text) = String::from_utf8(bytes) else {
+        return SourceRead::Unavailable;
+    };
+    let Some(id) = node_id_for(source) else {
+        return SourceRead::Unavailable;
+    };
+    if id.len() > 512 {
+        return SourceRead::Unavailable;
+    }
+    let (frontmatter, body) = split_frontmatter(&text);
+    let file_stem = canonical_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("untitled");
+    let title = frontmatter_field(frontmatter, "title")
+        .or_else(|| first_h1(body))
+        .unwrap_or_else(|| file_stem.to_string());
+    let (title, title_truncated) = truncate_utf8(title, MAX_TITLE_BYTES);
+    let last_updated = frontmatter_field(frontmatter, "last_updated").unwrap_or_default();
+    let (last_updated, last_updated_truncated) =
+        truncate_utf8(last_updated, MAX_LAST_UPDATED_BYTES);
+    let node = KnowledgeNode {
+        path: format!("{id}.md"),
+        id: id.clone(),
+        title,
+        folder: source.folder,
+        last_updated,
+        in_degree: 0,
+        out_degree: 0,
+    };
+
+    let mut raw_edges = Vec::new();
+    for key in ["cross_refs", "cross_ref"] {
+        for target_hint in frontmatter_list(frontmatter, key) {
+            raw_edges.push(RawEdge {
+                source: id.clone(),
+                target_hint,
+                kind: KnowledgeEdgeKind::CrossRef,
+            });
+        }
+    }
+    for target_hint in frontmatter_list(frontmatter, "related") {
+        raw_edges.push(RawEdge {
+            source: id.clone(),
+            target_hint,
+            kind: KnowledgeEdgeKind::Related,
+        });
+    }
+    raw_edges.extend(parse_body_edges(&id, body));
+    let original_edge_count = raw_edges.len();
+    raw_edges.retain(|edge| edge.target_hint.len() <= MAX_EDGE_HINT_BYTES);
+    let edge_hints_truncated = original_edge_count != raw_edges.len();
+
+    SourceRead::Parsed(ParsedSource {
+        node,
+        raw_edges,
+        body: body.to_string(),
+        truncated: title_truncated || last_updated_truncated || edge_hints_truncated,
+    })
+}
+
+fn node_id_for(source: &SourceFile) -> Option<String> {
+    let relative = source.path.strip_prefix(&source.root).ok()?;
+    let mut components = Vec::new();
+    for component in relative.iter() {
+        components.push(component.to_str()?);
+    }
+    let relative = components.join("/");
+    let stem = strip_markdown_extension(&relative);
+    if stem.is_empty() {
+        None
+    } else {
+        Some(format!("{}/{}", source.folder.as_str(), stem))
+    }
+}
+
+fn strip_markdown_extension(value: &str) -> &str {
+    let Some(suffix_start) = value.len().checked_sub(3) else {
+        return value;
+    };
+    match (value.get(..suffix_start), value.get(suffix_start..)) {
+        (Some(stem), Some(extension)) if extension.eq_ignore_ascii_case(".md") => stem,
+        _ => value,
+    }
+}
+
+fn split_frontmatter(text: &str) -> (&str, &str) {
+    let Some(after_opening) = text
+        .strip_prefix("---\r\n")
+        .or_else(|| text.strip_prefix("---\n"))
+    else {
+        return ("", text);
+    };
+
+    let mut consumed = 0;
+    for line in after_opening.split_inclusive('\n') {
+        let line_without_ending = line.trim_end_matches(['\r', '\n']);
+        if line_without_ending == "---" {
+            return (&after_opening[..consumed], &after_opening[consumed + line.len()..]);
+        }
+        consumed += line.len();
+    }
+    if after_opening[consumed..].trim_end_matches('\r') == "---" {
+        return (&after_opening[..consumed], "");
+    }
+    ("", text)
+}
+
+fn frontmatter_field(frontmatter: &str, key: &str) -> Option<String> {
+    frontmatter.lines().find_map(|line| {
+        if line.starts_with(char::is_whitespace) {
+            return None;
+        }
+        let (candidate, value) = line.split_once(':')?;
+        if !candidate.trim().eq_ignore_ascii_case(key) {
+            return None;
+        }
+        let value = trim_matching_quotes(value.trim());
+        (!value.is_empty()).then(|| value.to_string())
+    })
+}
+
+/// Parse a YAML-shaped field line-by-line. This intentionally is not a YAML parser: corpus values
+/// such as issue references containing `#NNN` must not be truncated as YAML comments.
+fn frontmatter_list(frontmatter: &str, key: &str) -> Vec<String> {
+    let lines: Vec<&str> = frontmatter.lines().collect();
+    let mut output = Vec::new();
+    let mut index = 0;
+    while index < lines.len() {
+        let line = lines[index];
+        if line.starts_with(char::is_whitespace) {
+            index += 1;
+            continue;
+        }
+        let Some((candidate, raw_value)) = line.split_once(':') else {
+            index += 1;
+            continue;
+        };
+        if !candidate.trim().eq_ignore_ascii_case(key) {
+            index += 1;
+            continue;
+        }
+
+        let raw_value = raw_value.trim();
+        if raw_value.starts_with('[') && raw_value.ends_with(']') {
+            for part in raw_value[1..raw_value.len() - 1].split(',') {
+                let value = trim_matching_quotes(part.trim());
+                if !value.is_empty() {
+                    output.push(value.to_string());
+                }
+            }
+        } else if !raw_value.is_empty() {
+            let value = trim_matching_quotes(raw_value);
+            if !value.is_empty() {
+                output.push(value.to_string());
+            }
+        } else {
+            index += 1;
+            while index < lines.len() {
+                let nested = lines[index];
+                if let Some(value) = nested.trim_start().strip_prefix("- ") {
+                    let value = trim_matching_quotes(value.trim());
+                    if !value.is_empty() {
+                        output.push(value.to_string());
+                    }
+                    index += 1;
+                    continue;
+                }
+                if nested.trim().is_empty() {
+                    index += 1;
+                    continue;
+                }
+                break;
+            }
+            continue;
+        }
+        index += 1;
+    }
+    output
+}
+
+fn trim_matching_quotes(value: &str) -> &str {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        &value[1..value.len() - 1]
+    } else {
+        value
+    }
+}
+
+fn first_h1(body: &str) -> Option<String> {
+    body.lines().find_map(|line| {
+        line.strip_prefix("# ")
+            .map(str::trim)
+            .filter(|title| !title.is_empty())
+            .map(str::to_string)
+    })
+}
+
+fn parse_body_edges(source: &str, body: &str) -> Vec<RawEdge> {
+    static WIKILINK: OnceLock<Regex> = OnceLock::new();
+    static GLOBAL: OnceLock<Regex> = OnceLock::new();
+    static RELATED: OnceLock<Regex> = OnceLock::new();
+    static FROM: OnceLock<Regex> = OnceLock::new();
+
+    let wikilink = WIKILINK.get_or_init(|| Regex::new(r"\[\[([^\]]+?)\]\]").unwrap());
+    let global =
+        GLOBAL.get_or_init(|| Regex::new(r"(?i)->\s*global:\s*(.+?)\s*$").unwrap());
+    let related = RELATED
+        .get_or_init(|| Regex::new(r"(?i)(?:<->|->)\s*related:\s*(.+?)\s*$").unwrap());
+    let from = FROM.get_or_init(|| Regex::new(r"(?i)<-\s*from:\s*(.+?)\s*$").unwrap());
+
+    let mut edges = Vec::new();
+    for captures in wikilink.captures_iter(body) {
+        let target = captures[1].split('|').next().unwrap_or("").trim();
+        if !target.is_empty() {
+            edges.push(RawEdge {
+                source: source.to_string(),
+                target_hint: target.to_string(),
+                kind: KnowledgeEdgeKind::Wikilink,
+            });
+        }
+    }
+    for line in body.lines() {
+        for (regex, kind) in [
+            (global, KnowledgeEdgeKind::Global),
+            (related, KnowledgeEdgeKind::Related),
+            (from, KnowledgeEdgeKind::From),
+        ] {
+            let Some(captures) = regex.captures(line) else {
+                continue;
+            };
+            let target = captures[1].trim();
+            if !target.is_empty() {
+                edges.push(RawEdge {
+                    source: source.to_string(),
+                    target_hint: target.to_string(),
+                    kind,
+                });
+            }
+            break;
+        }
+    }
+    edges
+}
+
+impl NodeLookup {
+    fn from_nodes(nodes: &[KnowledgeNode]) -> Self {
+        let mut lookup = Self::default();
+        for node in nodes {
+            insert_lookup(&mut lookup.by_id, normalize_lookup(&node.id), &node.id);
+            let basename = node.id.rsplit('/').next().unwrap_or(&node.id);
+            insert_lookup(
+                &mut lookup.by_basename,
+                normalize_lookup(basename),
+                &node.id,
+            );
+            insert_lookup(
+                &mut lookup.by_title,
+                normalize_lookup(&node.title),
+                &node.id,
+            );
+        }
+        lookup
+    }
+}
+
+fn insert_lookup(map: &mut HashMap<String, Vec<String>>, key: String, id: &str) {
+    map.entry(key).or_default().push(id.to_string());
+}
+
+fn normalize_lookup(value: &str) -> String {
+    value.trim().to_lowercase()
+}
+
+fn resolve_hint(hint: &str, lookup: &NodeLookup) -> Option<String> {
+    let mut value = hint.trim();
+    if let Some(inner) = embedded_wikilink(value) {
+        value = inner;
+    }
+    value = value.split('|').next().unwrap_or("").trim();
+    let normalized_slashes = value.replace('\\', "/");
+    let unannotated = strip_path_annotation(normalized_slashes.trim().trim_matches(['<', '>']));
+    let mut slug = unannotated.to_string();
+    while let Some(rest) = slug.strip_prefix("./") {
+        slug = rest.to_string();
+    }
+    slug = normalize_parent_relative_hint(slug)?;
+    slug = strip_markdown_extension(&slug).to_string();
+    if slug.is_empty()
+        || slug.starts_with('/')
+        || slug.get(1..2) == Some(":")
+        || slug
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+    {
+        return None;
+    }
+
+    let explicit_path = slug.contains('/');
+    if explicit_path {
+        let prefix = slug.split('/').next()?;
+        if KnowledgeFolder::from_id_prefix(prefix).is_none() {
+            return None;
+        }
+    }
+
+    if let Some(id) = unique_lookup(&lookup.by_id, &normalize_lookup(&slug)) {
+        return Some(id);
+    }
+    // An explicit path that did not match an allow-listed ID must not fall back by basename: that
+    // would turn `clients/foo.md` into an edge to an unrelated allow-listed `patterns/foo.md`.
+    if explicit_path {
+        return None;
+    }
+
+    let basename = slug.rsplit('/').next().unwrap_or(&slug);
+    unique_lookup(&lookup.by_basename, &normalize_lookup(basename))
+        .or_else(|| unique_lookup(&lookup.by_title, &normalize_lookup(&slug)))
+}
+
+/// Corpus research pages sometimes refer to a sibling allow-listed subtree with
+/// `../patterns/foo.md`. These strings are lookup hints only (never filesystem paths), but parent
+/// components are still normalized narrowly: after removing leading parents, the hint must name
+/// one of the three global wiki allow-list roots. `../clients/foo.md` therefore remains invalid.
+fn normalize_parent_relative_hint(mut slug: String) -> Option<String> {
+    let had_parent_prefix = slug.starts_with("../");
+    while let Some(rest) = slug.strip_prefix("../") {
+        slug = rest.to_string();
+    }
+
+    if let Some(rest) = slug.strip_prefix("wiki/") {
+        slug = rest.to_string();
+    }
+    if !had_parent_prefix {
+        return Some(slug);
+    }
+
+    let (prefix, remainder) = slug.split_once('/')?;
+    if remainder.is_empty()
+        || !WIKI_FOLDERS
+            .into_iter()
+            .any(|folder| folder.as_str() == prefix)
+    {
+        return None;
+    }
+    Some(slug)
+}
+
+fn embedded_wikilink(value: &str) -> Option<&str> {
+    let opening = value.find("[[")? + 2;
+    let remainder = value.get(opening..)?;
+    let closing = remainder.find("]]")?;
+    remainder.get(..closing)
+}
+
+fn strip_path_annotation(value: &str) -> &str {
+    let lower = value.to_ascii_lowercase();
+    let Some(extension_start) = lower.rfind(".md") else {
+        return value;
+    };
+    let extension_end = extension_start + 3;
+    let Some(remainder) = value.get(extension_end..) else {
+        return value;
+    };
+    let annotation_follows = remainder.is_empty()
+        || remainder.starts_with('#')
+        || remainder.starts_with('(')
+        || remainder
+            .chars()
+            .next()
+            .is_some_and(char::is_whitespace);
+    if annotation_follows {
+        value.get(..extension_end).unwrap_or(value)
+    } else {
+        value
+    }
+}
+
+fn unique_lookup(map: &HashMap<String, Vec<String>>, key: &str) -> Option<String> {
+    let matches = map.get(key)?;
+    (matches.len() == 1).then(|| matches[0].clone())
+}
+
+fn build_edges(
+    raw_edges: Vec<RawEdge>,
+    lookup: &NodeLookup,
+    max_item_bytes: usize,
+) -> (Vec<KnowledgeEdge>, bool) {
+    let mut edges = Vec::new();
+    let mut seen = HashSet::new();
+    let mut truncated = false;
+    let mut item_bytes = 0usize;
+
+    for raw in raw_edges {
+        if edges.len() >= MAX_EDGES {
+            truncated = true;
+            break;
+        }
+        let Some(target) = resolve_hint(&raw.target_hint, lookup) else {
+            continue;
+        };
+        if target == raw.source {
+            continue;
+        }
+        let key = (raw.source.clone(), target.clone(), raw.kind);
+        if seen.contains(&key) {
+            continue;
+        }
+        let edge = KnowledgeEdge {
+            source: raw.source,
+            target,
+            kind: raw.kind,
+        };
+        let edge_bytes = serialized_item_bytes(&edge);
+        if item_bytes.saturating_add(edge_bytes) > max_item_bytes {
+            truncated = true;
+            break;
+        }
+        item_bytes += edge_bytes;
+        seen.insert(key);
+        edges.push(edge);
+    }
+    (edges, truncated)
+}
+
+fn truncate_utf8(mut value: String, max_bytes: usize) -> (String, bool) {
+    if value.len() <= max_bytes {
+        return (value, false);
+    }
+    let mut boundary = max_bytes;
+    while !value.is_char_boundary(boundary) {
+        boundary -= 1;
+    }
+    value.truncate(boundary);
+    (value, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_page(root: &Path, relative: &str, contents: &str) {
+        let path = root.join(relative);
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, contents).unwrap();
+    }
+
+    #[test]
+    fn scanner_enforces_allowlists_and_builds_all_five_edge_kinds() {
+        let wiki = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "patterns/source.md",
+            "---\ntitle: Source #153\nlast_updated: 2026-07-18\ncross_refs:\n  - wiki/practices/cross.md\n  - clients/cross.md\nrelated: [research/frontmatter-related.md]\n---\n# Source\n[[Wiki Target]]\n-> global: patterns/global.md\n-> related: [[body-related]] (strong match)\n<-> related: wiki/research/frontmatter-related.md (§details)\n<- from: research/from.md\n",
+        );
+        write_page(
+            wiki.path(),
+            "practices/cross.md",
+            "---\ntitle: Cross\n---\n# Cross\n",
+        );
+        write_page(
+            wiki.path(),
+            "practices/wiki-target.md",
+            "---\ntitle: Wiki Target\n---\n",
+        );
+        write_page(wiki.path(), "patterns/global.md", "# Global\n");
+        write_page(wiki.path(), "practices/body-related.md", "# Related\n");
+        write_page(
+            wiki.path(),
+            "research/frontmatter-related.md",
+            "# Frontmatter Related\n",
+        );
+        write_page(wiki.path(), "research/from.md", "# From\n");
+        write_page(
+            wiki.path(),
+            "clients/cross.md",
+            "---\ntitle: Private Client\n---\n",
+        );
+        write_page(
+            project.path(),
+            ".ai-docs/project-dna.md",
+            "---\ntitle: Project DNA\n---\n# Project DNA\n",
+        );
+        write_page(
+            project.path(),
+            ".ai-docs/bug-patterns.md",
+            "# Bug Patterns\n",
+        );
+        write_page(
+            project.path(),
+            ".ai-docs/architecture.md",
+            "# Must Not Be Scanned\n",
+        );
+
+        let graph = scan_knowledge(wiki.path(), Some(project.path()), MAX_NODES);
+        let node_ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+        assert!(node_ids.contains("patterns/source"));
+        assert!(node_ids.contains("project/project-dna"));
+        assert!(node_ids.contains("project/bug-patterns"));
+        assert!(!node_ids.iter().any(|id| id.contains("clients")));
+        assert!(!node_ids.contains("project/architecture"));
+
+        let kinds: HashSet<_> = graph.edges.iter().map(|edge| edge.kind).collect();
+        assert_eq!(
+            kinds,
+            HashSet::from([
+                KnowledgeEdgeKind::CrossRef,
+                KnowledgeEdgeKind::Wikilink,
+                KnowledgeEdgeKind::Global,
+                KnowledgeEdgeKind::Related,
+                KnowledgeEdgeKind::From,
+            ])
+        );
+        assert!(graph.edges.iter().all(|edge| {
+            node_ids.contains(edge.source.as_str()) && node_ids.contains(edge.target.as_str())
+        }));
+        assert!(graph.edges.iter().any(|edge| {
+            edge.kind == KnowledgeEdgeKind::Related
+                && edge.target == "practices/body-related"
+        }));
+        assert!(graph.edges.iter().any(|edge| {
+            edge.kind == KnowledgeEdgeKind::Related
+                && edge.target == "research/frontmatter-related"
+        }));
+        assert!(!serde_json::to_string(&graph)
+            .unwrap()
+            .contains(&wiki.path().to_string_lossy().to_string()));
+        assert_eq!(
+            graph
+                .nodes
+                .iter()
+                .find(|node| node.id == "patterns/source")
+                .unwrap()
+                .title,
+            "Source #153"
+        );
+    }
+
+    #[test]
+    fn relative_allowlisted_hints_resolve_without_disallowed_basename_fallback() {
+        let nodes = vec![KnowledgeNode {
+            id: "patterns/cross".to_string(),
+            title: "Cross".to_string(),
+            folder: KnowledgeFolder::Patterns,
+            path: "patterns/cross.md".to_string(),
+            last_updated: String::new(),
+            in_degree: 0,
+            out_degree: 0,
+        }];
+        let lookup = NodeLookup::from_nodes(&nodes);
+        assert_eq!(
+            resolve_hint("patterns/cross.md", &lookup).as_deref(),
+            Some("patterns/cross")
+        );
+        assert_eq!(
+            resolve_hint("../patterns/cross.md", &lookup).as_deref(),
+            Some("patterns/cross")
+        );
+        assert_eq!(
+            resolve_hint(
+                "../../wiki/patterns/cross.md (corpus annotation)",
+                &lookup,
+            )
+            .as_deref(),
+            Some("patterns/cross")
+        );
+        assert_eq!(resolve_hint("clients/cross.md", &lookup), None);
+        assert_eq!(resolve_hint("partners/cross.md", &lookup), None);
+        assert_eq!(resolve_hint("../clients/cross.md", &lookup), None);
+        assert_eq!(resolve_hint("../partners/cross.md", &lookup), None);
+        assert_eq!(resolve_hint("../project/project-dna.md", &lookup), None);
+        assert_eq!(
+            resolve_hint("../patterns/../clients/cross.md", &lookup),
+            None
+        );
+    }
+
+    #[test]
+    fn project_root_is_bound_to_the_requested_session_only() {
+        let first = Path::new("D:/projects/first");
+        let second = Path::new("D:/projects/second");
+        let sessions = [("session-a", first), ("session-b", second)];
+
+        assert!(resolve_project_root_from_sessions(None, sessions.iter().copied())
+            .ok()
+            .flatten()
+            .is_none());
+        assert_eq!(
+            resolve_project_root_from_sessions(Some("session-a"), sessions.iter().copied())
+                .ok()
+                .flatten()
+                .as_deref(),
+            Some(first)
+        );
+        assert_eq!(
+            resolve_project_root_from_sessions(Some("session-b"), sessions.iter().copied())
+                .ok()
+                .flatten()
+                .as_deref(),
+            Some(second)
+        );
+
+        // Keeping the old graph's session id after the live session switches cannot resolve the
+        // replacement project's identically-named `project/project-dna` node.
+        let switched = [("session-b", second)];
+        let error = match resolve_project_root_from_sessions(
+            Some("session-a"),
+            switched.iter().copied(),
+        ) {
+            Ok(_) => panic!("stale session unexpectedly resolved a project"),
+            Err(error) => error,
+        };
+        assert_eq!(error.status, axum::http::StatusCode::NOT_FOUND);
+
+        let invalid = match resolve_project_root_from_sessions(
+            Some("../session-a"),
+            sessions.iter().copied(),
+        ) {
+            Ok(_) => panic!("invalid session id unexpectedly resolved a project"),
+            Err(error) => error,
+        };
+        assert_eq!(invalid.status, axum::http::StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn knowledge_queries_accept_snake_and_camel_case_session_ids() {
+        let snake: KnowledgeGraphQuery = serde_json::from_value(serde_json::json!({
+            "session_id": "session-a",
+            "max_nodes": 12
+        }))
+        .unwrap();
+        assert_eq!(snake.session_id.as_deref(), Some("session-a"));
+        assert_eq!(snake.max_nodes, Some(12));
+
+        let camel: KnowledgePageQuery = serde_json::from_value(serde_json::json!({
+            "id": "patterns/example",
+            "sessionId": "session-b"
+        }))
+        .unwrap();
+        assert_eq!(camel.session_id.as_deref(), Some("session-b"));
+    }
+
+    #[test]
+    fn preview_is_id_based_strips_frontmatter_and_caps_content() {
+        let wiki = TempDir::new().unwrap();
+        let body = format!("# Preview\n{}", "é".repeat(MAX_PREVIEW_BYTES));
+        write_page(
+            wiki.path(),
+            "patterns/preview.md",
+            &format!(
+                "---\ntitle: Preview Title\nlast_updated: 2026-07-18\n---\n{body}"
+            ),
+        );
+
+        let page = preview_knowledge_page(wiki.path(), None, "patterns/preview").unwrap();
+        assert_eq!(page.id, "patterns/preview");
+        assert_eq!(page.path, "patterns/preview.md");
+        assert_eq!(page.title, "Preview Title");
+        assert!(!page.content.contains("last_updated:"));
+        assert!(page.truncated);
+        assert!(page.content.len() <= MAX_PREVIEW_BYTES);
+        assert!(page.content.is_char_boundary(page.content.len()));
+        assert!(preview_knowledge_page(wiki.path(), None, "patterns/missing").is_none());
+    }
+
+    #[test]
+    fn preview_id_validation_rejects_traversal_and_absolute_forms() {
+        for invalid in [
+            "",
+            "../clients/secret",
+            "patterns/../clients/secret",
+            "/patterns/secret",
+            "C:/patterns/secret",
+            "\\\\server\\patterns\\secret",
+            "patterns\\secret",
+            "clients/secret",
+            "project/architecture",
+        ] {
+            assert!(validate_knowledge_id(invalid).is_err(), "accepted {invalid}");
+        }
+        assert!(validate_knowledge_id("patterns/nested/page").is_ok());
+        assert!(validate_knowledge_id("project/project-dna").is_ok());
+    }
+
+    #[test]
+    fn node_and_file_bounds_degrade_safely() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/a.md", "# A\n");
+        write_page(wiki.path(), "patterns/b.md", "# B\n");
+        write_page(wiki.path(), "patterns/c.md", "# C\n");
+        write_page(
+            wiki.path(),
+            "patterns/oversize.md",
+            &"x".repeat(MAX_FILE_BYTES + 1),
+        );
+
+        let graph = scan_knowledge(wiki.path(), None, 2);
+        assert_eq!(graph.nodes.len(), 2);
+        assert!(graph.truncated);
+
+        let uncapped = scan_knowledge(wiki.path(), None, MAX_NODES);
+        assert!(uncapped.truncated);
+        assert!(!uncapped
+            .nodes
+            .iter()
+            .any(|node| node.id.ends_with("oversize")));
+
+        let missing = scan_knowledge(&wiki.path().join("missing"), None, MAX_NODES);
+        assert!(missing.nodes.is_empty());
+        assert!(missing.edges.is_empty());
+    }
+
+    #[test]
+    fn metadata_and_serialized_graph_size_are_bounded() {
+        let wiki = TempDir::new().unwrap();
+        let oversized_title = "é".repeat(MAX_TITLE_BYTES);
+        let oversized_updated = "x".repeat(MAX_LAST_UPDATED_BYTES + 50);
+        write_page(
+            wiki.path(),
+            "patterns/metadata.md",
+            &format!(
+                "---\ntitle: {oversized_title}\nlast_updated: {oversized_updated}\n---\n# Body\n"
+            ),
+        );
+
+        let graph = scan_knowledge(wiki.path(), None, MAX_NODES);
+        let node = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "patterns/metadata")
+            .unwrap();
+        assert!(node.title.len() <= MAX_TITLE_BYTES);
+        assert!(node.title.is_char_boundary(node.title.len()));
+        assert!(node.last_updated.len() <= MAX_LAST_UPDATED_BYTES);
+        assert!(graph.truncated);
+        assert!(serde_json::to_vec(&graph).unwrap().len() <= MAX_GRAPH_RESPONSE_BYTES);
+
+        let page = preview_knowledge_page(wiki.path(), None, "patterns/metadata").unwrap();
+        assert!(page.title.len() <= MAX_TITLE_BYTES);
+        assert!(page.truncated);
+    }
+
+    #[test]
+    fn directory_entry_collection_is_bounded_before_sorting() {
+        let root = TempDir::new().unwrap();
+        for index in 0..12 {
+            write_page(root.path(), &format!("page-{index:02}.md"), "# Page\n");
+        }
+        let canonical_root = fs::canonicalize(root.path()).unwrap();
+        let mut entries_seen = MAX_SCAN_ENTRIES - 3;
+        let mut output = Vec::new();
+        let mut truncated = false;
+
+        collect_markdown_files(
+            &canonical_root,
+            &canonical_root,
+            0,
+            MAX_DISCOVERED_FILES,
+            &mut entries_seen,
+            &mut output,
+            &mut truncated,
+        );
+
+        assert_eq!(entries_seen, MAX_SCAN_ENTRIES);
+        assert_eq!(output.len(), 3);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn resolved_edges_are_hard_capped() {
+        let nodes: Vec<_> = (0..51)
+            .map(|index| KnowledgeNode {
+                id: format!("patterns/page-{index}"),
+                title: format!("Page {index}"),
+                folder: KnowledgeFolder::Patterns,
+                path: format!("patterns/page-{index}.md"),
+                last_updated: String::new(),
+                in_degree: 0,
+                out_degree: 0,
+            })
+            .collect();
+        let lookup = NodeLookup::from_nodes(&nodes);
+        let raw_edges = nodes
+            .iter()
+            .flat_map(|source| {
+                nodes.iter().filter_map(move |target| {
+                    (source.id != target.id).then(|| RawEdge {
+                        source: source.id.clone(),
+                        target_hint: target.id.clone(),
+                        kind: KnowledgeEdgeKind::CrossRef,
+                    })
+                })
+            })
+            .collect();
+
+        let (edges, truncated) = build_edges(raw_edges, &lookup, MAX_GRAPH_ITEM_BYTES);
+        assert_eq!(edges.len(), MAX_EDGES);
+        assert!(truncated);
+    }
+
+    #[test]
+    fn resolved_edges_respect_the_serialized_response_budget() {
+        let nodes = vec![
+            KnowledgeNode {
+                id: "patterns/source".to_string(),
+                title: "Source".to_string(),
+                folder: KnowledgeFolder::Patterns,
+                path: "patterns/source.md".to_string(),
+                last_updated: String::new(),
+                in_degree: 0,
+                out_degree: 0,
+            },
+            KnowledgeNode {
+                id: "patterns/target".to_string(),
+                title: "Target".to_string(),
+                folder: KnowledgeFolder::Patterns,
+                path: "patterns/target.md".to_string(),
+                last_updated: String::new(),
+                in_degree: 0,
+                out_degree: 0,
+            },
+        ];
+        let lookup = NodeLookup::from_nodes(&nodes);
+        let raw_edges = vec![RawEdge {
+            source: "patterns/source".to_string(),
+            target_hint: "patterns/target".to_string(),
+            kind: KnowledgeEdgeKind::CrossRef,
+        }];
+
+        let (edges, truncated) = build_edges(raw_edges, &lookup, 1);
+        assert!(edges.is_empty());
+        assert!(truncated);
+    }
+
+    #[test]
+    fn wiki_root_precedence_and_tilde_expansion_are_pure() {
+        let home = Path::new("C:/Users/tester");
+        assert_eq!(
+            resolve_wiki_root_from(
+                Some(OsString::from("D:/configured/wiki")),
+                Some("~/ignored"),
+                Some(home),
+            ),
+            PathBuf::from("D:/configured/wiki")
+        );
+        assert_eq!(
+            resolve_wiki_root_from(None, Some("~/.ai-docs/wiki"), Some(home)),
+            home.join(".ai-docs/wiki")
+        );
+        assert_eq!(
+            expand_tilde_path(Path::new("~someone/wiki"), Some(home)),
+            PathBuf::from("~someone/wiki")
+        );
+        assert_eq!(strip_markdown_extension("éxy"), "éxy");
+        assert_eq!(strip_markdown_extension("é.md"), "é");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn scanner_skips_symlinked_subtrees_and_files() {
+        use std::os::unix::fs::symlink;
+
+        let wiki = TempDir::new().unwrap();
+        let private = TempDir::new().unwrap();
+        write_page(private.path(), "secret.md", "# Private\n");
+        fs::create_dir_all(wiki.path().join("practices")).unwrap();
+        symlink(private.path(), wiki.path().join("patterns")).unwrap();
+        symlink(
+            private.path().join("secret.md"),
+            wiki.path().join("practices/secret.md"),
+        )
+        .unwrap();
+
+        let graph = scan_knowledge(wiki.path(), None, MAX_NODES);
+        assert!(graph.nodes.is_empty());
+    }
+}

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -9,6 +9,7 @@ pub mod events;
 pub mod health;
 pub mod heartbeats;
 pub mod inject;
+pub mod knowledge;
 pub mod learnings;
 pub mod planners;
 pub mod queue;

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -1,7 +1,7 @@
 use crate::http::handlers::{
     actions, agents, application_state, artifacts, cells, conversations, evaluator, events, health,
-    heartbeats, inject, learnings, planners, queue, resolver, session_files, sessions, templates,
-    workers,
+    heartbeats, inject, knowledge, learnings, planners, queue, resolver, session_files, sessions,
+    templates, workers,
 };
 use crate::http::state::AppState;
 use crate::cli::health as cli_health;
@@ -197,6 +197,9 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route("/api/learnings", get(learnings::list_learnings))
         .route("/api/learnings", post(learnings::submit_learning))
         .route("/api/project-dna", get(learnings::get_project_dna))
+        // Read-only institutional knowledge graph + id-based markdown preview.
+        .route("/api/knowledge/graph", get(knowledge::get_knowledge_graph))
+        .route("/api/knowledge/page", get(knowledge::get_knowledge_page))
         // Session-scoped learning routes (preferred - work with multiple projects)
         .route(
             "/api/sessions/{id}/learnings",

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -16,11 +16,37 @@ use axum::{
     http::{Request, StatusCode},
 };
 use parking_lot::RwLock;
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tempfile::TempDir;
 use tower::ServiceExt;
+
+static KNOWLEDGE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct ScopedEnvironmentVariable {
+    key: &'static str,
+    previous: Option<OsString>,
+}
+
+impl ScopedEnvironmentVariable {
+    fn set(key: &'static str, value: impl AsRef<OsStr>) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for ScopedEnvironmentVariable {
+    fn drop(&mut self) {
+        if let Some(previous) = self.previous.as_ref() {
+            std::env::set_var(self.key, previous);
+        } else {
+            std::env::remove_var(self.key);
+        }
+    }
+}
 
 /// Helper to get the default max_qa_iterations for test fixtures
 fn test_default_max_qa_iterations() -> u8 {
@@ -1024,6 +1050,370 @@ async fn test_patch_session_updates_persisted_session_not_loaded_in_memory() {
     assert_eq!(updated.color.as_deref(), Some("#7aa2f7"));
 
     let _ = std::fs::remove_dir_all(storage.session_dir(&session_id));
+}
+
+// --- Knowledge graph endpoint tests ---
+
+fn write_knowledge_fixture(root: &Path, relative: &str, contents: impl AsRef<[u8]>) {
+    let path = root.join(relative);
+    std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+    std::fs::write(path, contents).unwrap();
+}
+
+#[tokio::test]
+async fn test_knowledge_endpoints_enforce_allowlist_edges_and_id_preview() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    write_knowledge_fixture(
+        wiki.path(),
+        "patterns/source.md",
+        r#"---
+title: Public Source
+last_updated: 2026-07-18
+cross_refs:
+  - wiki/practices/cross.md
+  - clients/private-client.md
+---
+# Source body
+[[Wiki Target]]
+-> global: patterns/global.md
+-> related: [[Body Related]] (typed annotation)
+<- from: research/from.md
+"#,
+    );
+    write_knowledge_fixture(wiki.path(), "practices/cross.md", "# Cross\n");
+    write_knowledge_fixture(
+        wiki.path(),
+        "practices/wiki-target.md",
+        "---\ntitle: Wiki Target\n---\n# Wiki target\n",
+    );
+    write_knowledge_fixture(wiki.path(), "patterns/global.md", "# Global\n");
+    write_knowledge_fixture(
+        wiki.path(),
+        "practices/body-related.md",
+        "---\ntitle: Body Related\n---\n# Related\n",
+    );
+    write_knowledge_fixture(wiki.path(), "research/from.md", "# From\n");
+    write_knowledge_fixture(
+        wiki.path(),
+        "clients/private-client.md",
+        "---\ntitle: Private Client Dossier\n---\n# Never expose this\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "patterns/oversized.md",
+        vec![b'x'; 256 * 1024 + 1],
+    );
+    write_knowledge_fixture(
+        project.path(),
+        ".ai-docs/project-dna.md",
+        "---\ntitle: Project DNA\n---\n# Local knowledge\n",
+    );
+    write_knowledge_fixture(
+        project.path(),
+        ".ai-docs/architecture.md",
+        "# Not an allow-listed project file\n",
+    );
+
+    let (_storage_dir, app, controller, _storage) =
+        setup_isolated_test_app_with_controller().await;
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-knowledge",
+            project.path().to_str().unwrap(),
+            &["worker-1"],
+        ));
+
+    let graph_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph?session_id=session-knowledge")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(graph_response.status(), StatusCode::OK);
+    let graph = read_json_body(graph_response).await;
+    let nodes = graph["nodes"].as_array().unwrap();
+    let node_ids: std::collections::HashSet<_> = nodes
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect();
+    assert!(node_ids.contains("patterns/source"));
+    assert!(node_ids.contains("project/project-dna"));
+    assert!(!node_ids.contains("project/architecture"));
+    assert!(!node_ids.contains("patterns/oversized"));
+    assert!(graph["truncated"].as_bool().unwrap());
+
+    let edges = graph["edges"].as_array().unwrap();
+    let edge_kinds: std::collections::HashSet<_> = edges
+        .iter()
+        .filter_map(|edge| edge["kind"].as_str())
+        .collect();
+    assert_eq!(
+        edge_kinds,
+        std::collections::HashSet::from([
+            "cross_ref",
+            "wikilink",
+            "global",
+            "related",
+            "from",
+        ])
+    );
+    assert!(edges.iter().all(|edge| {
+        edge["source"]
+            .as_str()
+            .is_some_and(|id| node_ids.contains(id))
+            && edge["target"]
+                .as_str()
+                .is_some_and(|id| node_ids.contains(id))
+    }));
+
+    let serialized_graph = serde_json::to_string(&graph).unwrap();
+    assert!(!serialized_graph.contains("Private Client Dossier"));
+    assert!(!serialized_graph.contains("clients/private-client"));
+    assert!(!serialized_graph.contains(wiki.path().to_string_lossy().as_ref()));
+    assert!(!serialized_graph.contains(project.path().to_string_lossy().as_ref()));
+
+    let preview_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(
+                    "/api/knowledge/page?id=patterns%2Fsource&session_id=session-knowledge",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(preview_response.status(), StatusCode::OK);
+    let preview = read_json_body(preview_response).await;
+    assert_eq!(preview["id"], "patterns/source");
+    assert_eq!(preview["path"], "patterns/source.md");
+    assert!(preview["content"].as_str().unwrap().contains("# Source body"));
+    assert!(!preview["content"].as_str().unwrap().contains("title: Public Source"));
+    assert!(!serde_json::to_string(&preview)
+        .unwrap()
+        .contains(wiki.path().to_string_lossy().as_ref()));
+
+    for invalid_id in [
+        "patterns%2F..%2Fclients%2Fprivate-client",
+        "%2Fpatterns%2Fsource",
+        "clients%2Fprivate-client",
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/knowledge/page?id={invalid_id}&session_id=session-knowledge"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    let missing_response = app
+        .oneshot(
+            Request::builder()
+                .uri(
+                    "/api/knowledge/page?id=patterns%2Fmissing&session_id=session-knowledge",
+                )
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let project_a = TempDir::new().unwrap();
+    let project_b = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    write_knowledge_fixture(
+        project_a.path(),
+        ".ai-docs/project-dna.md",
+        "---\ntitle: Project Alpha\n---\n# Alpha-only knowledge\n",
+    );
+    write_knowledge_fixture(
+        project_b.path(),
+        ".ai-docs/project-dna.md",
+        "---\ntitle: Project Beta\n---\n# Beta-only knowledge\n",
+    );
+
+    let (_storage_dir, app, controller, _storage) =
+        setup_isolated_test_app_with_controller().await;
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-alpha",
+            project_a.path().to_str().unwrap(),
+            &["session-alpha-worker-1"],
+        ));
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-beta",
+            project_b.path().to_str().unwrap(),
+            &["session-beta-worker-1"],
+        ));
+
+    for (session_id, expected_title, expected_body, excluded_body) in [
+        (
+            "session-alpha",
+            "Project Alpha",
+            "Alpha-only knowledge",
+            "Beta-only knowledge",
+        ),
+        (
+            "session-beta",
+            "Project Beta",
+            "Beta-only knowledge",
+            "Alpha-only knowledge",
+        ),
+    ] {
+        let graph_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/api/knowledge/graph?session_id={session_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(graph_response.status(), StatusCode::OK);
+        let graph = read_json_body(graph_response).await;
+        let project_node = graph["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|node| node["id"] == "project/project-dna")
+            .expect("session-scoped project node");
+        assert_eq!(project_node["title"], expected_title);
+
+        let page_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/knowledge/page?id=project%2Fproject-dna&session_id={session_id}"
+                    ))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(page_response.status(), StatusCode::OK);
+        let page = read_json_body(page_response).await;
+        assert!(page["content"].as_str().unwrap().contains(expected_body));
+        assert!(!page["content"].as_str().unwrap().contains(excluded_body));
+    }
+
+    let global_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(global_response.status(), StatusCode::OK);
+    let global_graph = read_json_body(global_response).await;
+    assert!(global_graph["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|node| node["folder"] != "project"));
+
+    let unknown_session = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph?session_id=session-missing")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(unknown_session.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_knowledge_graph_enforces_hard_node_cap() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    for index in 0..405 {
+        write_knowledge_fixture(
+            wiki.path(),
+            &format!("patterns/page-{index:03}.md"),
+            format!("# Page {index}\n"),
+        );
+    }
+
+    let app = setup_test_app().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let graph = read_json_body(response).await;
+    assert_eq!(graph["nodes"].as_array().unwrap().len(), 400);
+    assert!(graph["truncated"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_knowledge_graph_missing_root_returns_empty_graph() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let missing_parent = TempDir::new().unwrap();
+    let missing_root = missing_parent.path().join("does-not-exist");
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", &missing_root);
+
+    let app = setup_test_app().await;
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let graph = read_json_body(response).await;
+    assert!(graph["nodes"].as_array().unwrap().is_empty());
+    assert!(graph["edges"].as_array().unwrap().is_empty());
 }
 
 // --- Session-scoped learnings endpoint tests ---
@@ -5489,6 +5879,60 @@ async fn test_post_heartbeat_rejects_invalid_status() {
 }
 
 #[tokio::test]
+async fn test_completed_heartbeat_is_excluded_from_stall_sweep() {
+    let (app, controller) = setup_test_app_with_controller().await;
+
+    let temp_dir = std::env::temp_dir().join(format!(
+        "hive-test-heartbeat-completed-{}",
+        uuid::Uuid::new_v4()
+    ));
+    let _ = std::fs::create_dir_all(&temp_dir);
+
+    controller
+        .read()
+        .insert_test_session(make_test_session_with_agents(
+            "session-hb-completed",
+            temp_dir.to_str().unwrap(),
+            &["worker-done", "worker-active"],
+        ));
+
+    for (agent_id, status) in [
+        ("worker-done", "completed"),
+        ("worker-active", "working"),
+    ] {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/sessions/session-hb-completed/heartbeat")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({ "agent_id": agent_id, "status": status })
+                            .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    // Heartbeat timestamps have second precision in the stall sweep. Let both
+    // entries age past a zero-second threshold so status is the deciding factor.
+    tokio::time::sleep(std::time::Duration::from_millis(1_100)).await;
+    let stalled = controller
+        .read()
+        .get_stalled_agents("session-hb-completed", std::time::Duration::ZERO);
+    let stalled_ids: Vec<_> = stalled.into_iter().map(|(id, _)| id).collect();
+
+    assert_eq!(stalled_ids, vec!["worker-active"]);
+    assert!(!stalled_ids.iter().any(|id| id == "worker-done"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
 async fn test_get_active_sessions_returns_only_running() {
     let (app, controller) = setup_test_app_with_controller().await;
 
@@ -6848,6 +7292,37 @@ async fn test_heartbeat_advances_queue_counters() {
         row["no_progress_count"], 1,
         "second identical heartbeat is no-progress"
     );
+
+    let completed = serde_json::json!({
+        "agent_id": "session-queue-hb-worker-2",
+        "status": "completed",
+        "summary": "verified complete"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/session-queue-hb/heartbeat")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&completed).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let completed_snap = fetch_queue_snapshot(&app, "session-queue-hb").await;
+    assert_eq!(completed_snap["running"], 0);
+    assert_eq!(completed_snap["finalized"], 1);
+    let completed_row = completed_snap["rows"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["worker_id"] == "session-queue-hb-worker-2")
+        .expect("completed queue row for worker-2");
+    assert_eq!(completed_row["status"], "finalized");
+    assert_eq!(completed_row["last_status"], "completed");
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -3279,6 +3279,13 @@ Last updated: {timestamp}
             "idle",
             "Waiting for task activation",
         );
+        let completed_heartbeat = heartbeat_snippet(
+            "http://localhost:18800",
+            session_id,
+            &agent_id,
+            "completed",
+            "Completed fusion variant",
+        );
         let polling_instructions =
             get_polling_instructions(cli, &task_file, None, Some(&heartbeat_command));
         let scope_block = Self::scope_block(".");
@@ -3296,7 +3303,6 @@ Branch: {branch}
 ## Rules
 - Commit all changes to your branch
 - Do NOT interact with other variants
-- When complete, update your task file status to COMPLETED
 
 ## Task Coordination
 Send a startup heartbeat before reading the task file:
@@ -3304,7 +3310,18 @@ Send a startup heartbeat before reading the task file:
 {startup_heartbeat}
 ```
 
-Read {task_file}. Begin work only when Status is ACTIVE.{polling_instructions}"#,
+Read {task_file}. Begin work only when Status is ACTIVE.{polling_instructions}
+
+## Completion Protocol (MANDATORY)
+
+1. Run the focused validation required for this variant and review the final diff.
+2. Commit only the completed variant work on the current backend-created Fusion branch. Do not push or switch branches.
+3. Update {task_file} to `Status: COMPLETED` and add the result summary.
+4. Send this completed heartbeat exactly as shown:
+   ```bash
+   {completed_heartbeat}
+   ```
+5. Report the commit SHA and validation evidence, then stop. Do not replace the completed status with an idle or working heartbeat unless a new ACTIVE assignment is issued."#,
             variant_name = variant_name,
             worktree_path = worktree_path,
             branch = branch,
@@ -3313,6 +3330,7 @@ Read {task_file}. Begin work only when Status is ACTIVE.{polling_instructions}"#
             task_file = task_file,
             startup_heartbeat = startup_heartbeat,
             polling_instructions = polling_instructions,
+            completed_heartbeat = completed_heartbeat,
         )
     }
 
@@ -3639,7 +3657,7 @@ Last updated: {timestamp}
     /// they must not mutate the project or its git state. Used for BOTH the worker
     /// prompt and the task file so the two surfaces stay consistent.
     fn scope_block_read_only() -> String {
-        "## Scope (Read-Only)\n\nThis is a research role. You MUST NOT create, modify, move, or delete any files, and you MUST NOT run commands that mutate the project or its git state. Read freely and investigate, then report your findings to the Queen via the conversation API — your only deliverable is knowledge.".to_string()
+        "## Scope (Read-Only)\n\nThis is a research role. You MUST NOT create, modify, move, or delete project files, and you MUST NOT run commands that mutate the project or its git state. The only permitted filesystem write is updating the status/result fields in the exact Hive control-plane task file named by your prompt. Read freely and investigate, then report your findings to the Queen via the conversation API — your deliverable is knowledge.".to_string()
     }
 
     fn queen_quality_reconciliation_log_lines(has_evaluator: bool) -> &'static str {
@@ -3651,13 +3669,18 @@ Last updated: {timestamp}
     }
 
     fn queen_required_protocol(session_root: &Path, has_evaluator: bool) -> String {
+        let mark_worker_status_path =
+            Self::prompt_path(&session_root.join("tools").join("mark-worker-status.md"));
         if !has_evaluator {
-            return r#"## Required Protocol
+            return format!(
+                r#"## Required Protocol
 ```text
 1. You MUST follow every numbered protocol in this prompt exactly as written.
 2. You MUST use the inline bash polling commands shown in this prompt. You MUST NOT use `/loop`.
-```"#
-                .to_string();
+3. When you independently verify a managed principal, researcher, or Fusion variant is complete, you MUST immediately mark its exact agent ID `completed` using `{mark_worker_status_path}`. The UI completion checkoff and stall monitor depend on it.
+```"#,
+                mark_worker_status_path = mark_worker_status_path,
+            );
         }
 
         let milestone_ready_path =
@@ -3672,9 +3695,11 @@ Last updated: {timestamp}
 3. The Evaluator is created PROGRAMMATICALLY by the backend at session launch (`spawn_launch_evaluator_agents`). It already exists as `AgentRole::Evaluator`.
 4. You MUST NOT spawn an Evaluator yourself. DO NOT `curl POST /workers` with `role=evaluator`. DO NOT `curl POST /evaluators`.
 5. You MUST signal the existing Evaluator via `{milestone_ready_path}` and WAIT for `{qa_verdict_path}`.
+6. When you independently verify a managed principal, researcher, or Fusion variant is complete, you MUST immediately mark its exact agent ID `completed` using `{mark_worker_status_path}`. The UI completion checkoff and stall monitor depend on it.
 ```"#,
             milestone_ready_path = milestone_ready_path,
             qa_verdict_path = qa_verdict_path,
+            mark_worker_status_path = mark_worker_status_path,
         )
     }
 
@@ -4146,9 +4171,20 @@ Hard rule: The Evaluator AND the Prince are created PROGRAMMATICALLY by the back
 
         let mut variables = HashMap::new();
         variables.insert("qa_worker_index".to_string(), index.to_string());
+        let qa_worker_agent_id = format!("{}-qa-worker-{}", session_id, index);
         variables.insert(
             "qa_worker_agent_id".to_string(),
-            format!("{}-qa-worker-{}", session_id, index),
+            qa_worker_agent_id.clone(),
+        );
+        variables.insert(
+            "qa_worker_completed_heartbeat".to_string(),
+            heartbeat_snippet(
+                "http://localhost:18800",
+                session_id,
+                &qa_worker_agent_id,
+                "completed",
+                "Completed QA assignment",
+            ),
         );
         variables.insert(
             "custom_instructions".to_string(),
@@ -4450,8 +4486,8 @@ Do not run the debate. Stop after writing the plan.
         let mut task_files = String::new();
         for v in variants {
             variant_info.push_str(&format!(
-                "| {} | {} | {} | {} |\n",
-                v.index, v.name, v.branch, v.worktree_path
+                "| {} | {} | `{}` | {} | {} |\n",
+                v.index, v.name, v.agent_id, v.branch, v.worktree_path
             ));
             task_files.push_str(&format!(
                 "- Variant {} ({}): `{}`\n",
@@ -4531,8 +4567,8 @@ You are the **Queen** monitoring a Fusion session where {variant_count} variants
 
 ## Variants
 
-| # | Name | Branch | Worktree |
-|---|------|--------|----------|
+| # | Name | Agent ID | Branch | Worktree |
+|---|------|----------|--------|----------|
 {variant_info}
 
 ## Task Files to Monitor
@@ -4581,6 +4617,7 @@ Write status updates to `.hive-manager/{session_id}/coordination.log`:
 ## Learning Tools
 
 Read tool docs in `.hive-manager/{session_id}/tools/` for:
+- `mark-worker-status.md` — Mark each independently verified variant complete
 - `submit-learning.md` — Record observations
 - `list-learnings.md` — View existing learnings
 "#,
@@ -5295,14 +5332,14 @@ This tests that:
             smoke_worker_start_heartbeat = heartbeat_snippet(
                 "http://localhost:18800",
                 session_id,
-                "worker-1",
+                &format!("{session_id}-worker-1"),
                 "working",
                 "Starting smoke test",
             ),
             smoke_worker_completed_heartbeat = heartbeat_snippet(
                 "http://localhost:18800",
                 session_id,
-                "worker-1",
+                &format!("{session_id}-worker-1"),
                 "completed",
                 "Smoke test done",
             ),
@@ -5991,10 +6028,11 @@ When the objective and every configured gate are complete, send an idle heartbea
             stop_conditions: &stop_conditions,
         });
 
+        let agent_id = format!("{session_id}-worker-{index}");
         let activation_wait_heartbeat = heartbeat_snippet(
             "http://localhost:18800",
             session_id,
-            &format!("worker-{index}"),
+            &agent_id,
             "idle",
             "Waiting for task activation",
         );
@@ -6010,9 +6048,16 @@ When the objective and every configured gate are complete, send an idle heartbea
         let working_heartbeat = heartbeat_snippet(
             "http://localhost:18800",
             session_id,
-            &format!("worker-{index}"),
+            &agent_id,
             "working",
             "Executing assigned workstream",
+        );
+        let completed_heartbeat = heartbeat_snippet(
+            "http://localhost:18800",
+            session_id,
+            &agent_id,
+            "completed",
+            "Completed assigned workstream",
         );
 
         let role_section = if is_research {
@@ -6021,20 +6066,55 @@ When the objective and every configured gate are complete, send an idle heartbea
             "## Your Role: EXECUTOR\n\nYou are a managed coding principal with implementation authority only inside the ACTIVE assignment contract."
         };
 
-        let completion_rule = if is_research {
-            "Report findings, update the task file to COMPLETED, and send the Queen a concise evidence summary. Do not commit."
+        let validation_and_handoff_rule = if is_research {
+            "Verify every material conclusion against cited evidence and confirm that the repository and git state remain unchanged. Do not commit."
         } else {
             match execution_policy.workspace_strategy {
                 WorkspaceStrategy::SharedCell => {
-                    "Run focused validation and leave the reviewed changes uncommitted for the Queen. Update the task file to COMPLETED and report evidence; the Queen owns the shared git state."
+                    "Run focused validation, review the owned diff, and leave the reviewed changes uncommitted for the Queen; the Queen owns the shared git state."
                 }
                 WorkspaceStrategy::IsolatedCell => {
-                    "Run focused validation, commit only the completed assignment on the current backend-created cell branch, then update the task file to COMPLETED and report the commit SHA plus evidence. Do not push."
+                    "Run focused validation and commit only the completed assignment on the current backend-created cell branch. Do not push or switch branches."
                 }
                 WorkspaceStrategy::None => {
-                    "Run focused validation, update the task file to COMPLETED, and report evidence. Do not mutate git without explicit operator authorization."
+                    "Run focused validation and review the owned changes. Do not mutate git without explicit operator authorization."
                 }
             }
+        };
+
+        let completion_protocol = if is_research {
+            format!(
+                r#"## Completion Protocol (MANDATORY)
+
+1. {validation_and_handoff_rule}
+2. Update the authoritative task file at {task_file} to `Status: COMPLETED` and add the evidence summary.
+3. Send this completed heartbeat exactly as shown:
+   ```bash
+   {completed_heartbeat}
+   ```
+4. Send the Queen a concise findings summary with citations, then stop. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
+"#,
+                validation_and_handoff_rule = validation_and_handoff_rule,
+                task_file = task_file,
+                completed_heartbeat = completed_heartbeat,
+            )
+        } else {
+            format!(
+                r#"## Completion Protocol (MANDATORY)
+
+1. {validation_and_handoff_rule}
+2. Complete the Learnings Protocol below before changing the task status.
+3. Update the authoritative task file at {task_file} to `Status: COMPLETED` and add the result summary.
+4. Send this completed heartbeat exactly as shown:
+   ```bash
+   {completed_heartbeat}
+   ```
+5. Send the Queen the commit SHA when applicable plus focused validation evidence, then stop. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
+"#,
+                validation_and_handoff_rule = validation_and_handoff_rule,
+                task_file = task_file,
+                completed_heartbeat = completed_heartbeat,
+            )
         };
 
         let learnings_section = if is_research {
@@ -6090,9 +6170,11 @@ Use only the native tools exposed by the configured harness. The Capability Card
 3. Begin only when Status is ACTIVE.
 4. Stay inside the objective and owned paths. Ask the Queen when ownership or acceptance criteria are unclear.
 5. If blocked, set Status to BLOCKED and report the exact blocker.
-6. On completion: {completion_rule}
+6. When work is complete, follow the mandatory Completion Protocol below exactly.
 
 {polling_instructions}
+
+{completion_protocol}
 
 ## Communication
 
@@ -6106,7 +6188,7 @@ Use only the native tools exposed by the configured harness. The Capability Card
 Heartbeat while active:
 {working_heartbeat}
 
-{learnings_section}{project_context}After completion, send an idle heartbeat and continue monitoring the inbox. Do not take a new task until its task file status is ACTIVE."#,
+{learnings_section}{project_context}After reporting completion, stop and continue monitoring the inbox without sending another heartbeat. Do not take a new task until its task file status is ACTIVE; once reactivated, send a working heartbeat."#,
             index = index,
             role_name = role_name,
             role_kernel = role_kernel,
@@ -6122,8 +6204,8 @@ Heartbeat while active:
             workspace_path = workspace_path,
             task_file = task_file,
             scope_block = scope_block,
-            completion_rule = completion_rule,
             polling_instructions = polling_instructions,
+            completion_protocol = completion_protocol,
             worker_conversation = worker_conversation,
             queen_conversation = queen_conversation,
             shared_conversation = shared_conversation,
@@ -6396,6 +6478,7 @@ Tool documentation is in `.hive-manager/{session_id}/tools/`. Read these files f
 | List Planners | `list-planners.md` | Get list of all planners and their status |
 | Spawn Worker | `spawn-worker.md` | Reference only - Planners use this to spawn workers |
 | List Workers | `list-workers.md` | Get list of all workers and their status |
+| Mark Worker Status | `mark-worker-status.md` | Mark each independently verified worker complete |
 | Submit Learning | `submit-learning.md` | Record a learning via HTTP API |
 | List Learnings | `list-learnings.md` | Get all learnings for this session |
 | Delete Learning | `delete-learning.md` | Remove a learning by ID |
@@ -6585,10 +6668,11 @@ Log each iteration to `.hive-manager/{session_id}/coordination.log`:
         session_id: &str,
         default_cli: &str,
     ) -> Result<(), String> {
-        let worker_task_file_example = ".hive-manager/tasks/worker-N-task.md".to_string();
+        let worker_task_file_example = "<absolute task path returned by the backend>".to_string();
         let qa_task_file_example =
             format!(".hive-manager/{}/tasks/qa-worker-N-task.md", session_id);
-        let worker_one_task_file_example = ".hive-manager/tasks/worker-1-task.md".to_string();
+        let worker_one_task_file_example =
+            "<absolute task path returned for worker 1>".to_string();
 
         // Spawn Worker tool
         let spawn_worker_tool = format!(
@@ -6663,8 +6747,12 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
 ## Notes
 
 - Workers spawn in a new Windows Terminal tab (visible window)
-- Each worker's task file is `.hive-manager/tasks/worker-N-task.md` inside its assigned workspace, whether that workspace is the shared cell or an isolated cell
-- Workers poll their task files for ACTIVE status
+- Treat the absolute `task_file` returned by the API as authoritative; do not reconstruct it from the worker ID
+- Shared-cell Hive: the task file is under `.hive-manager/tasks/` in the shared primary workspace
+- Isolated-cell Hive: the task file is under `.hive-manager/tasks/` in that worker's isolated workspace
+- Research/no-worktree Hive: the task file is under `.hive-manager/{session_id}/tasks/` in the operator project
+- Workers poll the returned task file for ACTIVE status
+- Dynamic principals are supported by Hive/Research sessions. Fusion variants use their pre-created Fusion task files instead of this endpoint
 - Use this to spawn workers sequentially as tasks complete
 "#,
             session_id = session_id,
@@ -6793,6 +6881,62 @@ curl "http://localhost:18800/api/sessions/{session_id}/workers"
             session_id,
             "list-workers.md",
             &list_workers_tool,
+        )?;
+
+        let completed_status_example = heartbeat_snippet(
+            "http://localhost:18800",
+            session_id,
+            "<exact-agent-id>",
+            "completed",
+            "Queen verified completion: replace with concise gate evidence",
+        );
+        let mark_worker_status_tool = format!(
+            r#"# Mark Worker Status Tool
+
+Record an agent heartbeat/status after independently verifying its state. The Queen MUST use this tool after verifying a managed principal, researcher, or Fusion variant is complete because the UI completion checkoff and stall monitor read this status.
+
+## HTTP API
+
+**Endpoint:** `POST http://localhost:18800/api/sessions/{session_id}/heartbeat`
+
+**Headers:**
+```text
+Content-Type: application/json
+```
+
+## Request Body
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| agent_id | string | Yes | Exact full agent ID from the roster or worker API, such as `{session_id}-worker-2` or `{session_id}-fusion-1` |
+| status | string | Yes | `working`, `idle`, or `completed` |
+| summary | string | No | Concise evidence-backed status summary |
+
+## Mark a Verified Completion
+
+Replace `<exact-agent-id>` with the verified agent's exact full ID and replace the summary with the gates you checked, then run:
+
+```bash
+{completed_status_example}
+```
+
+For a Fusion variant or another agent type, keep the request identical and use the exact ID shown in the Queen roster.
+
+## Verification Rule
+
+- Verify the deliverable and required gates before sending `completed`; a task-file claim alone is not sufficient.
+- Use the exact full agent ID. A shortened ID such as `worker-N` will not drive that agent's UI status, and the `<exact-agent-id>` placeholder fails validation if left unchanged.
+- Send `completed` immediately after verification. A later `working` or `idle` heartbeat replaces it, so do not downgrade a completed agent unless it has received a new ACTIVE assignment.
+"#,
+            session_id = session_id,
+            completed_status_example = completed_status_example,
+        );
+
+        Self::write_tool_file(
+            project_path,
+            session_id,
+            "mark-worker-status.md",
+            &mark_worker_status_tool,
         )?;
 
         // Submit Learning tool
@@ -13847,8 +13991,8 @@ fn include_in_worker_roster(role: &AgentRole) -> bool {
 mod tests {
     use super::{
         extract_model_arg, parse_persisted_session_state, serialize_session_state, AgentConfig,
-        AgentInfo, AuthStrategy, CompletionError, QaWorkerConfig, Session, SessionController,
-        SessionError, SessionState, SessionType,
+        AgentInfo, AuthStrategy, CompletionError, FusionVariantMetadata, QaWorkerConfig, Session,
+        SessionController, SessionError, SessionState, SessionType,
     };
     use crate::domain::{ArtifactBundle, HiveExecutionPolicy, WorkspaceStrategy};
     use crate::pty::{AgentRole, AgentStatus, PtyManager, WorkerRole};
@@ -13902,6 +14046,40 @@ mod tests {
         let _completed = SessionState::Completed;
         let _closed = SessionState::Closed;
         let _failed = SessionState::Failed("error".to_string());
+    }
+
+    #[test]
+    fn stall_sweep_excludes_completed_heartbeats() {
+        let controller = test_controller();
+        controller
+            .update_heartbeat("session-stall", "session-stall-worker-1", "working", None)
+            .expect("record working heartbeat");
+        controller
+            .update_heartbeat(
+                "session-stall",
+                "session-stall-worker-2",
+                "completed",
+                Some("Queen verified completion"),
+            )
+            .expect("record completed heartbeat");
+
+        let stale_at = Utc::now() - Duration::minutes(5);
+        let mut heartbeats = controller.agent_heartbeats.write();
+        for heartbeat in heartbeats
+            .get_mut("session-stall")
+            .expect("session heartbeat map")
+            .values_mut()
+        {
+            heartbeat.last_activity = stale_at;
+        }
+        drop(heartbeats);
+
+        let stalled = controller.get_stalled_agents(
+            "session-stall",
+            std::time::Duration::from_secs(30),
+        );
+        assert_eq!(stalled.len(), 1);
+        assert_eq!(stalled[0].0, "session-stall-worker-1");
     }
 
     #[test]
@@ -14164,6 +14342,41 @@ mod tests {
         assert!(prompt.contains("axe-core"));
         assert!(prompt.contains("/repo/execution"));
         assert!(!prompt.contains("UI Tester"));
+        assert!(prompt.contains("## Completion Protocol (MANDATORY)"));
+        assert!(
+            prompt.contains(".hive-manager/session-123/tasks/qa-worker-1-task.md")
+        );
+        assert!(prompt.contains(r#""agent_id":"session-123-qa-worker-1""#));
+        assert!(prompt.contains(r#""status":"completed""#));
+        assert!(!prompt.contains("{{qa_worker_completed_heartbeat}}"));
+    }
+
+    #[test]
+    fn every_qa_worker_prompt_has_a_ready_completed_heartbeat() {
+        for specialization in ["ui", "api", "a11y", "adversarial"] {
+            let prompt = SessionController::build_qa_worker_prompt(
+                "session-qa",
+                3,
+                specialization,
+                &AgentConfig::default(),
+                &AuthStrategy::default(),
+                "/repo/execution",
+            );
+
+            let completion = extract_markdown_section(
+                &prompt,
+                "## Completion Protocol (MANDATORY)",
+            );
+            assert!(
+                completion.contains(r#""agent_id":"session-qa-qa-worker-3""#),
+                "missing exact agent ID for {specialization}"
+            );
+            assert!(
+                completion.contains(r#""status":"completed""#),
+                "missing completed status for {specialization}"
+            );
+            assert!(completion.contains("curl -fsS -X POST"));
+        }
     }
 
     #[test]
@@ -14424,8 +14637,25 @@ mod tests {
         assert!(worker_content.contains("| flags | string[] | No |"));
         assert!(worker_content.contains("Omit to inherit principal flags; send `[]` to clear them"));
         assert!(!worker_content.contains(r#"{\"role_type\": \"backend\", \"cli\""#));
-        assert!(worker_content.contains("inside its assigned workspace"));
+        assert!(worker_content.contains("absolute `task_file` returned by the API"));
+        assert!(worker_content.contains("Shared-cell Hive"));
+        assert!(worker_content.contains("Isolated-cell Hive"));
+        assert!(worker_content.contains("Research/no-worktree Hive"));
         assert!(!worker_content.contains("inside that worker's worktree"));
+
+        let status_tool_path = temp_dir
+            .path()
+            .join(".hive-manager")
+            .join("session-123")
+            .join("tools")
+            .join("mark-worker-status.md");
+        let status_content =
+            std::fs::read_to_string(status_tool_path).expect("read status tool doc");
+        assert!(status_content.contains("Queen MUST use this tool"));
+        assert!(status_content.contains(r#""agent_id":"<exact-agent-id>""#));
+        assert!(status_content.contains(r#""status":"completed""#));
+        assert!(status_content.contains("shortened ID such as `worker-N`"));
+        assert!(status_content.contains("placeholder fails validation"));
     }
 
     fn shared_meta_harness_policy() -> HiveExecutionPolicy {
@@ -14526,6 +14756,8 @@ mod tests {
         assert!(prompt.contains("Principals do not commit"));
         assert!(prompt.contains("backend-created hive/session-modern/primary branch"));
         assert!(prompt.contains("Managed principals are visible Hive agents"));
+        assert!(prompt.contains("mark-worker-status.md"));
+        assert!(prompt.contains("UI completion checkoff and stall monitor depend on it"));
         assert!(!prompt.contains("full Claude Code capabilities"));
         assert!(!prompt.contains("Claude Code Tools"));
         assert!(!prompt.contains("git checkout -b"));
@@ -14555,6 +14787,9 @@ mod tests {
             .contains("Runtime CWD: /repo/.hive-manager/worktrees/session-modern/primary"));
         assert!(shared_prompt.contains("leave the reviewed changes uncommitted for the Queen"));
         assert!(shared_prompt.contains("Learnings Protocol (MANDATORY)"));
+        assert!(shared_prompt.contains("Completion Protocol (MANDATORY)"));
+        assert!(shared_prompt.contains(r#""agent_id":"session-modern-worker-1""#));
+        assert!(shared_prompt.contains(r#""status":"completed""#));
         assert!(shared_prompt.contains("Begin only when Status is ACTIVE"));
         assert!(shared_prompt.contains("Polling Protocol (MANDATORY)"));
         assert!(shared_prompt.contains("while true; do"));
@@ -14563,7 +14798,7 @@ mod tests {
         let isolated_policy = HiveExecutionPolicy {
             launch_kind: crate::domain::HiveLaunchKind::Hive,
             workspace_strategy: crate::domain::WorkspaceStrategy::IsolatedCell,
-            ..shared_policy
+            ..shared_policy.clone()
         };
         let isolated_prompt = SessionController::build_worker_prompt(
             1,
@@ -14575,8 +14810,28 @@ mod tests {
             &isolated_policy,
         );
         assert!(isolated_prompt.contains("Commit the completed assignment"));
-        assert!(isolated_prompt.contains("report the commit SHA plus evidence"));
+        assert!(isolated_prompt
+            .contains("commit SHA when applicable plus focused validation evidence"));
         assert!(isolated_prompt.contains("Do not create or switch branches"));
+
+        let no_workspace_policy = HiveExecutionPolicy {
+            workspace_strategy: WorkspaceStrategy::None,
+            ..shared_policy
+        };
+        let no_workspace_prompt = SessionController::build_worker_prompt(
+            1,
+            &principal,
+            "session-modern-queen",
+            "session-modern",
+            Path::new("/repo"),
+            Path::new("/repo"),
+            &no_workspace_policy,
+        );
+        assert!(no_workspace_prompt
+            .contains("/repo/.hive-manager/session-modern/tasks/worker-1-task.md"));
+        assert!(no_workspace_prompt.contains("Do not mutate git without explicit operator"));
+        assert!(no_workspace_prompt.contains("Completion Protocol (MANDATORY)"));
+        assert!(no_workspace_prompt.contains(r#""status":"completed""#));
     }
 
     #[test]
@@ -14682,6 +14937,12 @@ mod tests {
         assert!(prompt.contains(&expected_task_path));
         assert!(!prompt.contains("## Your Role: EXECUTOR"));
         assert!(!prompt.contains("Learnings Protocol (MANDATORY)"));
+        assert!(prompt.contains("Completion Protocol (MANDATORY)"));
+        assert!(prompt.contains(r#""agent_id":"session-research-readonly-worker-1""#));
+        assert!(prompt.contains(r#""status":"completed""#));
+        assert!(prompt.contains("repository and git state remain unchanged"));
+        assert!(prompt.contains("only permitted filesystem write"));
+        assert!(prompt.contains("exact Hive control-plane task file"));
 
         // Task file (read_only=true): read-only role constraints, no EXECUTOR.
         let task_path = SessionController::write_task_file_with_status(
@@ -14695,6 +14956,7 @@ mod tests {
         let task = std::fs::read_to_string(&task_path).unwrap();
         assert!(task.contains("RESEARCHER (READ-ONLY)"));
         assert!(!task.contains("EXECUTOR"));
+        assert!(task.contains("only permitted filesystem write"));
     }
 
     #[test]
@@ -14745,6 +15007,11 @@ mod tests {
             expected
         );
         assert_eq!(extract_markdown_section(&task_file, "## Scope"), expected);
+        let fusion_completion =
+            extract_markdown_section(&fusion_prompt, "## Completion Protocol (MANDATORY)");
+        assert!(fusion_completion.contains(r#""agent_id":"session-scope-equality-fusion-1""#));
+        assert!(fusion_completion.contains(r#""status":"completed""#));
+        assert!(fusion_completion.contains("curl -fsS -X POST"));
     }
 
     #[test]
@@ -14795,6 +15062,32 @@ mod tests {
             extract_markdown_section(&swarm_queen_prompt, "## Required Protocol")
                 .starts_with(&expected)
         );
+        assert!(expected.contains("mark-worker-status.md"));
+        assert!(expected.contains("UI completion checkoff and stall monitor depend on it"));
+    }
+
+    #[test]
+    fn fusion_queen_roster_exposes_exact_agent_ids() {
+        let variants = vec![FusionVariantMetadata {
+            index: 1,
+            name: "Safe Variant".to_string(),
+            slug: "safe-variant".to_string(),
+            branch: "fusion/session-123/variant-1".to_string(),
+            worktree_path: "/repo/.hive-manager/worktrees/session-123/fusion-1".to_string(),
+            task_file: "/repo/.hive-manager/session-123/tasks/fusion-1.md".to_string(),
+            agent_id: "session-123-fusion-1".to_string(),
+        }];
+        let prompt = SessionController::build_fusion_queen_prompt(
+            "claude",
+            Path::new("/repo"),
+            "session-123",
+            &variants,
+            "Test task",
+            false,
+        );
+
+        assert!(prompt.contains("| # | Name | Agent ID | Branch | Worktree |"));
+        assert!(prompt.contains("| 1 | Safe Variant | `session-123-fusion-1` |"));
     }
 
     #[test]

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -225,13 +225,15 @@ impl QueueRepo {
         })
     }
 
-    /// Record a heartbeat for a running row and advance the progress counters.
+    /// Record a heartbeat for a nonterminal row and advance the progress counters.
     ///
     /// State machine: if the incoming `status` equals the stored `last_status`, the worker
     /// made no progress → `no_progress_count += 1`. If it changed (or there was no prior
     /// status), it is a continuation → `continuation_count += 1`, `no_progress_count = 0`,
-    /// and `last_status` is updated. Always refreshes `heartbeat_at`. Returns `true` if a
-    /// row was updated.
+    /// and `last_status` is updated. A `completed` heartbeat atomically moves a queued or
+    /// running row to the existing terminal `finalized` state so stale-run maintenance cannot
+    /// reclaim verified work. Failed rows are never overwritten. Always refreshes
+    /// `heartbeat_at`. Returns `true` if a row was updated.
     pub fn record_heartbeat(
         &self,
         session_id: &str,
@@ -242,7 +244,10 @@ impl QueueRepo {
         self.db.with_conn(|conn| {
             conn.execute(
                 "UPDATE agent_run_queue
-                 SET heartbeat_at = ?3,
+                 SET status = CASE
+                         WHEN ?4 = 'completed' AND status IN ('queued', 'running')
+                         THEN 'finalized' ELSE status END,
+                     heartbeat_at = ?3,
                      updated_at = ?3,
                      no_progress_count = CASE
                          WHEN last_status IS NOT NULL AND last_status = ?4
@@ -251,7 +256,8 @@ impl QueueRepo {
                          WHEN last_status IS NULL OR last_status <> ?4
                          THEN continuation_count + 1 ELSE continuation_count END,
                      last_status = ?4
-                 WHERE session_id = ?1 AND worker_id = ?2",
+                 WHERE session_id = ?1 AND worker_id = ?2
+                   AND status IN ('queued', 'running')",
                 params![session_id, worker_id, now_ms, status],
             )?;
             Ok(conn.changes() >= 1)
@@ -545,6 +551,37 @@ mod tests {
 
         // The reclaimed row is now claimable again.
         assert!(repo.try_claim("stale", 1000, 10000).unwrap());
+    }
+
+    #[test]
+    fn test_completed_heartbeat_finalizes_and_cannot_be_reclaimed() {
+        let repo = repo();
+        let mut row = sample_row("r1", "s1", "s1-worker-1");
+        row.status = QueueStatus::Running;
+        row.heartbeat_at = Some(100);
+        repo.enqueue(&row).unwrap();
+
+        assert!(repo
+            .record_heartbeat("s1", "s1-worker-1", "completed", 200)
+            .unwrap());
+
+        let completed = repo.get_row("r1").unwrap().unwrap();
+        assert_eq!(completed.status, QueueStatus::Finalized);
+        assert_eq!(completed.last_status.as_deref(), Some("completed"));
+        assert_eq!(completed.heartbeat_at, Some(200));
+        assert!(repo.reclaim_stuck(1_000, 2_000).unwrap().is_empty());
+        assert!(!repo.try_claim("r1", 1_000, 2_000).unwrap());
+
+        let mut failed = sample_row("failed", "s1", "s1-worker-2");
+        failed.status = QueueStatus::Failed;
+        repo.enqueue(&failed).unwrap();
+        assert!(!repo
+            .record_heartbeat("s1", "s1-worker-2", "completed", 300)
+            .unwrap());
+        assert_eq!(
+            repo.get_row("failed").unwrap().unwrap().status,
+            QueueStatus::Failed
+        );
     }
 
     #[test]

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -721,6 +721,16 @@ You MUST use your native browser tools directly. Do NOT search the codebase for 
 - URL: {{auth_bypass_url}}
 - Token: {{auth_bypass_token}}
 
+## Completion Protocol (MANDATORY)
+
+1. Prepare the final criterion-numbered evidence described below.
+2. In `.hive-manager/{{session_id}}/tasks/qa-worker-{{qa_worker_index}}-task.md`, set `Status: COMPLETED` and add the evidence under a Result section.
+3. Send this completed heartbeat exactly as shown:
+   ```bash
+   {{qa_worker_completed_heartbeat}}
+   ```
+4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+
 ## Report Format
 
 ```text
@@ -783,6 +793,16 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
 - URL: {{auth_bypass_url}}
 - Token: {{auth_bypass_token}}
 
+## Completion Protocol (MANDATORY)
+
+1. Prepare the final criterion-numbered evidence described below.
+2. In `.hive-manager/{{session_id}}/tasks/qa-worker-{{qa_worker_index}}-task.md`, set `Status: COMPLETED` and add the evidence under a Result section.
+3. Send this completed heartbeat exactly as shown:
+   ```bash
+   {{qa_worker_completed_heartbeat}}
+   ```
+4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+
 ## Report Format
 
 ```text
@@ -844,6 +864,16 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
 
 - URL: {{auth_bypass_url}}
 - Token: {{auth_bypass_token}}
+
+## Completion Protocol (MANDATORY)
+
+1. Prepare the final criterion-numbered evidence described below.
+2. In `.hive-manager/{{session_id}}/tasks/qa-worker-{{qa_worker_index}}-task.md`, set `Status: COMPLETED` and add the evidence under a Result section.
+3. Send this completed heartbeat exactly as shown:
+   ```bash
+   {{qa_worker_completed_heartbeat}}
+   ```
+4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -912,6 +942,16 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
 
 - URL: {{auth_bypass_url}}
 - Token: {{auth_bypass_token}}
+
+## Completion Protocol (MANDATORY)
+
+1. Prepare the final criterion-numbered evidence described below.
+2. In `.hive-manager/{{session_id}}/tasks/qa-worker-{{qa_worker_index}}-task.md`, set `Status: COMPLETED` and add the evidence under a Result section.
+3. Send this completed heartbeat exactly as shown:
+   ```bash
+   {{qa_worker_completed_heartbeat}}
+   ```
+4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -1207,6 +1247,10 @@ You are the Queen agent orchestrating a Hive session with direct worker manageme
 2. **Monitor progress**: Check coordination.log for updates
 3. **Add workers**: Request additional workers if needed
 
+## Verified Completion Status (MANDATORY)
+
+When you independently verify a worker is complete, immediately use `.hive-manager/{{session_id}}/tools/mark-worker-status.md` to mark its exact full agent ID `completed`. The UI completion checkoff and stall monitor depend on it.
+
 ## Start Here
 
 Before assigning work, read project context via HTTP API:
@@ -1345,6 +1389,10 @@ Ground your research in existing institutional knowledge before delegating.
 4. **Poll & heartbeat** while researchers work — check the coordination log and worker conversations for progress.
 5. **Collect** each researcher's findings summary as they report in via the conversation API (researchers report findings to you directly — they do not write files into the project).
 
+### Verified Completion Status (MANDATORY)
+
+When you independently verify a researcher's findings are complete, immediately use `.hive-manager/{{session_id}}/tools/mark-worker-status.md` to mark its exact full agent ID `completed`. The UI completion checkoff and stall monitor depend on it.
+
 ### Inter-Agent Communication
 #### Check your inbox:
 curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?since=<last_check_ts>"
@@ -1414,6 +1462,10 @@ You are the Queen agent orchestrating a Fusion session with competing candidate 
 1. **Assign tasks**: Send messages to workers via the coordination system
 2. **Monitor progress**: Check coordination.log for updates
 3. **Add workers**: Request additional workers if needed
+
+## Verified Completion Status (MANDATORY)
+
+When you independently verify a Fusion variant is complete, immediately use `.hive-manager/{{session_id}}/tools/mark-worker-status.md` to mark its exact full agent ID `completed`. The UI completion checkoff and stall monitor depend on it.
 
 ## Start Here
 
@@ -1550,6 +1602,10 @@ You are the Queen agent orchestrating a Swarm session with hierarchical planning
 1. **Delegate to planners**: Assign high-level tasks to domain planners
 2. **Monitor progress**: Check coordination.log for updates from planners
 3. **Coordinate cross-domain**: Handle dependencies between planner domains
+
+## Verified Completion Status (MANDATORY)
+
+When you independently verify a planner or worker is complete, immediately use `.hive-manager/{{session_id}}/tools/mark-worker-status.md` to mark its exact full agent ID `completed`. The UI completion checkoff and stall monitor depend on it.
 
 ## Start Here
 
@@ -2123,6 +2179,29 @@ mod tests {
             DEFAULT_API_BASE_URL
         );
         assert_eq!(normalize_api_base_url(None), DEFAULT_API_BASE_URL);
+    }
+
+    #[test]
+    fn builtin_queen_prompts_require_marking_verified_completions() {
+        for template_name in ["queen-hive", "queen-research", "queen-fusion", "queen-swarm"] {
+            let prompt = TemplateEngine::default()
+                .render_template(
+                    template_name,
+                    &PromptContext {
+                        session_id: "session-123".to_string(),
+                        project_path: ".".to_string(),
+                        task: None,
+                        variables: HashMap::new(),
+                    },
+                )
+                .expect("render Queen prompt");
+
+            assert!(prompt.contains("Completion Status (MANDATORY)"));
+            assert!(prompt.contains(
+                ".hive-manager/session-123/tools/mark-worker-status.md"
+            ));
+            assert!(prompt.contains("UI completion checkoff and stall monitor depend on it"));
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
+  import { Brain, CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
   import { page } from '$app/stores';
   import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type ResumeReport, type HiveLaunchConfig, type ResearchLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { layout, RAIL_WIDTH } from '$lib/stores/layout';
@@ -84,6 +84,11 @@
 
   let collapsed = $derived($layout.leftCollapsed);
   let sidebarWidth = $derived(collapsed ? RAIL_WIDTH : $layout.leftWidth);
+  let knowledgeHref = $derived(
+    $activeSession
+      ? `/knowledge?session_id=${encodeURIComponent($activeSession.id)}`
+      : '/knowledge',
+  );
 
   onMount(async () => {
     // Get current working directory first
@@ -368,11 +373,12 @@
   <div class="sidebar-header" class:collapsed>
     <nav class="view-toggle" class:collapsed aria-label="View switcher">
       {#each [
-        { path: '/', icon: House, label: 'Sessions' },
-        { path: '/dashboard', icon: Kanban, label: 'Dashboard' }
-      ] as { path, icon: Icon, label } (path)}
+        { path: '/', href: '/', icon: House, label: 'Sessions' },
+        { path: '/dashboard', href: '/dashboard', icon: Kanban, label: 'Dashboard' },
+        { path: '/knowledge', href: knowledgeHref, icon: Brain, label: 'Knowledge' }
+      ] as { path, href, icon: Icon, label } (path)}
         <a
-          href={path}
+          {href}
           class="view-link"
           class:active={$page.url.pathname === path}
           aria-label={label}

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte
@@ -12,6 +12,23 @@
     onSelect: (id: string, trigger?: Element) => void;
   }
 
+  interface DragSnapshot {
+    id: string;
+    x: number;
+    y: number;
+    vx: number;
+    vy: number;
+    fx: number | null;
+    fy: number | null;
+  }
+
+  const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+  function getReducedMotionQuery(): MediaQueryList | null {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return null;
+    return window.matchMedia(REDUCED_MOTION_QUERY);
+  }
+
   let { nodes, edges, selectedId, onSelect }: Props = $props();
   let host: HTMLDivElement;
   let svg: SVGSVGElement;
@@ -27,7 +44,9 @@
   let dragStartX = 0;
   let dragStartY = 0;
   let dragMoved = false;
-  let wasPinned = false;
+  let dragSnapshot: DragSnapshot | null = null;
+  let reducedMotionQuery = getReducedMotionQuery();
+  let reducedMotion = $state(reducedMotionQuery?.matches ?? false);
 
   let positionById = $derived.by(() => new Map(positions.map((node) => [node.id, node])));
   let pinnedCount = $derived(positions.filter((node) => node.fx !== null).length);
@@ -50,7 +69,7 @@
   }
 
   function animate() {
-    if (!simulation) {
+    if (!simulation || reducedMotion) {
       animationFrame = null;
       return;
     }
@@ -64,6 +83,11 @@
   }
 
   function scheduleAnimation() {
+    if (reducedMotion) {
+      stopAnimation();
+      if (simulation) positions = [...simulation.nodes];
+      return;
+    }
     if (animationFrame === null) animationFrame = requestAnimationFrame(animate);
   }
 
@@ -76,7 +100,7 @@
     stopAnimation();
     simulation = createForceSimulation(currentNodes, currentEdges, currentWidth, currentHeight);
     positions = [...simulation.nodes];
-    scheduleAnimation();
+    untrack(() => scheduleAnimation());
 
     return () => stopAnimation();
   });
@@ -88,7 +112,7 @@
 
     simulation.setBounds(currentWidth, currentHeight);
     positions = [...simulation.nodes];
-    scheduleAnimation();
+    untrack(() => scheduleAnimation());
   });
 
   onMount(() => {
@@ -103,7 +127,25 @@
     updateSize();
     const observer = new ResizeObserver(updateSize);
     observer.observe(host);
-    return () => observer.disconnect();
+
+    reducedMotionQuery ??= getReducedMotionQuery();
+    const updateMotionPreference = () => {
+      const nextReducedMotion = reducedMotionQuery?.matches ?? false;
+      if (nextReducedMotion === reducedMotion) return;
+      reducedMotion = nextReducedMotion;
+      if (reducedMotion) {
+        stopAnimation();
+        if (simulation) positions = [...simulation.nodes];
+      } else {
+        scheduleAnimation();
+      }
+    };
+    reducedMotionQuery?.addEventListener('change', updateMotionPreference);
+
+    return () => {
+      observer.disconnect();
+      reducedMotionQuery?.removeEventListener('change', updateMotionPreference);
+    };
   });
 
   function graphPoint(event: PointerEvent): { x: number; y: number } {
@@ -123,7 +165,15 @@
     dragStartX = event.clientX;
     dragStartY = event.clientY;
     dragMoved = false;
-    wasPinned = node.fx !== null;
+    dragSnapshot = {
+      id: node.id,
+      x: node.x,
+      y: node.y,
+      vx: node.vx,
+      vy: node.vy,
+      fx: node.fx,
+      fy: node.fy,
+    };
     simulation.setPinned(node.id, node.x, node.y);
     positions = [...simulation.nodes];
     scheduleAnimation();
@@ -140,20 +190,47 @@
     scheduleAnimation();
   }
 
+  function releasePointerCapture(pointerId: number) {
+    if (draggingElement?.hasPointerCapture(pointerId)) {
+      draggingElement.releasePointerCapture(pointerId);
+    }
+  }
+
   function finishPointer(event: PointerEvent) {
     if (!draggingId || !simulation) return;
     const selected = draggingId;
     const trigger = draggingElement;
-    if (!dragMoved && !wasPinned) simulation.unpin(selected);
+    const startedPinned = dragSnapshot !== null && dragSnapshot.fx !== null && dragSnapshot.fy !== null;
+    if (!dragMoved && !startedPinned) simulation.unpin(selected);
+    releasePointerCapture(event.pointerId);
     draggingId = null;
     draggingElement = null;
+    dragSnapshot = null;
     positions = [...simulation.nodes];
     scheduleAnimation();
     onSelect(selected, trigger ?? undefined);
-    const target = event.currentTarget;
-    if (target instanceof SVGSVGElement && target.hasPointerCapture(event.pointerId)) {
-      target.releasePointerCapture(event.pointerId);
+  }
+
+  function cancelPointer(event: PointerEvent) {
+    if (!draggingId || !simulation) return;
+    const snapshot = dragSnapshot;
+    if (snapshot?.id === draggingId) {
+      const node = simulation.nodes.find((entry) => entry.id === snapshot.id);
+      if (node) {
+        node.x = snapshot.x;
+        node.y = snapshot.y;
+        node.vx = snapshot.vx;
+        node.vy = snapshot.vy;
+        node.fx = snapshot.fx;
+        node.fy = snapshot.fy;
+      }
     }
+    releasePointerCapture(event.pointerId);
+    draggingId = null;
+    draggingElement = null;
+    dragSnapshot = null;
+    positions = [...simulation.nodes];
+    scheduleAnimation();
   }
 
   function unpinNode(id: string) {
@@ -194,7 +271,7 @@
     aria-label={`Interactive knowledge graph with ${nodes.length} pages and ${edges.length} relationships`}
     onpointermove={handlePointerMove}
     onpointerup={finishPointer}
-    onpointercancel={finishPointer}
+    onpointercancel={cancelPointer}
   >
     <defs>
       <pattern id="knowledge-grid" width="28" height="28" patternUnits="userSpaceOnUse">

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte
@@ -1,0 +1,422 @@
+<script lang="ts">
+  import { onMount, untrack } from 'svelte';
+  import { ArrowClockwise } from 'phosphor-svelte';
+  import { createForceSimulation, type ForceNode, type ForceSimulation } from '$lib/knowledge/forceSim';
+  import { EDGE_COLORS, folderColor, nodeDegree } from '$lib/knowledge/graphUtils';
+  import type { KnowledgeEdge, KnowledgeNode } from '$lib/knowledge/types';
+
+  interface Props {
+    nodes: KnowledgeNode[];
+    edges: KnowledgeEdge[];
+    selectedId: string | null;
+    onSelect: (id: string, trigger?: Element) => void;
+  }
+
+  let { nodes, edges, selectedId, onSelect }: Props = $props();
+  let host: HTMLDivElement;
+  let svg: SVGSVGElement;
+  let width = $state(900);
+  let height = $state(620);
+  let positions = $state<ForceNode[]>([]);
+  let simulation: ForceSimulation | null = null;
+  let animationFrame: number | null = null;
+  let resetVersion = $state(0);
+  let hoveredId = $state<string | null>(null);
+  let draggingId: string | null = null;
+  let draggingElement: SVGGElement | null = null;
+  let dragStartX = 0;
+  let dragStartY = 0;
+  let dragMoved = false;
+  let wasPinned = false;
+
+  let positionById = $derived.by(() => new Map(positions.map((node) => [node.id, node])));
+  let pinnedCount = $derived(positions.filter((node) => node.fx !== null).length);
+  let selectedNeighbors = $derived.by(() => {
+    const ids = new Set<string>();
+    if (!selectedId) return ids;
+    ids.add(selectedId);
+    for (const edge of edges) {
+      if (edge.source === selectedId) ids.add(edge.target);
+      if (edge.target === selectedId) ids.add(edge.source);
+    }
+    return ids;
+  });
+
+  function stopAnimation() {
+    if (animationFrame !== null) {
+      cancelAnimationFrame(animationFrame);
+      animationFrame = null;
+    }
+  }
+
+  function animate() {
+    if (!simulation) {
+      animationFrame = null;
+      return;
+    }
+    const alpha = simulation.tick();
+    positions = [...simulation.nodes];
+    if (alpha > 0.008 || draggingId !== null) {
+      animationFrame = requestAnimationFrame(animate);
+    } else {
+      animationFrame = null;
+    }
+  }
+
+  function scheduleAnimation() {
+    if (animationFrame === null) animationFrame = requestAnimationFrame(animate);
+  }
+
+  $effect(() => {
+    const currentNodes = nodes;
+    const currentEdges = edges;
+    resetVersion;
+    const currentWidth = untrack(() => width);
+    const currentHeight = untrack(() => height);
+    stopAnimation();
+    simulation = createForceSimulation(currentNodes, currentEdges, currentWidth, currentHeight);
+    positions = [...simulation.nodes];
+    scheduleAnimation();
+
+    return () => stopAnimation();
+  });
+
+  $effect(() => {
+    const currentWidth = width;
+    const currentHeight = height;
+    if (!simulation) return;
+
+    simulation.setBounds(currentWidth, currentHeight);
+    positions = [...simulation.nodes];
+    scheduleAnimation();
+  });
+
+  onMount(() => {
+    const updateSize = () => {
+      const rect = host.getBoundingClientRect();
+      const nextWidth = Math.max(Math.round(rect.width), 320);
+      const nextHeight = Math.max(Math.round(rect.height), 320);
+      if (Math.abs(nextWidth - width) > 4) width = nextWidth;
+      if (Math.abs(nextHeight - height) > 4) height = nextHeight;
+    };
+
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(host);
+    return () => observer.disconnect();
+  });
+
+  function graphPoint(event: PointerEvent): { x: number; y: number } {
+    const rect = svg.getBoundingClientRect();
+    return {
+      x: ((event.clientX - rect.left) / Math.max(rect.width, 1)) * width,
+      y: ((event.clientY - rect.top) / Math.max(rect.height, 1)) * height,
+    };
+  }
+
+  function handlePointerDown(event: PointerEvent, node: ForceNode) {
+    if (event.button !== 0 || !simulation) return;
+    event.preventDefault();
+    (event.currentTarget as SVGGElement).setPointerCapture(event.pointerId);
+    draggingId = node.id;
+    draggingElement = event.currentTarget as SVGGElement;
+    dragStartX = event.clientX;
+    dragStartY = event.clientY;
+    dragMoved = false;
+    wasPinned = node.fx !== null;
+    simulation.setPinned(node.id, node.x, node.y);
+    positions = [...simulation.nodes];
+    scheduleAnimation();
+  }
+
+  function handlePointerMove(event: PointerEvent) {
+    if (!draggingId || !simulation) return;
+    if (Math.hypot(event.clientX - dragStartX, event.clientY - dragStartY) > 3) {
+      dragMoved = true;
+    }
+    const point = graphPoint(event);
+    simulation.setPinned(draggingId, point.x, point.y);
+    positions = [...simulation.nodes];
+    scheduleAnimation();
+  }
+
+  function finishPointer(event: PointerEvent) {
+    if (!draggingId || !simulation) return;
+    const selected = draggingId;
+    const trigger = draggingElement;
+    if (!dragMoved && !wasPinned) simulation.unpin(selected);
+    draggingId = null;
+    draggingElement = null;
+    positions = [...simulation.nodes];
+    scheduleAnimation();
+    onSelect(selected, trigger ?? undefined);
+    const target = event.currentTarget;
+    if (target instanceof SVGSVGElement && target.hasPointerCapture(event.pointerId)) {
+      target.releasePointerCapture(event.pointerId);
+    }
+  }
+
+  function unpinNode(id: string) {
+    simulation?.unpin(id);
+    if (simulation) positions = [...simulation.nodes];
+    scheduleAnimation();
+  }
+
+  function unpinAll() {
+    simulation?.unpinAll();
+    if (simulation) positions = [...simulation.nodes];
+    scheduleAnimation();
+  }
+
+  function radius(node: KnowledgeNode): number {
+    return Math.min(11, 5 + Math.sqrt(nodeDegree(node)) * 1.25);
+  }
+
+  function shortTitle(title: string): string {
+    return title.length > 34 ? `${title.slice(0, 31)}…` : title;
+  }
+</script>
+
+<div class="graph-host" bind:this={host}>
+  <div class="graph-controls" aria-label="Graph layout controls">
+    <span class="pin-count">{pinnedCount} pinned</span>
+    <button type="button" onclick={unpinAll} disabled={pinnedCount === 0}>Unpin all</button>
+    <button type="button" onclick={() => resetVersion += 1} title="Reset graph layout">
+      <ArrowClockwise size={13} weight="light" />
+      Reset
+    </button>
+  </div>
+
+  <svg
+    bind:this={svg}
+    viewBox={`0 0 ${width} ${height}`}
+    role="group"
+    aria-label={`Interactive knowledge graph with ${nodes.length} pages and ${edges.length} relationships`}
+    onpointermove={handlePointerMove}
+    onpointerup={finishPointer}
+    onpointercancel={finishPointer}
+  >
+    <defs>
+      <pattern id="knowledge-grid" width="28" height="28" patternUnits="userSpaceOnUse">
+        <path d="M 28 0 L 0 0 0 28" fill="none" stroke="var(--border-structural)" stroke-width="0.45" />
+      </pattern>
+      <filter id="node-glow" x="-100%" y="-100%" width="300%" height="300%">
+        <feGaussianBlur stdDeviation="2" result="glow" />
+        <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
+      </filter>
+    </defs>
+    <rect width={width} height={height} fill="url(#knowledge-grid)" />
+
+    <g class="edges" aria-hidden="true">
+      {#each edges as edge, index (`${edge.source}:${edge.target}:${edge.kind}:${index}`)}
+        {@const source = positionById.get(edge.source)}
+        {@const target = positionById.get(edge.target)}
+        {#if source && target}
+          <line
+            x1={source.x}
+            y1={source.y}
+            x2={target.x}
+            y2={target.y}
+            stroke={EDGE_COLORS[edge.kind]}
+            class:muted={selectedId !== null && edge.source !== selectedId && edge.target !== selectedId}
+            class:related={edge.kind === 'related'}
+          />
+        {/if}
+      {/each}
+    </g>
+
+    <g class="nodes">
+      {#each positions as node (node.id)}
+        {@const isSelected = node.id === selectedId}
+        {@const isMuted = selectedId !== null && !selectedNeighbors.has(node.id)}
+        <g
+          class="node"
+          class:selected={isSelected}
+          class:muted={isMuted}
+          class:pinned={node.fx !== null}
+          transform={`translate(${node.x} ${node.y})`}
+          role="button"
+          tabindex="0"
+          aria-label={`${node.title}, ${node.folder}, ${nodeDegree(node)} connections${node.fx !== null ? ', pinned' : ''}`}
+          onpointerdown={(event) => handlePointerDown(event, node)}
+          onmouseenter={() => hoveredId = node.id}
+          onmouseleave={() => hoveredId = null}
+          ondblclick={() => unpinNode(node.id)}
+          onkeydown={(event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              onSelect(node.id, event.currentTarget);
+            }
+          }}
+        >
+          <circle class="node-halo" r={radius(node) + 5} fill={folderColor(node.folder)} />
+          <circle class="node-core" r={radius(node)} fill={folderColor(node.folder)} />
+          {#if node.fx !== null}
+            <circle class="pin-mark" cx={radius(node) - 1} cy={-radius(node) + 1} r="2.5" />
+          {/if}
+          {#if isSelected || hoveredId === node.id || nodes.length <= 36}
+            <text x={radius(node) + 7} y="4">{shortTitle(node.title)}</text>
+          {/if}
+          <title>{node.title} · {node.path} · Double-click to unpin</title>
+        </g>
+      {/each}
+    </g>
+  </svg>
+
+  <div class="graph-hint">Drag to pin · Double-click to release · Select to read</div>
+</div>
+
+<style>
+  .graph-host {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    min-height: 320px;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 50% 45%, color-mix(in srgb, var(--accent-cyan) 5%, transparent), transparent 54%),
+      var(--bg-void);
+  }
+
+  svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    touch-action: none;
+    user-select: none;
+  }
+
+  .edges line {
+    stroke-width: 1;
+    stroke-opacity: 0.38;
+    transition: stroke-opacity 160ms ease;
+  }
+
+  .edges line.related {
+    stroke-dasharray: 4 4;
+  }
+
+  .edges line.muted {
+    stroke-opacity: 0.055;
+  }
+
+  .node {
+    cursor: grab;
+    outline: none;
+    opacity: 0.9;
+    transition: opacity 160ms ease;
+  }
+
+  .node:active {
+    cursor: grabbing;
+  }
+
+  .node.muted {
+    opacity: 0.16;
+  }
+
+  .node-core {
+    stroke: var(--bg-void);
+    stroke-width: 2;
+  }
+
+  .node-halo {
+    opacity: 0.08;
+  }
+
+  .node:hover .node-halo,
+  .node:focus-visible .node-halo,
+  .node.selected .node-halo {
+    opacity: 0.28;
+  }
+
+  .node:hover .node-core,
+  .node:focus-visible .node-core,
+  .node.selected .node-core {
+    stroke: var(--text-primary);
+    filter: url(#node-glow);
+  }
+
+  .node.selected .node-core {
+    stroke-width: 2.5;
+  }
+
+  .node text {
+    fill: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    paint-order: stroke;
+    stroke: var(--bg-void);
+    stroke-width: 3px;
+    stroke-linejoin: round;
+    pointer-events: none;
+  }
+
+  .pin-mark {
+    fill: var(--bg-void);
+    stroke: var(--text-primary);
+    stroke-width: 1;
+    pointer-events: none;
+  }
+
+  .graph-controls {
+    position: absolute;
+    top: var(--space-3);
+    right: var(--space-3);
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: var(--space-1);
+    border: 1px solid var(--border-structural);
+    background: color-mix(in srgb, var(--bg-surface) 91%, transparent);
+    backdrop-filter: blur(8px);
+  }
+
+  .graph-controls button {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    border: 0;
+    padding: 5px 7px;
+    background: transparent;
+    color: var(--text-secondary);
+    font: 10px var(--font-mono);
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .graph-controls button:hover:not(:disabled) {
+    color: var(--accent-cyan);
+    background: var(--bg-elevated);
+  }
+
+  .graph-controls button:disabled {
+    opacity: 0.4;
+    cursor: default;
+  }
+
+  .pin-count {
+    padding: 0 6px;
+    color: var(--text-disabled);
+    font: 10px var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .graph-hint {
+    position: absolute;
+    left: var(--space-3);
+    bottom: var(--space-3);
+    color: var(--text-disabled);
+    font: 10px var(--font-mono);
+    letter-spacing: 0.025em;
+    pointer-events: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .node,
+    .edges line {
+      transition: none;
+    }
+  }
+</style>

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+const forceMocks = vi.hoisted(() => {
+  const pinnedNode = {
+    id: 'patterns/pinned',
+    title: 'Pinned Pattern',
+    folder: 'patterns',
+    path: 'patterns/pinned.md',
+    last_updated: null,
+    in_degree: 0,
+    out_degree: 0,
+    x: 120,
+    y: 140,
+    vx: 0,
+    vy: 0,
+    fx: 120,
+    fy: 140,
+  };
+  const simulation = {
+    nodes: [pinnedNode],
+    alpha: 0,
+    tick: vi.fn(() => 0),
+    reheat: vi.fn(),
+    setBounds: vi.fn(),
+    setPinned: vi.fn(),
+    unpin: vi.fn(),
+    unpinAll: vi.fn(),
+  };
+  return {
+    pinnedNode,
+    simulation,
+    createForceSimulation: vi.fn(() => simulation),
+  };
+});
+
+vi.mock('$lib/knowledge/forceSim', () => ({
+  createForceSimulation: forceMocks.createForceSimulation,
+}));
+
+import KnowledgeGraph from './KnowledgeGraph.svelte';
+
+let resizeCallback: ResizeObserverCallback;
+let hostSize = { width: 760, height: 520 };
+
+beforeEach(() => {
+  forceMocks.createForceSimulation.mockClear();
+  forceMocks.simulation.setBounds.mockClear();
+  forceMocks.pinnedNode.fx = 120;
+  forceMocks.pinnedNode.fy = 140;
+  hostSize = { width: 760, height: 520 };
+
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    right: hostSize.width,
+    bottom: hostSize.height,
+    left: 0,
+    width: hostSize.width,
+    height: hostSize.height,
+    toJSON: () => ({}),
+  }));
+  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
+  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  vi.stubGlobal('ResizeObserver', class {
+    constructor(callback: ResizeObserverCallback) {
+      resizeCallback = callback;
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('KnowledgeGraph', () => {
+  it('updates simulation bounds without recreating the pinned layout on resize', async () => {
+    const { getByText } = render(KnowledgeGraph, {
+      props: {
+        nodes: [forceMocks.pinnedNode],
+        edges: [],
+        selectedId: null,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    expect(forceMocks.createForceSimulation).toHaveBeenCalledOnce();
+    expect(forceMocks.simulation.setBounds).toHaveBeenLastCalledWith(760, 520);
+    expect(getByText('1 pinned')).toBeTruthy();
+
+    hostSize = { width: 480, height: 360 };
+    resizeCallback([], {} as ResizeObserver);
+    await tick();
+
+    expect(forceMocks.createForceSimulation).toHaveBeenCalledOnce();
+    expect(forceMocks.simulation.setBounds).toHaveBeenLastCalledWith(480, 360);
+    expect(forceMocks.pinnedNode.fx).toBe(120);
+    expect(forceMocks.pinnedNode.fy).toBe(140);
+    expect(getByText('1 pinned')).toBeTruthy();
+  });
+});

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render } from '@testing-library/svelte';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 
 const forceMocks = vi.hoisted(() => {
@@ -15,8 +15,8 @@ const forceMocks = vi.hoisted(() => {
     y: 140,
     vx: 0,
     vy: 0,
-    fx: 120,
-    fy: 140,
+    fx: 120 as number | null,
+    fy: 140 as number | null,
   };
   const simulation = {
     nodes: [pinnedNode],
@@ -43,13 +43,43 @@ import KnowledgeGraph from './KnowledgeGraph.svelte';
 
 let resizeCallback: ResizeObserverCallback;
 let hostSize = { width: 760, height: 520 };
+let reducedMotionMatches = false;
+let motionChangeListener: (() => void) | null = null;
+let requestAnimationFrameMock: ReturnType<typeof vi.fn>;
+let cancelAnimationFrameMock: ReturnType<typeof vi.fn>;
 
 beforeEach(() => {
   forceMocks.createForceSimulation.mockClear();
+  forceMocks.simulation.tick.mockClear();
   forceMocks.simulation.setBounds.mockClear();
+  forceMocks.simulation.setPinned.mockClear();
+  forceMocks.simulation.unpin.mockClear();
+  forceMocks.simulation.unpinAll.mockClear();
+  forceMocks.pinnedNode.x = 120;
+  forceMocks.pinnedNode.y = 140;
+  forceMocks.pinnedNode.vx = 0;
+  forceMocks.pinnedNode.vy = 0;
   forceMocks.pinnedNode.fx = 120;
   forceMocks.pinnedNode.fy = 140;
+  forceMocks.simulation.setPinned.mockImplementation((_id, x, y) => {
+    forceMocks.pinnedNode.x = x;
+    forceMocks.pinnedNode.y = y;
+    forceMocks.pinnedNode.vx = 0;
+    forceMocks.pinnedNode.vy = 0;
+    forceMocks.pinnedNode.fx = x;
+    forceMocks.pinnedNode.fy = y;
+  });
+  forceMocks.simulation.unpin.mockImplementation(() => {
+    forceMocks.pinnedNode.fx = null;
+    forceMocks.pinnedNode.fy = null;
+  });
+  forceMocks.simulation.unpinAll.mockImplementation(() => {
+    forceMocks.pinnedNode.fx = null;
+    forceMocks.pinnedNode.fy = null;
+  });
   hostSize = { width: 760, height: 520 };
+  reducedMotionMatches = false;
+  motionChangeListener = null;
 
   vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(() => ({
     x: 0,
@@ -62,8 +92,32 @@ beforeEach(() => {
     height: hostSize.height,
     toJSON: () => ({}),
   }));
-  vi.stubGlobal('requestAnimationFrame', vi.fn(() => 1));
-  vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  requestAnimationFrameMock = vi.fn(() => 1);
+  cancelAnimationFrameMock = vi.fn();
+  vi.stubGlobal('requestAnimationFrame', requestAnimationFrameMock);
+  vi.stubGlobal('cancelAnimationFrame', cancelAnimationFrameMock);
+  vi.stubGlobal('PointerEvent', class extends MouseEvent {
+    readonly pointerId: number;
+
+    constructor(type: string, init: PointerEventInit = {}) {
+      super(type, init);
+      this.pointerId = init.pointerId ?? 0;
+    }
+  });
+  vi.stubGlobal('matchMedia', vi.fn((media: string) => ({
+    get matches() {
+      return reducedMotionMatches;
+    },
+    media,
+    onchange: null,
+    addEventListener: vi.fn((_type: string, listener: () => void) => {
+      motionChangeListener = listener;
+    }),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(() => true),
+  })));
   vi.stubGlobal('ResizeObserver', class {
     constructor(callback: ResizeObserverCallback) {
       resizeCallback = callback;
@@ -105,5 +159,88 @@ describe('KnowledgeGraph', () => {
     expect(forceMocks.pinnedNode.fx).toBe(120);
     expect(forceMocks.pinnedNode.fy).toBe(140);
     expect(getByText('1 pinned')).toBeTruthy();
+  });
+
+  it('uses a static layout when reduced motion is requested and reacts to preference changes', async () => {
+    reducedMotionMatches = true;
+    const { container } = render(KnowledgeGraph, {
+      props: {
+        nodes: [forceMocks.pinnedNode],
+        edges: [],
+        selectedId: null,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled();
+    expect(forceMocks.simulation.tick).not.toHaveBeenCalled();
+    expect(container.querySelector('.node')?.getAttribute('transform')).toBe('translate(120 140)');
+
+    reducedMotionMatches = false;
+    motionChangeListener?.();
+    await tick();
+
+    expect(requestAnimationFrameMock).toHaveBeenCalledOnce();
+  });
+
+  it('rolls back a cancelled drag without selecting or retaining a partial pin', async () => {
+    reducedMotionMatches = true;
+    forceMocks.pinnedNode.vx = 1.5;
+    forceMocks.pinnedNode.vy = -0.75;
+    forceMocks.pinnedNode.fx = null;
+    forceMocks.pinnedNode.fy = null;
+    const onSelect = vi.fn();
+    const { container, getByRole, getByText } = render(KnowledgeGraph, {
+      props: {
+        nodes: [forceMocks.pinnedNode],
+        edges: [],
+        selectedId: null,
+        onSelect,
+      },
+    });
+    await tick();
+
+    const node = getByRole('button', { name: /Pinned Pattern/ });
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    const setPointerCapture = vi.fn();
+    const releasePointerCapture = vi.fn();
+    Object.assign(node, {
+      setPointerCapture,
+      hasPointerCapture: vi.fn(() => true),
+      releasePointerCapture,
+    });
+    vi.spyOn(svg!, 'getBoundingClientRect').mockReturnValue({
+      x: 0,
+      y: 0,
+      top: 0,
+      right: 760,
+      bottom: 520,
+      left: 0,
+      width: 760,
+      height: 520,
+      toJSON: () => ({}),
+    });
+
+    await fireEvent.pointerDown(node, { button: 0, pointerId: 7, clientX: 120, clientY: 140 });
+    await fireEvent.pointerMove(node, { pointerId: 7, clientX: 300, clientY: 260 });
+    expect(forceMocks.pinnedNode.fx).not.toBeNull();
+    expect(forceMocks.pinnedNode.x).not.toBe(120);
+
+    await fireEvent.pointerCancel(node, { pointerId: 7 });
+    await tick();
+
+    expect(forceMocks.pinnedNode).toMatchObject({
+      x: 120,
+      y: 140,
+      vx: 1.5,
+      vy: -0.75,
+      fx: null,
+      fy: null,
+    });
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(releasePointerCapture).toHaveBeenCalledOnce();
+    expect(getByText('0 pinned')).toBeTruthy();
   });
 });

--- a/src/lib/components/knowledge/KnowledgePagePreview.svelte
+++ b/src/lib/components/knowledge/KnowledgePagePreview.svelte
@@ -1,0 +1,352 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { X } from 'phosphor-svelte';
+  import MarkdownInline from './MarkdownInline.svelte';
+  import { parseMarkdown } from '$lib/knowledge/markdown';
+  import { folderColor, formatLastUpdated } from '$lib/knowledge/graphUtils';
+  import type { KnowledgePage } from '$lib/knowledge/types';
+
+  interface FocusTarget {
+    readonly isConnected: boolean;
+    focus: (options?: FocusOptions) => void;
+  }
+
+  interface Props {
+    selectedId: string;
+    page: KnowledgePage | null;
+    loading: boolean;
+    error: string | null;
+    onClose: () => void | Promise<unknown>;
+    onRetry: () => void;
+    returnFocus?: FocusTarget | null;
+  }
+
+  let {
+    selectedId,
+    page,
+    loading,
+    error,
+    onClose,
+    onRetry,
+    returnFocus = null,
+  }: Props = $props();
+  let closeButton: HTMLButtonElement;
+  let blocks = $derived(page ? parseMarkdown(page.content) : []);
+
+  onMount(() => {
+    closeButton.focus({ preventScroll: true });
+  });
+
+  async function closePreview() {
+    const target = returnFocus;
+    try {
+      await onClose();
+    } finally {
+      await tick();
+      if (target?.isConnected) target.focus({ preventScroll: true });
+    }
+  }
+</script>
+
+<aside class="preview" aria-label="Knowledge page preview" aria-busy={loading}>
+  <header>
+    <div class="preview-kicker">Read-only preview</div>
+    <button
+      bind:this={closeButton}
+      type="button"
+      class="close"
+      onclick={closePreview}
+      aria-label="Close page preview"
+    >
+      <X size={16} weight="light" />
+    </button>
+  </header>
+
+  {#if loading}
+    <div class="preview-state">
+      <span class="loader"></span>
+      <strong>Opening page</strong>
+      <span>{selectedId}</span>
+    </div>
+  {:else if error}
+    <div class="preview-state error-state" role="alert">
+      <strong>Page unavailable</strong>
+      <span>{error}</span>
+      <button type="button" onclick={onRetry}>Try again</button>
+    </div>
+  {:else if page}
+    <div class="page-head">
+      <div class="folder-label">
+        <span style:background={folderColor(page.folder)}></span>
+        {page.folder}
+      </div>
+      <h2>{page.title}</h2>
+      <div class="page-meta">
+        <code>{page.path}</code>
+        <span>Updated {formatLastUpdated(page.last_updated)}</span>
+        {#if page.truncated}<span class="truncated">Preview capped for safety</span>{/if}
+      </div>
+    </div>
+
+    <article class="markdown">
+      {#each blocks as block, index (index)}
+        {#if block.type === 'heading'}
+          {#if block.level === 1}<h1><MarkdownInline text={block.text} /></h1>
+          {:else if block.level === 2}<h2><MarkdownInline text={block.text} /></h2>
+          {:else if block.level === 3}<h3><MarkdownInline text={block.text} /></h3>
+          {:else}<h4><MarkdownInline text={block.text} /></h4>{/if}
+        {:else if block.type === 'paragraph'}
+          <p><MarkdownInline text={block.text} /></p>
+        {:else if block.type === 'quote'}
+          <blockquote><MarkdownInline text={block.text} /></blockquote>
+        {:else if block.type === 'code'}
+          <div class="code-block">
+            {#if block.language}<span>{block.language}</span>{/if}
+            <pre><code>{block.text}</code></pre>
+          </div>
+        {:else if block.type === 'list'}
+          {#if block.ordered}
+            <ol>{#each block.items as item}<li><MarkdownInline text={item} /></li>{/each}</ol>
+          {:else}
+            <ul>{#each block.items as item}<li><MarkdownInline text={item} /></li>{/each}</ul>
+          {/if}
+        {:else}
+          <hr />
+        {/if}
+      {/each}
+    </article>
+  {/if}
+</aside>
+
+<style>
+  .preview {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    min-height: 0;
+    background: var(--bg-surface);
+    border-left: 1px solid var(--border-structural);
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 44px;
+    padding: 0 var(--space-3) 0 var(--space-4);
+    border-bottom: 1px solid var(--border-structural);
+  }
+
+  .preview-kicker,
+  .folder-label {
+    font: var(--text-micro) var(--font-mono);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+  }
+
+  .close:hover {
+    color: var(--text-primary);
+    border-color: var(--border-structural);
+    background: var(--bg-elevated);
+  }
+
+  .page-head {
+    padding: var(--space-5) var(--space-5) var(--space-4);
+    border-bottom: 1px solid var(--border-structural);
+    background: linear-gradient(150deg, color-mix(in srgb, var(--accent-cyan) 4%, transparent), transparent 52%);
+  }
+
+  .folder-label {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+  }
+
+  .folder-label span {
+    width: 7px;
+    height: 7px;
+  }
+
+  .page-head h2 {
+    margin: var(--space-3) 0;
+    font-family: var(--font-display);
+    font-size: var(--text-h1);
+    line-height: 1.15;
+    letter-spacing: 0.015em;
+  }
+
+  .page-meta {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-1);
+    color: var(--text-disabled);
+    font: var(--text-micro) var(--font-mono);
+  }
+
+  .page-meta code {
+    overflow: hidden;
+    color: var(--text-secondary);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .page-meta .truncated {
+    color: var(--accent-amber);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .markdown {
+    flex: 1;
+    overflow: auto;
+    padding: var(--space-5);
+    color: var(--text-primary);
+    font-size: 13px;
+    line-height: 1.65;
+  }
+
+  .markdown h1,
+  .markdown h2,
+  .markdown h3,
+  .markdown h4 {
+    margin: 1.55em 0 0.55em;
+    color: var(--text-primary);
+    font-family: var(--font-display);
+    line-height: 1.2;
+  }
+
+  .markdown h1:first-child,
+  .markdown h2:first-child,
+  .markdown h3:first-child {
+    margin-top: 0;
+  }
+
+  .markdown h1 { font-size: 22px; }
+  .markdown h2 { font-size: 19px; }
+  .markdown h3 { font-size: 16px; }
+  .markdown h4 { font-size: 14px; color: var(--accent-chrome); }
+
+  .markdown p {
+    margin: 0 0 1em;
+    white-space: pre-wrap;
+  }
+
+  .markdown ul,
+  .markdown ol {
+    margin: 0 0 1em;
+    padding-left: 1.5em;
+  }
+
+  .markdown li {
+    margin-bottom: 0.3em;
+  }
+
+  .markdown li::marker {
+    color: var(--accent-cyan);
+  }
+
+  .markdown blockquote {
+    margin: 1em 0;
+    padding: var(--space-2) var(--space-3);
+    border-left: 2px solid var(--accent-amber);
+    background: color-mix(in srgb, var(--accent-amber) 5%, transparent);
+    color: var(--text-secondary);
+    white-space: pre-wrap;
+  }
+
+  .markdown hr {
+    margin: var(--space-5) 0;
+    border: 0;
+    border-top: 1px solid var(--border-structural);
+  }
+
+  .code-block {
+    position: relative;
+    margin: 1em 0;
+    border: 1px solid var(--border-structural);
+    background: var(--bg-void);
+  }
+
+  .code-block > span {
+    position: absolute;
+    top: 5px;
+    right: 7px;
+    color: var(--text-disabled);
+    font: 9px var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .code-block pre {
+    margin: 0;
+    padding: var(--space-3);
+    overflow: auto;
+    color: var(--accent-chrome);
+    font: 11px/1.55 var(--font-mono);
+  }
+
+  .preview-state {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    padding: var(--space-5);
+    color: var(--text-secondary);
+    text-align: center;
+  }
+
+  .preview-state strong {
+    color: var(--text-primary);
+    font-family: var(--font-display);
+  }
+
+  .preview-state span:not(.loader) {
+    max-width: 280px;
+    font: var(--text-micro) var(--font-mono);
+    overflow-wrap: anywhere;
+  }
+
+  .preview-state button {
+    margin-top: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border: 1px solid var(--accent-cyan);
+    background: transparent;
+    color: var(--accent-cyan);
+    font: var(--text-small) var(--font-mono);
+    cursor: pointer;
+  }
+
+  .loader {
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--border-structural);
+    border-top-color: var(--accent-cyan);
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+  }
+
+  .error-state strong {
+    color: var(--status-error);
+  }
+
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  @media (prefers-reduced-motion: reduce) {
+    .loader { animation: none; }
+  }
+</style>

--- a/src/lib/components/knowledge/KnowledgePagePreview.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgePagePreview.svelte.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import KnowledgePagePreview from './KnowledgePagePreview.svelte';
+import type { KnowledgePage } from '$lib/knowledge/types';
+
+const page: KnowledgePage = {
+  id: 'patterns/safe-preview',
+  title: 'Safe Preview',
+  folder: 'patterns',
+  path: 'patterns/safe-preview.md',
+  last_updated: '2026-07-18T00:00:00Z',
+  truncated: true,
+  content: `# Safe **Preview**
+
+Keep <script>alert('never')</script> visible as text.
+
+[Docs](https://example.com/docs) and [unsafe](javascript:alert(1)).`,
+};
+
+afterEach(cleanup);
+
+describe('KnowledgePagePreview', () => {
+  it('renders structured markdown as escaped, read-only content', async () => {
+    const onClose = vi.fn();
+    const { container, getByRole, getByText } = render(KnowledgePagePreview, {
+      props: {
+        selectedId: page.id,
+        page,
+        loading: false,
+        error: null,
+        onClose,
+        onRetry: vi.fn(),
+      },
+    });
+
+    expect(container.querySelector('script')).toBeNull();
+    expect(container.textContent).toContain("<script>alert('never')</script>");
+    expect(getByRole('link', { name: 'Docs' }).getAttribute('href')).toBe('https://example.com/docs');
+    expect(container.querySelector('a[href^="javascript:"]')).toBeNull();
+    expect(getByText('Preview capped for safety')).toBeTruthy();
+
+    await fireEvent.click(getByRole('button', { name: 'Close page preview' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('offers a retry action for preview errors', async () => {
+    const onRetry = vi.fn();
+    const { getByRole } = render(KnowledgePagePreview, {
+      props: {
+        selectedId: page.id,
+        page: null,
+        loading: false,
+        error: 'Preview failed',
+        onClose: vi.fn(),
+        onRetry,
+      },
+    });
+
+    await fireEvent.click(getByRole('button', { name: 'Try again' }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('moves focus into the preview and restores the invoking control on close', async () => {
+    const returnFocus = document.createElement('button');
+    document.body.append(returnFocus);
+    returnFocus.focus();
+    const onClose = vi.fn();
+    const { getByRole } = render(KnowledgePagePreview, {
+      props: {
+        selectedId: page.id,
+        page,
+        loading: false,
+        error: null,
+        onClose,
+        onRetry: vi.fn(),
+        returnFocus,
+      },
+    });
+
+    const closeButton = getByRole('button', { name: 'Close page preview' });
+    expect(document.activeElement).toBe(closeButton);
+
+    await fireEvent.click(closeButton);
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(document.activeElement).toBe(returnFocus);
+    returnFocus.remove();
+  });
+});

--- a/src/lib/components/knowledge/KnowledgeTable.svelte
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte
@@ -1,0 +1,203 @@
+<script lang="ts">
+  import { compareKnowledgeNodes, formatLastUpdated, folderColor, nodeDegree } from '$lib/knowledge/graphUtils';
+  import type { KnowledgeNode, KnowledgeSortKey, SortDirection } from '$lib/knowledge/types';
+
+  interface Props {
+    nodes: KnowledgeNode[];
+    selectedId: string | null;
+    onSelect: (id: string, trigger?: Element) => void;
+  }
+
+  let { nodes, selectedId, onSelect }: Props = $props();
+  let sortKey = $state<KnowledgeSortKey>('title');
+  let sortDirection = $state<SortDirection>('asc');
+  let sortedNodes = $derived(
+    [...nodes].sort((left, right) => compareKnowledgeNodes(left, right, sortKey, sortDirection)),
+  );
+
+  const columns: { key: KnowledgeSortKey; label: string }[] = [
+    { key: 'title', label: 'Title' },
+    { key: 'folder', label: 'Folder' },
+    { key: 'degree', label: 'Degree' },
+    { key: 'last_updated', label: 'Last updated' },
+  ];
+
+  function setSort(key: KnowledgeSortKey) {
+    if (sortKey === key) {
+      sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      sortKey = key;
+      sortDirection = key === 'last_updated' || key === 'degree' ? 'desc' : 'asc';
+    }
+  }
+
+  function ariaSort(key: KnowledgeSortKey): 'ascending' | 'descending' | 'none' {
+    if (sortKey !== key) return 'none';
+    return sortDirection === 'asc' ? 'ascending' : 'descending';
+  }
+
+</script>
+
+<div class="table-scroll">
+  <table class="lattice-table knowledge-table">
+    <thead>
+      <tr>
+        {#each columns as column (column.key)}
+          <th aria-sort={ariaSort(column.key)}>
+            <button type="button" onclick={() => setSort(column.key)}>
+              {column.label}
+              <span class="sort-mark" class:active={sortKey === column.key} aria-hidden="true">
+                {sortKey === column.key ? (sortDirection === 'asc' ? '↑' : '↓') : '↕'}
+              </span>
+            </button>
+          </th>
+        {/each}
+      </tr>
+    </thead>
+    <tbody>
+      {#each sortedNodes as node (node.id)}
+        <tr
+          class:selected={node.id === selectedId}
+        >
+          <td>
+            <button
+              type="button"
+              class="title"
+              aria-label={`Open ${node.title}`}
+              onclick={(event) => onSelect(node.id, event.currentTarget)}
+            >
+              {node.title}
+            </button>
+            <span class="path">{node.path}</span>
+          </td>
+          <td>
+            <span class="folder-dot" style:background={folderColor(node.folder)}></span>
+            <span class="folder-name">{node.folder}</span>
+          </td>
+          <td class="degree">
+            <strong>{nodeDegree(node)}</strong>
+            <span>{node.in_degree} in · {node.out_degree} out</span>
+          </td>
+          <td class="updated">{formatLastUpdated(node.last_updated)}</td>
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .table-scroll {
+    height: 100%;
+    overflow: auto;
+    background: var(--bg-void);
+  }
+
+  .knowledge-table {
+    min-width: 680px;
+  }
+
+  th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: var(--bg-surface);
+  }
+
+  th button {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+    cursor: pointer;
+    text-align: left;
+  }
+
+  th button:hover {
+    color: var(--accent-cyan);
+  }
+
+  .sort-mark {
+    color: var(--text-disabled);
+  }
+
+  .sort-mark.active {
+    color: var(--accent-cyan);
+  }
+
+  tbody tr.selected td {
+    background: color-mix(in srgb, var(--accent-cyan) 7%, var(--bg-surface));
+  }
+
+  tbody tr.selected td:first-child {
+    box-shadow: inset 2px 0 var(--accent-cyan);
+  }
+
+  td:first-child {
+    width: 48%;
+  }
+
+  .title,
+  .path,
+  .degree span {
+    display: block;
+  }
+
+  .title {
+    width: 100%;
+    padding: 0;
+    border: 0;
+    outline: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .title:hover,
+  .title:focus-visible {
+    color: var(--accent-cyan);
+  }
+
+  .title:focus-visible {
+    box-shadow: inset 2px 0 var(--accent-cyan);
+  }
+
+  .path,
+  .degree span {
+    margin-top: 2px;
+    color: var(--text-disabled);
+    font-size: var(--text-micro);
+  }
+
+  .folder-dot {
+    display: inline-block;
+    width: 7px;
+    height: 7px;
+    margin-right: var(--space-2);
+    box-shadow: 0 0 6px currentColor;
+  }
+
+  .folder-name {
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .degree strong {
+    color: var(--text-primary);
+    font-weight: 500;
+  }
+
+  .updated {
+    white-space: nowrap;
+    color: var(--text-secondary);
+  }
+</style>

--- a/src/lib/components/knowledge/KnowledgeTable.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import KnowledgeTable from './KnowledgeTable.svelte';
+import type { KnowledgeNode } from '$lib/knowledge/types';
+
+const nodes: KnowledgeNode[] = [
+  {
+    id: 'beta',
+    title: 'Beta',
+    folder: 'practices',
+    path: 'practices/beta.md',
+    last_updated: '2026-07-18T00:00:00Z',
+    in_degree: 1,
+    out_degree: 0,
+  },
+  {
+    id: 'alpha',
+    title: 'Alpha',
+    folder: 'patterns',
+    path: 'patterns/alpha.md',
+    last_updated: '2026-07-01T00:00:00Z',
+    in_degree: 2,
+    out_degree: 3,
+  },
+];
+
+function rowTitles(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('tbody .title')).map((element) =>
+    element.textContent?.trim() ?? '',
+  );
+}
+
+afterEach(cleanup);
+
+describe('KnowledgeTable', () => {
+  it('sorts every row and exposes a native action without replacing table semantics', async () => {
+    const onSelect = vi.fn();
+    const { container, getByRole } = render(KnowledgeTable, {
+      props: { nodes, selectedId: null, onSelect },
+    });
+
+    expect(rowTitles(container)).toEqual(['Alpha', 'Beta']);
+
+    await fireEvent.click(getByRole('button', { name: /Degree/ }));
+    expect(rowTitles(container)).toEqual(['Alpha', 'Beta']);
+    expect(getByRole('columnheader', { name: /Degree/ }).getAttribute('aria-sort')).toBe('descending');
+
+    await fireEvent.click(getByRole('button', { name: /Degree/ }));
+    expect(rowTitles(container)).toEqual(['Beta', 'Alpha']);
+
+    const alphaAction = getByRole('button', { name: 'Open Alpha' });
+    expect(alphaAction.tagName).toBe('BUTTON');
+    expect(alphaAction.closest('tr')?.getAttribute('role')).toBeNull();
+    expect(alphaAction.closest('tr')?.hasAttribute('tabindex')).toBe(false);
+
+    await fireEvent.click(alphaAction);
+    expect(onSelect).toHaveBeenCalledWith('alpha', alphaAction);
+  });
+});

--- a/src/lib/components/knowledge/MarkdownInline.svelte
+++ b/src/lib/components/knowledge/MarkdownInline.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import { parseInlineMarkdown } from '$lib/knowledge/markdown';
+
+  interface Props { text: string; }
+  let { text }: Props = $props();
+  let tokens = $derived(parseInlineMarkdown(text));
+</script>
+
+<span class="inline-markdown">
+  {#each tokens as token, index (index)}
+    {#if token.type === 'strong'}
+      <strong>{token.text}</strong>
+    {:else if token.type === 'emphasis'}
+      <em>{token.text}</em>
+    {:else if token.type === 'code'}
+      <code>{token.text}</code>
+    {:else if token.type === 'link'}
+      <a href={token.href} target="_blank" rel="noreferrer">{token.text}</a>
+    {:else if token.type === 'wikilink'}
+      <span class="wikilink">{token.text}</span>
+    {:else}
+      {token.text}
+    {/if}
+  {/each}
+</span>
+
+<style>
+  .inline-markdown :global(strong) { color: var(--text-primary); font-weight: 600; }
+  .inline-markdown :global(em) { color: var(--accent-chrome); }
+  .inline-markdown :global(code) {
+    padding: 1px 4px;
+    border: 1px solid var(--border-structural);
+    background: var(--bg-void);
+    color: var(--accent-chrome);
+    font: 0.9em var(--font-mono);
+  }
+  .inline-markdown :global(a) {
+    color: var(--accent-cyan);
+    text-decoration-color: color-mix(in srgb, var(--accent-cyan) 45%, transparent);
+    text-underline-offset: 2px;
+  }
+  .inline-markdown :global(a:hover) { text-decoration-color: var(--accent-cyan); }
+  .wikilink {
+    color: var(--accent-cyan);
+    font-family: var(--font-mono);
+  }
+  .wikilink::before { content: '[['; color: var(--text-disabled); }
+  .wikilink::after { content: ']]'; color: var(--text-disabled); }
+</style>

--- a/src/lib/knowledge/forceSim.test.ts
+++ b/src/lib/knowledge/forceSim.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { createForceSimulation } from './forceSim';
+import type { KnowledgeEdge, KnowledgeNode } from './types';
+
+function node(id: string): KnowledgeNode {
+  return {
+    id,
+    title: id,
+    folder: 'patterns',
+    path: `patterns/${id}.md`,
+    last_updated: null,
+    in_degree: 1,
+    out_degree: 1,
+  };
+}
+
+const nodes = [node('alpha'), node('beta'), node('gamma')];
+const edges: KnowledgeEdge[] = [
+  { source: 'alpha', target: 'beta', kind: 'related' },
+  { source: 'beta', target: 'gamma', kind: 'wikilink' },
+];
+
+describe('dependency-free knowledge force simulation', () => {
+  it('settles deterministically to finite positions inside the canvas', () => {
+    const first = createForceSimulation(nodes, edges, 800, 500);
+    const second = createForceSimulation(nodes, edges, 800, 500);
+
+    for (let index = 0; index < 240; index += 1) {
+      first.tick();
+      second.tick();
+    }
+
+    expect(first.alpha).toBeLessThan(0.01);
+    for (let index = 0; index < first.nodes.length; index += 1) {
+      const current = first.nodes[index];
+      expect(Number.isFinite(current.x)).toBe(true);
+      expect(Number.isFinite(current.y)).toBe(true);
+      expect(current.x).toBeGreaterThanOrEqual(28);
+      expect(current.x).toBeLessThanOrEqual(772);
+      expect(current.y).toBeGreaterThanOrEqual(28);
+      expect(current.y).toBeLessThanOrEqual(472);
+      expect(current.x).toBeCloseTo(second.nodes[index].x, 8);
+      expect(current.y).toBeCloseTo(second.nodes[index].y, 8);
+    }
+  });
+
+  it('pins, moves, and releases nodes while reheating the layout', () => {
+    const simulation = createForceSimulation(nodes, edges, 640, 480);
+    simulation.setPinned('beta', 120, 140);
+    for (let index = 0; index < 20; index += 1) simulation.tick();
+
+    const beta = simulation.nodes.find((entry) => entry.id === 'beta');
+    expect(beta?.x).toBe(120);
+    expect(beta?.y).toBe(140);
+    expect(beta?.fx).toBe(120);
+
+    simulation.setPinned('beta', 190, 210);
+    simulation.tick();
+    expect(beta?.x).toBe(190);
+    expect(beta?.y).toBe(210);
+
+    simulation.unpin('beta');
+    expect(beta?.fx).toBeNull();
+    expect(beta?.fy).toBeNull();
+    expect(simulation.alpha).toBeGreaterThan(0);
+  });
+
+  it('preserves and clamps pinned state when the canvas bounds change', () => {
+    const simulation = createForceSimulation(nodes, edges, 800, 500);
+    simulation.setPinned('beta', 700, 420);
+
+    simulation.setBounds(320, 260);
+
+    const beta = simulation.nodes.find((entry) => entry.id === 'beta');
+    expect(beta?.fx).toBe(302);
+    expect(beta?.fy).toBe(242);
+    expect(beta?.x).toBe(302);
+    expect(beta?.y).toBe(242);
+    expect(simulation.alpha).toBeGreaterThan(0);
+  });
+});

--- a/src/lib/knowledge/forceSim.ts
+++ b/src/lib/knowledge/forceSim.ts
@@ -1,0 +1,207 @@
+import type { KnowledgeEdge, KnowledgeNode } from './types';
+
+export interface ForceNode extends KnowledgeNode {
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  fx: number | null;
+  fy: number | null;
+}
+
+export interface ForceSimulation {
+  readonly nodes: ForceNode[];
+  readonly alpha: number;
+  tick: () => number;
+  reheat: (value?: number) => void;
+  setBounds: (width: number, height: number) => void;
+  setPinned: (id: string, x: number, y: number) => void;
+  unpin: (id: string) => void;
+  unpinAll: () => void;
+}
+
+function hashString(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function initialPosition(id: string, index: number, count: number, width: number, height: number) {
+  const hash = hashString(id);
+  const angle = (index / Math.max(count, 1)) * Math.PI * 2 + ((hash & 255) / 255) * 0.45;
+  const ring = 0.18 + (((hash >>> 8) & 255) / 255) * 0.24;
+  const radius = Math.min(width, height) * ring;
+  return {
+    x: width / 2 + Math.cos(angle) * radius,
+    y: height / 2 + Math.sin(angle) * radius,
+  };
+}
+
+/** Dependency-free, bounded force simulation for the knowledge graph. */
+export function createForceSimulation(
+  sourceNodes: KnowledgeNode[],
+  edges: KnowledgeEdge[],
+  initialWidth: number,
+  initialHeight: number,
+): ForceSimulation {
+  let width = Math.max(initialWidth, 240);
+  let height = Math.max(initialHeight, 240);
+  let currentAlpha = 1;
+
+  const nodes: ForceNode[] = sourceNodes.map((node, index) => ({
+    ...node,
+    ...initialPosition(node.id, index, sourceNodes.length, width, height),
+    vx: 0,
+    vy: 0,
+    fx: null,
+    fy: null,
+  }));
+  const byId = new Map(nodes.map((node) => [node.id, node]));
+  const linked = edges
+    .map((edge) => {
+      const source = byId.get(edge.source);
+      const target = byId.get(edge.target);
+      return source && target ? { source, target } : null;
+    })
+    .filter((edge): edge is { source: ForceNode; target: ForceNode } => edge !== null);
+
+  function tick(): number {
+    if (nodes.length === 0) {
+      currentAlpha = 0;
+      return currentAlpha;
+    }
+
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    // Pairwise charge. The graph is capped at 400 nodes by the backend, keeping
+    // this deterministic O(n²) pass comfortably bounded and dependency-free.
+    for (let leftIndex = 0; leftIndex < nodes.length; leftIndex += 1) {
+      const left = nodes[leftIndex];
+      for (let rightIndex = leftIndex + 1; rightIndex < nodes.length; rightIndex += 1) {
+        const right = nodes[rightIndex];
+        let dx = right.x - left.x;
+        let dy = right.y - left.y;
+        let distanceSquared = dx * dx + dy * dy;
+        if (distanceSquared < 1) {
+          dx = ((hashString(`${left.id}:${right.id}`) & 1) || -1) * 0.75;
+          dy = 0.75;
+          distanceSquared = dx * dx + dy * dy;
+        }
+        const distance = Math.sqrt(distanceSquared);
+        const force = (720 * currentAlpha) / Math.max(distanceSquared, 36);
+        const forceX = (dx / distance) * force;
+        const forceY = (dy / distance) * force;
+        left.vx -= forceX;
+        left.vy -= forceY;
+        right.vx += forceX;
+        right.vy += forceY;
+      }
+    }
+
+    for (const link of linked) {
+      const dx = link.target.x - link.source.x;
+      const dy = link.target.y - link.source.y;
+      const distance = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+      const desiredDistance = 72;
+      const force = (distance - desiredDistance) * 0.045 * currentAlpha;
+      const forceX = (dx / distance) * force;
+      const forceY = (dy / distance) * force;
+      link.source.vx += forceX;
+      link.source.vy += forceY;
+      link.target.vx -= forceX;
+      link.target.vy -= forceY;
+    }
+
+    for (const node of nodes) {
+      if (node.fx !== null && node.fy !== null) {
+        node.x = node.fx;
+        node.y = node.fy;
+        node.vx = 0;
+        node.vy = 0;
+        continue;
+      }
+
+      node.vx += (centerX - node.x) * 0.006 * currentAlpha;
+      node.vy += (centerY - node.y) * 0.006 * currentAlpha;
+      node.vx *= 0.84;
+      node.vy *= 0.84;
+      node.x += node.vx;
+      node.y += node.vy;
+
+      const padding = 28;
+      if (node.x < padding) {
+        node.x = padding;
+        node.vx *= -0.25;
+      } else if (node.x > width - padding) {
+        node.x = width - padding;
+        node.vx *= -0.25;
+      }
+      if (node.y < padding) {
+        node.y = padding;
+        node.vy *= -0.25;
+      } else if (node.y > height - padding) {
+        node.y = height - padding;
+        node.vy *= -0.25;
+      }
+    }
+
+    currentAlpha = Math.max(0, currentAlpha * 0.972 - 0.0015);
+    return currentAlpha;
+  }
+
+  return {
+    nodes,
+    get alpha() {
+      return currentAlpha;
+    },
+    tick,
+    reheat(value = 0.45) {
+      currentAlpha = Math.max(currentAlpha, value);
+    },
+    setBounds(nextWidth, nextHeight) {
+      width = Math.max(nextWidth, 240);
+      height = Math.max(nextHeight, 240);
+      for (const node of nodes) {
+        if (node.fx !== null && node.fy !== null) {
+          node.fx = Math.min(Math.max(node.fx, 18), width - 18);
+          node.fy = Math.min(Math.max(node.fy, 18), height - 18);
+          node.x = node.fx;
+          node.y = node.fy;
+        } else {
+          node.x = Math.min(Math.max(node.x, 28), width - 28);
+          node.y = Math.min(Math.max(node.y, 28), height - 28);
+        }
+      }
+      currentAlpha = Math.max(currentAlpha, 0.25);
+    },
+    setPinned(id, x, y) {
+      const node = byId.get(id);
+      if (!node) return;
+      node.fx = Math.min(Math.max(x, 18), width - 18);
+      node.fy = Math.min(Math.max(y, 18), height - 18);
+      node.x = node.fx;
+      node.y = node.fy;
+      node.vx = 0;
+      node.vy = 0;
+      currentAlpha = Math.max(currentAlpha, 0.35);
+    },
+    unpin(id) {
+      const node = byId.get(id);
+      if (!node) return;
+      node.fx = null;
+      node.fy = null;
+      currentAlpha = Math.max(currentAlpha, 0.25);
+    },
+    unpinAll() {
+      for (const node of nodes) {
+        node.fx = null;
+        node.fy = null;
+      }
+      currentAlpha = Math.max(currentAlpha, 0.5);
+    },
+  };
+}

--- a/src/lib/knowledge/graphUtils.test.ts
+++ b/src/lib/knowledge/graphUtils.test.ts
@@ -59,6 +59,26 @@ describe('knowledge graph utilities', () => {
     expect(normalized.truncated).toBe(true);
   });
 
+  it('keeps the first valid node for each id and validates edges against unique nodes', () => {
+    const duplicateAlpha = {
+      ...graph.nodes[0],
+      title: 'Duplicate Alpha',
+      path: 'research/duplicate-alpha.md',
+    };
+    const normalized = normalizeKnowledgeGraph({
+      nodes: [graph.nodes[0], duplicateAlpha, graph.nodes[1]],
+      edges: [
+        graph.edges[0],
+        { source: 'alpha', target: 'missing', kind: 'related' },
+      ],
+    });
+
+    expect(normalized.nodes).toHaveLength(2);
+    expect(normalized.nodes[0]).toEqual(graph.nodes[0]);
+    expect(normalized.nodes.map((entry) => entry.id)).toEqual(['alpha', 'beta']);
+    expect(normalized.edges).toEqual([graph.edges[0]]);
+  });
+
   it('filters both endpoints together so the visible graph cannot contain dangling edges', () => {
     const filtered = filterKnowledgeGraph(graph, 'alpha', 'all');
     expect(filtered.nodes.map((entry) => entry.id)).toEqual(['alpha']);
@@ -81,4 +101,3 @@ describe('knowledge graph utilities', () => {
       .toBe('beta');
   });
 });
-

--- a/src/lib/knowledge/graphUtils.test.ts
+++ b/src/lib/knowledge/graphUtils.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import {
+  compareKnowledgeNodes,
+  filterKnowledgeGraph,
+  normalizeKnowledgeGraph,
+  nodeDegree,
+} from './graphUtils';
+import type { KnowledgeGraph, KnowledgeNode } from './types';
+
+function node(
+  id: string,
+  title: string,
+  folder: string,
+  inDegree: number,
+  outDegree: number,
+  lastUpdated: string,
+): KnowledgeNode {
+  return {
+    id,
+    title,
+    folder,
+    path: `${folder}/${id}.md`,
+    last_updated: lastUpdated,
+    in_degree: inDegree,
+    out_degree: outDegree,
+  };
+}
+
+const graph: KnowledgeGraph = {
+  nodes: [
+    node('alpha', 'Alpha Pattern', 'patterns', 1, 3, '2026-07-01T00:00:00Z'),
+    node('beta', 'Beta Practice', 'practices', 2, 0, '2026-07-12T00:00:00Z'),
+    node('gamma', 'Gamma Research', 'research', 4, 4, '2026-06-01T00:00:00Z'),
+  ],
+  edges: [
+    { source: 'alpha', target: 'beta', kind: 'related' },
+    { source: 'gamma', target: 'alpha', kind: 'wikilink' },
+  ],
+};
+
+describe('knowledge graph utilities', () => {
+  it('normalizes the API boundary and rejects malformed or dangling relationships', () => {
+    const normalized = normalizeKnowledgeGraph({
+      nodes: [
+        graph.nodes[0],
+        graph.nodes[1],
+        { id: '', title: 'Invalid', folder: 'patterns', path: 'invalid.md' },
+      ],
+      edges: [
+        graph.edges[0],
+        { source: 'alpha', target: 'private-client-page', kind: 'cross_ref' },
+        { source: 'alpha', target: 'beta', kind: 'unknown' },
+      ],
+      truncated: true,
+    });
+
+    expect(normalized.nodes.map((entry) => entry.id)).toEqual(['alpha', 'beta']);
+    expect(normalized.edges).toEqual([graph.edges[0]]);
+    expect(normalized.truncated).toBe(true);
+  });
+
+  it('filters both endpoints together so the visible graph cannot contain dangling edges', () => {
+    const filtered = filterKnowledgeGraph(graph, 'alpha', 'all');
+    expect(filtered.nodes.map((entry) => entry.id)).toEqual(['alpha']);
+    expect(filtered.edges).toEqual([]);
+
+    const folderFiltered = filterKnowledgeGraph(graph, '', 'patterns');
+    expect(folderFiltered.nodes.map((entry) => entry.id)).toEqual(['alpha']);
+    expect(folderFiltered.edges).toEqual([]);
+  });
+
+  it('sorts all table columns and computes total degree', () => {
+    expect(nodeDegree(graph.nodes[0])).toBe(4);
+    expect([...graph.nodes].sort((a, b) => compareKnowledgeNodes(a, b, 'title', 'desc'))[0].id)
+      .toBe('gamma');
+    expect([...graph.nodes].sort((a, b) => compareKnowledgeNodes(a, b, 'folder', 'asc'))[0].id)
+      .toBe('alpha');
+    expect([...graph.nodes].sort((a, b) => compareKnowledgeNodes(a, b, 'degree', 'desc'))[0].id)
+      .toBe('gamma');
+    expect([...graph.nodes].sort((a, b) => compareKnowledgeNodes(a, b, 'last_updated', 'desc'))[0].id)
+      .toBe('beta');
+  });
+});
+

--- a/src/lib/knowledge/graphUtils.ts
+++ b/src/lib/knowledge/graphUtils.ts
@@ -1,0 +1,202 @@
+import {
+  KNOWLEDGE_EDGE_KINDS,
+  type KnowledgeEdge,
+  type KnowledgeEdgeKind,
+  type KnowledgeGraph,
+  type KnowledgeNode,
+  type KnowledgeSortKey,
+  type SortDirection,
+} from './types';
+
+export const FOLDER_COLORS: Record<string, string> = {
+  patterns: '#00e5ff',
+  practices: '#00ff66',
+  research: '#ff9d00',
+  project: '#a3b8cc',
+};
+
+export const EDGE_COLORS: Record<KnowledgeEdgeKind, string> = {
+  cross_ref: '#00e5ff',
+  wikilink: '#8b949e',
+  global: '#ff9d00',
+  related: '#00ff66',
+  from: '#a3b8cc',
+};
+
+export const EDGE_LABELS: Record<KnowledgeEdgeKind, string> = {
+  cross_ref: 'Cross reference',
+  wikilink: 'Wikilink',
+  global: 'Global',
+  related: 'Related',
+  from: 'Provenance',
+};
+
+const DEFAULT_FOLDER_COLOR = '#ff6bcb';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null;
+}
+
+function degreeValue(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.floor(value)
+    : 0;
+}
+
+function updatedValue(value: unknown): string | number | null {
+  if (typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value))) {
+    return value;
+  }
+  return null;
+}
+
+function normalizeNode(value: unknown): KnowledgeNode | null {
+  if (!isRecord(value)) return null;
+  const id = stringValue(value.id);
+  const title = stringValue(value.title);
+  const folder = stringValue(value.folder);
+  const path = stringValue(value.path);
+  if (!id || !title || !folder || !path) return null;
+
+  return {
+    id,
+    title,
+    folder,
+    path,
+    last_updated: updatedValue(value.last_updated),
+    in_degree: degreeValue(value.in_degree),
+    out_degree: degreeValue(value.out_degree),
+  };
+}
+
+function normalizeEdge(value: unknown): KnowledgeEdge | null {
+  if (!isRecord(value)) return null;
+  const source = stringValue(value.source);
+  const target = stringValue(value.target);
+  const kind = stringValue(value.kind);
+  if (
+    !source ||
+    !target ||
+    !kind ||
+    !KNOWLEDGE_EDGE_KINDS.includes(kind as KnowledgeEdgeKind)
+  ) {
+    return null;
+  }
+
+  return { source, target, kind: kind as KnowledgeEdgeKind };
+}
+
+/**
+ * Treat the backend as a trust boundary. Invalid records and dangling edges are
+ * discarded so the graph renderer never receives an unusable endpoint.
+ */
+export function normalizeKnowledgeGraph(value: unknown): KnowledgeGraph {
+  if (!isRecord(value)) return { nodes: [], edges: [] };
+
+  const nodes = Array.isArray(value.nodes)
+    ? value.nodes.map(normalizeNode).filter((node): node is KnowledgeNode => node !== null)
+    : [];
+  const nodeIds = new Set(nodes.map((node) => node.id));
+  const edges = Array.isArray(value.edges)
+    ? value.edges
+        .map(normalizeEdge)
+        .filter(
+          (edge): edge is KnowledgeEdge =>
+            edge !== null && nodeIds.has(edge.source) && nodeIds.has(edge.target),
+        )
+    : [];
+
+  return { nodes, edges, truncated: value.truncated === true };
+}
+
+export function normalizeKnowledgePage(value: unknown): import('./types').KnowledgePage | null {
+  if (!isRecord(value)) return null;
+  const id = stringValue(value.id);
+  const title = stringValue(value.title);
+  const folder = stringValue(value.folder);
+  const path = stringValue(value.path);
+  if (!id || !title || !folder || !path || typeof value.content !== 'string') return null;
+
+  return {
+    id,
+    title,
+    folder,
+    path,
+    content: value.content,
+    last_updated: updatedValue(value.last_updated),
+    truncated: value.truncated === true,
+  };
+}
+
+export function folderColor(folder: string): string {
+  return FOLDER_COLORS[folder.toLowerCase()] ?? DEFAULT_FOLDER_COLOR;
+}
+
+export function nodeDegree(node: KnowledgeNode): number {
+  return node.in_degree + node.out_degree;
+}
+
+export function timestampValue(value: string | number | null): number {
+  if (value === null) return 0;
+  if (typeof value === 'number') {
+    // Rust timestamps may be seconds or milliseconds since the epoch.
+    return value < 10_000_000_000 ? value * 1000 : value;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export function formatLastUpdated(value: string | number | null): string {
+  const timestamp = timestampValue(value);
+  if (timestamp === 0) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  }).format(new Date(timestamp));
+}
+
+export function compareKnowledgeNodes(
+  left: KnowledgeNode,
+  right: KnowledgeNode,
+  key: KnowledgeSortKey,
+  direction: SortDirection,
+): number {
+  let comparison = 0;
+  if (key === 'degree') {
+    comparison = nodeDegree(left) - nodeDegree(right);
+  } else if (key === 'last_updated') {
+    comparison = timestampValue(left.last_updated) - timestampValue(right.last_updated);
+  } else {
+    comparison = left[key].localeCompare(right[key], undefined, { sensitivity: 'base' });
+  }
+
+  if (comparison === 0) {
+    comparison = left.title.localeCompare(right.title, undefined, { sensitivity: 'base' });
+  }
+  return direction === 'asc' ? comparison : -comparison;
+}
+
+export function filterKnowledgeGraph(
+  graph: KnowledgeGraph,
+  query: string,
+  folder: string,
+): KnowledgeGraph {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  const nodes = graph.nodes.filter((node) => {
+    if (folder !== 'all' && node.folder !== folder) return false;
+    if (!normalizedQuery) return true;
+    return [node.title, node.path, node.folder].some((value) =>
+      value.toLocaleLowerCase().includes(normalizedQuery),
+    );
+  });
+  const visibleIds = new Set(nodes.map((node) => node.id));
+  const edges = graph.edges.filter(
+    (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target),
+  );
+  return { nodes, edges, truncated: graph.truncated };
+}

--- a/src/lib/knowledge/graphUtils.ts
+++ b/src/lib/knowledge/graphUtils.ts
@@ -97,10 +97,16 @@ function normalizeEdge(value: unknown): KnowledgeEdge | null {
 export function normalizeKnowledgeGraph(value: unknown): KnowledgeGraph {
   if (!isRecord(value)) return { nodes: [], edges: [] };
 
-  const nodes = Array.isArray(value.nodes)
-    ? value.nodes.map(normalizeNode).filter((node): node is KnowledgeNode => node !== null)
-    : [];
-  const nodeIds = new Set(nodes.map((node) => node.id));
+  const nodes: KnowledgeNode[] = [];
+  const nodeIds = new Set<string>();
+  if (Array.isArray(value.nodes)) {
+    for (const valueNode of value.nodes) {
+      const normalizedNode = normalizeNode(valueNode);
+      if (normalizedNode === null || nodeIds.has(normalizedNode.id)) continue;
+      nodeIds.add(normalizedNode.id);
+      nodes.push(normalizedNode);
+    }
+  }
   const edges = Array.isArray(value.edges)
     ? value.edges
         .map(normalizeEdge)

--- a/src/lib/knowledge/markdown.test.ts
+++ b/src/lib/knowledge/markdown.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { parseInlineMarkdown, parseMarkdown } from './markdown';
+
+describe('knowledge markdown parser', () => {
+  it('parses common wiki blocks without producing raw HTML', () => {
+    const blocks = parseMarkdown(`# Title
+
+Paragraph with <script>alert('x')</script>.
+
+- first
+- second
+
+> note
+
+\`\`\`ts
+const answer = 42;
+\`\`\``);
+
+    expect(blocks).toEqual([
+      { type: 'heading', level: 1, text: 'Title' },
+      { type: 'paragraph', text: "Paragraph with <script>alert('x')</script>." },
+      { type: 'list', ordered: false, items: ['first', 'second'] },
+      { type: 'quote', text: 'note' },
+      { type: 'code', language: 'ts', text: 'const answer = 42;' },
+    ]);
+  });
+
+  it('keeps inline rendering structured and rejects executable links', () => {
+    expect(parseInlineMarkdown('Use **care** with `fetch` and [[safe-pattern]].')).toEqual([
+      { type: 'text', text: 'Use ' },
+      { type: 'strong', text: 'care' },
+      { type: 'text', text: ' with ' },
+      { type: 'code', text: 'fetch' },
+      { type: 'text', text: ' and ' },
+      { type: 'wikilink', text: 'safe-pattern' },
+      { type: 'text', text: '.' },
+    ]);
+    expect(parseInlineMarkdown('[unsafe](javascript:alert(1))')).toEqual([
+      { type: 'text', text: '[unsafe](javascript:alert(1)' },
+      { type: 'text', text: ')' },
+    ]);
+  });
+});

--- a/src/lib/knowledge/markdown.ts
+++ b/src/lib/knowledge/markdown.ts
@@ -1,0 +1,148 @@
+export type MarkdownBlock =
+  | { type: 'heading'; level: number; text: string }
+  | { type: 'paragraph'; text: string }
+  | { type: 'quote'; text: string }
+  | { type: 'code'; language: string; text: string }
+  | { type: 'list'; ordered: boolean; items: string[] }
+  | { type: 'rule' };
+
+export type MarkdownInline =
+  | { type: 'text'; text: string }
+  | { type: 'strong'; text: string }
+  | { type: 'emphasis'; text: string }
+  | { type: 'code'; text: string }
+  | { type: 'link'; text: string; href: string }
+  | { type: 'wikilink'; text: string };
+
+function safeLink(value: string): string | null {
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' || url.protocol === 'http:' ? url.toString() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse a deliberately small inline subset without ever emitting HTML. */
+export function parseInlineMarkdown(source: string): MarkdownInline[] {
+  const tokens: MarkdownInline[] = [];
+  const pattern = /(`[^`\n]+`|\*\*[^*\n]+\*\*|__[^_\n]+__|\*[^*\n]+\*|_([^_\n]+)_|\[([^\]\n]+)\]\(([^)\n]+)\)|\[\[([^\]\n]+)\]\])/g;
+  let cursor = 0;
+
+  for (const match of source.matchAll(pattern)) {
+    const start = match.index ?? 0;
+    if (start > cursor) tokens.push({ type: 'text', text: source.slice(cursor, start) });
+    const raw = match[0];
+
+    if (raw.startsWith('`')) {
+      tokens.push({ type: 'code', text: raw.slice(1, -1) });
+    } else if (raw.startsWith('**') || raw.startsWith('__')) {
+      tokens.push({ type: 'strong', text: raw.slice(2, -2) });
+    } else if (raw.startsWith('[[')) {
+      tokens.push({ type: 'wikilink', text: raw.slice(2, -2) });
+    } else if (raw.startsWith('[')) {
+      const linkMatch = raw.match(/^\[([^\]]+)\]\(([^)]+)\)$/);
+      const href = linkMatch ? safeLink(linkMatch[2].trim()) : null;
+      if (linkMatch && href) {
+        tokens.push({ type: 'link', text: linkMatch[1], href });
+      } else {
+        tokens.push({ type: 'text', text: raw });
+      }
+    } else {
+      tokens.push({ type: 'emphasis', text: raw.slice(1, -1) });
+    }
+    cursor = start + raw.length;
+  }
+
+  if (cursor < source.length) tokens.push({ type: 'text', text: source.slice(cursor) });
+  return tokens.length > 0 ? tokens : [{ type: 'text', text: source }];
+}
+
+function isBlockStart(line: string): boolean {
+  return (
+    /^#{1,6}\s+/.test(line) ||
+    /^```/.test(line) ||
+    /^>\s?/.test(line) ||
+    /^\s*[-*+]\s+/.test(line) ||
+    /^\s*\d+[.)]\s+/.test(line) ||
+    /^\s*(?:---+|___+|\*\*\*+)\s*$/.test(line)
+  );
+}
+
+/** A small, safe block-level markdown parser. Svelte escapes every text field. */
+export function parseMarkdown(source: string): MarkdownBlock[] {
+  const lines = source.replace(/\r\n?/g, '\n').split('\n');
+  const blocks: MarkdownBlock[] = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+
+    const fence = line.match(/^```\s*([^\s`]*)/);
+    if (fence) {
+      const language = fence[1] ?? '';
+      const code: string[] = [];
+      index += 1;
+      while (index < lines.length && !/^```\s*$/.test(lines[index])) {
+        code.push(lines[index]);
+        index += 1;
+      }
+      if (index < lines.length) index += 1;
+      blocks.push({ type: 'code', language, text: code.join('\n') });
+      continue;
+    }
+
+    const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+    if (heading) {
+      blocks.push({ type: 'heading', level: heading[1].length, text: heading[2] });
+      index += 1;
+      continue;
+    }
+
+    if (/^\s*(?:---+|___+|\*\*\*+)\s*$/.test(line)) {
+      blocks.push({ type: 'rule' });
+      index += 1;
+      continue;
+    }
+
+    if (/^>\s?/.test(line)) {
+      const quote: string[] = [];
+      while (index < lines.length && /^>\s?/.test(lines[index])) {
+        quote.push(lines[index].replace(/^>\s?/, ''));
+        index += 1;
+      }
+      blocks.push({ type: 'quote', text: quote.join('\n') });
+      continue;
+    }
+
+    const unordered = line.match(/^\s*[-*+]\s+(.+)/);
+    const ordered = line.match(/^\s*\d+[.)]\s+(.+)/);
+    if (unordered || ordered) {
+      const isOrdered = Boolean(ordered);
+      const pattern = isOrdered ? /^\s*\d+[.)]\s+(.+)/ : /^\s*[-*+]\s+(.+)/;
+      const items: string[] = [];
+      while (index < lines.length) {
+        const item = lines[index].match(pattern);
+        if (!item) break;
+        items.push(item[1]);
+        index += 1;
+      }
+      blocks.push({ type: 'list', ordered: isOrdered, items });
+      continue;
+    }
+
+    const paragraph = [line.trim()];
+    index += 1;
+    while (index < lines.length && lines[index].trim() && !isBlockStart(lines[index])) {
+      paragraph.push(lines[index].trim());
+      index += 1;
+    }
+    blocks.push({ type: 'paragraph', text: paragraph.join(' ') });
+  }
+
+  return blocks;
+}

--- a/src/lib/knowledge/navigation.ts
+++ b/src/lib/knowledge/navigation.ts
@@ -1,0 +1,3 @@
+// Kept behind a local module so route-scope behavior can be tested with the
+// lightweight Svelte Vitest configuration, which does not install SvelteKit aliases.
+export { page as routePage } from '$app/stores';

--- a/src/lib/knowledge/types.ts
+++ b/src/lib/knowledge/types.ts
@@ -1,0 +1,45 @@
+export const KNOWLEDGE_EDGE_KINDS = [
+  'cross_ref',
+  'wikilink',
+  'global',
+  'related',
+  'from',
+] as const;
+
+export type KnowledgeEdgeKind = (typeof KNOWLEDGE_EDGE_KINDS)[number];
+
+export interface KnowledgeNode {
+  id: string;
+  title: string;
+  folder: string;
+  path: string;
+  last_updated: string | number | null;
+  in_degree: number;
+  out_degree: number;
+}
+
+export interface KnowledgeEdge {
+  source: string;
+  target: string;
+  kind: KnowledgeEdgeKind;
+}
+
+export interface KnowledgeGraph {
+  nodes: KnowledgeNode[];
+  edges: KnowledgeEdge[];
+  truncated?: boolean;
+}
+
+export interface KnowledgePage {
+  id: string;
+  title: string;
+  folder: string;
+  path: string;
+  content: string;
+  last_updated: string | number | null;
+  truncated?: boolean;
+}
+
+export type KnowledgeView = 'graph' | 'table';
+export type KnowledgeSortKey = 'title' | 'folder' | 'degree' | 'last_updated';
+export type SortDirection = 'asc' | 'desc';

--- a/src/lib/stores/knowledge.test.ts
+++ b/src/lib/stores/knowledge.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+function graphPayload() {
+  return {
+    nodes: [
+      {
+        id: 'patterns/steady-state',
+        title: 'Steady State',
+        folder: 'patterns',
+        path: 'patterns/steady-state.md',
+        last_updated: '2026-07-18T00:00:00Z',
+        in_degree: 1,
+        out_degree: 1,
+      },
+      {
+        id: 'practices/safe fetch',
+        title: 'Safe Fetch',
+        folder: 'practices',
+        path: 'practices/safe-fetch.md',
+        last_updated: null,
+        in_degree: 1,
+        out_degree: 0,
+      },
+    ],
+    edges: [
+      { source: 'patterns/steady-state', target: 'practices/safe fetch', kind: 'related' },
+      { source: 'patterns/steady-state', target: 'clients/private', kind: 'cross_ref' },
+    ],
+    truncated: true,
+  };
+}
+
+function graphWithout(id: string) {
+  const graph = graphPayload();
+  return {
+    ...graph,
+    nodes: graph.nodes.filter((node) => node.id !== id),
+    edges: graph.edges.filter((edge) => edge.source !== id && edge.target !== id),
+  };
+}
+
+describe('knowledge store', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('loads and normalizes the graph, then fetches a preview by encoded node id', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'practices/safe fetch',
+        title: 'Safe Fetch',
+        folder: 'practices',
+        path: 'practices/safe-fetch.md',
+        content: '# Safe fetch',
+        last_updated: '2026-07-18T00:00:00Z',
+        truncated: false,
+      }));
+
+    expect(await store.loadGraph()).toBe(true);
+    const graphUrl = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(graphUrl.pathname).toBe('/api/knowledge/graph');
+    expect(graphUrl.search).toBe('');
+    expect(get(store).graph.nodes).toHaveLength(2);
+    expect(get(store).graph.edges).toHaveLength(1);
+    expect(get(store).graph.truncated).toBe(true);
+
+    expect(await store.selectNode('practices/safe fetch')).toBe(true);
+    const pageUrl = new URL(String(fetchMock.mock.calls[1][0]));
+    expect(pageUrl.pathname).toBe('/api/knowledge/page');
+    expect(pageUrl.search).toBe('?id=practices%2Fsafe%20fetch');
+    expect(get(store).page?.title).toBe('Safe Fetch');
+  });
+
+  it('adds the exact encoded session id to graph, preview, and retry requests', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    const sessionId = 'session/alpha + beta&scope';
+    const page = {
+      id: 'practices/safe fetch',
+      title: 'Safe Fetch',
+      folder: 'practices',
+      path: 'practices/safe-fetch.md',
+      content: '# Safe fetch',
+      last_updated: null,
+    };
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse(page))
+      .mockResolvedValueOnce(jsonResponse(page));
+
+    expect(await store.loadGraph(sessionId)).toBe(true);
+    expect(await store.selectNode('practices/safe fetch', sessionId)).toBe(true);
+    expect(await store.retryPage(sessionId)).toBe(true);
+
+    const graphUrl = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(graphUrl.pathname).toBe('/api/knowledge/graph');
+    expect(graphUrl.search).toBe(
+      '?session_id=session%2Falpha%20%2B%20beta%26scope',
+    );
+
+    for (const call of fetchMock.mock.calls.slice(1)) {
+      const pageUrl = new URL(String(call[0]));
+      expect(pageUrl.pathname).toBe('/api/knowledge/page');
+      expect(pageUrl.search).toBe(
+        '?id=practices%2Fsafe%20fetch&session_id=session%2Falpha%20%2B%20beta%26scope',
+      );
+    }
+  });
+
+  it('keeps the previous graph visible on refresh failure and exposes a friendly error', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({}, 503));
+
+    await store.loadGraph();
+    expect(await store.loadGraph()).toBe(false);
+
+    expect(get(store).graph.nodes).toHaveLength(2);
+    expect(get(store).loading).toBe(false);
+    expect(get(store).refreshing).toBe(false);
+    expect(get(store).error).toContain('(503)');
+  });
+
+  it('does not let an older preview response replace a newer selection', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    let resolveFirst!: (value: Response) => void;
+    const first = new Promise<Response>((resolve) => { resolveFirst = resolve; });
+    fetchMock
+      .mockImplementationOnce(() => first)
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'research/newer',
+        title: 'Newer',
+        folder: 'research',
+        path: 'research/newer.md',
+        content: 'newer',
+        last_updated: null,
+      }));
+
+    const olderRequest = store.selectNode('patterns/older');
+    const newerRequest = store.selectNode('research/newer');
+    await newerRequest;
+    resolveFirst(jsonResponse({
+      id: 'patterns/older',
+      title: 'Older',
+      folder: 'patterns',
+      path: 'patterns/older.md',
+      content: 'older',
+      last_updated: null,
+    }));
+    await olderRequest;
+
+    expect(get(store).selectedId).toBe('research/newer');
+    expect(get(store).page?.title).toBe('Newer');
+  });
+
+  it('clears a selection removed by refresh and ignores its in-flight preview', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    let resolvePage!: (value: Response) => void;
+    const pageResponse = new Promise<Response>((resolve) => { resolvePage = resolve; });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockImplementationOnce(() => pageResponse)
+      .mockResolvedValueOnce(jsonResponse(graphWithout('patterns/steady-state')));
+
+    await store.loadGraph();
+    const pageRequest = store.selectNode('patterns/steady-state');
+    expect(get(store).pageLoading).toBe(true);
+
+    expect(await store.loadGraph()).toBe(true);
+    expect(get(store)).toMatchObject({
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+
+    resolvePage(jsonResponse({
+      id: 'patterns/steady-state',
+      title: 'Steady State',
+      folder: 'patterns',
+      path: 'patterns/steady-state.md',
+      content: 'stale preview',
+      last_updated: null,
+    }));
+    expect(await pageRequest).toBe(false);
+    expect(get(store)).toMatchObject({ selectedId: null, page: null, pageLoading: false });
+  });
+
+  it('clears a removed selection page error after a successful refresh', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({}, 503))
+      .mockResolvedValueOnce(jsonResponse(graphWithout('patterns/steady-state')));
+
+    await store.loadGraph();
+    expect(await store.selectNode('patterns/steady-state')).toBe(false);
+    expect(get(store).pageError).toContain('(503)');
+
+    expect(await store.loadGraph()).toBe(true);
+    expect(get(store)).toMatchObject({
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+  });
+
+  it('preserves the selected page when its node remains after refresh', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'patterns/steady-state',
+        title: 'Steady State',
+        folder: 'patterns',
+        path: 'patterns/steady-state.md',
+        content: 'retained preview',
+        last_updated: null,
+      }))
+      .mockResolvedValueOnce(jsonResponse(graphPayload()));
+
+    await store.loadGraph();
+    await store.selectNode('patterns/steady-state');
+    const page = get(store).page;
+
+    expect(await store.loadGraph()).toBe(true);
+    expect(get(store)).toMatchObject({
+      selectedId: 'patterns/steady-state',
+      page,
+      pageLoading: false,
+      pageError: null,
+    });
+  });
+
+  it('clears the same node preview when changing from session to global scope', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    const sessionId = 'session-a';
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'patterns/steady-state',
+        title: 'Steady State',
+        folder: 'patterns',
+        path: 'patterns/steady-state.md',
+        content: 'session preview',
+        last_updated: null,
+      }))
+      .mockResolvedValueOnce(jsonResponse(graphPayload()));
+
+    await store.loadGraph(sessionId);
+    await store.selectNode('patterns/steady-state', sessionId);
+    expect(get(store).page?.content).toBe('session preview');
+
+    expect(await store.loadGraph(null)).toBe(true);
+    expect(get(store).graph.nodes.some((node) => node.id === 'patterns/steady-state')).toBe(true);
+    expect(get(store)).toMatchObject({
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+  });
+
+  it('invalidates an in-flight global preview when changing to session scope', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    let resolvePage!: (value: Response) => void;
+    let resolveGraph!: (value: Response) => void;
+    const pageResponse = new Promise<Response>((resolve) => { resolvePage = resolve; });
+    const graphResponse = new Promise<Response>((resolve) => { resolveGraph = resolve; });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockImplementationOnce(() => pageResponse)
+      .mockImplementationOnce(() => graphResponse);
+
+    await store.loadGraph(null);
+    const pageRequest = store.selectNode('patterns/steady-state', null);
+    expect(get(store).pageLoading).toBe(true);
+
+    const scopedGraphRequest = store.loadGraph('session-b');
+    expect(get(store)).toMatchObject({
+      graph: { nodes: [], edges: [], truncated: false },
+      loading: true,
+      refreshing: false,
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+
+    resolvePage(jsonResponse({
+      id: 'patterns/steady-state',
+      title: 'Steady State',
+      folder: 'patterns',
+      path: 'patterns/steady-state.md',
+      content: 'stale global preview',
+      last_updated: null,
+    }));
+    expect(await pageRequest).toBe(false);
+    expect(get(store)).toMatchObject({
+      graph: { nodes: [], edges: [], truncated: false },
+      loading: true,
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+    });
+
+    resolveGraph(jsonResponse(graphPayload()));
+    expect(await scopedGraphRequest).toBe(true);
+    expect(get(store).graph.nodes).toHaveLength(2);
+  });
+
+  it('keeps the previous scope cleared when a replacement scope load fails', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    let resolveGraph!: (value: Response) => void;
+    const graphResponse = new Promise<Response>((resolve) => { resolveGraph = resolve; });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockResolvedValueOnce(jsonResponse({
+        id: 'patterns/steady-state',
+        title: 'Steady State',
+        folder: 'patterns',
+        path: 'patterns/steady-state.md',
+        content: 'scope a preview',
+        last_updated: null,
+      }))
+      .mockImplementationOnce(() => graphResponse);
+
+    await store.loadGraph('session-a');
+    await store.selectNode('patterns/steady-state', 'session-a');
+    expect(get(store).graph.nodes).toHaveLength(2);
+    expect(get(store).page?.content).toBe('scope a preview');
+
+    const replacementRequest = store.loadGraph('session-b');
+    expect(get(store)).toMatchObject({
+      graph: { nodes: [], edges: [], truncated: false },
+      loading: true,
+      refreshing: false,
+      error: null,
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+
+    resolveGraph(jsonResponse({}, 503));
+    expect(await replacementRequest).toBe(false);
+    expect(get(store)).toMatchObject({
+      graph: { nodes: [], edges: [], truncated: false },
+      loading: false,
+      refreshing: false,
+      selectedId: null,
+      page: null,
+      pageLoading: false,
+      pageError: null,
+    });
+    expect(get(store).error).toContain('(503)');
+  });
+
+  it('keeps only the latest scope visible when graph loads overlap', async () => {
+    const { createKnowledgeStore } = await import('./knowledge');
+    const store = createKnowledgeStore();
+    let resolveMiddleGraph!: (value: Response) => void;
+    const middleGraphResponse = new Promise<Response>((resolve) => {
+      resolveMiddleGraph = resolve;
+    });
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(graphPayload()))
+      .mockImplementationOnce(() => middleGraphResponse)
+      .mockResolvedValueOnce(jsonResponse(graphWithout('patterns/steady-state')));
+
+    await store.loadGraph('session-a');
+    const middleRequest = store.loadGraph('session-b');
+    expect(get(store).graph.nodes).toHaveLength(0);
+
+    expect(await store.loadGraph('session-c')).toBe(true);
+    expect(get(store).graph.nodes.map((node) => node.id)).toEqual(['practices/safe fetch']);
+
+    resolveMiddleGraph(jsonResponse(graphPayload()));
+    expect(await middleRequest).toBe(false);
+    expect(get(store).graph.nodes.map((node) => node.id)).toEqual(['practices/safe fetch']);
+    expect(get(store).error).toBeNull();
+  });
+});

--- a/src/lib/stores/knowledge.ts
+++ b/src/lib/stores/knowledge.ts
@@ -1,0 +1,200 @@
+import { writable } from 'svelte/store';
+import { apiUrl } from '$lib/config';
+import { normalizeKnowledgeGraph, normalizeKnowledgePage } from '$lib/knowledge/graphUtils';
+import type { KnowledgeGraph, KnowledgePage } from '$lib/knowledge/types';
+
+export interface KnowledgeState {
+  graph: KnowledgeGraph;
+  loading: boolean;
+  refreshing: boolean;
+  error: string | null;
+  selectedId: string | null;
+  page: KnowledgePage | null;
+  pageLoading: boolean;
+  pageError: string | null;
+}
+
+const EMPTY_GRAPH: KnowledgeGraph = { nodes: [], edges: [], truncated: false };
+
+function responseError(response: Response, subject: string): string {
+  return `${subject} request failed (${response.status})`;
+}
+
+function errorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === 'string' && error.trim()) return error;
+  return fallback;
+}
+
+function withSessionId(path: string, sessionId: string | null): string {
+  if (sessionId === null) return path;
+  const separator = path.includes('?') ? '&' : '?';
+  return `${path}${separator}session_id=${encodeURIComponent(sessionId)}`;
+}
+
+export function createKnowledgeStore() {
+  let graphRequest = 0;
+  let pageRequest = 0;
+  let graphScope: string | null = null;
+  let hasGraphScope = false;
+  const { subscribe, set, update } = writable<KnowledgeState>({
+    graph: EMPTY_GRAPH,
+    loading: false,
+    refreshing: false,
+    error: null,
+    selectedId: null,
+    page: null,
+    pageLoading: false,
+    pageError: null,
+  });
+
+  async function loadGraph(sessionId: string | null = null): Promise<boolean> {
+    const request = ++graphRequest;
+    const scopeChanged = hasGraphScope && graphScope !== sessionId;
+    graphScope = sessionId;
+    hasGraphScope = true;
+
+    if (scopeChanged) pageRequest += 1;
+    update((state) => {
+      if (scopeChanged) {
+        return {
+          ...state,
+          graph: EMPTY_GRAPH,
+          loading: true,
+          refreshing: false,
+          error: null,
+          selectedId: null,
+          page: null,
+          pageLoading: false,
+          pageError: null,
+        };
+      }
+
+      return {
+        ...state,
+        loading: state.graph.nodes.length === 0,
+        refreshing: state.graph.nodes.length > 0,
+        error: null,
+      };
+    });
+
+    try {
+      const response = await fetch(apiUrl(withSessionId('/api/knowledge/graph', sessionId)));
+      if (!response.ok) throw new Error(responseError(response, 'Knowledge graph'));
+      const graph = normalizeKnowledgeGraph(await response.json());
+      if (request !== graphRequest) return false;
+      update((state) => {
+        const selectedId = state.selectedId;
+        const selectionStillExists = selectedId === null
+          || graph.nodes.some((node) => node.id === selectedId);
+
+        if (selectionStillExists) {
+          return { ...state, graph, loading: false, refreshing: false, error: null };
+        }
+
+        pageRequest += 1;
+        return {
+          ...state,
+          graph,
+          loading: false,
+          refreshing: false,
+          error: null,
+          selectedId: null,
+          page: null,
+          pageLoading: false,
+          pageError: null,
+        };
+      });
+      return true;
+    } catch (error) {
+      if (request !== graphRequest) return false;
+      update((state) => ({
+        ...state,
+        loading: false,
+        refreshing: false,
+        error: errorMessage(error, 'Unable to load the knowledge graph.'),
+      }));
+      return false;
+    }
+  }
+
+  async function selectNode(
+    id: string | null,
+    sessionId: string | null = null,
+  ): Promise<boolean> {
+    const request = ++pageRequest;
+    if (!id) {
+      update((state) => ({
+        ...state,
+        selectedId: null,
+        page: null,
+        pageLoading: false,
+        pageError: null,
+      }));
+      return true;
+    }
+
+    update((state) => ({
+      ...state,
+      selectedId: id,
+      page: null,
+      pageLoading: true,
+      pageError: null,
+    }));
+
+    try {
+      const path = withSessionId(
+        `/api/knowledge/page?id=${encodeURIComponent(id)}`,
+        sessionId,
+      );
+      const response = await fetch(apiUrl(path));
+      if (!response.ok) throw new Error(responseError(response, 'Knowledge page'));
+      const page = normalizeKnowledgePage(await response.json());
+      if (!page) throw new Error('Knowledge page returned an invalid response.');
+      if (request !== pageRequest) return false;
+      update((state) => ({ ...state, page, pageLoading: false, pageError: null }));
+      return true;
+    } catch (error) {
+      if (request !== pageRequest) return false;
+      update((state) => ({
+        ...state,
+        page: null,
+        pageLoading: false,
+        pageError: errorMessage(error, 'Unable to load the knowledge page.'),
+      }));
+      return false;
+    }
+  }
+
+  return {
+    subscribe,
+    loadGraph,
+    selectNode,
+    retryPage(sessionId: string | null = null) {
+      let selectedId: string | null = null;
+      const unsubscribe = subscribe((state) => {
+        selectedId = state.selectedId;
+      });
+      unsubscribe();
+      return selectNode(selectedId, sessionId);
+    },
+    reset() {
+      graphRequest += 1;
+      pageRequest += 1;
+      graphScope = null;
+      hasGraphScope = false;
+      set({
+        graph: EMPTY_GRAPH,
+        loading: false,
+        refreshing: false,
+        error: null,
+        selectedId: null,
+        page: null,
+        pageLoading: false,
+        pageError: null,
+      });
+    },
+  };
+}
+
+export const knowledgeStore = createKnowledgeStore();

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -1,0 +1,596 @@
+<script lang="ts">
+  import { routePage } from '$lib/knowledge/navigation';
+  import {
+    ArrowClockwise,
+    Brain,
+    GitBranch,
+    House,
+    Kanban,
+    ListBullets,
+    MagnifyingGlass,
+  } from 'phosphor-svelte';
+  import KnowledgeGraph from '$lib/components/knowledge/KnowledgeGraph.svelte';
+  import KnowledgePagePreview from '$lib/components/knowledge/KnowledgePagePreview.svelte';
+  import KnowledgeTable from '$lib/components/knowledge/KnowledgeTable.svelte';
+  import {
+    EDGE_COLORS,
+    EDGE_LABELS,
+    filterKnowledgeGraph,
+    folderColor,
+  } from '$lib/knowledge/graphUtils';
+  import { KNOWLEDGE_EDGE_KINDS, type KnowledgeView } from '$lib/knowledge/types';
+  import { knowledgeStore } from '$lib/stores/knowledge';
+
+  interface FocusTarget {
+    readonly isConnected: boolean;
+    focus: (options?: FocusOptions) => void;
+  }
+
+  let sessionId = $derived($routePage.url.searchParams.get('session_id') || null);
+  let query = $state('');
+  let folder = $state('all');
+  let view = $state<KnowledgeView>('graph');
+  let previewReturnFocus = $state.raw<FocusTarget | null>(null);
+
+  let folders = $derived.by(() => {
+    const preferredOrder = ['patterns', 'practices', 'research', 'project'];
+    return [...new Set($knowledgeStore.graph.nodes.map((node) => node.folder))].sort(
+      (left, right) => {
+        const leftIndex = preferredOrder.indexOf(left);
+        const rightIndex = preferredOrder.indexOf(right);
+        if (leftIndex !== -1 || rightIndex !== -1) {
+          return (leftIndex === -1 ? preferredOrder.length : leftIndex) -
+            (rightIndex === -1 ? preferredOrder.length : rightIndex);
+        }
+        return left.localeCompare(right);
+      },
+    );
+  });
+  let filteredGraph = $derived(filterKnowledgeGraph($knowledgeStore.graph, query, folder));
+
+  $effect(() => {
+    const currentSessionId = sessionId;
+    knowledgeStore.loadGraph(currentSessionId);
+  });
+
+  function selectNode(id: string, trigger?: Element) {
+    if (trigger && typeof (trigger as Element & { focus?: unknown }).focus === 'function') {
+      previewReturnFocus = trigger as Element & FocusTarget;
+    }
+    return knowledgeStore.selectNode(id, sessionId);
+  }
+
+  function folderCount(name: string): number {
+    return $knowledgeStore.graph.nodes.filter((node) => node.folder === name).length;
+  }
+</script>
+
+<svelte:head><title>Knowledge · Hive Manager</title></svelte:head>
+
+<div class="knowledge-page">
+  <header class="page-header">
+    <div class="identity">
+      <div class="identity-mark" aria-hidden="true"><Brain size={20} weight="light" /></div>
+      <div>
+        <div class="eyebrow">Institutional memory</div>
+        <h1>Knowledge Atlas</h1>
+      </div>
+    </div>
+
+    <div class="corpus-stats" aria-label="Knowledge corpus totals">
+      <div><strong>{$knowledgeStore.graph.nodes.length}</strong><span>Pages</span></div>
+      <div><strong>{$knowledgeStore.graph.edges.length}</strong><span>Links</span></div>
+      <div><strong>{folders.length}</strong><span>Folders</span></div>
+    </div>
+
+    <nav class="page-nav" aria-label="Main views">
+      <a href="/" title="Session view"><House size={16} weight="light" /><span>Sessions</span></a>
+      <a href="/dashboard" title="Dashboard"><Kanban size={16} weight="light" /><span>Dashboard</span></a>
+    </nav>
+  </header>
+
+  <section class="toolbar" aria-label="Knowledge controls">
+    <label class="search-field">
+      <MagnifyingGlass size={15} weight="light" aria-hidden="true" />
+      <span class="sr-only">Search knowledge</span>
+      <input bind:value={query} type="search" placeholder="Search title, path, or folder…" />
+      {#if query}<kbd>{filteredGraph.nodes.length}</kbd>{/if}
+    </label>
+
+    <label class="folder-field">
+      <span class="sr-only">Filter by folder</span>
+      <select bind:value={folder} aria-label="Filter by folder">
+        <option value="all">All folders ({$knowledgeStore.graph.nodes.length})</option>
+        {#each folders as name (name)}
+          <option value={name}>{name} ({folderCount(name)})</option>
+        {/each}
+      </select>
+    </label>
+
+    <div class="view-switch" aria-label="Knowledge view">
+      <button
+        type="button"
+        class:active={view === 'graph'}
+        aria-pressed={view === 'graph'}
+        onclick={() => view = 'graph'}
+      >
+        <GitBranch size={14} weight="light" />Graph
+      </button>
+      <button
+        type="button"
+        class:active={view === 'table'}
+        aria-pressed={view === 'table'}
+        onclick={() => view = 'table'}
+      >
+        <ListBullets size={14} weight="light" />Table
+      </button>
+    </div>
+
+    <button
+      type="button"
+      class="refresh"
+      class:spinning={$knowledgeStore.refreshing}
+      onclick={() => knowledgeStore.loadGraph(sessionId)}
+      disabled={$knowledgeStore.loading || $knowledgeStore.refreshing}
+      aria-label="Refresh knowledge graph"
+      title="Refresh knowledge graph"
+    >
+      <ArrowClockwise size={15} weight="light" />
+    </button>
+  </section>
+
+  {#if $knowledgeStore.error && $knowledgeStore.graph.nodes.length > 0}
+    <div class="notice error-notice" role="alert">
+      Refresh failed: {$knowledgeStore.error}. Showing the last loaded graph.
+    </div>
+  {/if}
+  {#if $knowledgeStore.graph.truncated}
+    <div class="notice cap-notice">
+      This atlas reached its safety cap. Refine the corpus to see pages beyond the current bounded scan.
+    </div>
+  {/if}
+
+  <div class="workspace" class:preview-open={$knowledgeStore.selectedId !== null}>
+    <main class="atlas-panel" aria-live="polite">
+      {#if $knowledgeStore.loading && $knowledgeStore.graph.nodes.length === 0}
+        <div class="full-state loading-state">
+          <div class="radar" aria-hidden="true"><span></span></div>
+          <strong>Mapping the corpus</strong>
+          <p>Scanning the safe wiki folders and project knowledge…</p>
+        </div>
+      {:else if $knowledgeStore.error && $knowledgeStore.graph.nodes.length === 0}
+        <div class="full-state error-state" role="alert">
+          <Brain size={32} weight="light" />
+          <strong>Knowledge map unavailable</strong>
+          <p>{$knowledgeStore.error}</p>
+          <button type="button" onclick={() => knowledgeStore.loadGraph(sessionId)}>Try again</button>
+        </div>
+      {:else if $knowledgeStore.graph.nodes.length === 0}
+        <div class="full-state empty-state">
+          <Brain size={32} weight="light" />
+          <strong>No knowledge pages found</strong>
+          <p>Add markdown under patterns, practices, research, or the project’s .ai-docs folder.</p>
+          <button type="button" onclick={() => knowledgeStore.loadGraph(sessionId)}>Scan again</button>
+        </div>
+      {:else if filteredGraph.nodes.length === 0}
+        <div class="full-state empty-state">
+          <MagnifyingGlass size={30} weight="light" />
+          <strong>No matching pages</strong>
+          <p>Try a broader search or choose another folder.</p>
+          <button type="button" onclick={() => { query = ''; folder = 'all'; }}>Clear filters</button>
+        </div>
+      {:else}
+        <div class="view-frame">
+          <div class="result-strip">
+            <span>{filteredGraph.nodes.length} of {$knowledgeStore.graph.nodes.length} pages</span>
+            <span>{filteredGraph.edges.length} visible relationships</span>
+          </div>
+          <div class="view-body">
+            {#if view === 'graph'}
+              <KnowledgeGraph
+                nodes={filteredGraph.nodes}
+                edges={filteredGraph.edges}
+                selectedId={$knowledgeStore.selectedId}
+                onSelect={selectNode}
+              />
+            {:else}
+              <KnowledgeTable
+                nodes={filteredGraph.nodes}
+                selectedId={$knowledgeStore.selectedId}
+                onSelect={selectNode}
+              />
+            {/if}
+          </div>
+          <footer class="legend">
+            <div class="legend-group" aria-label="Folder colors">
+              {#each folders as name (name)}
+                <span><i style:background={folderColor(name)}></i>{name}</span>
+              {/each}
+            </div>
+            {#if view === 'graph'}
+              <div class="legend-group edge-legend" aria-label="Relationship types">
+                {#each KNOWLEDGE_EDGE_KINDS as kind (kind)}
+                  <span><i style:background={EDGE_COLORS[kind]}></i>{EDGE_LABELS[kind]}</span>
+                {/each}
+              </div>
+            {/if}
+          </footer>
+        </div>
+      {/if}
+    </main>
+
+    {#if $knowledgeStore.selectedId}
+      <KnowledgePagePreview
+        selectedId={$knowledgeStore.selectedId}
+        page={$knowledgeStore.page}
+        loading={$knowledgeStore.pageLoading}
+        error={$knowledgeStore.pageError}
+        onClose={() => knowledgeStore.selectNode(null, sessionId)}
+        onRetry={() => knowledgeStore.retryPage(sessionId)}
+        returnFocus={previewReturnFocus}
+      />
+    {/if}
+  </div>
+</div>
+
+<style>
+  :global(*) { box-sizing: border-box; }
+  :global(body) { overflow: hidden; }
+
+  .knowledge-page {
+    display: flex;
+    flex-direction: column;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    background: var(--bg-void);
+    color: var(--text-primary);
+    font-family: var(--font-body);
+  }
+
+  .page-header {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    min-height: 72px;
+    padding: 0 var(--space-5);
+    border-bottom: 1px solid var(--border-structural);
+    background:
+      linear-gradient(90deg, color-mix(in srgb, var(--accent-cyan) 4%, transparent), transparent 34%),
+      var(--bg-surface);
+  }
+
+  .identity {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+  }
+
+  .identity-mark {
+    display: grid;
+    place-items: center;
+    width: 38px;
+    height: 38px;
+    border: 1px solid var(--accent-cyan);
+    color: var(--accent-cyan);
+    background: color-mix(in srgb, var(--accent-cyan) 7%, transparent);
+    box-shadow: inset 0 0 12px color-mix(in srgb, var(--accent-cyan) 5%, transparent);
+  }
+
+  .eyebrow {
+    margin-bottom: 2px;
+    color: var(--text-disabled);
+    font: var(--text-micro) var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+  }
+
+  h1 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--text-h1);
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .corpus-stats {
+    display: flex;
+    align-items: stretch;
+    border: 1px solid var(--border-structural);
+    background: var(--bg-void);
+  }
+
+  .corpus-stats div {
+    display: flex;
+    align-items: baseline;
+    gap: 5px;
+    padding: 6px 11px;
+    border-right: 1px solid var(--border-structural);
+  }
+
+  .corpus-stats div:last-child { border-right: 0; }
+  .corpus-stats strong { color: var(--accent-cyan); font: 14px var(--font-mono); }
+  .corpus-stats span { color: var(--text-disabled); font: 9px var(--font-mono); text-transform: uppercase; }
+
+  .page-nav {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--space-2);
+  }
+
+  .page-nav a {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 7px 9px;
+    border: 1px solid transparent;
+    color: var(--text-secondary);
+    font: var(--text-small) var(--font-mono);
+    text-decoration: none;
+  }
+
+  .page-nav a:hover {
+    border-color: var(--border-structural);
+    background: var(--bg-elevated);
+    color: var(--accent-cyan);
+  }
+
+  .toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    min-height: 52px;
+    padding: var(--space-2) var(--space-4);
+    border-bottom: 1px solid var(--border-structural);
+    background: var(--bg-surface);
+  }
+
+  .search-field {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    width: min(430px, 42vw);
+    height: 34px;
+    padding: 0 var(--space-3);
+    border: 1px solid var(--border-structural);
+    background: var(--bg-void);
+    color: var(--text-disabled);
+  }
+
+  .search-field:focus-within {
+    border-color: var(--accent-cyan);
+    color: var(--accent-cyan);
+  }
+
+  .search-field input {
+    flex: 1;
+    min-width: 0;
+    border: 0;
+    outline: 0;
+    background: transparent;
+    color: var(--text-primary);
+    font: var(--text-small) var(--font-mono);
+  }
+
+  .search-field input::placeholder { color: var(--text-disabled); }
+  .search-field kbd { color: var(--accent-cyan); font: var(--text-micro) var(--font-mono); }
+
+  .folder-field select {
+    height: 34px;
+    min-width: 170px;
+    padding: 0 28px 0 var(--space-3);
+    border: 1px solid var(--border-structural);
+    border-radius: 0;
+    outline: 0;
+    background: var(--bg-void);
+    color: var(--text-secondary);
+    font: var(--text-small) var(--font-mono);
+    text-transform: capitalize;
+  }
+
+  .folder-field select:focus { border-color: var(--accent-cyan); }
+
+  .view-switch {
+    display: flex;
+    margin-left: auto;
+    border: 1px solid var(--border-structural);
+  }
+
+  .view-switch button,
+  .refresh {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 32px;
+    padding: 0 var(--space-3);
+    border: 0;
+    border-right: 1px solid var(--border-structural);
+    background: var(--bg-void);
+    color: var(--text-secondary);
+    font: var(--text-micro) var(--font-mono);
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .view-switch button:last-child { border-right: 0; }
+  .view-switch button:hover, .view-switch button.active { color: var(--accent-cyan); background: var(--bg-elevated); }
+  .view-switch button.active { box-shadow: inset 0 -2px var(--accent-cyan); }
+
+  .refresh {
+    width: 34px;
+    padding: 0;
+    border: 1px solid var(--border-structural);
+  }
+
+  .refresh:hover:not(:disabled) { color: var(--accent-cyan); background: var(--bg-elevated); }
+  .refresh:disabled { opacity: 0.45; cursor: wait; }
+  .refresh.spinning :global(svg) { animation: spin 0.8s linear infinite; }
+
+  .notice {
+    padding: 5px var(--space-4);
+    border-bottom: 1px solid var(--border-structural);
+    color: var(--text-secondary);
+    background: var(--bg-elevated);
+    font: var(--text-micro) var(--font-mono);
+  }
+
+  .error-notice { color: var(--status-warning); }
+  .cap-notice { color: var(--accent-amber); }
+
+  .workspace {
+    flex: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .workspace.preview-open { grid-template-columns: minmax(0, 1fr) minmax(330px, 390px); }
+
+  .atlas-panel {
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .view-frame {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    height: 100%;
+  }
+
+  .result-strip {
+    display: flex;
+    justify-content: space-between;
+    padding: 5px var(--space-3);
+    border-bottom: 1px solid var(--border-structural);
+    color: var(--text-disabled);
+    background: var(--bg-void);
+    font: 9px var(--font-mono);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .view-body { flex: 1; min-height: 0; }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-3);
+    min-height: 34px;
+    padding: 0 var(--space-3);
+    border-top: 1px solid var(--border-structural);
+    background: var(--bg-surface);
+    overflow-x: auto;
+  }
+
+  .legend-group {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    white-space: nowrap;
+  }
+
+  .legend-group span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--text-secondary);
+    font: 9px var(--font-mono);
+    text-transform: uppercase;
+  }
+
+  .legend-group i { width: 6px; height: 6px; }
+  .edge-legend i { width: 13px; height: 1px; }
+
+  .full-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: var(--space-5);
+    color: var(--text-secondary);
+    text-align: center;
+    background:
+      linear-gradient(var(--border-structural) 1px, transparent 1px),
+      linear-gradient(90deg, var(--border-structural) 1px, transparent 1px);
+    background-size: 28px 28px;
+  }
+
+  .full-state > * { position: relative; }
+  .full-state strong { margin-top: var(--space-3); color: var(--text-primary); font: 18px var(--font-display); }
+  .full-state p { max-width: 430px; margin: var(--space-2) 0 0; font-size: var(--text-small); }
+  .full-state button {
+    margin-top: var(--space-4);
+    padding: var(--space-2) var(--space-4);
+    border: 1px solid var(--accent-cyan);
+    background: var(--bg-void);
+    color: var(--accent-cyan);
+    font: var(--text-small) var(--font-mono);
+    cursor: pointer;
+  }
+
+  .error-state > :global(svg) { color: var(--status-error); }
+  .empty-state > :global(svg) { color: var(--text-disabled); }
+
+  .radar {
+    position: relative;
+    width: 48px;
+    height: 48px;
+    border: 1px solid var(--border-structural);
+    border-radius: 50%;
+    background: radial-gradient(circle, var(--accent-cyan) 0 2px, transparent 3px);
+    overflow: hidden;
+  }
+
+  .radar::before, .radar::after { content: ''; position: absolute; background: var(--border-structural); }
+  .radar::before { left: 50%; top: 0; width: 1px; height: 100%; }
+  .radar::after { top: 50%; left: 0; height: 1px; width: 100%; }
+  .radar span { position: absolute; inset: 50% 50% 0 0; background: linear-gradient(45deg, transparent, color-mix(in srgb, var(--accent-cyan) 28%, transparent)); transform-origin: 100% 0; animation: radar 1.5s linear infinite; }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @keyframes spin { to { transform: rotate(360deg); } }
+  @keyframes radar { to { transform: rotate(360deg); } }
+
+  @media (max-width: 920px) {
+    .page-header { grid-template-columns: 1fr auto; }
+    .corpus-stats { display: none; }
+    .workspace.preview-open { grid-template-columns: minmax(0, 1fr) minmax(300px, 42vw); }
+    .edge-legend { display: none; }
+  }
+
+  @media (max-width: 700px) {
+    .page-header { min-height: 62px; padding: 0 var(--space-3); }
+    .page-nav span { display: none; }
+    .identity-mark { display: none; }
+    .toolbar { flex-wrap: wrap; min-height: auto; padding: var(--space-2); }
+    .search-field { width: 100%; }
+    .folder-field { flex: 1; }
+    .folder-field select { width: 100%; min-width: 0; }
+    .view-switch { margin-left: 0; }
+    .workspace.preview-open { grid-template-columns: 1fr; }
+    .workspace.preview-open .atlas-panel { display: none; }
+    .legend { display: none; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .refresh.spinning :global(svg), .radar span { animation: none; }
+  }
+</style>

--- a/src/routes/knowledge/knowledge-page.svelte.test.ts
+++ b/src/routes/knowledge/knowledge-page.svelte.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/svelte';
+
+const pageStore = vi.hoisted(() => {
+  type PageValue = { url: URL };
+  let value: PageValue = { url: new URL('http://localhost/knowledge') };
+  const subscribers = new Set<(next: PageValue) => void>();
+  return {
+    subscribe(run: (next: PageValue) => void) {
+      subscribers.add(run);
+      run(value);
+      return () => subscribers.delete(run);
+    },
+    set(next: PageValue) {
+      value = next;
+      for (const subscriber of subscribers) subscriber(value);
+    },
+  };
+});
+
+vi.mock('$lib/knowledge/navigation', () => ({ routePage: pageStore }));
+
+import KnowledgePage from './+page.svelte';
+import { knowledgeStore } from '$lib/stores/knowledge';
+
+function jsonResponse(payload: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue(payload),
+  } as unknown as Response;
+}
+
+describe('Knowledge route scope', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    knowledgeStore.reset();
+    pageStore.set({ url: new URL('http://localhost/knowledge?session_id=session-a') });
+    fetchMock = vi.fn().mockResolvedValue(jsonResponse({ nodes: [], edges: [] }));
+    vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    cleanup();
+    knowledgeStore.reset();
+    vi.unstubAllGlobals();
+  });
+
+  it('reloads the graph when query navigation changes the session scope', async () => {
+    render(KnowledgePage);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const firstUrl = new URL(String(fetchMock.mock.calls[0][0]));
+    expect(firstUrl.pathname).toBe('/api/knowledge/graph');
+    expect(firstUrl.searchParams.get('session_id')).toBe('session-a');
+
+    pageStore.set({ url: new URL('http://localhost/knowledge?session_id=session-b') });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const secondUrl = new URL(String(fetchMock.mock.calls[1][0]));
+    expect(secondUrl.pathname).toBe('/api/knowledge/graph');
+    expect(secondUrl.searchParams.get('session_id')).toBe('session-b');
+  });
+});


### PR DESCRIPTION
## Summary

- add a dedicated Knowledge Atlas with graph and table views, search, filtering, sorting, safe previews, and accessible keyboard/focus behavior
- expose privacy-bounded knowledge graph/page APIs for allow-listed global wiki folders and session-scoped project knowledge
- require exact-ID completed heartbeats across managed, research, Fusion, and QA workers
- give Queens an explicit verification/status tool and exact Fusion roster IDs
- atomically finalize durable queue rows on completed heartbeats so finished work is not reclaimed
- synchronize release metadata to version 0.35.1

## Why

Issue #153 had no dedicated, privacy-safe way to explore the project and global knowledge graph. Issue #155 left completed workers reporting only task-file state, so the UI and stall monitor could continue treating verified work as active or reclaimable.

## User impact

Operators can now browse institutional knowledge without exposing private wiki folders or mixing project data across sessions. Worker completion is reflected consistently in the UI, stall sweep, and durable queue.

## Root cause

- The knowledge corpus had no bounded API or dedicated UI, and project-local pages were not tied to an explicit session identity.
- Completion prompts omitted a final heartbeat, Queens lacked a documented status tool, and durable queue rows remained running after verified completion.

## Validation

- `cargo test --lib` — 494 passed, 1 ignored, 0 failed
- `cargo check --lib`
- `npm test` — 92 passed
- `npm run check` — 0 errors, 0 warnings
- `npm run build`
- `git diff --check`
- `cargo metadata --no-deps --format-version 1` reports 0.35.1

Rustfmt was unavailable in the installed Rust toolchain; compilation, tests, and diff whitespace checks are clean.

Closes #153
Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Knowledge Atlas with interactive graph and sortable table views, search and folder filtering.
  * Added session-scoped “knowledge graph” and “knowledge page” endpoints with safe, read-only page previews.
  * Introduced a dedicated knowledge page preview panel with loading, error, and focus management.
* **Bug Fixes**
  * Completed worker heartbeats now properly finalize queue items and are excluded from stall handling and reclamation.
* **Documentation**
  * Updated the displayed application/Hive Manager version to **0.35.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->