### PR TITLE
feat: forgiving preview URLs + dock/pop-out, knowledge atlas relationship entities (#157, #158)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,38 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - "feat/**"
+
+permissions:
+  contents: read
+
+jobs:
+  frontend-test:
+    name: Svelte check and vitest
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Svelte check
+        run: npm run check
+
+      - name: Vitest
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.35.1"
+version = "0.36.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/permissions/main-window-commands.toml
+++ b/src-tauri/permissions/main-window-commands.toml
@@ -54,4 +54,9 @@ commands.allow = [
     "get_run_journal",
     "list_session_files",
     "open_preview_window",
+    "close_preview_window",
+    "dock_preview_window",
+    "undock_preview_window",
+    "reload_preview_window",
+    "get_preview_status",
 ]

--- a/src-tauri/src/acl_parity.rs
+++ b/src-tauri/src/acl_parity.rs
@@ -1,0 +1,429 @@
+//! Compile-time parity guard for the Tauri v2 command ACL (PR #154 invariant).
+//!
+//! Tauri v2 denies any `invoke` whose command is not explicitly allowed by a
+//! capability. `capabilities/default.json` grants the main window the
+//! `main-window-commands` permission, whose `commands.allow` list is the single
+//! source of truth for what the main window may call. If a command is added to
+//! `tauri::generate_handler![...]` but not to that manifest, the build is clean,
+//! clippy is clean, CI is green — and the feature dies with an ACL denial the
+//! first time a user clicks it.
+//!
+//! This test reads both lists out of the real source at compile time via
+//! `include_str!` and asserts they describe the same SET of commands.
+//!
+//! Parsing notes (these are load-bearing, do not "simplify" them):
+//!  * The handler block is located with real bracket-depth matching. A non-greedy
+//!    regex such as `generate_handler!\s*\[(.*?)\]` truncates at the first `]` it
+//!    finds and silently yields a short list — a parser that reads the wrong
+//!    block is worse than no test at all.
+//!  * Comparison is on the bare final path segment, so `preview::open_preview_window`
+//!    and the manifest's `"open_preview_window"` match.
+//!  * Comparison is SET-based. The two lists are set-equal but NOT order-equal.
+
+use std::collections::{BTreeSet, HashMap};
+
+/// The real `lib.rs` source, captured at compile time.
+const LIB_RS: &str = include_str!("lib.rs");
+
+/// The real capability permission manifest, captured at compile time.
+const MANIFEST_TOML: &str = include_str!("../permissions/main-window-commands.toml");
+
+/// Non-zero floor so a parser that silently matches nothing can never pass green.
+/// The real count was 52 when this test was written; this only needs to be a
+/// number a broken parser could not plausibly reach.
+const MIN_EXPECTED_COMMANDS: usize = 50;
+
+/// Comment style for the scanner below.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum CommentStyle {
+    /// Rust: `//` to end of line, plus `/* ... */`.
+    Rust,
+    /// TOML: `#` to end of line.
+    Toml,
+}
+
+/// Returns the byte range of the *contents* of the bracketed block whose opening
+/// `[` is at `open_idx`, using true bracket-depth matching.
+///
+/// Brackets inside comments and inside double-quoted strings are ignored, so a
+/// `// [note]` or `"a]b"` inside the block cannot terminate it early.
+fn matching_bracket_body(src: &str, open_idx: usize, style: CommentStyle) -> Option<(usize, usize)> {
+    let bytes = src.as_bytes();
+    if bytes.get(open_idx) != Some(&b'[') {
+        return None;
+    }
+
+    let mut depth: usize = 0;
+    let mut i = open_idx;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        let next = bytes.get(i + 1).copied();
+
+        if in_line_comment {
+            if c == b'\n' {
+                in_line_comment = false;
+            }
+            i += 1;
+            continue;
+        }
+        if in_block_comment {
+            if c == b'*' && next == Some(b'/') {
+                in_block_comment = false;
+                i += 2;
+                continue;
+            }
+            i += 1;
+            continue;
+        }
+        if in_string {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+            i += 1;
+            continue;
+        }
+
+        match (style, c, next) {
+            (CommentStyle::Rust, b'/', Some(b'/')) => {
+                in_line_comment = true;
+                i += 2;
+                continue;
+            }
+            (CommentStyle::Rust, b'/', Some(b'*')) => {
+                in_block_comment = true;
+                i += 2;
+                continue;
+            }
+            (CommentStyle::Toml, b'#', _) => {
+                in_line_comment = true;
+                i += 1;
+                continue;
+            }
+            (_, b'"', _) => {
+                in_string = true;
+                i += 1;
+                continue;
+            }
+            (_, b'[', _) => depth += 1,
+            (_, b']', _) => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some((open_idx + 1, i));
+                }
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    None
+}
+
+/// Strips comments (`//` and `/* */` for Rust, `#` for TOML) from a block body,
+/// preserving newlines so adjacent entries can never be glued together.
+///
+/// Uses the same state machine as the bracket matcher, so a comma or bracket
+/// inside a comment cannot be mistaken for a separator.
+fn strip_comments(body: &str, style: CommentStyle) -> String {
+    let bytes = body.as_bytes();
+    let mut out = String::with_capacity(body.len());
+    let mut i = 0usize;
+    let mut in_line_comment = false;
+    let mut in_block_comment = false;
+    let mut in_string = false;
+
+    while i < bytes.len() {
+        let c = bytes[i];
+        let next = bytes.get(i + 1).copied();
+
+        if in_line_comment {
+            if c == b'\n' {
+                in_line_comment = false;
+                out.push('\n');
+            }
+            i += 1;
+            continue;
+        }
+        if in_block_comment {
+            if c == b'*' && next == Some(b'/') {
+                in_block_comment = false;
+                i += 2;
+                continue;
+            }
+            if c == b'\n' {
+                out.push('\n');
+            }
+            i += 1;
+            continue;
+        }
+        if in_string {
+            if c == b'\\' {
+                // Copy the backslash, then the escaped character whole.
+                out.push('\\');
+                i = copy_one_char(body, i + 1, &mut out);
+                continue;
+            }
+            if c == b'"' {
+                in_string = false;
+            }
+        } else {
+            match (style, c, next) {
+                (CommentStyle::Rust, b'/', Some(b'/')) => {
+                    in_line_comment = true;
+                    i += 2;
+                    continue;
+                }
+                (CommentStyle::Rust, b'/', Some(b'*')) => {
+                    in_block_comment = true;
+                    i += 2;
+                    continue;
+                }
+                (CommentStyle::Toml, b'#', _) => {
+                    in_line_comment = true;
+                    i += 1;
+                    continue;
+                }
+                (_, b'"', _) => in_string = true,
+                _ => {}
+            }
+        }
+
+        i = copy_one_char(body, i, &mut out);
+    }
+
+    out
+}
+
+/// Copies the single UTF-8 character starting at byte index `i` into `out` and
+/// returns the index just past it. Keeps multi-byte sequences intact.
+fn copy_one_char(src: &str, i: usize, out: &mut String) -> usize {
+    let bytes = src.as_bytes();
+    if i >= bytes.len() {
+        return i;
+    }
+    let mut end = i + 1;
+    while end < bytes.len() && (bytes[end] & 0b1100_0000) == 0b1000_0000 {
+        end += 1;
+    }
+    out.push_str(&src[i..end]);
+    end
+}
+
+/// Splits a comma-separated block into trimmed, non-empty entries.
+/// Trailing commas and arbitrary whitespace/newlines are absorbed by the trim.
+fn split_entries(body: &str) -> Vec<String> {
+    body.split(',')
+        .map(str::trim)
+        .filter(|entry| !entry.is_empty())
+        .map(str::to_string)
+        .collect()
+}
+
+/// `preview::open_preview_window` -> `open_preview_window`
+fn bare_command_name(path: &str) -> String {
+    path.rsplit("::")
+        .next()
+        .unwrap_or(path)
+        .trim()
+        .to_string()
+}
+
+/// Commands registered in `tauri::generate_handler![...]` in `lib.rs`.
+fn handler_commands() -> Vec<String> {
+    let occurrences = LIB_RS.match_indices("generate_handler!").count();
+    assert_eq!(
+        occurrences, 1,
+        "expected exactly one `generate_handler!` invocation in lib.rs, found {occurrences}. \
+         This test must parse THE command registry; disambiguate before proceeding."
+    );
+
+    let macro_idx = LIB_RS
+        .find("generate_handler!")
+        .expect("checked by the assert above");
+    let open_idx = LIB_RS[macro_idx..]
+        .find('[')
+        .map(|offset| macro_idx + offset)
+        .expect("`generate_handler!` must be followed by a `[` command list");
+
+    let (start, end) = matching_bracket_body(LIB_RS, open_idx, CommentStyle::Rust)
+        .expect("unbalanced brackets in the `generate_handler!` block in lib.rs");
+
+    let cleaned = strip_comments(&LIB_RS[start..end], CommentStyle::Rust);
+    split_entries(&cleaned)
+        .iter()
+        .map(|entry| bare_command_name(entry))
+        .collect()
+}
+
+/// Commands allowed by `permissions/main-window-commands.toml` (`commands.allow`).
+fn manifest_commands() -> Vec<String> {
+    let key_idx = MANIFEST_TOML
+        .find("commands.allow")
+        .expect("`commands.allow` key missing from main-window-commands.toml");
+    let open_idx = MANIFEST_TOML[key_idx..]
+        .find('[')
+        .map(|offset| key_idx + offset)
+        .expect("`commands.allow` must be assigned a `[` array");
+
+    let (start, end) = matching_bracket_body(MANIFEST_TOML, open_idx, CommentStyle::Toml)
+        .expect("unbalanced brackets in `commands.allow` in main-window-commands.toml");
+
+    let cleaned = strip_comments(&MANIFEST_TOML[start..end], CommentStyle::Toml);
+    split_entries(&cleaned)
+        .iter()
+        .map(|entry| {
+            let unquoted = entry.trim_matches(|c| c == '"' || c == '\'');
+            assert!(
+                !unquoted.is_empty(),
+                "empty entry in `commands.allow`: {entry:?}"
+            );
+            assert!(
+                entry.starts_with('"') || entry.starts_with('\''),
+                "unquoted entry in `commands.allow`: {entry:?}"
+            );
+            bare_command_name(unquoted)
+        })
+        .collect()
+}
+
+/// Names appearing more than once, with their counts, sorted for stable output.
+fn duplicates(items: &[String]) -> Vec<(String, usize)> {
+    let mut counts: HashMap<&str, usize> = HashMap::new();
+    for item in items {
+        *counts.entry(item.as_str()).or_insert(0) += 1;
+    }
+    let mut dupes: Vec<(String, usize)> = counts
+        .into_iter()
+        .filter(|(_, count)| *count > 1)
+        .map(|(name, count)| (name.to_string(), count))
+        .collect();
+    dupes.sort();
+    dupes
+}
+
+fn format_list(names: &[&String]) -> String {
+    if names.is_empty() {
+        return "    (none)".to_string();
+    }
+    names
+        .iter()
+        .map(|name| format!("    - {name}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// The load-bearing invariant: every command the main window can invoke must be
+/// allowed by the capability manifest, and vice versa.
+#[test]
+fn generate_handler_and_acl_manifest_are_set_equal() {
+    let handler = handler_commands();
+    let manifest = manifest_commands();
+
+    // Floor: a parser that silently matched nothing must never pass green.
+    assert!(
+        handler.len() >= MIN_EXPECTED_COMMANDS,
+        "parsed only {} command(s) from `generate_handler!` in lib.rs, expected at least {}. \
+         The parser is broken (or the command registry shrank drastically).",
+        handler.len(),
+        MIN_EXPECTED_COMMANDS
+    );
+    assert!(
+        manifest.len() >= MIN_EXPECTED_COMMANDS,
+        "parsed only {} command(s) from `commands.allow` in main-window-commands.toml, \
+         expected at least {}. The parser is broken (or the manifest was gutted).",
+        manifest.len(),
+        MIN_EXPECTED_COMMANDS
+    );
+
+    // Duplicates would let a count-only check hide a missing entry.
+    let handler_dupes = duplicates(&handler);
+    assert!(
+        handler_dupes.is_empty(),
+        "duplicate command(s) in `generate_handler!` in lib.rs: {handler_dupes:?}"
+    );
+    let manifest_dupes = duplicates(&manifest);
+    assert!(
+        manifest_dupes.is_empty(),
+        "duplicate command(s) in `commands.allow` in main-window-commands.toml: {manifest_dupes:?}"
+    );
+
+    let handler_set: BTreeSet<String> = handler.iter().cloned().collect();
+    let manifest_set: BTreeSet<String> = manifest.iter().cloned().collect();
+
+    if handler_set != manifest_set {
+        let missing_from_manifest: Vec<&String> =
+            handler_set.difference(&manifest_set).collect();
+        let missing_from_handler: Vec<&String> =
+            manifest_set.difference(&handler_set).collect();
+
+        panic!(
+            "\nTauri command ACL parity violation (PR #154 invariant).\n\
+             \n\
+             `tauri::generate_handler!` in src-tauri/src/lib.rs registered {handler_len} command(s).\n\
+             `commands.allow` in src-tauri/permissions/main-window-commands.toml allowed {manifest_len} command(s).\n\
+             \n\
+             Registered in generate_handler! but MISSING from the ACL manifest\n\
+             (these will fail at runtime with an ACL denial the first time a user invokes them);\n\
+             fix by adding each to commands.allow in main-window-commands.toml:\n\
+             {missing_from_manifest}\n\
+             \n\
+             Allowed by the ACL manifest but NOT registered in generate_handler!\n\
+             (stale grant, or the command was renamed/removed);\n\
+             fix by removing each from commands.allow, or re-registering it in lib.rs:\n\
+             {missing_from_handler}\n",
+            handler_len = handler.len(),
+            manifest_len = manifest.len(),
+            missing_from_manifest = format_list(&missing_from_manifest),
+            missing_from_handler = format_list(&missing_from_handler),
+        );
+    }
+}
+
+/// Guards the parser itself: proves bracket-depth matching consumes nested
+/// brackets and comment noise instead of truncating at the first `]`.
+///
+/// A non-greedy regex over this fixture stops at `[0]` and reports 1 command;
+/// the correct answer is 4.
+#[test]
+fn bracket_depth_matching_does_not_truncate() {
+    let fixture = r#"
+        .invoke_handler(tauri::generate_handler![
+            // PTY commands [see docs]
+            create_pty,
+            some_module::nested_arrays[0],
+            /* block comment with ] and , inside */
+            preview::open_preview_window,
+            last_command,
+        ])
+    "#;
+
+    let macro_idx = fixture.find("generate_handler!").unwrap();
+    let open_idx = macro_idx + fixture[macro_idx..].find('[').unwrap();
+    let (start, end) =
+        matching_bracket_body(fixture, open_idx, CommentStyle::Rust).expect("balanced brackets");
+
+    let cleaned = strip_comments(&fixture[start..end], CommentStyle::Rust);
+    let names: Vec<String> = split_entries(&cleaned)
+        .iter()
+        .map(|entry| bare_command_name(entry))
+        .collect();
+
+    assert_eq!(
+        names,
+        vec![
+            "create_pty",
+            "nested_arrays[0]",
+            "open_preview_window",
+            "last_command",
+        ],
+        "bracket-depth matching truncated or mis-split the handler block"
+    );
+}

--- a/src-tauri/src/cli/registry.rs
+++ b/src-tauri/src/cli/registry.rs
@@ -390,6 +390,7 @@ mod tests {
                 port: 18800,
             },
             global_wiki_path: None,
+            knowledge_wiki_folders: None,
         }
     }
 

--- a/src-tauri/src/http/handlers/knowledge.rs
+++ b/src-tauri/src/http/handlers/knowledge.rs
@@ -108,9 +108,15 @@ impl KnowledgeFolder {
 /// Security property: entries are *matched against* the compiled-in `WIKI_FOLDERS` variants. They
 /// select, they never construct. An unrecognized entry — `"agents"`, `"../../../etc"`, an absolute
 /// path — is logged and dropped, so config can only ever narrow or reorder the scan, never widen
-/// it or aim it at a directory outside the wiki root. Absent or fully-unrecognized config falls
-/// back to the built-in default rather than scanning nothing, so a typo degrades to the documented
-/// behavior instead of silently emptying the Atlas.
+/// it or aim it at a directory outside the wiki root.
+///
+/// Fail closed: this is a privacy boundary, not a display preference. `None` — the key absent,
+/// which is what every pre-existing `config.json` deserializes to — means "no operator opinion"
+/// and selects the built-in default. `Some(_)` is an operator-supplied boundary and is never
+/// widened past what it names, so a list that resolves to nothing (empty, blank, or entirely
+/// unrecognized) selects nothing. A typo empties the Atlas — loud, obvious, and instantly
+/// self-correcting — instead of silently restoring `clients`, `partners`, and `vendors` to a
+/// graph the operator believed excluded them.
 fn resolve_wiki_folders_from(configured: Option<&[String]>) -> Vec<KnowledgeFolder> {
     let Some(configured) = configured else {
         return WIKI_FOLDERS.to_vec();
@@ -140,10 +146,16 @@ fn resolve_wiki_folders_from(configured: Option<&[String]>) -> Vec<KnowledgeFold
     }
 
     if selected.is_empty() {
-        WIKI_FOLDERS.to_vec()
-    } else {
-        selected
+        // `error!` rather than `warn!`: `lib.rs` initializes `EnvFilter::from_default_env()` with no
+        // fallback directive, so with `RUST_LOG` unset — the normal case for a GUI-launched desktop
+        // build — anything below ERROR is filtered out and this failure would be fully silent.
+        tracing::error!(
+            configured_entries = configured.len(),
+            "knowledge_wiki_folders named no recognized folder; the Knowledge Atlas will scan no \
+             global-wiki folders. Remove the key entirely to restore the built-in default set."
+        );
     }
+    selected
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -1704,16 +1716,18 @@ mod tests {
     fn configured_folders_can_only_narrow_the_compiled_allowlist() {
         assert_eq!(resolve_wiki_folders_from(None), WIKI_FOLDERS.to_vec());
 
-        // Absent-equivalent inputs fall back to the documented default rather than scanning
-        // nothing, so a typo degrades gracefully instead of silently emptying the Atlas.
-        assert_eq!(resolve_wiki_folders_from(Some(&[])), WIKI_FOLDERS.to_vec());
+        // `None` is the only absent-equivalent input: no operator opinion, so the built-in default
+        // applies. Anything the operator actually wrote is a boundary, and a boundary naming no
+        // recognized folder selects none of them rather than quietly restoring all seven.
+        let none_selected = Vec::<KnowledgeFolder>::new();
+        assert_eq!(resolve_wiki_folders_from(Some(&[])), none_selected);
         assert_eq!(
             resolve_wiki_folders_from(Some(&[String::new()])),
-            WIKI_FOLDERS.to_vec()
+            none_selected
         );
         assert_eq!(
             resolve_wiki_folders_from(Some(&["   ".to_string()])),
-            WIKI_FOLDERS.to_vec()
+            none_selected
         );
 
         // Narrowing: a privacy-conscious machine drops the entity roots.
@@ -1751,14 +1765,17 @@ mod tests {
             "config must select among compiled-in variants, never construct new ones"
         );
 
-        // Even an entirely hostile list cannot widen: it collapses to the built-in default, which
-        // still excludes `agents` and `project`.
+        // An entirely unrecognized list cannot widen — and it does not fall back to the default
+        // either. It selects nothing, so a typo empties the Atlas instead of restoring the entity
+        // roots the operator was trying to exclude.
         let effective = resolve_wiki_folders_from(Some(&[
             "agents".to_string(),
             "../../../etc".to_string(),
         ]));
-        assert_eq!(effective, WIKI_FOLDERS.to_vec());
-        assert!(!effective.contains(&KnowledgeFolder::Project));
+        assert!(
+            effective.is_empty(),
+            "a fully unrecognized narrowing must select nothing, got {effective:?}"
+        );
     }
 
     /// End-to-end proof that narrowing is enforced where it matters — the filesystem walk — and
@@ -1815,6 +1832,38 @@ mod tests {
         assert!(
             preview_knowledge_page(wiki.path(), &hostile, None, "agents/recruiting/candidate")
                 .is_none()
+        );
+    }
+
+    /// Fail-closed at the scan layer. The failure pinned here is the fail-open one: an operator
+    /// who typos `["clients"]` intends to *exclude* the entity roots, and must never end up with
+    /// `clients/`, `partners/`, and `vendors/` rendered in a graph they believe excludes them.
+    #[test]
+    fn unrecognized_narrowing_scans_nothing_rather_than_falling_open() {
+        let wiki = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "patterns/kept.md",
+            "---\ntitle: Kept\n---\n# Kept\n",
+        );
+        write_page(
+            wiki.path(),
+            "clients/acme/dashboard.md",
+            "---\ntitle: Acme\n---\n# Acme\n",
+        );
+
+        let typo = resolve_wiki_folders_from(Some(&["cleints".to_string()]));
+        assert!(typo.is_empty(), "a typo must not resolve to the default set");
+
+        let graph = scan_knowledge(wiki.path(), &typo, None, MAX_NODES);
+        assert!(
+            graph.nodes.is_empty(),
+            "a typo'd narrowing must not scan the entity roots, got {:?}",
+            graph.nodes
+        );
+        assert!(
+            preview_knowledge_page(wiki.path(), &typo, None, "clients/acme/dashboard").is_none(),
+            "a typo'd narrowing must not leave client pages previewable"
         );
     }
 

--- a/src-tauri/src/http/handlers/knowledge.rs
+++ b/src-tauri/src/http/handlers/knowledge.rs
@@ -16,10 +16,27 @@ use super::validate_session_id;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 
-const WIKI_FOLDERS: [KnowledgeFolder; 3] = [
+/// Compiled-in ceiling for the global wiki subtrees the Atlas may read. Operator config can only
+/// narrow or re-select within this array (see `resolve_wiki_folders_from`); it can never add a
+/// folder, so an operator config value can never become an arbitrary filesystem path.
+///
+/// `agents/` is deliberately excluded, and that exclusion is a product decision, not an oversight:
+///   1. Privacy. It holds third-party recruiting-candidate dossiers with personal contact details
+///      of people who never consented to appear in a graph UI.
+///   2. Signal. It is 63 of roughly 163 otherwise-reachable files, so including it would swamp the
+///      graph with one subtree.
+///   3. Correctness. It carries 11 unfiltered `README.md` / `_TEMPLATE.md` files. Duplicate
+///      basenames collide in the `by_title` / `by_basename` maps, `unique_lookup` then returns
+///      `None` for the ambiguous key, and unrelated edges elsewhere in the graph silently drop.
+/// Re-including `agents` therefore requires fixing (3) first, not just adding the variant.
+const WIKI_FOLDERS: [KnowledgeFolder; 7] = [
     KnowledgeFolder::Patterns,
     KnowledgeFolder::Practices,
     KnowledgeFolder::Research,
+    KnowledgeFolder::Clients,
+    KnowledgeFolder::Partners,
+    KnowledgeFolder::Vendors,
+    KnowledgeFolder::Operations,
 ];
 const PROJECT_FILES: [&str; 2] = ["project-dna.md", "bug-patterns.md"];
 const DEFAULT_WIKI_ROOT: &str = "~/.ai-docs/wiki";
@@ -48,24 +65,84 @@ pub(crate) enum KnowledgeFolder {
     Patterns,
     Practices,
     Research,
+    Clients,
+    Partners,
+    Vendors,
+    Operations,
     Project,
 }
 
 impl KnowledgeFolder {
+    /// Directory name on disk and the stable node-ID prefix carried over the API.
+    ///
+    /// This is a *separate* mechanism from the `#[serde(rename_all = "snake_case")]` wire encoding
+    /// above; the two only happen to agree. Both must be updated together when a variant is added,
+    /// and `as_str_matches_the_serialized_folder_tag` pins them to each other.
     fn as_str(self) -> &'static str {
         match self {
             Self::Patterns => "patterns",
             Self::Practices => "practices",
             Self::Research => "research",
+            Self::Clients => "clients",
+            Self::Partners => "partners",
+            Self::Vendors => "vendors",
+            Self::Operations => "operations",
             Self::Project => "project",
         }
     }
 
+    /// Map an ID prefix onto the *compiled-in* allowlist, deliberately ignoring any operator
+    /// narrowing. Narrowing is enforced once, at enumeration: a folder excluded by config produces
+    /// no sources, so its IDs 404 instead of 400. Keeping validation on the superset means the
+    /// status code for an unknown page does not leak which folders an operator has switched off.
     fn from_id_prefix(prefix: &str) -> Option<Self> {
         WIKI_FOLDERS
             .into_iter()
             .chain(std::iter::once(Self::Project))
             .find(|folder| folder.as_str() == prefix)
+    }
+}
+
+/// Resolve the effective wiki folder set from optional operator config.
+///
+/// Security property: entries are *matched against* the compiled-in `WIKI_FOLDERS` variants. They
+/// select, they never construct. An unrecognized entry — `"agents"`, `"../../../etc"`, an absolute
+/// path — is logged and dropped, so config can only ever narrow or reorder the scan, never widen
+/// it or aim it at a directory outside the wiki root. Absent or fully-unrecognized config falls
+/// back to the built-in default rather than scanning nothing, so a typo degrades to the documented
+/// behavior instead of silently emptying the Atlas.
+fn resolve_wiki_folders_from(configured: Option<&[String]>) -> Vec<KnowledgeFolder> {
+    let Some(configured) = configured else {
+        return WIKI_FOLDERS.to_vec();
+    };
+
+    let mut selected: Vec<KnowledgeFolder> = Vec::new();
+    for raw in configured {
+        let name = raw.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            continue;
+        }
+        match WIKI_FOLDERS
+            .into_iter()
+            .find(|folder| folder.as_str() == name)
+        {
+            Some(folder) => {
+                if !selected.contains(&folder) {
+                    selected.push(folder);
+                }
+            }
+            None => tracing::warn!(
+                entry = %raw,
+                "ignoring unrecognized knowledge_wiki_folders entry; the Knowledge Atlas folder \
+                 set is bounded to the compiled-in wiki allowlist"
+            ),
+        }
+    }
+
+    if selected.is_empty() {
+        WIKI_FOLDERS.to_vec()
+    } else {
+        selected
     }
 }
 
@@ -188,13 +265,14 @@ pub async fn get_knowledge_graph(
     }
     let max_nodes = query.max_nodes.unwrap_or(MAX_NODES).min(MAX_NODES);
     let wiki_root = resolve_wiki_root(&state).await;
+    let wiki_folders = resolve_wiki_folders(&state).await;
     let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
     let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
         return Ok(Json(KnowledgeGraphResponse::default()));
     };
 
     let graph = tokio::task::spawn_blocking(move || {
-        scan_knowledge(&wiki_root, project_root.as_deref(), max_nodes)
+        scan_knowledge(&wiki_root, &wiki_folders, project_root.as_deref(), max_nodes)
     })
     .await
     .unwrap_or_default();
@@ -212,6 +290,7 @@ pub async fn get_knowledge_page(
 ) -> Result<Json<KnowledgePageResponse>, ApiError> {
     validate_knowledge_id(&query.id)?;
     let wiki_root = resolve_wiki_root(&state).await;
+    let wiki_folders = resolve_wiki_folders(&state).await;
     let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
     let id = query.id;
     let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
@@ -219,7 +298,7 @@ pub async fn get_knowledge_page(
     };
 
     let page = tokio::task::spawn_blocking(move || {
-        preview_knowledge_page(&wiki_root, project_root.as_deref(), &id)
+        preview_knowledge_page(&wiki_root, &wiki_folders, project_root.as_deref(), &id)
     })
     .await
     .ok()
@@ -233,6 +312,11 @@ async fn resolve_wiki_root(state: &AppState) -> PathBuf {
     let configured = state.config.read().await.global_wiki_path.clone();
     let env_root = std::env::var_os("HIVE_WIKI_ROOT").filter(|value| !value.is_empty());
     resolve_wiki_root_from(env_root, configured.as_deref(), user_home().as_deref())
+}
+
+async fn resolve_wiki_folders(state: &AppState) -> Vec<KnowledgeFolder> {
+    let configured = state.config.read().await.knowledge_wiki_folders.clone();
+    resolve_wiki_folders_from(configured.as_deref())
 }
 
 fn resolve_wiki_root_from(
@@ -328,13 +412,18 @@ fn resolve_project_root_from_sessions<'a>(
 }
 
 /// Build a bounded graph from the global wiki and the session project's allowlisted documents.
+///
+/// `wiki_folders` is the effective folder set, already resolved against the compiled-in
+/// `WIKI_FOLDERS` ceiling by `resolve_wiki_folders_from`. Callers must never synthesize it from
+/// raw operator input.
 pub(crate) fn scan_knowledge(
     wiki_root: &Path,
+    wiki_folders: &[KnowledgeFolder],
     project_root: Option<&Path>,
     max_nodes: usize,
 ) -> KnowledgeGraphResponse {
     let node_cap = max_nodes.clamp(1, MAX_NODES);
-    let enumeration = enumerate_sources(wiki_root, project_root);
+    let enumeration = enumerate_sources(wiki_root, wiki_folders, project_root);
     let mut truncated = enumeration.truncated;
     let mut nodes = Vec::new();
     let mut raw_edges = Vec::new();
@@ -409,6 +498,7 @@ pub(crate) fn scan_knowledge(
 /// Resolve an allowlisted page ID and return its bounded Markdown preview.
 pub(crate) fn preview_knowledge_page(
     wiki_root: &Path,
+    wiki_folders: &[KnowledgeFolder],
     project_root: Option<&Path>,
     id: &str,
 ) -> Option<KnowledgePageResponse> {
@@ -416,7 +506,7 @@ pub(crate) fn preview_knowledge_page(
         return None;
     }
 
-    let source = enumerate_sources(wiki_root, project_root)
+    let source = enumerate_sources(wiki_root, wiki_folders, project_root)
         .sources
         .into_iter()
         .find(|source| node_id_for(source).as_deref() == Some(id))?;
@@ -479,12 +569,18 @@ fn validate_knowledge_id(id: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
-fn enumerate_sources(wiki_root: &Path, project_root: Option<&Path>) -> SourceEnumeration {
+fn enumerate_sources(
+    wiki_root: &Path,
+    wiki_folders: &[KnowledgeFolder],
+    project_root: Option<&Path>,
+) -> SourceEnumeration {
     let mut enumeration = SourceEnumeration::default();
     let mut entries_seen = 0;
     let canonical_wiki_root = fs::canonicalize(wiki_root).ok();
 
-    for folder in WIKI_FOLDERS {
+    // The subtree path is always `wiki_root` joined with a `KnowledgeFolder::as_str()` literal, so
+    // no caller-supplied string ever reaches the filesystem here.
+    for &folder in wiki_folders {
         let subtree = wiki_root.join(folder.as_str());
         let Ok(metadata) = fs::symlink_metadata(&subtree) else {
             continue;
@@ -1146,8 +1242,19 @@ fn resolve_hint(hint: &str, lookup: &NodeLookup) -> Option<String> {
 
 /// Corpus research pages sometimes refer to a sibling allow-listed subtree with
 /// `../patterns/foo.md`. These strings are lookup hints only (never filesystem paths), but parent
-/// components are still normalized narrowly: after removing leading parents, the hint must name
-/// one of the three global wiki allow-list roots. `../clients/foo.md` therefore remains invalid.
+/// components are still normalized narrowly: after removing leading parents, the hint must name one
+/// of the global wiki allow-list roots in `WIKI_FOLDERS`. That set now spans the operational roots
+/// (`patterns`, `practices`, `research`) *and* the relationship/entity roots (`clients`,
+/// `partners`, `vendors`, `operations`), so `../clients/foo.md` resolves — that cross-half linking
+/// is the point of this folder set.
+///
+/// Still invalid, by design: `../agents/foo.md` (never allow-listed, see `WIKI_FOLDERS`) and
+/// `../project/project-dna.md` (`project` is session-scoped and must not be reachable from a
+/// global-wiki hint).
+///
+/// This gate intentionally uses the compiled-in ceiling rather than the operator-narrowed set. A
+/// hint only becomes an edge when it resolves to a node that was actually enumerated, so narrowing
+/// already removes those edges; re-checking here would add nothing but a second source of truth.
 fn normalize_parent_relative_hint(mut slug: String) -> Option<String> {
     let had_parent_prefix = slug.starts_with("../");
     while let Some(rest) = slug.strip_prefix("../") {
@@ -1280,7 +1387,7 @@ mod tests {
         write_page(
             wiki.path(),
             "patterns/source.md",
-            "---\ntitle: Source #153\nlast_updated: 2026-07-18\ncross_refs:\n  - wiki/practices/cross.md\n  - clients/cross.md\nrelated: [research/frontmatter-related.md]\n---\n# Source\n[[Wiki Target]]\n-> global: patterns/global.md\n-> related: [[body-related]] (strong match)\n<-> related: wiki/research/frontmatter-related.md (§details)\n<- from: research/from.md\n",
+            "---\ntitle: Source #153\nlast_updated: 2026-07-18\ncross_refs:\n  - wiki/practices/cross.md\n  - agents/cross.md\nrelated: [research/frontmatter-related.md]\n---\n# Source\n[[Wiki Target]]\n-> global: patterns/global.md\n-> related: [[body-related]] (strong match)\n<-> related: wiki/research/frontmatter-related.md (§details)\n<- from: research/from.md\n",
         );
         write_page(
             wiki.path(),
@@ -1300,10 +1407,12 @@ mod tests {
             "# Frontmatter Related\n",
         );
         write_page(wiki.path(), "research/from.md", "# From\n");
+        // `agents/` is the never-allow-listed folder, so this fixture keeps proving the allowlist
+        // gate now that `clients/` is deliberately in-scope.
         write_page(
             wiki.path(),
-            "clients/cross.md",
-            "---\ntitle: Private Client\n---\n",
+            "agents/cross.md",
+            "---\ntitle: Recruiting Dossier\n---\n",
         );
         write_page(
             project.path(),
@@ -1321,13 +1430,21 @@ mod tests {
             "# Must Not Be Scanned\n",
         );
 
-        let graph = scan_knowledge(wiki.path(), Some(project.path()), MAX_NODES);
+        let graph = scan_knowledge(
+            wiki.path(),
+            &WIKI_FOLDERS,
+            Some(project.path()),
+            MAX_NODES,
+        );
         let node_ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
         assert!(node_ids.contains("patterns/source"));
         assert!(node_ids.contains("project/project-dna"));
         assert!(node_ids.contains("project/bug-patterns"));
-        assert!(!node_ids.iter().any(|id| id.contains("clients")));
+        assert!(!node_ids.iter().any(|id| id.contains("agents")));
         assert!(!node_ids.contains("project/architecture"));
+        assert!(!serde_json::to_string(&graph)
+            .unwrap()
+            .contains("Recruiting Dossier"));
 
         let kinds: HashSet<_> = graph.edges.iter().map(|edge| edge.kind).collect();
         assert_eq!(
@@ -1387,7 +1504,7 @@ mod tests {
             "# Bug Patterns\n",
         );
 
-        let graph = scan_knowledge(wiki.path(), Some(project.path()), MAX_NODES);
+        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, Some(project.path()), MAX_NODES);
         let node_ids: Vec<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
 
         assert_eq!(graph.nodes.len(), MAX_NODES);
@@ -1439,43 +1556,343 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn relative_allowlisted_hints_resolve_without_disallowed_basename_fallback() {
-        let nodes = vec![KnowledgeNode {
-            id: "patterns/cross".to_string(),
-            title: "Cross".to_string(),
-            folder: KnowledgeFolder::Patterns,
-            path: "patterns/cross.md".to_string(),
+    fn test_node(id: &str, title: &str, folder: KnowledgeFolder) -> KnowledgeNode {
+        KnowledgeNode {
+            id: id.to_string(),
+            title: title.to_string(),
+            folder,
+            path: format!("{id}.md"),
             last_updated: String::new(),
             in_degree: 0,
             out_degree: 0,
-        }];
+        }
+    }
+
+    /// The entity nodes below must actually exist for this test to mean anything. With a
+    /// patterns-only fixture the `clients/*` assertions passed for the wrong reason — the
+    /// exact-ID lookup simply missed and the explicit-path guard blocked the basename fallback —
+    /// so they would have stayed green even if the allowlist gate had been deleted entirely.
+    #[test]
+    fn relative_allowlisted_hints_resolve_without_disallowed_basename_fallback() {
+        let nodes = vec![
+            test_node("patterns/cross", "Pattern Cross", KnowledgeFolder::Patterns),
+            test_node("clients/cross", "Client Cross", KnowledgeFolder::Clients),
+            test_node("partners/cross", "Partner Cross", KnowledgeFolder::Partners),
+            test_node("vendors/cross", "Vendor Cross", KnowledgeFolder::Vendors),
+            test_node(
+                "operations/cross",
+                "Operations Cross",
+                KnowledgeFolder::Operations,
+            ),
+            test_node(
+                "clients/acme/dashboard",
+                "Acme Dashboard",
+                KnowledgeFolder::Clients,
+            ),
+        ];
         let lookup = NodeLookup::from_nodes(&nodes);
-        assert_eq!(
-            resolve_hint("patterns/cross.md", &lookup).as_deref(),
-            Some("patterns/cross")
-        );
-        assert_eq!(
-            resolve_hint("../patterns/cross.md", &lookup).as_deref(),
-            Some("patterns/cross")
-        );
-        assert_eq!(
-            resolve_hint(
+
+        for (hint, expected) in [
+            ("patterns/cross.md", "patterns/cross"),
+            ("../patterns/cross.md", "patterns/cross"),
+            (
                 "../../wiki/patterns/cross.md (corpus annotation)",
-                &lookup,
-            )
-            .as_deref(),
-            Some("patterns/cross")
-        );
-        assert_eq!(resolve_hint("clients/cross.md", &lookup), None);
-        assert_eq!(resolve_hint("partners/cross.md", &lookup), None);
-        assert_eq!(resolve_hint("../clients/cross.md", &lookup), None);
-        assert_eq!(resolve_hint("../partners/cross.md", &lookup), None);
-        assert_eq!(resolve_hint("../project/project-dna.md", &lookup), None);
+                "patterns/cross",
+            ),
+            // The entity roots resolve now, including through a parent-relative hint and into a
+            // nested `clients/<slug>/dashboard.md` page.
+            ("clients/cross.md", "clients/cross"),
+            ("../clients/cross.md", "clients/cross"),
+            ("partners/cross.md", "partners/cross"),
+            ("../partners/cross.md", "partners/cross"),
+            ("vendors/cross.md", "vendors/cross"),
+            ("operations/cross.md", "operations/cross"),
+            ("clients/acme/dashboard.md", "clients/acme/dashboard"),
+            ("../clients/acme/dashboard.md", "clients/acme/dashboard"),
+        ] {
+            assert_eq!(
+                resolve_hint(hint, &lookup).as_deref(),
+                Some(expected),
+                "hint {hint} did not resolve"
+            );
+        }
+
+        // `agents/` is never allow-listed, and an explicit path must not fall back by basename to
+        // one of the five genuinely-present `*/cross` nodes.
+        for rejected in [
+            "agents/cross.md",
+            "../agents/cross.md",
+            "agents/recruiting/candidate.md",
+            "../project/project-dna.md",
+            "../patterns/../agents/cross.md",
+        ] {
+            assert_eq!(resolve_hint(rejected, &lookup), None, "accepted {rejected}");
+        }
+
+        // Ambiguity guard: the bare basename `cross` now maps to five nodes across five folders,
+        // so `unique_lookup` declines rather than inventing an edge to whichever one hashed first.
+        // No node is titled plain "Cross", so the title fallback cannot rescue it either -- this is
+        // exactly the duplicate-basename failure mode that keeps `agents/` out of `WIKI_FOLDERS`.
+        assert_eq!(resolve_hint("cross", &lookup), None);
+        // An unambiguous title still resolves, so the guard above is narrow, not a blanket block.
         assert_eq!(
-            resolve_hint("../patterns/../clients/cross.md", &lookup),
-            None
+            resolve_hint("Acme Dashboard", &lookup).as_deref(),
+            Some("clients/acme/dashboard")
         );
+    }
+
+    /// `as_str()` (directory name + node-ID prefix) and the `serde(rename_all = "snake_case")`
+    /// wire tag are independent mechanisms that only happen to agree. Adding a variant that
+    /// updates one but not the other would ship a graph whose folder tags do not match the IDs
+    /// the frontend filters on, so pin them to each other.
+    #[test]
+    fn as_str_matches_the_serialized_folder_tag() {
+        for folder in WIKI_FOLDERS
+            .into_iter()
+            .chain(std::iter::once(KnowledgeFolder::Project))
+        {
+            let serialized = serde_json::to_string(&folder).unwrap();
+            assert_eq!(
+                serialized,
+                format!("\"{}\"", folder.as_str()),
+                "serde tag and as_str disagree for {folder:?}"
+            );
+        }
+
+        assert_eq!(
+            WIKI_FOLDERS.map(KnowledgeFolder::as_str),
+            [
+                "patterns",
+                "practices",
+                "research",
+                "clients",
+                "partners",
+                "vendors",
+                "operations",
+            ]
+        );
+    }
+
+    #[test]
+    fn id_prefix_gate_admits_entity_roots_and_still_rejects_agents() {
+        for allowed in [
+            "patterns",
+            "practices",
+            "research",
+            "clients",
+            "partners",
+            "vendors",
+            "operations",
+            "project",
+        ] {
+            assert!(
+                KnowledgeFolder::from_id_prefix(allowed).is_some(),
+                "{allowed} should be an allow-listed ID prefix"
+            );
+        }
+        for rejected in ["agents", "", "..", "Clients", "clients/acme", "etc"] {
+            assert!(
+                KnowledgeFolder::from_id_prefix(rejected).is_none(),
+                "{rejected} should not be an allow-listed ID prefix"
+            );
+        }
+    }
+
+    /// Operator config may only narrow or re-select within `WIKI_FOLDERS`. It must never be able to
+    /// widen the scan back to `agents/`, nor turn a string into a filesystem path.
+    #[test]
+    fn configured_folders_can_only_narrow_the_compiled_allowlist() {
+        assert_eq!(resolve_wiki_folders_from(None), WIKI_FOLDERS.to_vec());
+
+        // Absent-equivalent inputs fall back to the documented default rather than scanning
+        // nothing, so a typo degrades gracefully instead of silently emptying the Atlas.
+        assert_eq!(resolve_wiki_folders_from(Some(&[])), WIKI_FOLDERS.to_vec());
+        assert_eq!(
+            resolve_wiki_folders_from(Some(&[String::new()])),
+            WIKI_FOLDERS.to_vec()
+        );
+        assert_eq!(
+            resolve_wiki_folders_from(Some(&["   ".to_string()])),
+            WIKI_FOLDERS.to_vec()
+        );
+
+        // Narrowing: a privacy-conscious machine drops the entity roots.
+        assert_eq!(
+            resolve_wiki_folders_from(Some(&[
+                "patterns".to_string(),
+                "practices".to_string()
+            ])),
+            vec![KnowledgeFolder::Patterns, KnowledgeFolder::Practices]
+        );
+
+        // Case and surrounding whitespace are tolerated; duplicates collapse.
+        assert_eq!(
+            resolve_wiki_folders_from(Some(&[
+                "  Clients ".to_string(),
+                "CLIENTS".to_string(),
+                "clients".to_string(),
+            ])),
+            vec![KnowledgeFolder::Clients]
+        );
+
+        // Widening attempts are dropped, not honored, and never become paths.
+        assert_eq!(
+            resolve_wiki_folders_from(Some(&[
+                "agents".to_string(),
+                "../../../etc".to_string(),
+                "/etc/passwd".to_string(),
+                "C:\\Windows\\System32".to_string(),
+                "project".to_string(),
+                "..".to_string(),
+                "clients/../agents".to_string(),
+                "research".to_string(),
+            ])),
+            vec![KnowledgeFolder::Research],
+            "config must select among compiled-in variants, never construct new ones"
+        );
+
+        // Even an entirely hostile list cannot widen: it collapses to the built-in default, which
+        // still excludes `agents` and `project`.
+        let effective = resolve_wiki_folders_from(Some(&[
+            "agents".to_string(),
+            "../../../etc".to_string(),
+        ]));
+        assert_eq!(effective, WIKI_FOLDERS.to_vec());
+        assert!(!effective.contains(&KnowledgeFolder::Project));
+    }
+
+    /// End-to-end proof that narrowing is enforced where it matters — the filesystem walk — and
+    /// that an excluded folder yields no nodes and no preview.
+    #[test]
+    fn configured_narrowing_is_enforced_at_enumeration() {
+        let wiki = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "patterns/kept.md",
+            "---\ntitle: Kept\n---\n# Kept\n",
+        );
+        write_page(
+            wiki.path(),
+            "clients/acme/dashboard.md",
+            "---\ntitle: Acme\n---\n# Acme\n",
+        );
+        write_page(
+            wiki.path(),
+            "agents/recruiting/candidate.md",
+            "---\ntitle: Candidate\n---\n# Candidate\n",
+        );
+
+        let full = resolve_wiki_folders_from(None);
+        let graph = scan_knowledge(wiki.path(), &full, None, MAX_NODES);
+        let ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+        assert!(ids.contains("patterns/kept"));
+        assert!(ids.contains("clients/acme/dashboard"));
+        assert!(!ids.iter().any(|id| id.starts_with("agents/")));
+
+        // A machine that narrows to `patterns` loses the entity nodes...
+        let narrowed = resolve_wiki_folders_from(Some(&["patterns".to_string()]));
+        let narrowed_graph = scan_knowledge(wiki.path(), &narrowed, None, MAX_NODES);
+        let narrowed_ids: HashSet<_> = narrowed_graph
+            .nodes
+            .iter()
+            .map(|node| node.id.as_str())
+            .collect();
+        assert_eq!(narrowed_ids, HashSet::from(["patterns/kept"]));
+        assert!(
+            preview_knowledge_page(wiki.path(), &narrowed, None, "clients/acme/dashboard")
+                .is_none(),
+            "a config-excluded folder must not be previewable"
+        );
+
+        // ...and a config naming `agents` cannot get it back.
+        let hostile =
+            resolve_wiki_folders_from(Some(&["agents".to_string(), "patterns".to_string()]));
+        let hostile_graph = scan_knowledge(wiki.path(), &hostile, None, MAX_NODES);
+        assert!(!hostile_graph
+            .nodes
+            .iter()
+            .any(|node| node.id.starts_with("agents/")));
+        assert!(
+            preview_knowledge_page(wiki.path(), &hostile, None, "agents/recruiting/candidate")
+                .is_none()
+        );
+    }
+
+    /// Nested entity pages and the operational/relationship cross-half edges the Atlas exists to
+    /// show. `clients/<slug>/dashboard.md` is a future corpus shape, so it only exists here.
+    #[test]
+    fn nested_entity_pages_scan_and_cross_link_between_graph_halves() {
+        let wiki = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "clients/acme/dashboard.md",
+            "---\ntitle: Acme Dashboard\nlast_updated: 2026-07-18\n---\n# Acme\n\
+             [[partners/beta]]\n",
+        );
+        write_page(
+            wiki.path(),
+            "partners/beta.md",
+            "---\ntitle: Beta Partner\n---\n# Beta\n",
+        );
+        write_page(
+            wiki.path(),
+            "patterns/delivery.md",
+            "---\ntitle: Delivery\ncross_refs:\n  - clients/acme/dashboard.md\n---\n# Delivery\n\
+             [[partners/beta]]\n",
+        );
+
+        let folders = resolve_wiki_folders_from(None);
+        let graph = scan_knowledge(wiki.path(), &folders, None, MAX_NODES);
+        let ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+        assert!(ids.contains("clients/acme/dashboard"));
+        assert!(ids.contains("partners/beta"));
+
+        let dashboard = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "clients/acme/dashboard")
+            .unwrap();
+        assert_eq!(dashboard.title, "Acme Dashboard");
+        assert_eq!(dashboard.folder, KnowledgeFolder::Clients);
+        assert_eq!(dashboard.path, "clients/acme/dashboard.md");
+
+        let has_edge = |source: &str, target: &str, kind: KnowledgeEdgeKind| {
+            graph
+                .edges
+                .iter()
+                .any(|edge| edge.source == source && edge.target == target && edge.kind == kind)
+        };
+        // Entity <-> entity.
+        assert!(has_edge(
+            "clients/acme/dashboard",
+            "partners/beta",
+            KnowledgeEdgeKind::Wikilink
+        ));
+        // Operational -> entity, joining the two halves of the graph.
+        assert!(has_edge(
+            "patterns/delivery",
+            "clients/acme/dashboard",
+            KnowledgeEdgeKind::CrossRef
+        ));
+        assert!(has_edge(
+            "patterns/delivery",
+            "partners/beta",
+            KnowledgeEdgeKind::Wikilink
+        ));
+        assert_eq!(dashboard.in_degree, 1);
+        assert_eq!(dashboard.out_degree, 1);
+
+        assert!(!serde_json::to_string(&graph)
+            .unwrap()
+            .contains(&wiki.path().to_string_lossy().to_string()));
+
+        let page =
+            preview_knowledge_page(wiki.path(), &folders, None, "clients/acme/dashboard").unwrap();
+        assert_eq!(page.path, "clients/acme/dashboard.md");
+        assert_eq!(page.folder, KnowledgeFolder::Clients);
+        assert!(!serde_json::to_string(&page)
+            .unwrap()
+            .contains(&wiki.path().to_string_lossy().to_string()));
     }
 
     #[test]
@@ -1555,7 +1972,7 @@ mod tests {
             ),
         );
 
-        let page = preview_knowledge_page(wiki.path(), None, "patterns/preview").unwrap();
+        let page = preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/preview").unwrap();
         assert_eq!(page.id, "patterns/preview");
         assert_eq!(page.path, "patterns/preview.md");
         assert_eq!(page.title, "Preview Title");
@@ -1563,26 +1980,41 @@ mod tests {
         assert!(page.truncated);
         assert!(page.content.len() <= MAX_PREVIEW_BYTES);
         assert!(page.content.is_char_boundary(page.content.len()));
-        assert!(preview_knowledge_page(wiki.path(), None, "patterns/missing").is_none());
+        assert!(preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/missing").is_none());
     }
 
     #[test]
     fn preview_id_validation_rejects_traversal_and_absolute_forms() {
         for invalid in [
             "",
-            "../clients/secret",
-            "patterns/../clients/secret",
+            // `agents/` replaces the old `clients/` cases: `clients` is allow-listed now, so
+            // reusing it here would assert nothing about the folder gate.
+            "../agents/secret",
+            "patterns/../agents/secret",
+            "clients/../agents/secret",
             "/patterns/secret",
             "C:/patterns/secret",
             "\\\\server\\patterns\\secret",
             "patterns\\secret",
-            "clients/secret",
+            "clients\\acme\\dashboard",
+            "agents/secret",
+            "agents/recruiting/candidate",
+            "clients",
             "project/architecture",
         ] {
             assert!(validate_knowledge_id(invalid).is_err(), "accepted {invalid}");
         }
-        assert!(validate_knowledge_id("patterns/nested/page").is_ok());
-        assert!(validate_knowledge_id("project/project-dna").is_ok());
+        for valid in [
+            "patterns/nested/page",
+            "project/project-dna",
+            "clients/acme",
+            "clients/acme/dashboard",
+            "partners/beta",
+            "vendors/gamma",
+            "operations/runbook",
+        ] {
+            assert!(validate_knowledge_id(valid).is_ok(), "rejected {valid}");
+        }
     }
 
     #[test]
@@ -1597,18 +2029,18 @@ mod tests {
             &"x".repeat(MAX_FILE_BYTES + 1),
         );
 
-        let graph = scan_knowledge(wiki.path(), None, 2);
+        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, 2);
         assert_eq!(graph.nodes.len(), 2);
         assert!(graph.truncated);
 
-        let uncapped = scan_knowledge(wiki.path(), None, MAX_NODES);
+        let uncapped = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
         assert!(uncapped.truncated);
         assert!(!uncapped
             .nodes
             .iter()
             .any(|node| node.id.ends_with("oversize")));
 
-        let missing = scan_knowledge(&wiki.path().join("missing"), None, MAX_NODES);
+        let missing = scan_knowledge(&wiki.path().join("missing"), &WIKI_FOLDERS, None, MAX_NODES);
         assert!(missing.nodes.is_empty());
         assert!(missing.edges.is_empty());
     }
@@ -1626,7 +2058,7 @@ mod tests {
             ),
         );
 
-        let graph = scan_knowledge(wiki.path(), None, MAX_NODES);
+        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
         let node = graph
             .nodes
             .iter()
@@ -1638,7 +2070,7 @@ mod tests {
         assert!(graph.truncated);
         assert!(serde_json::to_vec(&graph).unwrap().len() <= MAX_GRAPH_RESPONSE_BYTES);
 
-        let page = preview_knowledge_page(wiki.path(), None, "patterns/metadata").unwrap();
+        let page = preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/metadata").unwrap();
         assert!(page.title.len() <= MAX_TITLE_BYTES);
         assert!(page.truncated);
     }
@@ -1774,7 +2206,7 @@ mod tests {
         )
         .unwrap();
 
-        let graph = scan_knowledge(wiki.path(), None, MAX_NODES);
+        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
         assert!(graph.nodes.is_empty());
     }
 }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -174,6 +174,27 @@ async fn setup_isolated_test_app_with_controller() -> (
     (storage_dir, app, controller, storage)
 }
 
+/// Setup an isolated test app whose persisted `config.json` already carries operator settings.
+///
+/// `AppState.config` is a snapshot taken once, when the router is constructed, so a test that needs
+/// the HTTP handlers to *observe* a config value must write that value before construction —
+/// saving it afterwards has no effect on the running app. The shared setup helpers are deliberately
+/// left alone (many tests depend on their default config); this variant seeds the storage base dir
+/// first and then delegates to the existing `setup_test_app_with_controller_at` seam.
+async fn setup_isolated_test_app_with_config(
+    seed_config: impl FnOnce(&mut crate::storage::AppConfig),
+) -> (TempDir, axum::Router) {
+    let storage_dir = TempDir::new().unwrap();
+    let seed_storage = SessionStorage::new_with_base(storage_dir.path().to_path_buf()).unwrap();
+    let mut config = seed_storage.load_config().unwrap();
+    seed_config(&mut config);
+    seed_storage.save_config(&config).unwrap();
+
+    let (app, _controller, _storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    (storage_dir, app)
+}
+
 /// Setup test app and return both the router and session controller for inserting test sessions
 async fn setup_test_app_with_controller() -> (axum::Router, Arc<RwLock<SessionController>>) {
     let storage = Arc::new(SessionStorage::new().unwrap());
@@ -1077,7 +1098,7 @@ title: Public Source
 last_updated: 2026-07-18
 cross_refs:
   - wiki/practices/cross.md
-  - clients/private-client.md
+  - agents/private-dossier.md
 ---
 # Source body
 [[Wiki Target]]
@@ -1099,10 +1120,12 @@ cross_refs:
         "---\ntitle: Body Related\n---\n# Related\n",
     );
     write_knowledge_fixture(wiki.path(), "research/from.md", "# From\n");
+    // `clients/` is allow-listed as of #158, so the non-allow-listed folder in this fixture must
+    // be `agents/` — otherwise these exclusion assertions would pass vacuously.
     write_knowledge_fixture(
         wiki.path(),
-        "clients/private-client.md",
-        "---\ntitle: Private Client Dossier\n---\n# Never expose this\n",
+        "agents/private-dossier.md",
+        "---\ntitle: Private Recruiting Dossier\n---\n# Never expose this\n",
     );
     write_knowledge_fixture(
         wiki.path(),
@@ -1178,8 +1201,8 @@ cross_refs:
     }));
 
     let serialized_graph = serde_json::to_string(&graph).unwrap();
-    assert!(!serialized_graph.contains("Private Client Dossier"));
-    assert!(!serialized_graph.contains("clients/private-client"));
+    assert!(!serialized_graph.contains("Private Recruiting Dossier"));
+    assert!(!serialized_graph.contains("agents/private-dossier"));
     assert!(!serialized_graph.contains(wiki.path().to_string_lossy().as_ref()));
     assert!(!serialized_graph.contains(project.path().to_string_lossy().as_ref()));
 
@@ -1206,9 +1229,10 @@ cross_refs:
         .contains(wiki.path().to_string_lossy().as_ref()));
 
     for invalid_id in [
-        "patterns%2F..%2Fclients%2Fprivate-client",
+        "patterns%2F..%2Fagents%2Fprivate-dossier",
         "%2Fpatterns%2Fsource",
-        "clients%2Fprivate-client",
+        "agents%2Fprivate-dossier",
+        "clients%2F..%2Fagents%2Fprivate-dossier",
     ] {
         let response = app
             .clone()
@@ -1237,6 +1261,313 @@ cross_refs:
         .await
         .unwrap();
     assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+}
+
+/// Issue #158: relationship/entity folders are first-class Atlas citizens, including the nested
+/// `clients/<slug>/dashboard.md` shape. That shape does not exist in the live corpus yet, so it
+/// only exists here as a synthetic fixture — this test is what keeps it working.
+#[tokio::test]
+async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_halves() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    write_knowledge_fixture(
+        wiki.path(),
+        "clients/acme/dashboard.md",
+        "---\ntitle: Acme Dashboard\nlast_updated: 2026-07-18\n---\n# Acme\n\
+         [[Beta Partner]]\n[[vendors/gamma]]\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "partners/beta.md",
+        "---\ntitle: Beta Partner\n---\n# Beta\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "vendors/gamma.md",
+        "---\ntitle: Gamma Vendor\n---\n# Gamma\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "operations/runbook.md",
+        "---\ntitle: Runbook\n---\n# Runbook\n<- from: ../clients/acme/dashboard.md\n",
+    );
+    // The operational half of the graph reaching across into the entity half.
+    write_knowledge_fixture(
+        wiki.path(),
+        "patterns/engagement.md",
+        "---\ntitle: Engagement Pattern\ncross_refs:\n  - clients/acme/dashboard.md\n---\n\
+         # Engagement\n[[partners/beta]]\n",
+    );
+    // Still never scanned.
+    write_knowledge_fixture(
+        wiki.path(),
+        "agents/recruiting/candidate.md",
+        "---\ntitle: Candidate Dossier\n---\n# Personal contact details\n",
+    );
+
+    let (_storage_dir, app, _controller, _storage) =
+        setup_isolated_test_app_with_controller().await;
+
+    let graph_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(graph_response.status(), StatusCode::OK);
+    let graph = read_json_body(graph_response).await;
+    let nodes = graph["nodes"].as_array().unwrap();
+    let node_ids: std::collections::HashSet<_> = nodes
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect();
+
+    for expected in [
+        "clients/acme/dashboard",
+        "partners/beta",
+        "vendors/gamma",
+        "operations/runbook",
+        "patterns/engagement",
+    ] {
+        assert!(node_ids.contains(expected), "missing node {expected}");
+    }
+    assert!(!node_ids.iter().any(|id| id.starts_with("agents/")));
+    assert!(!graph["truncated"].as_bool().unwrap());
+
+    let dashboard = nodes
+        .iter()
+        .find(|node| node["id"] == "clients/acme/dashboard")
+        .expect("nested client dashboard node");
+    assert_eq!(dashboard["title"], "Acme Dashboard");
+    assert_eq!(dashboard["folder"], "clients");
+    assert_eq!(dashboard["path"], "clients/acme/dashboard.md");
+    assert_eq!(dashboard["last_updated"], "2026-07-18");
+    // Two inbound (patterns cross_ref, operations from) and two outbound (partner, vendor).
+    assert_eq!(dashboard["in_degree"], 2);
+    assert_eq!(dashboard["out_degree"], 2);
+
+    let edges = graph["edges"].as_array().unwrap();
+    let has_edge = |source: &str, target: &str, kind: &str| {
+        edges.iter().any(|edge| {
+            edge["source"] == source && edge["target"] == target && edge["kind"] == kind
+        })
+    };
+    // Entity <-> entity, resolved by title and by explicit nested path.
+    assert!(has_edge(
+        "clients/acme/dashboard",
+        "partners/beta",
+        "wikilink"
+    ));
+    assert!(has_edge(
+        "clients/acme/dashboard",
+        "vendors/gamma",
+        "wikilink"
+    ));
+    // Operational -> entity: the cross-half edges that join the two halves of the graph.
+    assert!(has_edge(
+        "patterns/engagement",
+        "clients/acme/dashboard",
+        "cross_ref"
+    ));
+    assert!(has_edge("patterns/engagement", "partners/beta", "wikilink"));
+    // A parent-relative hint into an entity root now resolves (it did not before #158).
+    assert!(has_edge(
+        "operations/runbook",
+        "clients/acme/dashboard",
+        "from"
+    ));
+    assert!(edges.iter().all(|edge| {
+        edge["source"]
+            .as_str()
+            .is_some_and(|id| node_ids.contains(id))
+            && edge["target"]
+                .as_str()
+                .is_some_and(|id| node_ids.contains(id))
+    }));
+
+    let page_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=clients%2Facme%2Fdashboard")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(page_response.status(), StatusCode::OK);
+    let page = read_json_body(page_response).await;
+    assert_eq!(page["id"], "clients/acme/dashboard");
+    assert_eq!(page["path"], "clients/acme/dashboard.md");
+    assert_eq!(page["folder"], "clients");
+    assert!(page["content"].as_str().unwrap().contains("# Acme"));
+    assert!(!page["content"].as_str().unwrap().contains("title: Acme"));
+
+    // The never-allow-listed folder stays unreachable through the preview path too.
+    let agents_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=agents%2Frecruiting%2Fcandidate")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(agents_response.status(), StatusCode::BAD_REQUEST);
+
+    // No absolute filesystem path may appear in any response body. Compare against both the raw
+    // path and its JSON-escaped form -- on Windows the raw backslashes are re-escaped on the wire,
+    // so a raw-only check would miss a real leak.
+    let wiki_display = wiki.path().to_string_lossy().to_string();
+    let wiki_json_escaped = serde_json::to_string(&wiki_display)
+        .unwrap()
+        .trim_matches('"')
+        .to_string();
+    for body in [
+        serde_json::to_string(&graph).unwrap(),
+        serde_json::to_string(&page).unwrap(),
+    ] {
+        assert!(!body.contains(&wiki_display), "leaked wiki path: {body}");
+        assert!(
+            !body.contains(&wiki_json_escaped),
+            "leaked escaped wiki path: {body}"
+        );
+        assert!(!body.contains("Candidate Dossier"));
+    }
+}
+
+/// The operator-narrowing *wiring*, end to end: `knowledge_wiki_folders` in the persisted config
+/// must actually reach `scan_knowledge` / `preview_knowledge_page` via the HTTP handlers.
+///
+/// Every other narrowing test calls the pure `resolve_wiki_folders_from` directly and hands its
+/// result straight to the scanner, which bypasses `resolve_wiki_folders(state)` — the sole call
+/// site that reads config. Gutting that function to `WIKI_FOLDERS.to_vec()` left the whole suite
+/// green while silently defeating the narrowing an operator configured for privacy, so an operator
+/// who set `["patterns"]` to keep client/partner/vendor pages out of the Atlas would still get all
+/// seven folders scanned and rendered. This test is the one that goes red.
+#[tokio::test]
+async fn test_knowledge_operator_folder_narrowing_reaches_graph_and_page_endpoints() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    write_knowledge_fixture(
+        wiki.path(),
+        "patterns/kept.md",
+        "---\ntitle: Kept Pattern\n---\n# Kept pattern body\n",
+    );
+    // Both excluded folders are *allow-listed* in the compiled-in `WIKI_FOLDERS`. That is the point:
+    // their absence below can only come from operator config, so the assertions cannot pass
+    // vacuously the way they would against a never-allow-listed folder like `agents/`.
+    write_knowledge_fixture(
+        wiki.path(),
+        "clients/acme/dashboard.md",
+        "---\ntitle: Acme Client Dashboard\n---\n# Confidential client engagement\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "vendors/gamma.md",
+        "---\ntitle: Gamma Vendor\n---\n# Vendor contract terms\n",
+    );
+
+    let (_storage_dir, app) = setup_isolated_test_app_with_config(|config| {
+        config.knowledge_wiki_folders = Some(vec!["patterns".to_string()]);
+    })
+    .await;
+
+    let graph_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(graph_response.status(), StatusCode::OK);
+    let graph = read_json_body(graph_response).await;
+    let node_ids: std::collections::HashSet<_> = graph["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|node| node["id"].as_str())
+        .collect();
+
+    assert!(
+        node_ids.contains("patterns/kept"),
+        "the configured folder must still be scanned, got {node_ids:?}"
+    );
+    for excluded in ["clients/acme/dashboard", "vendors/gamma"] {
+        assert!(
+            !node_ids.contains(excluded),
+            "config narrowing did not reach the graph endpoint; {excluded} was scanned anyway \
+             (nodes: {node_ids:?})"
+        );
+    }
+
+    // The narrowed-out page must not be previewable either. It 404s rather than 400s because ID
+    // validation stays on the compiled-in superset by design, so the status code does not leak
+    // which folders the operator switched off.
+    let excluded_page_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=clients%2Facme%2Fdashboard")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(excluded_page_response.status(), StatusCode::NOT_FOUND);
+    let excluded_body = axum::body::to_bytes(excluded_page_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let excluded_body = String::from_utf8_lossy(&excluded_body);
+    assert!(
+        !excluded_body.contains("Confidential client engagement"),
+        "narrowed-out page leaked its content: {excluded_body}"
+    );
+
+    // Control: the configured folder is still fully readable, so the assertions above are about
+    // narrowing rather than a wholesale broken scan.
+    let kept_page_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=patterns%2Fkept")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(kept_page_response.status(), StatusCode::OK);
+    let kept_page = read_json_body(kept_page_response).await;
+    assert_eq!(kept_page["id"], "patterns/kept");
+    assert!(kept_page["content"]
+        .as_str()
+        .unwrap()
+        .contains("# Kept pattern body"));
+
+    // Nothing from the narrowed-out folders may appear anywhere in the graph payload either.
+    let graph_body = serde_json::to_string(&graph).unwrap();
+    for leaked in ["Acme Client Dashboard", "Gamma Vendor", "clients/", "vendors/"] {
+        assert!(
+            !graph_body.contains(leaked),
+            "narrowed-out folder leaked {leaked} into the graph: {graph_body}"
+        );
+    }
 }
 
 #[tokio::test]

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -1570,6 +1570,84 @@ async fn test_knowledge_operator_folder_narrowing_reaches_graph_and_page_endpoin
     }
 }
 
+/// The fail-closed property, pinned through the HTTP stack rather than against the pure resolver.
+///
+/// An operator config that names only unrecognized folders is still an operator-supplied privacy
+/// boundary, and must select nothing. If it instead fell back to the compiled-in default, a single
+/// typo would silently republish `clients/`, `partners/`, and `vendors/` into the Atlas the
+/// operator believed excluded them — and the resolver-level tests alone would not catch it, since
+/// the wiring layer is exactly where a previous regression went undetected.
+#[tokio::test]
+async fn test_knowledge_unrecognized_folder_config_fails_closed_at_endpoints() {
+    let _environment_lock = KNOWLEDGE_ENV_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let wiki = TempDir::new().unwrap();
+    let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
+
+    write_knowledge_fixture(
+        wiki.path(),
+        "patterns/kept.md",
+        "---\ntitle: Kept Pattern\n---\n# Kept pattern body\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "clients/acme/dashboard.md",
+        "---\ntitle: Acme Client Dashboard\n---\n# Confidential client engagement\n",
+    );
+    write_knowledge_fixture(
+        wiki.path(),
+        "vendors/gamma.md",
+        "---\ntitle: Gamma Vendor\n---\n# Vendor contract terms\n",
+    );
+
+    // A typo for `clients`. The intent is exclusionary, so the failure mode must be an empty
+    // Atlas, never a fully-populated one.
+    let (_storage_dir, app) = setup_isolated_test_app_with_config(|config| {
+        config.knowledge_wiki_folders = Some(vec!["cleints".to_string()]);
+    })
+    .await;
+
+    let graph_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(graph_response.status(), StatusCode::OK);
+    let graph = read_json_body(graph_response).await;
+    let nodes = graph["nodes"].as_array().unwrap();
+    assert!(
+        nodes.is_empty(),
+        "an unrecognized narrowing must fail closed, but the scan fell back to the default set \
+         and produced nodes: {nodes:?}"
+    );
+
+    let excluded_page_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=clients%2Facme%2Fdashboard")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(excluded_page_response.status(), StatusCode::NOT_FOUND);
+    let excluded_body = axum::body::to_bytes(excluded_page_response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let excluded_body = String::from_utf8_lossy(&excluded_body);
+    assert!(
+        !excluded_body.contains("Confidential client engagement"),
+        "fail-open narrowing leaked client page content: {excluded_body}"
+    );
+}
+
 #[tokio::test]
 async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
     let _environment_lock = KNOWLEDGE_ENV_LOCK

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,6 @@
 #[cfg(not(test))]
 mod commands;
+#[cfg(test)] mod acl_parity;
 pub mod actions;
 pub mod adapters;
 pub mod artifacts;
@@ -611,6 +612,11 @@ pub fn run() {
             get_session_plan,
             // Preview commands
             preview::open_preview_window,
+            preview::close_preview_window,
+            preview::dock_preview_window,
+            preview::undock_preview_window,
+            preview::reload_preview_window,
+            preview::get_preview_status,
             // Git commands
             list_branches,
             get_current_branch,

--- a/src-tauri/src/preview/mod.rs
+++ b/src-tauri/src/preview/mod.rs
@@ -3,32 +3,289 @@ use tauri::Url;
 #[cfg(not(test))]
 use crate::http::state::AppState;
 #[cfg(not(test))]
-use std::sync::Arc;
+use parking_lot::Mutex;
+#[cfg(not(test))]
+use serde::{Deserialize, Serialize};
+#[cfg(not(test))]
+use std::collections::BTreeMap;
+#[cfg(not(test))]
+use std::path::PathBuf;
+#[cfg(not(test))]
+use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(not(test))]
+use std::sync::{Arc, OnceLock};
 #[cfg(not(test))]
 use tauri::{
-    webview::NewWindowResponse, AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder,
+    webview::NewWindowResponse, AppHandle, Emitter, LogicalSize, Manager, PhysicalPosition,
+    PhysicalSize, State, WebviewUrl, WebviewWindow, WebviewWindowBuilder, WindowEvent,
 };
 
 #[cfg(not(test))]
 pub const PREVIEW_WINDOW_LABEL: &str = "operator-preview";
+#[cfg(not(test))]
+const MAIN_WINDOW_LABEL: &str = "main";
 const LOCAL_API_PORT: u16 = 18_800;
 const MAIN_DEV_SERVER_PORT: u16 = 1_420;
 
-/// Parse and validate an operator-supplied preview URL before it reaches a webview.
+// ---------------------------------------------------------------------------
+// URL entry (issue #157 §1)
+// ---------------------------------------------------------------------------
+
+/// True when a scheme candidate is spelled like a HOSTNAME rather than a scheme.
+///
+/// This is the tie-breaker for the one genuinely ambiguous input shape,
+/// `word:digits` - which is both a legal RFC 3986 `scheme:opaque` (`tel:12345`)
+/// and the `host:port` an operator types (`localhost:5173`).
+fn looks_like_hostname(candidate: &str) -> bool {
+    if candidate.is_empty() {
+        return false;
+    }
+
+    // RFC 3986 permits `+` in a scheme (`svn+ssh:`); a hostname never contains
+    // one, so its presence settles the ambiguity in favour of "scheme".
+    if !candidate
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.'))
+    {
+        return false;
+    }
+
+    // A dot makes it a multi-label name (`example.com`, `foo.localhost`, the
+    // FQDN-absolute `localhost.`). Single-label names are ambiguous with real
+    // schemes - `tel`, `mailto`, `vscode`, `steam` are all bare words - so only
+    // the well-known local one is accepted. This deliberately gives up on
+    // single-label intranet hosts (`myserver:8080`); typing the scheme is the
+    // documented workaround, and it is the only rule that also rejects
+    // `tel:12345`.
+    //
+    // IP literals need no case of their own here: `has_explicit_scheme` has
+    // already classified anything not starting with an ASCII letter as
+    // scheme-less, which covers IPv4 (`127.0.0.1:3000`, leading digit) and
+    // bracketed IPv6 (`[::1]:8080`, leading `[`).
+    candidate.contains('.') || candidate.eq_ignore_ascii_case("localhost")
+}
+
+/// Returns true when `input` already carries an explicit `scheme:` prefix.
+///
+/// This is a deliberate LEXICAL scan, not a parse. Neither parse success nor
+/// parse failure can classify scheme-less operator input, because it fails in
+/// two opposite ways:
+///   * `Url::parse("localhost:5173")` SUCCEEDS with the bogus scheme `localhost`
+///     and only dies later at the scheme allowlist.
+///   * `Url::parse("127.0.0.1:5173")` FAILS outright.
+/// Only a lexical scan puts both on the same path.
+///
+/// # Security
+///
+/// This must NOT key off `://`. Requiring the double slash classified every
+/// opaque and single-slash scheme as scheme-less, so `normalize_preview_input`
+/// prepended `https://` and the result sailed through the scheme allowlist as
+/// "https" - while the untrusted navigation gate then let wry navigate to the
+/// ORIGINAL string. `vscode:/x`, `steam:/run/1`, `ms-settings:/`, `tel:12345`,
+/// `javascript:0` and `ms-msdt:/id ...` all reached OS protocol handlers that
+/// way, and `http:/localhost:18800` flipped the reserved-API-port guard from
+/// reject to accept (WHATWG accepts any number of slashes after a special
+/// scheme, so the guard saw host `http`, port 443, path `/localhost:18800`).
+///
+/// Accepting any `scheme:` is equally wrong - it re-breaks `localhost:5173`,
+/// which is the entire point of forgiving entry. So a valid scheme prefix wins
+/// UNLESS the input is unambiguously `host:port`:
+///   (a) the body up to the first `/ ? # \` is non-empty and all ASCII digits, and
+///   (b) the scheme candidate is spelled like a hostname ([`looks_like_hostname`]).
+/// `explicit_scheme_detection_requires_a_host_port_shape` regression-locks the
+/// full trace table.
+fn has_explicit_scheme(input: &str) -> bool {
+    let Some(colon) = input.find(':') else {
+        return false;
+    };
+
+    let scheme = &input[..colon];
+
+    // A ':' that appears after a path separator is not a scheme delimiter
+    // (`example.com/a:b`).
+    if scheme.contains(['/', '?', '#', '\\']) {
+        return false;
+    }
+
+    // RFC 3986 scheme grammar: ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    if !scheme
+        .as_bytes()
+        .first()
+        .is_some_and(u8::is_ascii_alphabetic)
+    {
+        return false;
+    }
+    if !scheme
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'+' | b'-' | b'.'))
+    {
+        return false;
+    }
+
+    // A real scheme. Only the `host:port` shape outranks it.
+    let body = &input[colon + 1..];
+    let port_end = body.find(['/', '?', '#', '\\']).unwrap_or(body.len());
+    let port = &body[..port_end];
+
+    let looks_like_host_port = !port.is_empty()
+        && port.bytes().all(|byte| byte.is_ascii_digit())
+        && looks_like_hostname(scheme);
+
+    !looks_like_host_port
+}
+
+/// Extracts the host from scheme-less operator input, purely to choose between
+/// `http` and `https`.
+///
+/// The result is NEVER reassembled back into a URL. See
+/// [`normalize_preview_input`] for why that distinction is load-bearing.
+fn schemeless_host(input: &str) -> &str {
+    let rest = input.strip_prefix("//").unwrap_or(input);
+    let authority_end = rest.find(['/', '?', '#', '\\']).unwrap_or(rest.len());
+    let authority = &rest[..authority_end];
+
+    // Any userinfo is stripped so classification looks at the real host; the
+    // credentials themselves are rejected later by `validate_preview_url`.
+    let authority = match authority.rfind('@') {
+        Some(at) => &authority[at + 1..],
+        None => authority,
+    };
+
+    // IPv6 literals are bracketed, and the colons inside them are not port
+    // delimiters.
+    if let Some(after_bracket) = authority.strip_prefix('[') {
+        return match after_bracket.find(']') {
+            Some(end) => &after_bracket[..end],
+            None => after_bracket,
+        };
+    }
+
+    match authority.rfind(':') {
+        // An EMPTY port segment is vacuously all-digits, and stripping it is
+        // what makes `//localhost:/dashboard` classify as localhost-ish. Keeping
+        // the trailing colon yielded the host `localhost:`, which
+        // `is_localhostish_host` trims `.`/`[`/`]` from but not `:` - so the
+        // operator's plain-HTTP dev server was scheme-selected as `https` and
+        // failed the TLS handshake.
+        Some(colon) if authority[colon + 1..].bytes().all(|b| b.is_ascii_digit()) => {
+            &authority[..colon]
+        }
+        _ => authority,
+    }
+}
+
+/// Hosts that should default to `http://` rather than `https://`, because a
+/// local dev server almost never has a certificate.
+fn is_localhostish_host(host: &str) -> bool {
+    // A trailing dot is the FQDN-absolute spelling of the same name.
+    let host = host
+        .trim_end_matches('.')
+        .trim_matches(|c| c == '[' || c == ']')
+        .to_ascii_lowercase();
+
+    host == "localhost" || host.ends_with(".localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+/// Make forgiving operator input parseable: `localhost:5173` becomes
+/// `http://localhost:5173`, `github.com/owner/repo` becomes
+/// `https://github.com/owner/repo`. Input that already has a scheme is returned
+/// unchanged (trimmed).
+///
+/// # Security
+///
+/// When a scheme is missing this performs a PURE STRING PREPEND onto the
+/// trimmed raw input. It must never decompose the input into host + path and
+/// reassemble it. A reassembling normalizer turns `localhost:18800` into
+/// `http://localhost/18800`, which relocates the reserved Hive API port into
+/// the PATH: the parsed port becomes 80/443, the reserved-port check passes,
+/// and the local API is opened as untrusted preview content.
+/// `normalization_never_relocates_the_port` regression-locks this.
+pub(crate) fn normalize_preview_input(input: &str) -> String {
+    let trimmed = input.trim();
+    if trimmed.is_empty() || has_explicit_scheme(trimmed) {
+        return trimmed.to_string();
+    }
+
+    let host = schemeless_host(trimmed);
+    if host.is_empty() {
+        // Path-only input (`/relative/path`, `?q=1`) has no authority to attach a
+        // scheme to. It is returned unchanged so `Url::parse` rejects it. Prepending
+        // anyway would produce `https:///relative/path`, and the WHATWG
+        // "special authority ignore slashes" rule collapses the extra slash and
+        // promotes `relative` to the HOST - silently inventing an origin the
+        // operator never typed.
+        return trimmed.to_string();
+    }
+
+    let scheme = if is_localhostish_host(host) {
+        "http"
+    } else {
+        "https"
+    };
+
+    format!("{scheme}://{trimmed}")
+}
+
+/// Validate an operator-TYPED preview URL: normalize the forgiving entry forms
+/// first, then apply the real rules.
+///
+/// # Security
+///
+/// This is the ONLY entry point permitted to normalize, and the ONLY caller is
+/// the `open_preview_window` command. Normalization is an operator-input
+/// affordance for humans who type `localhost:5173`; it is pure downside anywhere
+/// else. A URL arriving from a live page is already absolute, so prepending a
+/// scheme to it can only ever LAUNDER a scheme the allowlist would otherwise
+/// reject. Keeping the navigation gate on [`validate_preview_url`] - which never
+/// normalizes - retires that whole class of bypass rather than patching its
+/// instances. `the_navigation_gate_never_normalizes` regression-locks it.
+pub(crate) fn validate_operator_preview_input(
+    input: &str,
+    configured_api_port: u16,
+) -> Result<Url, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err(
+            "Enter a preview URL. The scheme is optional: localhost:5173, \
+             github.com/owner/repo, or https://example.com"
+                .to_string(),
+        );
+    }
+
+    validate_preview_url(&normalize_preview_input(trimmed), configured_api_port)
+}
+
+/// Parse and validate a preview URL before it reaches a webview. The single
+/// source of truth for what preview content is allowed to be.
 ///
 /// Preview content is deliberately limited to ordinary web origins. The local Hive
 /// API is excluded because loading it as the top-level origin would bypass browser
 /// CORS protections for subsequent same-origin requests.
+///
+/// Takes the input EXACTLY as given - see
+/// [`validate_operator_preview_input`] for why normalization is quarantined to
+/// the operator path.
 pub(crate) fn validate_preview_url(input: &str, configured_api_port: u16) -> Result<Url, String> {
     let trimmed = input.trim();
     if trimmed.is_empty() {
-        return Err("Enter an http:// or https:// preview URL".to_string());
+        return Err(
+            "Enter a preview URL. The scheme is optional: localhost:5173, \
+             github.com/owner/repo, or https://example.com"
+                .to_string(),
+        );
     }
 
-    let url = Url::parse(trimmed).map_err(|_| "Enter a valid absolute preview URL".to_string())?;
+    let url = Url::parse(trimmed).map_err(|_| {
+        "Enter a valid preview URL, such as localhost:5173, 127.0.0.1:3000/x, \
+         or github.com/owner/repo"
+            .to_string()
+    })?;
 
     if !matches!(url.scheme(), "http" | "https") {
-        return Err("Preview URLs must use http:// or https://".to_string());
+        return Err(
+            "Preview URLs must be http or https. Try localhost:5173 or example.com/path"
+                .to_string(),
+        );
     }
 
     url.host_str()
@@ -61,14 +318,721 @@ fn is_trusted_main_window_origin(url: &Url) -> bool {
         return false;
     };
 
+    // The url crate PRESERVES a trailing FQDN dot, so `tauri.localhost.`,
+    // `localhost.:1420` and even `tauri.localhost..` reach the very same origin
+    // as the bare spellings while comparing unequal to them. Every trailing dot
+    // is folded, matching what `is_localhostish_host` already does.
+    let host = host.trim_end_matches('.');
+
     host.eq_ignore_ascii_case("tauri.localhost")
         || (host.eq_ignore_ascii_case("localhost")
             && url.port_or_known_default() == Some(MAIN_DEV_SERVER_PORT))
 }
 
+/// wry's `on_navigation` gate for UNTRUSTED remote preview content.
+///
+/// # Security
+///
+/// A `true` here lets wry navigate to the ORIGINAL url, so this must call
+/// [`validate_preview_url`] and never
+/// [`validate_operator_preview_input`]. Normalizing a navigation URL cannot
+/// help - it is already absolute - and can only launder a rejected scheme into
+/// an accepted one.
 fn preview_navigation_allowed(url: &Url, configured_api_port: u16) -> bool {
     validate_preview_url(url.as_str(), configured_api_port).is_ok()
 }
+
+// ---------------------------------------------------------------------------
+// Dock geometry (issue #157 §2)
+// ---------------------------------------------------------------------------
+
+/// Mirrors `main.minWidth` in tauri.conf.json. Docking must never ask the main
+/// window for a width the OS will refuse, because the refusal shows up as the
+/// two windows silently overlapping - the exact failure tiling exists to avoid.
+const MAIN_MIN_LOGICAL_WIDTH: f64 = 800.0;
+/// Narrowest useful docked preview column. Also the minimum size temporarily
+/// applied to the preview window while docked: its configured 640 logical
+/// minimum would fight the split on a 1080p display at 150% scale, which only
+/// has 1280 logical px of work area.
+const DOCKED_PREVIEW_MIN_LOGICAL_WIDTH: f64 = 420.0;
+#[cfg(not(test))]
+const DOCKED_PREVIEW_MIN_LOGICAL_HEIGHT: f64 = 360.0;
+/// Mirrors `operator-preview.minWidth` / `minHeight` in tauri.conf.json, so the
+/// constraint relaxed for docking is put back verbatim on undock.
+#[cfg(not(test))]
+const FLOATING_PREVIEW_MIN_LOGICAL_WIDTH: f64 = 640.0;
+#[cfg(not(test))]
+const FLOATING_PREVIEW_MIN_LOGICAL_HEIGHT: f64 = 480.0;
+/// Share of the monitor work area handed to the docked preview.
+const DOCKED_PREVIEW_WIDTH_FRACTION: f64 = 0.40;
+
+/// Split a monitor work area into two flush, non-overlapping columns:
+/// `(main_width, preview_width)` in physical pixels.
+///
+/// The preview width is subtracted from the total rather than computed
+/// independently, so the two columns provably sum to the work area exactly -
+/// no rounding gap, no rounding overlap.
+///
+/// Returns `Err` when the display simply cannot host both windows at their
+/// minimum widths. Refusing is deliberate: a "best effort" split that overlaps
+/// puts a native WebView2 HWND on top of the main window's HTML, and no CSS
+/// `z-index` in the app can ever paint over it.
+fn dock_split(work_area_width: u32, scale_factor: f64) -> Result<(u32, u32), String> {
+    let scale = if scale_factor.is_finite() && scale_factor > 0.0 {
+        scale_factor
+    } else {
+        1.0
+    };
+
+    let total = f64::from(work_area_width);
+    // Rounded UP so the integer columns below can never land a pixel under the
+    // minimum the OS will actually honour.
+    let main_min = (MAIN_MIN_LOGICAL_WIDTH * scale).ceil() as u32;
+    let preview_min = (DOCKED_PREVIEW_MIN_LOGICAL_WIDTH * scale).ceil() as u32;
+
+    if work_area_width < main_min.saturating_add(preview_min) {
+        return Err(format!(
+            "This display is too narrow to dock the preview beside Hive Manager. \
+             Docking needs about {needed} logical px of work area and this monitor has {have}. \
+             Pop the preview out instead.",
+            needed = (MAIN_MIN_LOGICAL_WIDTH + DOCKED_PREVIEW_MIN_LOGICAL_WIDTH).round() as i64,
+            have = (total / scale).round() as i64,
+        ));
+    }
+
+    // Clamped in integer pixels, then subtracted from the total. Both columns
+    // therefore respect their minimum AND sum to the work area exactly - no
+    // rounding gap, and more importantly no rounding overlap.
+    let preview_width = ((total * DOCKED_PREVIEW_WIDTH_FRACTION).round() as u32)
+        .clamp(preview_min, work_area_width - main_min);
+    let main_width = work_area_width - preview_width;
+
+    Ok((main_width, preview_width))
+}
+
+/// True when `(x, y)` - a window's top-left corner - falls inside one of the
+/// supplied monitor work areas, given as `(x, y, width, height)`.
+///
+/// Guards restoring a remembered position onto a monitor that no longer exists.
+/// A laptop undocked from an external display would otherwise reopen the preview
+/// at coordinates no screen covers, and the operator sees nothing at all.
+fn position_is_on_a_monitor(x: i32, y: i32, work_areas: &[(i32, i32, u32, u32)]) -> bool {
+    work_areas.iter().any(|&(monitor_x, monitor_y, width, height)| {
+        x >= monitor_x
+            && y >= monitor_y
+            && x < monitor_x.saturating_add(width as i32)
+            && y < monitor_y.saturating_add(height as i32)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Preview window runtime (issue #157 §2)
+// ---------------------------------------------------------------------------
+
+/// Emitted to the main window on every allowed preview navigation, so the
+/// address bar can show where in-page navigation actually went.
+#[cfg(not(test))]
+const PREVIEW_NAVIGATED_EVENT: &str = "preview-navigated";
+/// Emitted whenever the preview opens, closes, docks or undocks.
+#[cfg(not(test))]
+const PREVIEW_STATUS_EVENT: &str = "preview-status";
+#[cfg(not(test))]
+const PREVIEW_STATE_FILE: &str = "preview-window-state.json";
+/// Coalescing window for the resize/move storm produced by a window drag.
+#[cfg(not(test))]
+const RETILE_DEBOUNCE_MS: u64 = 60;
+
+/// A window rectangle as persisted between runs.
+///
+/// The position is PHYSICAL (absolute desktop coordinates, so it identifies the
+/// monitor) while the size is LOGICAL (DPI-independent, so restoring onto a
+/// differently scaled monitor preserves apparent size instead of halving or
+/// doubling it).
+#[cfg(not(test))]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+struct WindowGeometry {
+    x: i32,
+    y: i32,
+    width: f64,
+    height: f64,
+}
+
+#[cfg(not(test))]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+struct PersistedPreviewState {
+    #[serde(default)]
+    docked: bool,
+    #[serde(default)]
+    floating: Option<WindowGeometry>,
+    #[serde(default)]
+    main_restore: Option<WindowGeometry>,
+    #[serde(default)]
+    main_was_maximized: bool,
+    #[serde(default)]
+    session_urls: BTreeMap<String, String>,
+}
+
+#[cfg(not(test))]
+struct PreviewRuntime {
+    path: PathBuf,
+    state: PersistedPreviewState,
+    current_url: Option<String>,
+    events_wired: bool,
+}
+
+#[cfg(not(test))]
+static PREVIEW_RUNTIME: OnceLock<Mutex<PreviewRuntime>> = OnceLock::new();
+#[cfg(not(test))]
+static RETILE_PENDING: AtomicBool = AtomicBool::new(false);
+
+#[cfg(not(test))]
+fn runtime(app_state: &Arc<AppState>) -> &'static Mutex<PreviewRuntime> {
+    PREVIEW_RUNTIME.get_or_init(|| {
+        let path = app_state.storage.base_dir().join(PREVIEW_STATE_FILE);
+        let state = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|raw| serde_json::from_str::<PersistedPreviewState>(&raw).ok())
+            .unwrap_or_default();
+        Mutex::new(PreviewRuntime {
+            path,
+            state,
+            current_url: None,
+            events_wired: false,
+        })
+    })
+}
+
+/// Best-effort persistence. A failure here costs the operator a remembered
+/// window position, so it is logged rather than surfaced as a command error.
+#[cfg(not(test))]
+fn persist(runtime: &PreviewRuntime) {
+    let Ok(serialized) = serde_json::to_string_pretty(&runtime.state) else {
+        return;
+    };
+    let temp = runtime.path.with_extension("json.tmp");
+    if let Err(error) = std::fs::write(&temp, serialized) {
+        tracing::warn!("Failed to stage preview window state: {error}");
+        return;
+    }
+    if let Err(error) = std::fs::rename(&temp, &runtime.path) {
+        tracing::warn!("Failed to persist preview window state: {error}");
+        let _ = std::fs::remove_file(&temp);
+    }
+}
+
+/// What the main window needs to render the preview affordance.
+#[cfg(not(test))]
+#[derive(Debug, Clone, Serialize)]
+pub struct PreviewStatus {
+    /// The preview window currently exists.
+    open: bool,
+    /// The preview is tiled beside the main window.
+    docked: bool,
+    /// The URL the preview is showing right now.
+    url: Option<String>,
+    /// The last preview URL used for the session the caller asked about.
+    session_url: Option<String>,
+}
+
+#[cfg(not(test))]
+fn status_for(
+    app: &AppHandle,
+    runtime: &PreviewRuntime,
+    session_id: Option<&str>,
+) -> PreviewStatus {
+    let window = app.get_webview_window(PREVIEW_WINDOW_LABEL);
+    let open = window.is_some();
+
+    PreviewStatus {
+        open,
+        docked: open && runtime.state.docked,
+        url: if open {
+            runtime
+                .current_url
+                .clone()
+                .or_else(|| window.and_then(|w| w.url().ok()).map(|u| u.to_string()))
+        } else {
+            None
+        },
+        session_url: session_id.and_then(|id| runtime.state.session_urls.get(id).cloned()),
+    }
+}
+
+#[cfg(not(test))]
+fn emit_status(app: &AppHandle, status: &PreviewStatus) {
+    let _ = app.emit_to(MAIN_WINDOW_LABEL, PREVIEW_STATUS_EVENT, status);
+}
+
+#[cfg(not(test))]
+fn publish_status(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+    session_id: Option<&str>,
+) -> PreviewStatus {
+    let status = {
+        let guard = runtime(app_state).lock();
+        status_for(app, &guard, session_id)
+    };
+    emit_status(app, &status);
+    status
+}
+
+#[cfg(not(test))]
+fn require_window(app: &AppHandle, label: &str) -> Result<WebviewWindow, String> {
+    app.get_webview_window(label)
+        .ok_or_else(|| format!("The {label} window is not open"))
+}
+
+#[cfg(not(test))]
+fn read_geometry(window: &WebviewWindow) -> Option<WindowGeometry> {
+    let position = window.outer_position().ok()?;
+    let size = window.outer_size().ok()?;
+    let scale = window.scale_factor().ok()?;
+    if !scale.is_finite() || scale <= 0.0 {
+        return None;
+    }
+    Some(WindowGeometry {
+        x: position.x,
+        y: position.y,
+        width: f64::from(size.width) / scale,
+        height: f64::from(size.height) / scale,
+    })
+}
+
+/// Apply a geometry that was remembered from an earlier run, but only if some
+/// monitor still covers its top-left corner. Otherwise the window keeps whatever
+/// position the OS gave it, which is at least visible.
+#[cfg(not(test))]
+fn apply_remembered_geometry(window: &WebviewWindow, geometry: WindowGeometry) {
+    let work_areas: Vec<(i32, i32, u32, u32)> = window
+        .available_monitors()
+        .unwrap_or_default()
+        .iter()
+        .map(|monitor| {
+            let area = monitor.work_area();
+            (
+                area.position.x,
+                area.position.y,
+                area.size.width,
+                area.size.height,
+            )
+        })
+        .collect();
+
+    if !position_is_on_a_monitor(geometry.x, geometry.y, &work_areas) {
+        tracing::info!(
+            "Ignoring remembered window position ({}, {}): no connected monitor covers it",
+            geometry.x,
+            geometry.y
+        );
+        return;
+    }
+
+    if let Err(error) = apply_geometry(window, geometry) {
+        tracing::warn!("Failed to restore remembered window geometry: {error}");
+    }
+}
+
+#[cfg(not(test))]
+fn apply_geometry(window: &WebviewWindow, geometry: WindowGeometry) -> Result<(), String> {
+    // Position first: the logical size is resolved against the scale factor of
+    // whichever monitor the window is on, so it must land on the target monitor
+    // before the size is applied.
+    window
+        .set_position(PhysicalPosition::new(geometry.x, geometry.y))
+        .map_err(|error| format!("Failed to position window: {error}"))?;
+    window
+        .set_size(LogicalSize::new(geometry.width, geometry.height))
+        .map_err(|error| format!("Failed to resize window: {error}"))
+}
+
+/// Tile the main window and the preview side by side across the current
+/// monitor's work area.
+#[cfg(not(test))]
+fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), String> {
+    let main = require_window(app, MAIN_WINDOW_LABEL)?;
+    let preview = require_window(app, PREVIEW_WINDOW_LABEL)?;
+
+    let monitor = main
+        .current_monitor()
+        .map_err(|error| format!("Failed to read the current monitor: {error}"))?
+        .or(main
+            .primary_monitor()
+            .map_err(|error| format!("Failed to read the primary monitor: {error}"))?)
+        .ok_or_else(|| "Could not determine which monitor Hive Manager is on".to_string())?;
+
+    let scale = monitor.scale_factor();
+    let work_area = *monitor.work_area();
+
+    // Computed before anything is mutated: a display that cannot host the split
+    // must leave both windows exactly where they were.
+    let (main_width, preview_width) = dock_split(work_area.size.width, scale)?;
+
+    {
+        let mut guard = runtime(app_state).lock();
+        if !guard.state.docked {
+            // Snapshot the floating layout so undock restores it exactly.
+            guard.state.main_was_maximized = main.is_maximized().unwrap_or(false);
+            guard.state.main_restore = read_geometry(&main);
+            if let Some(geometry) = read_geometry(&preview) {
+                guard.state.floating = Some(geometry);
+            }
+        }
+        guard.state.docked = true;
+        persist(&guard);
+    }
+
+    // A maximized window ignores explicit geometry, so drop out of it first.
+    if main.is_maximized().unwrap_or(false) {
+        let _ = main.unmaximize();
+    }
+    if preview.is_maximized().unwrap_or(false) {
+        let _ = preview.unmaximize();
+    }
+    let _ = preview.set_min_size(Some(LogicalSize::new(
+        DOCKED_PREVIEW_MIN_LOGICAL_WIDTH,
+        DOCKED_PREVIEW_MIN_LOGICAL_HEIGHT,
+    )));
+
+    let top = work_area.position.y;
+    let height = work_area.size.height;
+
+    main.set_position(PhysicalPosition::new(work_area.position.x, top))
+        .map_err(|error| format!("Failed to position Hive Manager: {error}"))?;
+    main.set_size(PhysicalSize::new(main_width, height))
+        .map_err(|error| format!("Failed to resize Hive Manager: {error}"))?;
+    preview
+        .set_position(PhysicalPosition::new(
+            work_area.position.x + main_width as i32,
+            top,
+        ))
+        .map_err(|error| format!("Failed to position the preview: {error}"))?;
+    preview
+        .set_size(PhysicalSize::new(preview_width, height))
+        .map_err(|error| format!("Failed to resize the preview: {error}"))?;
+
+    Ok(())
+}
+
+/// Give the main window back the geometry it had before docking. Split out from
+/// [`leave_docked_mode`] because closing a docked preview must also do it -
+/// otherwise Hive Manager is stranded in the left-hand column with nothing
+/// beside it.
+#[cfg(not(test))]
+fn restore_main_window_geometry(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+) -> Result<(), String> {
+    let (geometry, was_maximized) = {
+        let mut guard = runtime(app_state).lock();
+        let geometry = guard.state.main_restore.take();
+        let was_maximized = std::mem::take(&mut guard.state.main_was_maximized);
+        persist(&guard);
+        (geometry, was_maximized)
+    };
+
+    let Some(main) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
+        return Ok(());
+    };
+
+    if was_maximized {
+        main.maximize()
+            .map_err(|error| format!("Failed to restore Hive Manager: {error}"))?;
+    } else if let Some(geometry) = geometry {
+        apply_remembered_geometry(&main, geometry);
+    }
+
+    Ok(())
+}
+
+/// Undo the docked LAYOUT on teardown while keeping the dock PREFERENCE, so the
+/// next open re-tiles.
+///
+/// Both teardown paths funnel through here - the `close_preview_window` command
+/// AND the native titlebar X, which reaches only `WindowEvent::Destroyed`
+/// (there is no `CloseRequested` handler in this crate). Closing a docked
+/// preview with the X used to skip the restore entirely, stranding Hive Manager
+/// in the left-hand column beside empty desktop - and since the emitted
+/// `open: false` hides the dock/pop-out/close cluster, no in-app control was
+/// left to undo it.
+#[cfg(not(test))]
+fn undock_layout_after_teardown(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+) -> Result<(), String> {
+    if !runtime(app_state).lock().state.docked {
+        return Ok(());
+    }
+    restore_main_window_geometry(app, app_state)
+}
+
+#[cfg(not(test))]
+fn leave_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), String> {
+    restore_main_window_geometry(app, app_state)?;
+
+    let floating = {
+        let mut guard = runtime(app_state).lock();
+        guard.state.docked = false;
+        persist(&guard);
+        guard.state.floating
+    };
+
+    let Some(preview) = app.get_webview_window(PREVIEW_WINDOW_LABEL) else {
+        return Ok(());
+    };
+
+    let _ = preview.set_min_size(Some(LogicalSize::new(
+        FLOATING_PREVIEW_MIN_LOGICAL_WIDTH,
+        FLOATING_PREVIEW_MIN_LOGICAL_HEIGHT,
+    )));
+
+    if let Some(geometry) = floating {
+        apply_remembered_geometry(&preview, geometry);
+    }
+
+    Ok(())
+}
+
+/// Keep the docked preview flush against the main window after the operator
+/// moves, resizes or DPI-shifts it.
+///
+/// This is a deliberately ONE-WAY follow: the preview tracks the main window and
+/// never the other way round. Resizing the main window here would emit another
+/// `Resized` and recurse.
+#[cfg(not(test))]
+fn follow_docked_preview(app: &AppHandle) -> Result<(), String> {
+    let main = require_window(app, MAIN_WINDOW_LABEL)?;
+    let preview = require_window(app, PREVIEW_WINDOW_LABEL)?;
+
+    let position = main
+        .outer_position()
+        .map_err(|error| format!("Failed to read the Hive Manager position: {error}"))?;
+    let size = main
+        .outer_size()
+        .map_err(|error| format!("Failed to read the Hive Manager size: {error}"))?;
+    let monitor = main
+        .current_monitor()
+        .map_err(|error| format!("Failed to read the current monitor: {error}"))?
+        .ok_or_else(|| "Could not determine which monitor Hive Manager is on".to_string())?;
+
+    let scale = monitor.scale_factor();
+    let work_area = *monitor.work_area();
+
+    let floor = (DOCKED_PREVIEW_MIN_LOGICAL_WIDTH * scale).round() as i32;
+    let work_right = work_area.position.x + work_area.size.width as i32;
+    let main_right = position.x + size.width as i32;
+    let available = work_right - main_right;
+
+    let (x, width) = if available >= floor {
+        (main_right, available)
+    } else {
+        // Degenerate case: the operator widened the main window past the work
+        // area minus the floor. Keep the preview on-screen at its minimum rather
+        // than pushing it off the desktop.
+        (work_right - floor, floor)
+    };
+
+    preview
+        .set_position(PhysicalPosition::new(x, position.y))
+        .map_err(|error| format!("Failed to position the preview: {error}"))?;
+    preview
+        .set_size(PhysicalSize::new(width.max(1) as u32, size.height))
+        .map_err(|error| format!("Failed to resize the preview: {error}"))?;
+
+    Ok(())
+}
+
+/// Wire the window listeners that keep the dock aligned and the persisted
+/// geometry current.
+///
+/// The main-window listener lives for the whole process, so it is installed at
+/// most once. The preview-window listener dies with its window, so it is
+/// re-attached to every preview window - a shared "already wired" flag here
+/// would silently leave a re-opened preview unwatched.
+#[cfg(not(test))]
+fn wire_window_events(app: &AppHandle, app_state: &Arc<AppState>, preview: &WebviewWindow) {
+    let wire_main = {
+        let mut guard = runtime(app_state).lock();
+        let first = !guard.events_wired;
+        guard.events_wired = true;
+        first
+    };
+
+    if let Some(main) = app.get_webview_window(MAIN_WINDOW_LABEL).filter(|_| wire_main) {
+        let follow_app = app.clone();
+        let follow_state = Arc::clone(app_state);
+        main.on_window_event(move |event| {
+            // `ScaleFactorChanged` is handled alongside `Resized`/`Moved` on
+            // purpose. On a mixed-DPI multi-monitor desktop the main window's
+            // physical rectangle changes when it crosses monitors without a
+            // reliable Moved/Resized pair, and a preview that ignored the DPI
+            // event would drift out of alignment or overlap.
+            if !matches!(
+                event,
+                WindowEvent::Resized(_)
+                    | WindowEvent::Moved(_)
+                    | WindowEvent::ScaleFactorChanged { .. }
+            ) {
+                return;
+            }
+
+            if !runtime(&follow_state).lock().state.docked {
+                return;
+            }
+
+            // Coalesce the event storm a window drag produces, and get off the
+            // window-event callback before touching window geometry.
+            if RETILE_PENDING.swap(true, Ordering::SeqCst) {
+                return;
+            }
+            let retile_app = follow_app.clone();
+            let retile_state = Arc::clone(&follow_state);
+            tauri::async_runtime::spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(RETILE_DEBOUNCE_MS)).await;
+                RETILE_PENDING.store(false, Ordering::SeqCst);
+                if !runtime(&retile_state).lock().state.docked {
+                    return;
+                }
+                if let Err(error) = follow_docked_preview(&retile_app) {
+                    tracing::debug!("Preview dock follow skipped: {error}");
+                }
+            });
+        });
+    }
+
+    let preview_app = app.clone();
+    let preview_state = Arc::clone(app_state);
+    preview.on_window_event(move |event| match event {
+        WindowEvent::Moved(_) | WindowEvent::Resized(_) => {
+            let Some(window) = preview_app.get_webview_window(PREVIEW_WINDOW_LABEL) else {
+                return;
+            };
+            let Some(geometry) = read_geometry(&window) else {
+                return;
+            };
+            // Held in memory and flushed on close/dock/undock rather than
+            // written on every frame of a drag.
+            let mut guard = runtime(&preview_state).lock();
+            if !guard.state.docked {
+                guard.state.floating = Some(geometry);
+            }
+        }
+        WindowEvent::Destroyed => {
+            let docked = {
+                let mut guard = runtime(&preview_state).lock();
+                guard.current_url = None;
+                persist(&guard);
+                guard.state.docked
+            };
+
+            // The native titlebar X lands here and nowhere else, so this arm
+            // has to mirror `close_preview_window` or a docked close strands
+            // the main window. Same discipline as the retile follow above: get
+            // off the window-event callback before touching window geometry.
+            // Idempotent when the command already restored - the geometry it
+            // takes is gone, so this second pass is a no-op.
+            if docked {
+                let restore_app = preview_app.clone();
+                let restore_state = Arc::clone(&preview_state);
+                tauri::async_runtime::spawn(async move {
+                    let restored = undock_layout_after_teardown(&restore_app, &restore_state);
+                    if let Err(error) = restored {
+                        tracing::warn!(
+                            "Failed to restore Hive Manager after the preview closed: {error}"
+                        );
+                    }
+                });
+            }
+
+            emit_status(
+                &preview_app,
+                &PreviewStatus {
+                    open: false,
+                    docked: false,
+                    url: None,
+                    session_url: None,
+                },
+            );
+        }
+        _ => {}
+    });
+}
+
+#[cfg(not(test))]
+fn create_preview_window(
+    app: &AppHandle,
+    app_state: &Arc<AppState>,
+    url: Url,
+    configured_api_port: u16,
+) -> Result<WebviewWindow, String> {
+    let mut config = app
+        .config()
+        .app
+        .windows
+        .iter()
+        .find(|config| config.label == PREVIEW_WINDOW_LABEL)
+        .cloned()
+        .ok_or_else(|| "Preview window configuration is missing".to_string())?;
+    config.url = WebviewUrl::External(url);
+    // Realised hidden so the remembered geometry can be applied before the
+    // operator sees the window at the configured default position.
+    config.visible = false;
+
+    let navigation_app = app.clone();
+    let navigation_state = Arc::clone(app_state);
+
+    let mut builder = WebviewWindowBuilder::from_config(app, &config)
+        .map_err(|error| format!("Failed to configure preview window: {error}"))?
+        .on_navigation(move |url| {
+            if !preview_navigation_allowed(url, configured_api_port) {
+                return false;
+            }
+            // Address-bar sync: this closure already sees every navigation, so
+            // the main window is told where in-page navigation actually went.
+            let current = url.to_string();
+            runtime(&navigation_state).lock().current_url = Some(current.clone());
+            let _ = navigation_app.emit_to(
+                MAIN_WINDOW_LABEL,
+                PREVIEW_NAVIGATED_EVENT,
+                serde_json::json!({ "url": current }),
+            );
+            true
+        })
+        .on_new_window(|_, _| NewWindowResponse::Deny);
+
+    // Owner semantics rather than a child webview. Verified against the
+    // `WebviewWindowBuilder::parent` doc contract in tauri 2.10.1: on Windows the
+    // parent is set as the OWNER window, so the preview stays above Hive Manager
+    // in the z-order, is destroyed automatically when Hive Manager closes, and is
+    // hidden when Hive Manager minimizes. No `unstable` cargo feature, no child
+    // webview, and no widening of the capability boundary.
+    if let Some(main) = app.get_webview_window(MAIN_WINDOW_LABEL) {
+        builder = builder
+            .parent(&main)
+            .map_err(|error| format!("Failed to parent the preview window: {error}"))?;
+    }
+
+    let window = builder
+        .build()
+        .map_err(|error| format!("Failed to open preview window: {error}"))?;
+
+    wire_window_events(app, app_state, &window);
+
+    let floating = { runtime(app_state).lock().state.floating };
+    if let Some(geometry) = floating {
+        apply_remembered_geometry(&window, geometry);
+    }
+
+    window
+        .show()
+        .map_err(|error| format!("Failed to show preview window: {error}"))?;
+
+    Ok(window)
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+// ---------------------------------------------------------------------------
 
 /// Open the operator preview, or navigate and focus the existing preview window.
 ///
@@ -81,9 +1045,24 @@ pub async fn open_preview_window(
     app: AppHandle,
     app_state: State<'_, Arc<AppState>>,
     url: String,
-) -> Result<(), String> {
+    session_id: Option<String>,
+) -> Result<PreviewStatus, String> {
     let configured_api_port = app_state.config.read().await.api.port;
-    let url = validate_preview_url(&url, configured_api_port)?;
+    // The one and only normalizing entry point: this URL was typed by a human.
+    let url = validate_operator_preview_input(&url, configured_api_port)?;
+    let state = Arc::clone(app_state.inner());
+
+    {
+        let mut guard = runtime(&state).lock();
+        guard.current_url = Some(url.to_string());
+        if let Some(session_id) = session_id.as_deref() {
+            guard
+                .state
+                .session_urls
+                .insert(session_id.to_string(), url.to_string());
+        }
+        persist(&guard);
+    }
 
     if let Some(window) = app.get_webview_window(PREVIEW_WINDOW_LABEL) {
         window
@@ -98,39 +1077,153 @@ pub async fn open_preview_window(
         window
             .set_focus()
             .map_err(|error| format!("Failed to focus preview window: {error}"))?;
-        return Ok(());
+    } else {
+        let window = create_preview_window(&app, &state, url, configured_api_port)?;
+
+        // The persisted dock preference survives across opens, so a freshly
+        // created window re-tiles itself. A display that can no longer host the
+        // split downgrades to floating instead of failing the open.
+        if runtime(&state).lock().state.docked {
+            if let Err(error) = enter_docked_mode(&app, &state) {
+                tracing::warn!("Preview opened floating instead of docked: {error}");
+                let mut guard = runtime(&state).lock();
+                guard.state.docked = false;
+                persist(&guard);
+            }
+        }
+
+        window
+            .set_focus()
+            .map_err(|error| format!("Failed to focus preview window: {error}"))?;
     }
 
-    let mut config = app
-        .config()
-        .app
-        .windows
-        .iter()
-        .find(|config| config.label == PREVIEW_WINDOW_LABEL)
-        .cloned()
-        .ok_or_else(|| "Preview window configuration is missing".to_string())?;
-    config.url = WebviewUrl::External(url);
+    Ok(publish_status(&app, &state, session_id.as_deref()))
+}
 
-    let window = WebviewWindowBuilder::from_config(&app, &config)
-        .map_err(|error| format!("Failed to configure preview window: {error}"))?
-        .on_navigation(move |url| preview_navigation_allowed(url, configured_api_port))
-        .on_new_window(|_, _| NewWindowResponse::Deny)
-        .build()
-        .map_err(|error| format!("Failed to open preview window: {error}"))?;
+/// Current preview state, plus the last URL used for `session_id` if the caller
+/// supplies one. Lets the main window prefill its address bar per session.
+#[cfg(not(test))]
+#[tauri::command]
+pub async fn get_preview_status(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    session_id: Option<String>,
+) -> Result<PreviewStatus, String> {
+    let state = Arc::clone(app_state.inner());
+    let guard = runtime(&state).lock();
+    Ok(status_for(&app, &guard, session_id.as_deref()))
+}
 
-    window
-        .set_focus()
-        .map_err(|error| format!("Failed to focus preview window: {error}"))?;
-    Ok(())
+/// Tile the preview beside the main window.
+#[cfg(not(test))]
+#[tauri::command]
+pub async fn dock_preview_window(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    session_id: Option<String>,
+) -> Result<PreviewStatus, String> {
+    let state = Arc::clone(app_state.inner());
+    enter_docked_mode(&app, &state)?;
+    Ok(publish_status(&app, &state, session_id.as_deref()))
+}
+
+/// Return the preview to a free-floating window at its remembered geometry, and
+/// give the main window back the size it had before docking.
+#[cfg(not(test))]
+#[tauri::command]
+pub async fn undock_preview_window(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    session_id: Option<String>,
+) -> Result<PreviewStatus, String> {
+    let state = Arc::clone(app_state.inner());
+    leave_docked_mode(&app, &state)?;
+    Ok(publish_status(&app, &state, session_id.as_deref()))
+}
+
+/// Reload whatever the preview is currently showing.
+#[cfg(not(test))]
+#[tauri::command]
+pub async fn reload_preview_window(app: AppHandle) -> Result<(), String> {
+    require_window(&app, PREVIEW_WINDOW_LABEL)?
+        .reload()
+        .map_err(|error| format!("Failed to reload the preview: {error}"))
+}
+
+/// Close the preview window, persisting its geometry first.
+#[cfg(not(test))]
+#[tauri::command]
+pub async fn close_preview_window(
+    app: AppHandle,
+    app_state: State<'_, Arc<AppState>>,
+    session_id: Option<String>,
+) -> Result<PreviewStatus, String> {
+    let state = Arc::clone(app_state.inner());
+
+    if let Some(window) = app.get_webview_window(PREVIEW_WINDOW_LABEL) {
+        {
+            let mut guard = runtime(&state).lock();
+            if !guard.state.docked {
+                if let Some(geometry) = read_geometry(&window) {
+                    guard.state.floating = Some(geometry);
+                }
+            }
+        }
+
+        // The dock *preference* survives the close (so the next open re-tiles);
+        // only the layout is undone here. Shared with the `Destroyed` arm so the
+        // titlebar X cannot diverge from this command.
+        undock_layout_after_teardown(&app, &state)?;
+
+        window
+            .destroy()
+            .map_err(|error| format!("Failed to close preview window: {error}"))?;
+    }
+
+    {
+        let mut guard = runtime(&state).lock();
+        guard.current_url = None;
+        persist(&guard);
+    }
+
+    Ok(publish_status(&app, &state, session_id.as_deref()))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// The operator-typed path: normalization THEN the rules.
     fn validate(input: &str) -> Result<Url, String> {
-        validate_preview_url(input, LOCAL_API_PORT)
+        validate_operator_preview_input(input, LOCAL_API_PORT)
     }
+
+    /// The untrusted navigation gate: the rules, and nothing but the rules.
+    fn navigable(input: &str) -> bool {
+        let url = Url::parse(input)
+            .unwrap_or_else(|error| panic!("{input:?} should parse as a URL, got {error:?}"));
+        preview_navigation_allowed(&url, LOCAL_API_PORT)
+    }
+
+    /// Every scheme verified to reach an OS protocol handler through the
+    /// `://`-only scheme test. `ms-msdt:` is the Follina launcher.
+    const OS_PROTOCOL_HANDLER_URLS: &[&str] = &[
+        "vscode:/x",
+        "steam:/run/1",
+        "ms-settings:/",
+        "javascript:0",
+        "tel:12345",
+        "ms-msdt:/id PCWDiagnostic /skip force /param IT_LaunchMethod=ContextMenu",
+    ];
+
+    /// Reserved-API-port spellings WHATWG special-scheme parsing accepts.
+    const SLASH_VARIANT_API_PORT_URLS: &[&str] = &[
+        "http:/localhost:18800",
+        "https:/localhost:18800",
+        r"http:\\localhost:18800",
+        r"http:/\localhost:18800",
+        "http:/127.0.0.1:18800",
+    ];
 
     #[test]
     fn accepts_http_and_https_urls_with_hosts() {
@@ -239,5 +1332,546 @@ mod tests {
             LOCAL_API_PORT
         ));
         assert!(!preview_navigation_allowed(&blocked_api, LOCAL_API_PORT));
+    }
+
+    /// Architectural lock for finding 1: the untrusted navigation gate must
+    /// never normalize.
+    ///
+    /// A `true` from `preview_navigation_allowed` lets wry navigate to the
+    /// ORIGINAL url, so any scheme the gate accepts is a scheme a page inside
+    /// the preview can reach - including OS protocol handlers. This asserts on
+    /// the gate itself rather than on `has_explicit_scheme`, so the gate cannot
+    /// regain normalization even if the lexical scan is rewritten again.
+    #[test]
+    fn the_navigation_gate_never_normalizes() {
+        for input in OS_PROTOCOL_HANDLER_URLS {
+            assert!(
+                !navigable(input),
+                "{input:?} reaches an OS protocol handler and must be denied \
+                 by the navigation gate"
+            );
+            assert!(
+                validate_preview_url(input, LOCAL_API_PORT).is_err(),
+                "{input:?} must be rejected by the rules themselves"
+            );
+        }
+
+        // The operator path normalizes, but must reach the same verdict.
+        for input in OS_PROTOCOL_HANDLER_URLS {
+            assert!(
+                validate(input).is_err(),
+                "{input:?} must be rejected on the operator path too"
+            );
+        }
+
+        // The sharp end of Layer 1, and the part that does NOT depend on the
+        // lexical scan being right. These genuinely ARE the `host:port` shape,
+        // so the operator path is correct to normalize them - but arriving at
+        // the gate the very same text is a real scheme with an opaque body, and
+        // a `true` there sends wry to the ORIGINAL string and into whatever
+        // handler owns `com.evil.app:`. The two paths must disagree here.
+        for input in ["localhost:5173", "example.com:80", "com.evil.app:12345"] {
+            let parsed = Url::parse(input)
+                .unwrap_or_else(|error| panic!("{input:?} should parse, got {error:?}"));
+            assert_eq!(
+                parsed.as_str(),
+                input,
+                "sanity: {input:?} reaches the gate as a scheme, unmodified"
+            );
+            assert!(
+                !navigable(input),
+                "{input:?} must be denied by the gate - normalizing there would \
+                 launder a custom scheme into https and navigate to the original"
+            );
+            assert!(
+                validate(input).is_ok(),
+                "{input:?} is exactly the forgiving entry an operator types, \
+                 and must still work on the operator path"
+            );
+        }
+
+        // Sanity: the gate still passes ordinary web content.
+        assert!(navigable("https://example.com/next"));
+        assert!(navigable("http://localhost:5173/dashboard"));
+    }
+
+    /// Regression lock for finding 2.
+    ///
+    /// `Url::parse` implements WHATWG special-scheme parsing and accepts a
+    /// scheme followed by zero, one or many `/` or `\`. Under the `://` scheme
+    /// test `http:/localhost:18800` was classified scheme-less, became
+    /// `https://http:/localhost:18800` (host `http`, port 443, path
+    /// `/localhost:18800`), and the reserved-API-port guard flipped from reject
+    /// to accept.
+    #[test]
+    fn slash_variant_spellings_still_hit_the_reserved_api_port() {
+        for input in SLASH_VARIANT_API_PORT_URLS {
+            // Whatever the slashes, this really is the Hive API origin.
+            let parsed = Url::parse(input)
+                .unwrap_or_else(|error| panic!("{input:?} should parse, got {error:?}"));
+            assert_eq!(
+                parsed.port_or_known_default(),
+                Some(LOCAL_API_PORT),
+                "sanity: {input:?} really does resolve to the reserved API port"
+            );
+
+            assert!(!navigable(input), "{input:?} must be denied by the gate");
+            assert!(
+                validate(input).is_err(),
+                "{input:?} must be rejected on the operator path"
+            );
+        }
+
+        // Same trick against the trusted app origin rather than the API port.
+        assert!(!navigable("http:/tauri.localhost"));
+        assert!(validate("http:/tauri.localhost").is_err());
+
+        // And the plain spellings are unchanged.
+        assert!(validate("http://localhost:18800").is_err());
+        assert!(!navigable("http://localhost:18800"));
+    }
+
+    /// Regression lock for finding 3.
+    ///
+    /// The url crate PRESERVES a trailing FQDN dot, so these spellings reach the
+    /// very same origin as the bare ones while comparing unequal to them.
+    #[test]
+    fn trusted_main_window_origin_folds_trailing_fqdn_dots() {
+        for input in [
+            "http://tauri.localhost.",
+            "https://tauri.localhost./app",
+            "http://tauri.localhost..",
+            "http://localhost.:1420",
+            "http://LOCALHOST.:1420",
+            "http://localhost..:1420",
+        ] {
+            let url = Url::parse(input)
+                .unwrap_or_else(|error| panic!("{input:?} should parse, got {error:?}"));
+            assert!(
+                is_trusted_main_window_origin(&url),
+                "{input:?} is the trusted app origin in FQDN-absolute spelling"
+            );
+            assert!(
+                validate(input).is_err(),
+                "{input:?} should be rejected on the operator path"
+            );
+            assert!(!navigable(input), "{input:?} should be denied by the gate");
+        }
+
+        // Sanity: the dot really is preserved, which is what made this a bypass.
+        assert_eq!(
+            Url::parse("http://tauri.localhost.").unwrap().host_str(),
+            Some("tauri.localhost."),
+            "sanity: the url crate keeps the trailing dot"
+        );
+
+        // Folding dots must not over-match: the dev-server port still gates the
+        // bare `localhost` case, and unrelated hosts stay allowed.
+        assert!(validate("http://localhost.:5173").is_ok());
+        assert!(validate("http://127.0.0.1:1420").is_ok());
+    }
+
+    // -- issue #157 §1: forgiving URL entry ---------------------------------
+
+    #[test]
+    fn scheme_detection_is_lexical_not_parse_based() {
+        // Parses successfully with the bogus scheme `localhost`.
+        assert!(!has_explicit_scheme("localhost:5173"));
+        // Fails to parse outright.
+        assert!(!has_explicit_scheme("127.0.0.1:5173"));
+        assert!(!has_explicit_scheme("[::1]:5173"));
+        assert!(!has_explicit_scheme("example.com"));
+        assert!(!has_explicit_scheme("//localhost:3000/api"));
+        // A `:` after a path separator is not a scheme delimiter.
+        assert!(!has_explicit_scheme("example.com/a:b//c"));
+
+        assert!(has_explicit_scheme("http://example.com"));
+        assert!(has_explicit_scheme("HTTPS://example.com"));
+        assert!(has_explicit_scheme("file:///tmp/x"));
+        assert!(has_explicit_scheme("ftp://example.com"));
+        assert!(has_explicit_scheme("x+y-z.1://example.com"));
+    }
+
+    /// Regression lock for the `://` scheme test (findings 1 and 2).
+    ///
+    /// Requiring a double slash classified every opaque and single-slash scheme
+    /// as SCHEME-LESS, so `https://` was prepended and the result passed the
+    /// allowlist as "https". Accepting any `scheme:` instead would re-break
+    /// `localhost:5173`. A scheme prefix therefore wins unless the input is
+    /// unambiguously `host:port`. This is the full trace table.
+    #[test]
+    fn explicit_scheme_detection_requires_a_host_port_shape() {
+        // SCHEME-LESS: the forgiving `host:port` entry the feature exists for.
+        for input in [
+            "localhost:5173",     // known local single-label name
+            "LOCALHOST:18800",    // ... case-insensitively
+            "localhost.:18800",   // ... and its FQDN-absolute spelling
+            "127.0.0.1:3000/x",   // IPv4: caught by the leading-digit guard
+            "[::1]:8080",         // IPv6: caught by the leading-`[` guard
+            "example.com:80",     // multi-label name
+            "foo.localhost:3000", //
+            "example.com:8443/path?q=1#frag",
+            "github.com/rdfitted/hive-manager", // no colon at all
+            "//localhost:18800/api",            // `/` inside the scheme candidate
+        ] {
+            assert!(
+                !has_explicit_scheme(input),
+                "{input:?} is operator `host:port` entry and must be scheme-less"
+            );
+        }
+
+        // EXPLICIT: a real scheme, handed to `Url::parse` untouched so the
+        // allowlist can reject it.
+        for input in [
+            "about:blank",
+            "javascript:alert(1)",
+            "javascript:0",   // digit body, but `javascript` is not a hostname
+            "tel:12345",      // the shape that forbids "any `scheme:` is explicit"
+            "mailto:1",       //
+            "svn+ssh:22",     // `+` is legal in a scheme, never in a hostname
+            "vscode:/x",      // non-digit body
+            "ms-settings:/",  // empty body
+            "steam:/run/1",   //
+            "data:text/html,<h1>x</h1>",
+            "file:///tmp/x",
+            "http://localhost:18800",
+        ] {
+            assert!(
+                has_explicit_scheme(input),
+                "{input:?} carries a real scheme and must NOT be normalized"
+            );
+        }
+
+        for input in OS_PROTOCOL_HANDLER_URLS.iter().chain(SLASH_VARIANT_API_PORT_URLS) {
+            assert!(
+                has_explicit_scheme(input),
+                "{input:?} carries a real scheme and must NOT be normalized"
+            );
+        }
+    }
+
+    #[test]
+    fn scheme_less_input_opens_with_the_right_scheme() {
+        for (input, expected) in [
+            ("localhost:5173", "http://localhost:5173/"),
+            ("127.0.0.1:3000/x", "http://127.0.0.1:3000/x"),
+            (
+                "github.com/rdfitted/hive-manager",
+                "https://github.com/rdfitted/hive-manager",
+            ),
+            ("[::1]:8080", "http://[::1]:8080/"),
+            ("foo.localhost:3000", "http://foo.localhost:3000/"),
+        ] {
+            let url = validate(input)
+                .unwrap_or_else(|error| panic!("{input:?} should validate, got {error:?}"));
+            assert_eq!(url.as_str(), expected, "wrong normalization for {input:?}");
+        }
+    }
+
+    #[test]
+    fn scheme_less_input_still_hits_every_rejection() {
+        for input in [
+            // Reserved Hive API port, in every spelling that reaches it.
+            "localhost:18800",
+            "127.0.0.1:18800",
+            "LOCALHOST:18800",
+            "//localhost:18800/api",
+            "localhost:18800/api/health",
+            "localhost.:18800",
+            // Origins reserved for the trusted main window.
+            "tauri.localhost",
+            "localhost:1420",
+        ] {
+            assert!(
+                validate(input).is_err(),
+                "{input:?} should be rejected after normalization"
+            );
+        }
+    }
+
+    /// Regression lock for a real bypass.
+    ///
+    /// A normalizer that decomposes input into host + path and reassembles it
+    /// turns `localhost:18800` into `http://localhost/18800`: the reserved port
+    /// moves into the PATH, `port_or_known_default()` returns 80, and the local
+    /// Hive API sails through validation. The only safe implementation is a
+    /// string prepend onto the trimmed raw input.
+    #[test]
+    fn normalization_never_relocates_the_port() {
+        for (input, scheme) in [
+            ("localhost:18800", "http"),
+            ("localhost:5173", "http"),
+            ("127.0.0.1:3000/x", "http"),
+            ("[::1]:8080", "http"),
+            ("foo.localhost:3000", "http"),
+            ("example.com:8443/path?q=1#frag", "https"),
+            ("github.com/rdfitted/hive-manager", "https"),
+            ("//localhost:18800/api", "http"),
+        ] {
+            let normalized = normalize_preview_input(input);
+            assert_eq!(
+                normalized,
+                format!("{scheme}://{input}"),
+                "normalization of {input:?} must be a pure prefix of the raw input"
+            );
+            assert!(
+                normalized.ends_with(input),
+                "normalization of {input:?} rewrote the input body"
+            );
+        }
+
+        // The specific shape of the bypass, named so a future refactor that
+        // reintroduces it fails here with an obvious message.
+        assert_ne!(
+            normalize_preview_input("localhost:18800"),
+            "http://localhost/18800",
+            "the reserved API port was relocated from the authority into the path"
+        );
+        assert_eq!(
+            Url::parse("http://localhost/18800")
+                .unwrap()
+                .port_or_known_default(),
+            Some(80),
+            "sanity: the bypass shape really does present as port 80"
+        );
+    }
+
+    #[test]
+    fn normalization_leaves_scheme_bearing_input_alone() {
+        for input in [
+            "http://localhost:5173/x",
+            "https://github.com/acme/repo",
+            "file:///tmp/index.html",
+            "ftp://example.com/file",
+        ] {
+            assert_eq!(normalize_preview_input(input), input);
+        }
+        assert_eq!(
+            normalize_preview_input("  https://example.com/x  "),
+            "https://example.com/x"
+        );
+        assert_eq!(normalize_preview_input("   "), "");
+    }
+
+    /// Path-only input must stay path-only.
+    ///
+    /// `https:///relative/path` is NOT hostless once parsed: the WHATWG
+    /// "special authority ignore slashes" rule eats the extra slash and promotes
+    /// `relative` to the host, so a naive prepend would turn a clearly invalid
+    /// entry into a live navigation to `https://relative/path`.
+    #[test]
+    fn normalization_refuses_to_invent_a_host_for_path_only_input() {
+        for input in ["/relative/path", "///a/b", "?q=1", "#frag", "//"] {
+            assert_eq!(
+                normalize_preview_input(input),
+                input,
+                "{input:?} has no authority and must not be given a scheme"
+            );
+            assert!(validate(input).is_err(), "{input:?} should be rejected");
+        }
+
+        // Contrast: protocol-relative input DOES carry an authority, and the
+        // pure prepend leaves the redundant slashes for `Url::parse` to collapse.
+        assert_eq!(
+            normalize_preview_input("//example.com/x"),
+            "https:////example.com/x"
+        );
+        assert_eq!(
+            validate("//example.com/x").unwrap().as_str(),
+            "https://example.com/x"
+        );
+    }
+
+    #[test]
+    fn localhost_classification_covers_the_documented_host_forms() {
+        for host in [
+            "localhost",
+            "LOCALHOST",
+            "localhost.",
+            "127.0.0.1",
+            "::1",
+            "[::1]",
+            "foo.localhost",
+            "a.b.LOCALHOST",
+        ] {
+            assert!(is_localhostish_host(host), "{host:?} should be localhost-ish");
+        }
+
+        for host in [
+            "example.com",
+            "localhost.example.com",
+            "notlocalhost",
+            "127.0.0.2",
+            "",
+        ] {
+            assert!(
+                !is_localhostish_host(host),
+                "{host:?} should not be localhost-ish"
+            );
+        }
+    }
+
+    #[test]
+    fn schemeless_host_extraction_handles_ports_paths_and_ipv6() {
+        assert_eq!(schemeless_host("localhost:5173"), "localhost");
+        assert_eq!(schemeless_host("127.0.0.1:3000/x"), "127.0.0.1");
+        assert_eq!(schemeless_host("github.com/a/b?c#d"), "github.com");
+        assert_eq!(schemeless_host("[::1]:8080"), "::1");
+        assert_eq!(schemeless_host("[::1]"), "::1");
+        assert_eq!(schemeless_host("//localhost:18800/api"), "localhost");
+        assert_eq!(schemeless_host("user:pass@example.com:8080"), "example.com");
+        // A non-numeric suffix is not a port, so it is left attached and simply
+        // fails to classify as localhost-ish.
+        assert_eq!(schemeless_host("data:text/html,x"), "data:text");
+    }
+
+    /// Regression lock for finding 4.
+    ///
+    /// The port-strip branch used to require a NON-EMPTY port segment, so an
+    /// authority with an empty port kept its trailing colon: `localhost:` is not
+    /// recognised by `is_localhostish_host` (which trims `.`, `[` and `]`, but
+    /// not `:`), so the operator's plain-HTTP dev server was scheme-selected as
+    /// `https` and died on the TLS handshake.
+    #[test]
+    fn schemeless_host_strips_an_empty_port_segment() {
+        assert_eq!(schemeless_host("localhost:/dashboard"), "localhost");
+        assert_eq!(schemeless_host("localhost:"), "localhost");
+        assert_eq!(schemeless_host("//localhost:/dashboard"), "localhost");
+        assert_eq!(schemeless_host("user@localhost:/x"), "localhost");
+        assert_eq!(schemeless_host("127.0.0.1:?q=1"), "127.0.0.1");
+
+        // ... and the stripped host now classifies, so the scheme is `http`.
+        for input in ["//localhost:/dashboard", "//127.0.0.1:/x"] {
+            let normalized = normalize_preview_input(input);
+            assert!(
+                normalized.starts_with("http://"),
+                "{input:?} is a local dev server and must not be given https, \
+                 got {normalized:?}"
+            );
+        }
+
+        // The empty port is NOT the `host:port` shape, so `localhost:/dashboard`
+        // is an EXPLICIT `localhost:` scheme and is rejected outright rather
+        // than silently navigated to a TLS failure. Pinned so the interaction
+        // with `has_explicit_scheme` stays deliberate.
+        assert!(has_explicit_scheme("localhost:/dashboard"));
+        assert!(validate("localhost:/dashboard").is_err());
+    }
+
+    /// Regression lock for finding 5.
+    ///
+    /// `restore_main_window_geometry` was reachable only from
+    /// `leave_docked_mode` and the `close_preview_window` command. There is no
+    /// `CloseRequested` handler in this crate, so closing a DOCKED preview with
+    /// the native titlebar X ran `WindowEvent::Destroyed` alone: the main window
+    /// stayed tiled in the left column beside empty desktop, and because the
+    /// emitted `open: false` hides the dock/pop-out/close cluster, no in-app
+    /// control was left to undo it.
+    ///
+    /// The window runtime is `#[cfg(not(test))]` and needs a live `AppHandle`,
+    /// so this asserts on the source text - the only way to keep the two
+    /// teardown paths in step.
+    #[test]
+    fn the_destroyed_arm_restores_the_main_window_like_the_close_command() {
+        const SOURCE: &str = include_str!("mod.rs");
+
+        let arm_start = SOURCE
+            .find("WindowEvent::Destroyed =>")
+            .expect("the preview window event handler must still match Destroyed");
+        let arm = &SOURCE[arm_start..];
+        let arm_end = arm
+            .find("_ => {}")
+            .expect("the Destroyed arm must still be followed by the catch-all arm");
+        let arm = &arm[..arm_end];
+
+        assert!(
+            arm.contains("undock_layout_after_teardown"),
+            "closing a docked preview with the titlebar X must put the main \
+             window back, exactly like close_preview_window does"
+        );
+        assert!(
+            arm.contains("state.docked"),
+            "the Destroyed arm must consult the dock state to decide whether \
+             to restore the main window layout"
+        );
+        assert!(
+            arm.contains("async_runtime::spawn"),
+            "window geometry must not be touched from inside the window-event \
+             callback - get off it first, as the retile follow does"
+        );
+
+        // The command path must keep using the shared helper, so the two
+        // teardown routes cannot drift apart again.
+        let command = SOURCE
+            .find("pub async fn close_preview_window")
+            .map(|start| &SOURCE[start..])
+            .expect("close_preview_window must still exist");
+        assert!(
+            command[..command.find("\n}\n").unwrap_or(command.len())]
+                .contains("undock_layout_after_teardown"),
+            "close_preview_window must share the teardown helper with the \
+             Destroyed arm"
+        );
+    }
+
+    // -- issue #157 §2: dock geometry ---------------------------------------
+
+    #[test]
+    fn dock_split_columns_are_flush_and_never_overlap() {
+        for (width, scale) in [
+            (1920u32, 1.0f64),
+            (1920, 1.5),
+            (2560, 1.0),
+            (3840, 2.0),
+            (1440, 1.0),
+            (1366, 1.0),
+        ] {
+            let (main, preview) = dock_split(width, scale)
+                .unwrap_or_else(|error| panic!("{width}@{scale} should split: {error}"));
+            assert_eq!(
+                main + preview,
+                width,
+                "columns must tile {width} exactly at scale {scale}"
+            );
+            assert!(
+                f64::from(main) >= MAIN_MIN_LOGICAL_WIDTH * scale,
+                "main column below its minimum at {width}@{scale}"
+            );
+            assert!(
+                f64::from(preview) >= DOCKED_PREVIEW_MIN_LOGICAL_WIDTH * scale,
+                "preview column below its minimum at {width}@{scale}"
+            );
+        }
+    }
+
+    #[test]
+    fn dock_split_refuses_displays_that_cannot_host_both_windows() {
+        // 1220 logical px is exactly the floor; anything under it must refuse
+        // rather than produce an overlapping "best effort" layout.
+        assert!(dock_split(1219, 1.0).is_err());
+        assert!(dock_split(1220, 1.0).is_ok());
+        // 1080p at 200% scale is only 960 logical px of work area.
+        assert!(dock_split(1920, 2.0).is_err());
+        // A nonsensical scale factor falls back to 1.0 instead of panicking.
+        assert!(dock_split(1920, 0.0).is_ok());
+        assert!(dock_split(1920, f64::NAN).is_ok());
+    }
+
+    #[test]
+    fn remembered_positions_are_only_restored_onto_a_live_monitor() {
+        // Primary at the origin, a second monitor to its left (negative x, the
+        // usual Windows layout for a display placed left of the primary).
+        let monitors = [(0i32, 0i32, 1920u32, 1040u32), (-2560, -200, 2560, 1400)];
+
+        assert!(position_is_on_a_monitor(10, 10, &monitors));
+        assert!(position_is_on_a_monitor(-2000, 0, &monitors));
+        assert!(position_is_on_a_monitor(1919, 1039, &monitors));
+
+        // The external display was unplugged: the remembered corner is nowhere.
+        assert!(!position_is_on_a_monitor(-2000, 0, &monitors[..1]));
+        // Just past the bottom-right corner of the primary.
+        assert!(!position_is_on_a_monitor(1920, 1040, &monitors[..1]));
+        // No monitors reported at all is treated as "do not restore".
+        assert!(!position_is_on_a_monitor(0, 0, &[]));
     }
 }

--- a/src-tauri/src/preview/mod.rs
+++ b/src-tauri/src/preview/mod.rs
@@ -4,9 +4,9 @@ use tauri::Url;
 use crate::http::state::AppState;
 #[cfg(not(test))]
 use parking_lot::Mutex;
-#[cfg(not(test))]
+// Unconditional: the persisted preview STATE MACHINE below is plain data and is
+// compiled in test builds too, so its transitions can be driven directly.
 use serde::{Deserialize, Serialize};
-#[cfg(not(test))]
 use std::collections::BTreeMap;
 #[cfg(not(test))]
 use std::path::PathBuf;
@@ -448,7 +448,6 @@ const RETILE_DEBOUNCE_MS: u64 = 60;
 /// monitor) while the size is LOGICAL (DPI-independent, so restoring onto a
 /// differently scaled monitor preserves apparent size instead of halving or
 /// doubling it).
-#[cfg(not(test))]
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 struct WindowGeometry {
     x: i32,
@@ -457,7 +456,6 @@ struct WindowGeometry {
     height: f64,
 }
 
-#[cfg(not(test))]
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct PersistedPreviewState {
     #[serde(default)]
@@ -468,8 +466,43 @@ struct PersistedPreviewState {
     main_restore: Option<WindowGeometry>,
     #[serde(default)]
     main_was_maximized: bool,
+    /// True while a docked LAYOUT is applied, i.e. `main_restore` holds a
+    /// snapshot that has NOT been consumed yet.
+    ///
+    /// Deliberately not the same bit as `docked`: that is the operator
+    /// PREFERENCE and survives a teardown so the next open re-tiles. Conflating
+    /// the two made a reopened dock skip the pre-dock snapshot, leaving the
+    /// undock/close after it with nothing to restore and Hive Manager stranded
+    /// in the left-hand column.
+    #[serde(default)]
+    layout_applied: bool,
     #[serde(default)]
     session_urls: BTreeMap<String, String>,
+}
+
+impl PersistedPreviewState {
+    /// A snapshot is owed whenever no live layout is applied - including the
+    /// reopen after a docked close, which keeps `docked` but has already had its
+    /// snapshot consumed.
+    fn needs_main_snapshot(&self) -> bool {
+        !self.layout_applied
+    }
+
+    fn record_main_snapshot(&mut self, geometry: Option<WindowGeometry>, maximized: bool) {
+        self.main_restore = geometry;
+        self.main_was_maximized = maximized;
+        self.layout_applied = true;
+    }
+
+    /// Consumes the snapshot. Clearing the flag alongside the `take` is what
+    /// keeps "a layout is live" and "a snapshot exists" from ever disagreeing.
+    fn take_main_restore(&mut self) -> (Option<WindowGeometry>, bool) {
+        self.layout_applied = false;
+        (
+            self.main_restore.take(),
+            std::mem::take(&mut self.main_was_maximized),
+        )
+    }
 }
 
 #[cfg(not(test))]
@@ -653,13 +686,20 @@ fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), S
     let main = require_window(app, MAIN_WINDOW_LABEL)?;
     let preview = require_window(app, PREVIEW_WINDOW_LABEL)?;
 
-    let monitor = main
+    // `match` rather than `.or(..)`: `.or` is EAGER, so it would call
+    // `primary_monitor()` on every dock even when the current monitor is
+    // already in hand - and its `?` would then propagate a teardown-race error
+    // out of a dock that had everything it needed. The fallback is a cold path.
+    let monitor = match main
         .current_monitor()
         .map_err(|error| format!("Failed to read the current monitor: {error}"))?
-        .or(main
+    {
+        Some(monitor) => Some(monitor),
+        None => main
             .primary_monitor()
-            .map_err(|error| format!("Failed to read the primary monitor: {error}"))?)
-        .ok_or_else(|| "Could not determine which monitor Hive Manager is on".to_string())?;
+            .map_err(|error| format!("Failed to read the primary monitor: {error}"))?,
+    }
+    .ok_or_else(|| "Could not determine which monitor Hive Manager is on".to_string())?;
 
     let scale = monitor.scale_factor();
     let work_area = *monitor.work_area();
@@ -670,10 +710,20 @@ fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), S
 
     {
         let mut guard = runtime(app_state).lock();
+        // Snapshot the pre-dock layout so undock/close restores it exactly.
+        // Gated on the LAYOUT bit, not the preference: a re-dock must not
+        // re-snapshot the already-tiled geometry as its own restore target, but
+        // a reopen after a docked close - which keeps the preference and has
+        // already spent its snapshot - must take a fresh one.
+        if guard.state.needs_main_snapshot() {
+            let geometry = read_geometry(&main);
+            let maximized = main.is_maximized().unwrap_or(false);
+            guard.state.record_main_snapshot(geometry, maximized);
+        }
+        // The FLOATING snapshot stays gated on the preference: a reopened
+        // preview is a brand-new window at config-default geometry, and
+        // re-snapshotting it there would clobber the remembered position.
         if !guard.state.docked {
-            // Snapshot the floating layout so undock restores it exactly.
-            guard.state.main_was_maximized = main.is_maximized().unwrap_or(false);
-            guard.state.main_restore = read_geometry(&main);
             if let Some(geometry) = read_geometry(&preview) {
                 guard.state.floating = Some(geometry);
             }
@@ -725,10 +775,9 @@ fn restore_main_window_geometry(
 ) -> Result<(), String> {
     let (geometry, was_maximized) = {
         let mut guard = runtime(app_state).lock();
-        let geometry = guard.state.main_restore.take();
-        let was_maximized = std::mem::take(&mut guard.state.main_was_maximized);
+        let taken = guard.state.take_main_restore();
         persist(&guard);
-        (geometry, was_maximized)
+        taken
     };
 
     let Some(main) = app.get_webview_window(MAIN_WINDOW_LABEL) else {
@@ -1773,12 +1822,20 @@ mod tests {
     /// teardown paths in step.
     #[test]
     fn the_destroyed_arm_restores_the_main_window_like_the_close_command() {
-        const SOURCE: &str = include_str!("mod.rs");
+        // This file is checked out with CRLF on Windows, so a `\n`-based
+        // delimiter search silently misses. That is not cosmetic: the
+        // command-path check below paired a missed delimiter with
+        // `unwrap_or(len())`, which widened the slice to the whole rest of the
+        // file - including this test's own assertion strings - so it passed by
+        // matching itself. Normalize once, and make every delimiter fatal
+        // rather than falling back to a wider slice.
+        let normalized = include_str!("mod.rs").replace("\r\n", "\n");
+        let source: &str = &normalized;
 
-        let arm_start = SOURCE
+        let arm_start = source
             .find("WindowEvent::Destroyed =>")
             .expect("the preview window event handler must still match Destroyed");
-        let arm = &SOURCE[arm_start..];
+        let arm = &source[arm_start..];
         let arm_end = arm
             .find("_ => {}")
             .expect("the Destroyed arm must still be followed by the catch-all arm");
@@ -1802,15 +1859,118 @@ mod tests {
 
         // The command path must keep using the shared helper, so the two
         // teardown routes cannot drift apart again.
-        let command = SOURCE
+        let command = source
             .find("pub async fn close_preview_window")
-            .map(|start| &SOURCE[start..])
+            .map(|start| &source[start..])
             .expect("close_preview_window must still exist");
+        let body_end = command
+            .find("\n}\n")
+            .expect("close_preview_window must be terminated by a column-0 closing brace");
         assert!(
-            command[..command.find("\n}\n").unwrap_or(command.len())]
-                .contains("undock_layout_after_teardown"),
+            command[..body_end].contains("undock_layout_after_teardown"),
             "close_preview_window must share the teardown helper with the \
              Destroyed arm"
+        );
+    }
+
+    /// Regression lock: the dock PREFERENCE and the live-layout FACT are
+    /// separate bits.
+    ///
+    /// `enter_docked_mode` used to gate its pre-dock snapshot on `!docked`, but
+    /// `docked` deliberately survives a teardown so the next open re-tiles -
+    /// while the teardown unconditionally CONSUMES `main_restore`. A docked
+    /// close therefore left `docked: true, main_restore: None`, the reopen
+    /// skipped the snapshot, and the undock/close after it had nothing to put
+    /// back: Hive Manager stranded in the left-hand column beside empty desktop.
+    #[test]
+    fn reopening_a_docked_preview_takes_a_fresh_restore_snapshot() {
+        let mut state = PersistedPreviewState::default();
+        let before = WindowGeometry {
+            x: 100,
+            y: 80,
+            width: 1280.0,
+            height: 800.0,
+        };
+
+        // open -> dock
+        assert!(state.needs_main_snapshot());
+        state.record_main_snapshot(Some(before), false);
+        state.docked = true;
+
+        // dock again: idempotent, must NOT re-snapshot the tiled geometry as the
+        // restore target - that would make undock a no-op.
+        assert!(
+            !state.needs_main_snapshot(),
+            "a redundant dock must not overwrite the pre-dock snapshot with the \
+             already-tiled geometry"
+        );
+
+        // close (the command or the titlebar X) restores and consumes the
+        // snapshot; the PREFERENCE survives so the next open re-tiles.
+        assert_eq!(state.take_main_restore().0.map(|g| g.x), Some(100));
+        assert!(state.docked, "the dock preference must survive a teardown");
+        // the Destroyed arm's second, idempotent pass
+        assert!(state.take_main_restore().0.is_none());
+
+        // reopen re-tiles off the surviving preference - and MUST snapshot again
+        assert!(
+            state.needs_main_snapshot(),
+            "a reopened dock that skips the snapshot leaves the undock/close \
+             after it with nothing to restore, stranding the main window in the \
+             docked column"
+        );
+        let reopened = WindowGeometry {
+            x: 220,
+            y: 140,
+            width: 1440.0,
+            height: 900.0,
+        };
+        state.record_main_snapshot(Some(reopened), false);
+
+        assert_eq!(state.take_main_restore().0.map(|g| g.x), Some(220));
+    }
+
+    /// The state machine above is only meaningful if the windowing layer
+    /// actually routes through it. That layer is `#[cfg(not(test))]` and needs a
+    /// live `AppHandle`, so - same discipline as the `Destroyed` arm lock above
+    /// - the wiring is pinned against the source text.
+    #[test]
+    fn the_dock_path_gates_its_snapshot_on_the_layout_bit_not_the_preference() {
+        // This file is checked out CRLF on Windows, so the `\n}\n` terminator
+        // below only finds a function end after normalization. Without it the
+        // slice silently runs to EOF and swallows this test's own assertion
+        // strings, which makes the lock pass against any source at all.
+        let source = include_str!("mod.rs").replace("\r\n", "\n");
+
+        /// The text of `fn <name>` up to the first column-0 `}`.
+        fn body_of<'a>(source: &'a str, name: &str) -> &'a str {
+            let needle = format!("fn {name}");
+            let body = source
+                .find(&needle)
+                .map(|start| &source[start..])
+                .unwrap_or_else(|| panic!("{name} must still exist"));
+            let end = body
+                .find("\n}\n")
+                .unwrap_or_else(|| panic!("{name} must have a column-0 closing brace"));
+            &body[..end]
+        }
+
+        let dock = body_of(&source, "enter_docked_mode");
+        assert!(
+            dock.contains("needs_main_snapshot"),
+            "enter_docked_mode must gate its pre-dock snapshot on the live-layout \
+             bit; gating on `docked` makes a reopened dock skip the snapshot"
+        );
+        assert!(
+            dock.contains("record_main_snapshot"),
+            "the snapshot must be recorded through the helper, so the geometry \
+             and the layout bit are always set together"
+        );
+
+        assert!(
+            body_of(&source, "restore_main_window_geometry").contains("take_main_restore"),
+            "the teardown must consume the snapshot through the helper, so the \
+             layout bit cannot stay set after the geometry is gone"
         );
     }
 

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1452,6 +1452,13 @@ pub struct AppConfig {
     /// scan; it can never widen it or point the scanner at an arbitrary directory. `None` (the
     /// default, and what every pre-existing `config.json` deserializes to) means the built-in
     /// folder set.
+    ///
+    /// **`Some(..)` fails closed.** This is a privacy boundary — its purpose is keeping entity
+    /// folders (`clients`, `partners`, `vendors`) out of a browsable graph — so a present-but-
+    /// unusable value scans *nothing* rather than reverting to the full default. A typo such as
+    /// `["pattern"]` therefore yields an empty Atlas and an error-level log, not a silent scan of
+    /// every folder the operator was trying to exclude. An empty Atlas is loud and self-correcting;
+    /// silently rendering data the operator believed was excluded is neither.
     #[serde(default)]
     pub knowledge_wiki_folders: Option<Vec<String>>,
 }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -779,6 +779,7 @@ impl SessionStorage {
                 port: 18800,
             },
             global_wiki_path: default_global_wiki_path(),
+            knowledge_wiki_folders: None,
         }
     }
 
@@ -1443,6 +1444,16 @@ pub struct AppConfig {
     /// files (written before this field existed) still deserialize.
     #[serde(default = "default_global_wiki_path")]
     pub global_wiki_path: Option<String>,
+    /// Optional operator narrowing of the Knowledge Atlas global-wiki folder set.
+    ///
+    /// Entries are *matched against* the compiled-in allowlist in
+    /// `http::handlers::knowledge::WIKI_FOLDERS` — they select, they never construct. An
+    /// unrecognized entry is logged and ignored, so this field can only narrow or reorder the
+    /// scan; it can never widen it or point the scanner at an arbitrary directory. `None` (the
+    /// default, and what every pre-existing `config.json` deserializes to) means the built-in
+    /// folder set.
+    #[serde(default)]
+    pub knowledge_wiki_folders: Option<Vec<String>>,
 }
 
 /// Default location of the global LLM wiki used by Research mode.

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.35.1",
+  "version": "0.36.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte
@@ -2,7 +2,13 @@
   import { onMount, untrack } from 'svelte';
   import { ArrowClockwise } from 'phosphor-svelte';
   import { createForceSimulation, type ForceNode, type ForceSimulation } from '$lib/knowledge/forceSim';
-  import { EDGE_COLORS, folderColor, nodeDegree } from '$lib/knowledge/graphUtils';
+  import {
+    EDGE_COLORS,
+    folderColor,
+    folderKindLabel,
+    isRelationshipFolder,
+    nodeDegree,
+  } from '$lib/knowledge/graphUtils';
   import type { KnowledgeEdge, KnowledgeNode } from '$lib/knowledge/types';
 
   interface Props {
@@ -249,6 +255,15 @@
     return Math.min(11, 5 + Math.sqrt(nodeDegree(node)) * 1.25);
   }
 
+  /**
+   * Side of a 45deg-rotated square whose half-diagonal equals `r`, so a diamond
+   * occupies exactly the circle's horizontal/vertical extent. Layout, label
+   * offsets and the pin mark all keep using radius() untouched.
+   */
+  function diamondSide(r: number): number {
+    return r * Math.SQRT2;
+  }
+
   function shortTitle(title: string): string {
     return title.length > 34 ? `${title.slice(0, 31)}…` : title;
   }
@@ -306,6 +321,11 @@
       {#each positions as node (node.id)}
         {@const isSelected = node.id === selectedId}
         {@const isMuted = selectedId !== null && !selectedNeighbors.has(node.id)}
+        {@const isRelationship = isRelationshipFolder(node.folder)}
+        {@const kindLabel = folderKindLabel(node.folder)}
+        {@const shapeLabel = isRelationship ? 'diamond' : 'circle'}
+        {@const tooltip =
+          `${node.title} · ${node.path} · ${kindLabel} (${shapeLabel}) · Double-click to unpin`}
         <g
           class="node"
           class:selected={isSelected}
@@ -314,7 +334,7 @@
           transform={`translate(${node.x} ${node.y})`}
           role="button"
           tabindex="0"
-          aria-label={`${node.title}, ${node.folder}, ${nodeDegree(node)} connections${node.fx !== null ? ', pinned' : ''}`}
+          aria-label={`${node.title}, ${node.folder} ${kindLabel}, ${nodeDegree(node)} connections${node.fx !== null ? ', pinned' : ''}`}
           onpointerdown={(event) => handlePointerDown(event, node)}
           onmouseenter={() => hoveredId = node.id}
           onmouseleave={() => hoveredId = null}
@@ -326,15 +346,38 @@
             }
           }}
         >
-          <circle class="node-halo" r={radius(node) + 5} fill={folderColor(node.folder)} />
-          <circle class="node-core" r={radius(node)} fill={folderColor(node.folder)} />
+          {#if isRelationship}
+            {@const haloSide = diamondSide(radius(node) + 5)}
+            {@const coreSide = diamondSide(radius(node))}
+            <rect
+              class="node-halo"
+              x={-haloSide / 2}
+              y={-haloSide / 2}
+              width={haloSide}
+              height={haloSide}
+              transform="rotate(45)"
+              fill={folderColor(node.folder)}
+            />
+            <rect
+              class="node-core"
+              x={-coreSide / 2}
+              y={-coreSide / 2}
+              width={coreSide}
+              height={coreSide}
+              transform="rotate(45)"
+              fill={folderColor(node.folder)}
+            />
+          {:else}
+            <circle class="node-halo" r={radius(node) + 5} fill={folderColor(node.folder)} />
+            <circle class="node-core" r={radius(node)} fill={folderColor(node.folder)} />
+          {/if}
           {#if node.fx !== null}
             <circle class="pin-mark" cx={radius(node) - 1} cy={-radius(node) + 1} r="2.5" />
           {/if}
           {#if isSelected || hoveredId === node.id || nodes.length <= 36}
             <text x={radius(node) + 7} y="4">{shortTitle(node.title)}</text>
           {/if}
-          <title>{node.title} · {node.path} · Double-click to unpin</title>
+          <title>{tooltip}</title>
         </g>
       {/each}
     </g>

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte
@@ -264,6 +264,16 @@
     return r * Math.SQRT2;
   }
 
+  /**
+   * Axis coordinate of the pin mark's centre. A circle's bounding-box corner
+   * inset 1px lands on the rim; a diamond's 45deg diagonal crosses its edge at
+   * r/2, nudged 1px out so the mark overhangs by a constant ~1.4px at every
+   * degree instead of drifting off the edge as the node grows.
+   */
+  function pinAxis(r: number, isRelationship: boolean): number {
+    return isRelationship ? r / 2 + 1 : r - 1;
+  }
+
   function shortTitle(title: string): string {
     return title.length > 34 ? `${title.slice(0, 31)}…` : title;
   }
@@ -372,7 +382,8 @@
             <circle class="node-core" r={radius(node)} fill={folderColor(node.folder)} />
           {/if}
           {#if node.fx !== null}
-            <circle class="pin-mark" cx={radius(node) - 1} cy={-radius(node) + 1} r="2.5" />
+            {@const pin = pinAxis(radius(node), isRelationship)}
+            <circle class="pin-mark" cx={pin} cy={-pin} r="2.5" />
           {/if}
           {#if isSelected || hoveredId === node.id || nodes.length <= 36}
             <text x={radius(node) + 7} y="4">{shortTitle(node.title)}</text>

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -240,6 +240,71 @@ describe('KnowledgeGraph', () => {
     expect(patternMark.querySelector('title')?.textContent).toContain('operational knowledge');
   });
 
+  it('keeps the pin mark touching the node edge for diamonds as well as circles', async () => {
+    reducedMotionMatches = true;
+    // Degree must be >= 3: the diamond's pin only detaches once the node grows,
+    // so a degree-0 fixture would pass against the unfixed code and prove nothing.
+    const degree = { in_degree: 2, out_degree: 2 };
+    const radius = Math.min(11, 5 + Math.sqrt(degree.in_degree + degree.out_degree) * 1.25);
+    const clientNode = {
+      ...forceMocks.pinnedNode,
+      ...degree,
+      id: 'clients/acme',
+      title: 'Acme Corp',
+      folder: 'clients',
+      path: 'clients/acme.md',
+      x: 200,
+      y: 220,
+      fx: 200 as number | null,
+      fy: 220 as number | null,
+    };
+    const patternNode = {
+      ...clientNode,
+      id: 'patterns/alpha',
+      title: 'Alpha Pattern',
+      folder: 'patterns',
+      path: 'patterns/alpha.md',
+    };
+    forceMocks.createForceSimulation.mockImplementationOnce(() => ({
+      ...forceMocks.simulation,
+      nodes: [clientNode, patternNode],
+    }));
+
+    const { getByRole } = render(KnowledgeGraph, {
+      props: {
+        nodes: [clientNode, patternNode],
+        edges: [],
+        selectedId: null,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    const pinOf = (name: RegExp) => {
+      const mark = getByRole('button', { name }).querySelector('.pin-mark');
+      expect(mark).not.toBeNull();
+      return {
+        cx: Number(mark!.getAttribute('cx')),
+        cy: Number(mark!.getAttribute('cy')),
+      };
+    };
+
+    // A diamond's boundary is the L1 circle |x| + |y| = r, so the perpendicular
+    // distance of the pin's centre past that edge is (|cx| + |cy| - r) / sqrt(2).
+    // Netting off the 2.5px pin radius and the 1px outward half of the core's
+    // 2px stroke leaves the visible gap, which must not be positive.
+    const diamond = pinOf(/Acme Corp/);
+    const diamondGap = (Math.abs(diamond.cx) + Math.abs(diamond.cy) - radius) / Math.SQRT2 - 3.5;
+    expect(diamondGap).toBeLessThanOrEqual(0);
+
+    // Circles are untouched by the shape-aware anchor: still the bounding-box
+    // corner inset 1px, which sits inside the rim at every degree.
+    const circle = pinOf(/Alpha Pattern/);
+    expect(circle.cx).toBeCloseTo(radius - 1, 10);
+    expect(circle.cy).toBeCloseTo(-(radius - 1), 10);
+    expect(Math.hypot(circle.cx, circle.cy) - radius - 3.5).toBeLessThanOrEqual(0);
+  });
+
   it('rolls back a cancelled drag without selecting or retaining a partial pin', async () => {
     reducedMotionMatches = true;
     forceMocks.pinnedNode.vx = 1.5;

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -184,6 +184,62 @@ describe('KnowledgeGraph', () => {
     expect(requestAnimationFrameMock).toHaveBeenCalledOnce();
   });
 
+  it('draws relationship folders as diamonds and names the distinction in the accessible label', async () => {
+    reducedMotionMatches = true;
+    const clientNode = {
+      ...forceMocks.pinnedNode,
+      id: 'clients/acme',
+      title: 'Acme Corp',
+      folder: 'clients',
+      path: 'clients/acme.md',
+      x: 200,
+      y: 220,
+      fx: null,
+      fy: null,
+    };
+    const patternNode = {
+      ...forceMocks.pinnedNode,
+      id: 'patterns/alpha',
+      title: 'Alpha Pattern',
+      folder: 'patterns',
+      path: 'patterns/alpha.md',
+      x: 90,
+      y: 110,
+      fx: null,
+      fy: null,
+    };
+    forceMocks.createForceSimulation.mockImplementationOnce(() => ({
+      ...forceMocks.simulation,
+      nodes: [clientNode, patternNode],
+    }));
+
+    const { getByRole } = render(KnowledgeGraph, {
+      props: {
+        nodes: [clientNode, patternNode],
+        edges: [],
+        selectedId: null,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    const clientMark = getByRole('button', { name: /Acme Corp/ });
+    const patternMark = getByRole('button', { name: /Alpha Pattern/ });
+
+    // Shape carries the relationship/operational split...
+    expect(clientMark.querySelector('.node-core')?.tagName.toLowerCase()).toBe('rect');
+    expect(clientMark.querySelector('.node-core')?.getAttribute('transform')).toBe('rotate(45)');
+    expect(patternMark.querySelector('.node-core')?.tagName.toLowerCase()).toBe('circle');
+    expect(clientMark.querySelector('.node-halo')?.tagName.toLowerCase()).toBe('rect');
+    expect(patternMark.querySelector('.node-halo')?.tagName.toLowerCase()).toBe('circle');
+
+    // ...and it is never the only signal: the accessible name says it too.
+    expect(clientMark.getAttribute('aria-label')).toContain('clients relationship entity');
+    expect(patternMark.getAttribute('aria-label')).toContain('patterns operational knowledge');
+    expect(clientMark.querySelector('title')?.textContent).toContain('relationship entity');
+    expect(patternMark.querySelector('title')?.textContent).toContain('operational knowledge');
+  });
+
   it('rolls back a cancelled drag without selecting or retaining a partial pin', async () => {
     reducedMotionMatches = true;
     forceMocks.pinnedNode.vx = 1.5;

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -283,10 +283,14 @@ describe('KnowledgeGraph', () => {
     const pinOf = (name: RegExp) => {
       const mark = getByRole('button', { name }).querySelector('.pin-mark');
       expect(mark).not.toBeNull();
-      return {
-        cx: Number(mark!.getAttribute('cx')),
-        cy: Number(mark!.getAttribute('cy')),
-      };
+      // Assert presence before converting: `Number(null)` is 0, so a pin that
+      // lost its coordinates entirely would otherwise read as (0, 0) and slip
+      // past the geometry assertions below as though it were well-placed.
+      const rawCx = mark!.getAttribute('cx');
+      const rawCy = mark!.getAttribute('cy');
+      expect(rawCx).not.toBeNull();
+      expect(rawCy).not.toBeNull();
+      return { cx: Number(rawCx), cy: Number(rawCy) };
     };
 
     // A diamond's boundary is the L1 circle |x| + |y| = r, so the perpendicular
@@ -295,7 +299,16 @@ describe('KnowledgeGraph', () => {
     // 2px stroke leaves the visible gap, which must not be positive.
     const diamond = pinOf(/Acme Corp/);
     const diamondGap = (Math.abs(diamond.cx) + Math.abs(diamond.cy) - radius) / Math.SQRT2 - 3.5;
+    // Bounded on BOTH sides. `<= 0` alone is satisfied by a pin retracted to
+    // the centre, so it would not notice the anchor collapsing inward - it only
+    // rejects the original bug, which overshot to +0.39. The lower bound is one
+    // pin-plus-stroke width, so the mark must still overlap the rim rather than
+    // float somewhere in the node's interior.
     expect(diamondGap).toBeLessThanOrEqual(0);
+    expect(diamondGap).toBeGreaterThanOrEqual(-3.5);
+    // The anchor is diagonal, so the two axes must stay mirror images; a fix
+    // that moved only one of them would keep the L1 distance plausible.
+    expect(diamond.cx).toBeCloseTo(-diamond.cy, 10);
 
     // Circles are untouched by the shape-aware anchor: still the bounding-box
     // corner inset 1px, which sits inside the rim at every degree.

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -1,8 +1,18 @@
 <script lang="ts">
     import { invoke } from '@tauri-apps/api/core';
-    import { tick } from 'svelte';
-    import { Browser, GitBranch } from 'phosphor-svelte';
+    import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+    import { writeText } from '@tauri-apps/plugin-clipboard-manager';
+    import { onDestroy, onMount, tick } from 'svelte';
+    import { ArrowClockwise, ArrowSquareOut, Browser, Columns, Copy, GitBranch, X } from 'phosphor-svelte';
     import { activeSession, serdeEnumVariantName } from '../../stores/sessions';
+
+    /** Mirrors `PreviewStatus` in src-tauri/src/preview/mod.rs. */
+    type PreviewStatus = {
+        open: boolean;
+        docked: boolean;
+        url: string | null;
+        session_url: string | null;
+    };
 
     let previewExpanded = false;
     let previewUrl = '';
@@ -11,6 +21,72 @@
     let previewInput: HTMLInputElement;
     let previewSessionId: string | null = null;
     let previewRequestId = 0;
+
+    let previewOpen = false;
+    let previewDocked = false;
+    let previewCurrentUrl = '';
+    let previewBusy = '';
+    let previewUrlCopied = false;
+
+    // Last URL previewed for each session, so switching sessions and coming back
+    // does not make the operator retype it. Seeded from the backend, which
+    // persists the same mapping across app restarts.
+    const rememberedPreviewUrls = new Map<string, string>();
+
+    let unlisteners: UnlistenFn[] = [];
+    let destroyed = false;
+    let copyResetTimer: ReturnType<typeof setTimeout> | undefined;
+
+    function applyPreviewStatus(status: PreviewStatus | null, sessionId: string | null) {
+        if (!status) return;
+        previewOpen = status.open;
+        previewDocked = status.docked;
+        previewCurrentUrl = status.url ?? '';
+        if (sessionId && status.session_url) {
+            rememberedPreviewUrls.set(sessionId, status.session_url);
+            if (!previewUrl) previewUrl = status.session_url;
+        }
+    }
+
+    async function refreshPreviewStatus(sessionId: string | null) {
+        try {
+            const status = await invoke<PreviewStatus>('get_preview_status', { sessionId });
+            if (sessionId === previewSessionId) applyPreviewStatus(status, sessionId);
+        } catch {
+            // A status probe failing must never block the header from rendering.
+        }
+    }
+
+    onMount(() => {
+        Promise.all([
+            listen<{ url: string }>('preview-navigated', (event) => {
+                if (!event.payload?.url) return;
+                previewCurrentUrl = event.payload.url;
+                previewOpen = true;
+            }),
+            listen<PreviewStatus>('preview-status', (event) => {
+                if (!event.payload) return;
+                previewOpen = event.payload.open;
+                previewDocked = event.payload.docked;
+                previewCurrentUrl = event.payload.url ?? '';
+            })
+        ])
+            .then((fns) => {
+                if (destroyed) {
+                    fns.forEach((fn) => fn());
+                    return;
+                }
+                unlisteners = fns;
+            })
+            .catch(() => {});
+    });
+
+    onDestroy(() => {
+        destroyed = true;
+        unlisteners.forEach((fn) => fn());
+        unlisteners = [];
+        if (copyResetTimer) clearTimeout(copyResetTimer);
+    });
 
     $: session = $activeSession;
     $: mode = session ? serdeEnumVariantName(session.session_type)?.toLowerCase() ?? 'session' : 'session';
@@ -34,9 +110,11 @@
         previewRequestId += 1;
         previewSessionId = session?.id ?? null;
         previewExpanded = false;
-        previewUrl = '';
+        // Per-session recall rather than an unconditional clear.
+        previewUrl = previewSessionId ? rememberedPreviewUrls.get(previewSessionId) ?? '' : '';
         previewError = '';
         openingPreview = false;
+        void refreshPreviewStatus(previewSessionId);
     }
 
     async function expandPreview() {
@@ -52,10 +130,15 @@
         if (!url || openingPreview) return;
 
         const requestId = ++previewRequestId;
+        const sessionId = previewSessionId;
         openingPreview = true;
         previewError = '';
         try {
-            await invoke('open_preview_window', { url });
+            const status = await invoke<PreviewStatus>('open_preview_window', { url, sessionId });
+            if (requestId === previewRequestId) {
+                if (sessionId) rememberedPreviewUrls.set(sessionId, url);
+                applyPreviewStatus(status, sessionId);
+            }
         } catch (error) {
             if (requestId === previewRequestId) {
                 previewError = String(error);
@@ -64,6 +147,70 @@
             if (requestId === previewRequestId) {
                 openingPreview = false;
             }
+        }
+    }
+
+    async function runPreviewAction(command: string, key: string) {
+        if (previewBusy) return;
+        const sessionId = previewSessionId;
+        previewBusy = key;
+        previewError = '';
+        try {
+            const status = await invoke<PreviewStatus>(command, { sessionId });
+            // Freshness gate, mirroring refreshPreviewStatus: the payload is
+            // session-scoped (status_for derives session_url from the caller's
+            // session_id), so a response that lands after the operator switched
+            // sessions would otherwise seed the OLD session's URL into the NEW
+            // session's input via applyPreviewStatus.
+            //
+            // Deliberately NOT the `++previewRequestId` pattern used by
+            // openPreview: bumping it from the dock/close path would invalidate
+            // a concurrently in-flight openPreview and skip its
+            // `openingPreview = false` reset, leaving the UI stuck busy.
+            if (sessionId === previewSessionId) applyPreviewStatus(status, sessionId);
+        } catch (error) {
+            previewError = String(error);
+        } finally {
+            // Unconditional, unlike openPreview's gated reset — this is why
+            // previewBusy needs no explicit clear on the session-change path
+            // (and must not get one, or the re-entrancy guard above would let a
+            // second action start while the first is still in flight).
+            previewBusy = '';
+        }
+    }
+
+    function togglePreviewDock() {
+        return runPreviewAction(previewDocked ? 'undock_preview_window' : 'dock_preview_window', 'dock');
+    }
+
+    function closePreview() {
+        return runPreviewAction('close_preview_window', 'close');
+    }
+
+    async function reloadPreview() {
+        if (previewBusy) return;
+        previewBusy = 'reload';
+        previewError = '';
+        try {
+            await invoke('reload_preview_window');
+        } catch (error) {
+            previewError = String(error);
+        } finally {
+            previewBusy = '';
+        }
+    }
+
+    async function copyPreviewUrl() {
+        if (!previewCurrentUrl) return;
+        try {
+            await writeText(previewCurrentUrl);
+            previewUrlCopied = true;
+            if (copyResetTimer) clearTimeout(copyResetTimer);
+            copyResetTimer = setTimeout(() => {
+                previewUrlCopied = false;
+            }, 1400);
+        } catch (error) {
+            previewError = String(error);
         }
     }
 
@@ -94,14 +241,22 @@
                 {#if previewExpanded}
                     <form class="preview-form" onsubmit={openPreview}>
                         <label class="sr-only" for="session-preview-url">Preview URL</label>
+                        <!--
+                            type="text", not type="url": native constraint validation
+                            rejects scheme-less input before submit ever fires, which
+                            would make the backend's forgiving normalization
+                            unreachable. inputmode/autocomplete keep the URL keyboard
+                            and autofill behaviour.
+                        -->
                         <input
                             id="session-preview-url"
                             bind:this={previewInput}
                             bind:value={previewUrl}
-                            type="url"
+                            type="text"
                             inputmode="url"
                             autocomplete="url"
-                            placeholder="http://localhost:5173 or PR URL"
+                            spellcheck="false"
+                            placeholder="localhost:5173, github.com/owner/repo"
                             oninput={clearPreviewError}
                             aria-invalid={previewError ? 'true' : undefined}
                             aria-describedby={previewError ? 'session-preview-error' : undefined}
@@ -115,21 +270,79 @@
                             {openingPreview ? 'Opening…' : 'Open'}
                         </button>
                     </form>
-                    {#if previewError}
-                        <span id="session-preview-error" class="preview-error" role="alert">{previewError}</span>
-                    {/if}
                 {:else}
                     <button
                         class="preview-toggle"
                         type="button"
                         onclick={expandPreview}
                         aria-expanded="false"
-                        aria-label="Enter a URL to open in the isolated preview window"
-                        title="Preview a dev server or pull request URL"
+                        aria-label="Enter a URL to open in the isolated preview browser. The scheme is optional, so localhost:5173 or github.com/owner/repo both work."
+                        title="Preview a dev server or pull request URL (the http:// is optional)"
                     >
                         <Browser size={16} weight="light" aria-hidden="true" />
                         Preview
                     </button>
+                {/if}
+
+                {#if previewOpen}
+                    <div class="preview-live" aria-live="polite">
+                        <span class="preview-live-mode">{previewDocked ? 'Docked' : 'Popped out'}</span>
+                        <span class="preview-live-url" title={previewCurrentUrl}>
+                            {previewUrlCopied ? 'Copied' : previewCurrentUrl || 'Loading…'}
+                        </span>
+                        <button
+                            class="preview-action"
+                            type="button"
+                            onclick={copyPreviewUrl}
+                            disabled={!previewCurrentUrl}
+                            title="Copy the current preview URL"
+                            aria-label="Copy the current preview URL"
+                        >
+                            <Copy size={13} weight="light" aria-hidden="true" />
+                        </button>
+                        <button
+                            class="preview-action"
+                            type="button"
+                            onclick={reloadPreview}
+                            disabled={Boolean(previewBusy)}
+                            title="Reload the preview"
+                            aria-label="Reload the preview"
+                        >
+                            <ArrowClockwise size={13} weight="light" aria-hidden="true" />
+                        </button>
+                        <button
+                            class="preview-action"
+                            type="button"
+                            onclick={togglePreviewDock}
+                            disabled={Boolean(previewBusy)}
+                            title={previewDocked
+                                ? 'Pop the preview out into a free-floating window'
+                                : 'Dock the preview beside Hive Manager'}
+                            aria-label={previewDocked
+                                ? 'Pop the preview out into a free-floating window'
+                                : 'Dock the preview beside Hive Manager'}
+                        >
+                            {#if previewDocked}
+                                <ArrowSquareOut size={13} weight="light" aria-hidden="true" />
+                            {:else}
+                                <Columns size={13} weight="light" aria-hidden="true" />
+                            {/if}
+                        </button>
+                        <button
+                            class="preview-action"
+                            type="button"
+                            onclick={closePreview}
+                            disabled={Boolean(previewBusy)}
+                            title="Close the preview"
+                            aria-label="Close the preview"
+                        >
+                            <X size={13} weight="light" aria-hidden="true" />
+                        </button>
+                    </div>
+                {/if}
+
+                {#if previewError}
+                    <span id="session-preview-error" class="preview-error" role="alert">{previewError}</span>
                 {/if}
             </div>
             <div class="stat">
@@ -310,6 +523,65 @@
     .preview-open:disabled {
         cursor: not-allowed;
         opacity: 0.5;
+    }
+
+    .preview-live {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        max-width: min(360px, 42vw);
+        height: 24px;
+        padding: 0 4px 0 8px;
+        border: 1px solid var(--border-structural);
+        border-radius: var(--radius-sm);
+        background: var(--bg-elevated);
+    }
+
+    .preview-live-mode {
+        flex-shrink: 0;
+        font-size: 9px;
+        font-weight: 800;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--accent-cyan);
+    }
+
+    .preview-live-url {
+        min-width: 0;
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-family: var(--font-mono);
+        font-size: 10px;
+        color: var(--text-secondary);
+    }
+
+    .preview-action {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        width: 20px;
+        height: 20px;
+        padding: 0;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--text-muted);
+        cursor: pointer;
+    }
+
+    .preview-action:hover:not(:disabled),
+    .preview-action:focus-visible {
+        color: var(--accent-cyan);
+        background: var(--bg-surface);
+        outline: none;
+    }
+
+    .preview-action:disabled {
+        cursor: not-allowed;
+        opacity: 0.4;
     }
 
     .preview-error {

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -169,7 +169,11 @@
             // `openingPreview = false` reset, leaving the UI stuck busy.
             if (sessionId === previewSessionId) applyPreviewStatus(status, sessionId);
         } catch (error) {
-            previewError = String(error);
+            // Same gate as the success path: the session-change reactive block
+            // clears previewError, so an ungated write here would replay the
+            // OLD session's failure into the NEW session's header — announced
+            // via role="alert" and flagging that session's URL input invalid.
+            if (sessionId === previewSessionId) previewError = String(error);
         } finally {
             // Unconditional, unlike openPreview's gated reset — this is why
             // previewBusy needs no explicit clear on the session-change path

--- a/src/lib/components/session/SessionHeader.svelte.test.ts
+++ b/src/lib/components/session/SessionHeader.svelte.test.ts
@@ -67,10 +67,18 @@ function fakeSession(id: string): Session {
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((resolvePromise) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
     resolve = resolvePromise;
+    reject = rejectPromise;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
+}
+
+/** Flushes the component's await continuations plus Svelte's scheduler. */
+async function flush() {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 const CLOSED_STATUS = { open: false, docked: false, url: null, session_url: null };
@@ -215,5 +223,73 @@ describe('SessionHeader preview action freshness', () => {
     // Without the freshness gate this is session-a's URL, and submitting it
     // would persist it under session-b's id.
     expect(input.value).toBe('');
+  });
+
+  /**
+   * Renders the header on session-a with the preview open, fires the dock
+   * action, and hands back a handle that rejects it on demand. The two tests
+   * below differ only in whether the operator switches sessions first, so the
+   * flush timing is identical — that is what makes the negative assertion in
+   * the second test meaningful rather than a race that happens to pass.
+   */
+  async function dockFailureHarness() {
+    const staleDock = deferred<unknown>();
+
+    tauriMocks.invoke.mockImplementation((command: string, args?: { sessionId?: string }) => {
+      if (command === 'get_preview_status') {
+        return Promise.resolve(
+          args?.sessionId === 'session-a'
+            ? { open: true, docked: false, url: 'http://127.0.0.1:5173/', session_url: null }
+            : CLOSED_STATUS,
+        );
+      }
+      if (command === 'dock_preview_window') return staleDock.promise;
+      return Promise.resolve(CLOSED_STATUS);
+    });
+
+    const { container } = render(SessionHeader);
+    storeMocks.setActiveSession?.(fakeSession('session-a'));
+
+    const dockButton = await waitFor(() => {
+      const buttons = container.querySelectorAll<HTMLButtonElement>('.preview-action');
+      const found = Array.from(buttons).find(
+        (button) => button.getAttribute('aria-label') === 'Dock the preview beside Hive Manager',
+      );
+      if (!found) throw new Error('dock button never rendered');
+      return found;
+    });
+    await fireEvent.click(dockButton);
+
+    return { container, staleDock };
+  }
+
+  it('surfaces a dock failure that lands while its own session is still active', async () => {
+    const { container, staleDock } = await dockFailureHarness();
+
+    staleDock.reject(new Error('dock failed for session-a'));
+    await staleDock.promise.catch(() => {});
+    await flush();
+
+    const error = container.querySelector('.preview-error');
+    expect(error?.textContent).toContain('dock failed for session-a');
+  });
+
+  it('drops a dock/close failure that rejects after the session changed', async () => {
+    const { container, staleDock } = await dockFailureHarness();
+
+    // The operator switches away while the dock request is still in flight.
+    storeMocks.setActiveSession?.(fakeSession('session-b'));
+    await waitFor(() => {
+      expect(container.querySelector('.preview-toggle')).not.toBeNull();
+    });
+
+    staleDock.reject(new Error('dock failed for session-a'));
+    await staleDock.promise.catch(() => {});
+    await flush();
+
+    // session-a's failure must not be announced in session-b's header, nor
+    // mark session-b's URL input invalid.
+    expect(container.querySelector('.preview-error')).toBeNull();
+    expect(container.querySelector('#session-preview-url')?.getAttribute('aria-invalid')).toBeFalsy();
   });
 });

--- a/src/lib/components/session/SessionHeader.svelte.test.ts
+++ b/src/lib/components/session/SessionHeader.svelte.test.ts
@@ -278,9 +278,15 @@ describe('SessionHeader preview action freshness', () => {
     const { container, staleDock } = await dockFailureHarness();
 
     // The operator switches away while the dock request is still in flight.
+    // Wait on a signal that only session-b can produce: `.preview-toggle`
+    // already exists for session-a, so waiting for it can resolve before the
+    // switch has been processed at all, leaving the rejection below to race
+    // against a header still bound to session-a.
     storeMocks.setActiveSession?.(fakeSession('session-b'));
     await waitFor(() => {
-      expect(container.querySelector('.preview-toggle')).not.toBeNull();
+      expect(tauriMocks.invoke).toHaveBeenCalledWith('get_preview_status', {
+        sessionId: 'session-b',
+      });
     });
 
     staleDock.reject(new Error('dock failed for session-a'));

--- a/src/lib/components/session/SessionHeader.svelte.test.ts
+++ b/src/lib/components/session/SessionHeader.svelte.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import type { Session } from '$lib/stores/sessions';
+import SessionHeader from './SessionHeader.svelte';
+
+/**
+ * Regression cover for the dockable-preview header (issue #157).
+ *
+ * The load-bearing assertion here is that the URL input stays `type="text"`.
+ * With `type="url"`, native constraint validation rejects scheme-less input
+ * before `submit` ever fires, so `openPreview` never runs and the backend's
+ * forgiving normalization is unreachable at runtime — while every Rust
+ * normalization test still passes. Nothing else in the suite catches that.
+ *
+ * Assertions are deliberately attribute-level: jsdom's constraint-validation
+ * implementation is not a faithful stand-in for a real browser, so exercising
+ * it would prove nothing about the shipped behaviour.
+ */
+
+const tauriMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  listen: vi.fn(() => Promise.resolve(() => {})),
+  writeText: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: tauriMocks.invoke,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: tauriMocks.listen,
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  writeText: tauriMocks.writeText,
+}));
+
+// `activeSession` is a derived store (src/lib/stores/sessions.ts:769-770), so it
+// cannot be set directly — the component only renders its body when it is
+// truthy. Swap it for a writable holding a minimal fake session and re-export
+// the real `serdeEnumVariantName`, which the header uses for its badges.
+const storeMocks = vi.hoisted(() => ({
+  setActiveSession: undefined as ((session: Session | null) => void) | undefined,
+}));
+
+vi.mock('$lib/stores/sessions', async () => {
+  const actual = await vi.importActual<typeof import('$lib/stores/sessions')>(
+    '$lib/stores/sessions',
+  );
+  const { writable } = await import('svelte/store');
+  const activeSession = writable<Session | null>(null);
+  storeMocks.setActiveSession = activeSession.set;
+  return { activeSession, serdeEnumVariantName: actual.serdeEnumVariantName };
+});
+
+function fakeSession(id: string): Session {
+  return {
+    id,
+    name: `Session ${id}`,
+    session_type: { Solo: { cli: 'claude' } },
+    project_path: 'D:/Code Projects/hive-manager',
+    state: 'Running',
+    created_at: '2026-07-18T12:00:00Z',
+    agents: [],
+  } as unknown as Session;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+const CLOSED_STATUS = { open: false, docked: false, url: null, session_url: null };
+
+/** Renders the header with `session` active and the preview form expanded. */
+async function renderExpanded(session: Session) {
+  const view = render(SessionHeader);
+  storeMocks.setActiveSession?.(session);
+
+  const toggle = await waitFor(() => {
+    const button = view.container.querySelector<HTMLButtonElement>('.preview-toggle');
+    if (!button) throw new Error('preview toggle never rendered');
+    return button;
+  });
+  await fireEvent.click(toggle);
+
+  const input = await waitFor(() => {
+    const found = view.container.querySelector<HTMLInputElement>('#session-preview-url');
+    if (!found) throw new Error('preview URL input never rendered');
+    return found;
+  });
+
+  return { ...view, input };
+}
+
+afterEach(() => {
+  cleanup();
+  tauriMocks.invoke.mockReset();
+  tauriMocks.listen.mockReset();
+  tauriMocks.listen.mockImplementation(() => Promise.resolve(() => {}));
+  storeMocks.setActiveSession?.(null);
+});
+
+describe('SessionHeader preview URL input', () => {
+  it('uses type="text" so scheme-less input survives native constraint validation', async () => {
+    tauriMocks.invoke.mockResolvedValue(CLOSED_STATUS);
+
+    const { input } = await renderExpanded(fakeSession('session-a'));
+
+    // The whole of issue #157 section 1 hangs off this one attribute.
+    expect(input.getAttribute('type')).toBe('text');
+    expect(input.type).toBe('text');
+
+    // The URL keyboard / autofill affordances must survive the type change.
+    expect(input.getAttribute('inputmode')).toBe('url');
+    expect(input.getAttribute('autocomplete')).toBe('url');
+
+    // The placeholder is the operator-facing promise that the scheme is optional.
+    const placeholder = input.getAttribute('placeholder') ?? '';
+    expect(placeholder).toContain('localhost:5173');
+    expect(placeholder).not.toMatch(/https?:\/\//);
+  });
+
+  it('submits a scheme-less URL to the backend verbatim, without pre-normalizing', async () => {
+    tauriMocks.invoke.mockResolvedValue(CLOSED_STATUS);
+
+    const { container, input } = await renderExpanded(fakeSession('session-a'));
+
+    await fireEvent.input(input, { target: { value: 'localhost:5173/dashboard' } });
+
+    const form = container.querySelector('.preview-form');
+    expect(form).not.toBeNull();
+    await fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(tauriMocks.invoke).toHaveBeenCalledWith('open_preview_window', {
+        url: 'localhost:5173/dashboard',
+        sessionId: 'session-a',
+      });
+    });
+  });
+
+  it('forwards a scheme-less bare host verbatim too', async () => {
+    tauriMocks.invoke.mockResolvedValue(CLOSED_STATUS);
+
+    const { container, input } = await renderExpanded(fakeSession('session-a'));
+
+    await fireEvent.input(input, { target: { value: 'github.com/owner/repo' } });
+    await fireEvent.submit(container.querySelector('.preview-form')!);
+
+    await waitFor(() => {
+      expect(tauriMocks.invoke).toHaveBeenCalledWith('open_preview_window', {
+        url: 'github.com/owner/repo',
+        sessionId: 'session-a',
+      });
+    });
+  });
+});
+
+describe('SessionHeader preview action freshness', () => {
+  it('drops a dock/close status that resolves after the session changed', async () => {
+    const staleDock = deferred<unknown>();
+
+    tauriMocks.invoke.mockImplementation((command: string, args?: { sessionId?: string }) => {
+      if (command === 'get_preview_status') {
+        return Promise.resolve(
+          args?.sessionId === 'session-a'
+            ? { open: true, docked: false, url: 'http://127.0.0.1:5173/', session_url: null }
+            : CLOSED_STATUS,
+        );
+      }
+      if (command === 'dock_preview_window') return staleDock.promise;
+      return Promise.resolve(CLOSED_STATUS);
+    });
+
+    const { container } = render(SessionHeader);
+    storeMocks.setActiveSession?.(fakeSession('session-a'));
+
+    const dockButton = await waitFor(() => {
+      const buttons = container.querySelectorAll<HTMLButtonElement>('.preview-action');
+      const found = Array.from(buttons).find(
+        (button) => button.getAttribute('aria-label') === 'Dock the preview beside Hive Manager',
+      );
+      if (!found) throw new Error('dock button never rendered');
+      return found;
+    });
+
+    // Dock request goes out for session-a and stays in flight...
+    await fireEvent.click(dockButton);
+    // ...while the operator switches to a session that has no remembered URL.
+    storeMocks.setActiveSession?.(fakeSession('session-b'));
+    await waitFor(() => {
+      expect(container.querySelector('.preview-toggle')).not.toBeNull();
+    });
+
+    // The late response carries session-a's URL. It must not be applied.
+    staleDock.resolve({
+      open: true,
+      docked: true,
+      url: 'http://127.0.0.1:5173/',
+      session_url: 'http://127.0.0.1:5173/',
+    });
+    await staleDock.promise;
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('.preview-toggle')!);
+    const input = await waitFor(() => {
+      const found = container.querySelector<HTMLInputElement>('#session-preview-url');
+      if (!found) throw new Error('preview URL input never rendered');
+      return found;
+    });
+
+    // Without the freshness gate this is session-a's URL, and submitting it
+    // would persist it under session-b's id.
+    expect(input.value).toBe('');
+  });
+});

--- a/src/lib/knowledge/graphUtils.test.ts
+++ b/src/lib/knowledge/graphUtils.test.ts
@@ -1,11 +1,29 @@
 import { describe, expect, it } from 'vitest';
 import {
+  FOLDER_COLORS,
+  RELATIONSHIP_FOLDERS,
   compareKnowledgeNodes,
   filterKnowledgeGraph,
+  folderColor,
+  folderKindLabel,
+  isRelationshipFolder,
   normalizeKnowledgeGraph,
   nodeDegree,
 } from './graphUtils';
 import type { KnowledgeGraph, KnowledgeNode } from './types';
+
+const EXPECTED_FOLDERS = [
+  'patterns',
+  'practices',
+  'research',
+  'project',
+  'clients',
+  'partners',
+  'vendors',
+  'operations',
+] as const;
+
+const UNKNOWN_FOLDER_COLOR = folderColor('folder-with-no-mapping');
 
 function node(
   id: string,
@@ -87,6 +105,51 @@ describe('knowledge graph utilities', () => {
     const folderFiltered = filterKnowledgeGraph(graph, '', 'patterns');
     expect(folderFiltered.nodes.map((entry) => entry.id)).toEqual(['alpha']);
     expect(folderFiltered.edges).toEqual([]);
+  });
+
+  it('carries the truncation flag through filtering so the cap notice cannot be filtered away', () => {
+    const truncatedGraph: KnowledgeGraph = { ...graph, truncated: true };
+
+    expect(filterKnowledgeGraph(truncatedGraph, '', 'all').truncated).toBe(true);
+    expect(filterKnowledgeGraph(truncatedGraph, 'alpha', 'patterns').truncated).toBe(true);
+    // A query that matches nothing must still report the corpus as truncated.
+    expect(filterKnowledgeGraph(truncatedGraph, 'no-such-page', 'all')).toMatchObject({
+      nodes: [],
+      edges: [],
+      truncated: true,
+    });
+    expect(filterKnowledgeGraph({ ...graph, truncated: false }, '', 'all').truncated).toBe(false);
+    expect(filterKnowledgeGraph(graph, '', 'all').truncated).toBeUndefined();
+  });
+
+  it('resolves a distinct color for every supported folder', () => {
+    expect(Object.keys(FOLDER_COLORS).sort()).toEqual([...EXPECTED_FOLDERS].sort());
+
+    for (const name of EXPECTED_FOLDERS) {
+      expect(folderColor(name)).toBe(FOLDER_COLORS[name]);
+      expect(folderColor(name)).not.toBe(UNKNOWN_FOLDER_COLOR);
+    }
+
+    expect(folderColor('clients')).not.toBe(UNKNOWN_FOLDER_COLOR);
+    expect(folderColor('Clients')).toBe(folderColor('clients'));
+    // Every folder must be its own hue — no two share a swatch.
+    expect(new Set(Object.values(FOLDER_COLORS)).size).toBe(EXPECTED_FOLDERS.length);
+  });
+
+  it('classifies relationship folders apart from operational ones with a text equivalent', () => {
+    expect([...RELATIONSHIP_FOLDERS].sort()).toEqual(['clients', 'partners', 'vendors']);
+    expect(RELATIONSHIP_FOLDERS.has('operations')).toBe(false);
+
+    for (const name of ['clients', 'partners', 'vendors']) {
+      expect(isRelationshipFolder(name)).toBe(true);
+      expect(folderKindLabel(name)).toBe('relationship entity');
+    }
+    for (const name of ['patterns', 'practices', 'research', 'project', 'operations']) {
+      expect(isRelationshipFolder(name)).toBe(false);
+      expect(folderKindLabel(name)).toBe('operational knowledge');
+    }
+
+    expect(isRelationshipFolder(' Clients ')).toBe(true);
   });
 
   it('sorts all table columns and computes total degree', () => {

--- a/src/lib/knowledge/graphUtils.ts
+++ b/src/lib/knowledge/graphUtils.ts
@@ -8,12 +8,34 @@ import {
   type SortDirection,
 } from './types';
 
+/**
+ * Hues are spread around the wheel so all eight folders stay separable in the
+ * dark UI: cyan 186, green 144, amber 37, silver 212 (low chroma), violet 274,
+ * coral 5, lime 81, indigo 227. `operations` (227) is the closest neighbour to
+ * `project` (212) by hue, but `project` is a 27%-saturation neutral while
+ * `operations` is fully saturated, so they never read as the same swatch.
+ */
 export const FOLDER_COLORS: Record<string, string> = {
   patterns: '#00e5ff',
   practices: '#00ff66',
   research: '#ff9d00',
   project: '#a3b8cc',
+  clients: '#c77dff',
+  partners: '#ff5f52',
+  vendors: '#b6f24a',
+  operations: '#6f8dff',
 };
+
+/**
+ * Relationship entities — *who* we work with. Everything else in
+ * {@link FOLDER_COLORS} is operational knowledge (*how* we work). The graph
+ * double-codes this split as shape + accessible text, never colour alone.
+ */
+export const RELATIONSHIP_FOLDERS: ReadonlySet<string> = new Set([
+  'clients',
+  'partners',
+  'vendors',
+]);
 
 export const EDGE_COLORS: Record<KnowledgeEdgeKind, string> = {
   cross_ref: '#00e5ff',
@@ -140,6 +162,19 @@ export function normalizeKnowledgePage(value: unknown): import('./types').Knowle
 
 export function folderColor(folder: string): string {
   return FOLDER_COLORS[folder.toLowerCase()] ?? DEFAULT_FOLDER_COLOR;
+}
+
+/** Case-folded so a folder string from the API cannot slip past the set. */
+export function isRelationshipFolder(folder: string): boolean {
+  return RELATIONSHIP_FOLDERS.has(folder.trim().toLowerCase());
+}
+
+/**
+ * Text equivalent of the node-shape encoding, for aria-labels and tooltips.
+ * Shape alone is not an accessible signal.
+ */
+export function folderKindLabel(folder: string): string {
+  return isRelationshipFolder(folder) ? 'relationship entity' : 'operational knowledge';
 }
 
 export function nodeDegree(node: KnowledgeNode): number {

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -17,6 +17,8 @@
     EDGE_LABELS,
     filterKnowledgeGraph,
     folderColor,
+    folderKindLabel,
+    isRelationshipFolder,
   } from '$lib/knowledge/graphUtils';
   import { KNOWLEDGE_EDGE_KINDS, type KnowledgeView } from '$lib/knowledge/types';
   import { knowledgeStore } from '$lib/stores/knowledge';
@@ -33,7 +35,18 @@
   let previewReturnFocus = $state.raw<FocusTarget | null>(null);
 
   let folders = $derived.by(() => {
-    const preferredOrder = ['patterns', 'practices', 'research', 'project'];
+    // Must stay lowercase and exact — indexOf does not case-fold, and a
+    // mismatch silently sorts the folder to the tail with no error.
+    const preferredOrder = [
+      'patterns',
+      'practices',
+      'research',
+      'project',
+      'clients',
+      'partners',
+      'vendors',
+      'operations',
+    ];
     return [...new Set($knowledgeStore.graph.nodes.map((node) => node.folder))].sort(
       (left, right) => {
         const leftIndex = preferredOrder.indexOf(left);
@@ -169,7 +182,10 @@
         <div class="full-state empty-state">
           <Brain size={32} weight="light" />
           <strong>No knowledge pages found</strong>
-          <p>Add markdown under patterns, practices, research, or the project’s .ai-docs folder.</p>
+          <p>
+            Add markdown under the wiki folders — patterns, practices, research, clients,
+            partners, vendors, operations — or the project’s .ai-docs folder.
+          </p>
           <button type="button" onclick={() => knowledgeStore.loadGraph(sessionId)}>Scan again</button>
         </div>
       {:else if filteredGraph.nodes.length === 0}
@@ -202,12 +218,22 @@
             {/if}
           </div>
           <footer class="legend">
-            <div class="legend-group" aria-label="Folder colors">
+            <div class="legend-group" aria-label="Folder colors and shapes">
               {#each folders as name (name)}
-                <span><i style:background={folderColor(name)}></i>{name}</span>
+                <span>
+                  <i
+                    class:diamond={isRelationshipFolder(name)}
+                    style:background={folderColor(name)}
+                  ></i>
+                  <span class="sr-only">{folderKindLabel(name)}:</span>{name}
+                </span>
               {/each}
             </div>
             {#if view === 'graph'}
+              <div class="legend-group" aria-label="Node shape key">
+                <span><i class="shape-key diamond"></i>Diamond · relationship entity</span>
+                <span><i class="shape-key circle"></i>Circle · operational knowledge</span>
+              </div>
               <div class="legend-group edge-legend" aria-label="Relationship types">
                 {#each KNOWLEDGE_EDGE_KINDS as kind (kind)}
                   <span><i style:background={EDGE_COLORS[kind]}></i>{EDGE_LABELS[kind]}</span>
@@ -505,6 +531,9 @@
   }
 
   .legend-group i { width: 6px; height: 6px; }
+  .legend-group i.diamond { transform: rotate(45deg); }
+  .shape-key { background: var(--text-secondary); }
+  .shape-key.circle { border-radius: 50%; }
   .edge-legend i { width: 13px; height: 1px; }
 
   .full-state {


### PR DESCRIPTION
Closes #157, closes #158. Version 0.35.1 → 0.36.0.

Built with a recon → implement → adversarial-review → fix pipeline. Recon returned a **NO_GO on the mechanism issue #157 itself prescribed**, and review found a **security regression the issue's own spec caused** — both detailed below, since they're the parts most worth a human eye.

## #157 — preview browser

### §1 Forgiving URL entry

`localhost:5173`, `127.0.0.1:3000/x`, `[::1]:8080`, `foo.localhost:3000`, `github.com/owner/repo` all work without typing a scheme. Localhost-ish hosts get `http`, public hosts `https`.

The input also changed `type="url"` → `type="text"`. That attribute is load-bearing, not cosmetic: native constraint validation rejects scheme-less input *before* submit fires, so with `type="url"` none of the backend work is reachable.

### §2 Dock / pop-out — mechanism deliberately changed from the issue

The issue specified "a separate child webview (Tauri v2 multiwebview, requires the `unstable` cargo feature)". A source-level feasibility review returned NO_GO:

1. **`unstable` is not opt-in per window.** It flips *every* webview from `WebviewKind::WindowContent` to `WindowChild` (`tauri-runtime-wry-2.10.0/src/lib.rs:4491-4496`), changing how the shipping main window is constructed on Windows even if no child webview is ever created. This is the documented cause of the upstream `WindowEvent::Focused` regression (tauri#9755 / #12568).
2. **It degrades the PR #154 ACL boundary.** `ipc/authority.rs:454-461` ORs window globs with webview globs, and `capabilities/default.json` is `"windows": ["main"]` — so a child webview of `main` matches and inherits all commands. Fixing it means `"webviews"` must *replace* `"windows"`, not join it, and getting that wrong fails silently with no test going red.
3. **Four open upstream bugs**, including tauri#10011 (Windows/WebView2 white-on-load) and broken positioning in Tauri's own multiwebview example.
4. **No semver guarantee** on `unstable`, against `tauri = "2"` (caret) in an app shipping an auto-updater.

Shipped instead on entirely stable APIs: the preview window is parented to main (correct z-order, auto-hide on minimize, auto-destroy with the owner) and **dock tiles it flush beside the main window rather than over it**. That choice is deliberate — on Windows a windowed WebView2 is a real HWND that main-webview HTML can never paint over, and this repo has 11 components using `position: fixed` (LaunchDialog, ShortcutsOverlay, MentionMenu, …) whose modals any overlapping pane would clip. Tiling has zero occlusion and needs no global "a modal is open" store coupling every dialog in the app to the browser pane.

Also included: address-bar sync from the existing navigation hook, reload, copy, per-session URL memory, and an in-app affordance showing preview state.

> If true in-window docking is still wanted, the honest next step is a throwaway spike behind a non-release cargo feature with explicit kill criteria (measure splitter-drag tracking lag and real modal occlusion), not a full cycle.

### Security regression found in review — and fixed

Normalization was initially wired into `validate_preview_url`, which is **also wry's `on_navigation` gate for untrusted preview content**. That gate returns a bool, and a `true` lets wry navigate to the *original* string. So scheme-less classification laundered rejected schemes into accepted ones:

| input | before | with the normalization bug | now |
|---|---|---|---|
| `vscode:/x`, `steam:/run/1`, `ms-settings:/`, `javascript:0`, `tel:12345` | rejected | **accepted** → OS protocol handler | rejected |
| `ms-msdt:/id PCWDiagnostic /skip force /param …` | rejected | **accepted** | rejected |
| `http:/localhost:18800` (single slash, legal per WHATWG) | rejected | **accepted** (host `http`, port 443) | rejected |

Fixed architecturally rather than by patching instances: `validate_preview_url` no longer normalizes and stays the navigation gate's validator, while `validate_operator_preview_input` normalizes and is reachable **only** from the command path. Locked by `the_navigation_gate_never_normalizes`.

Two sibling bugs came with it: `is_trusted_main_window_origin` didn't fold the trailing FQDN dot, so `tauri.localhost.` bypassed a guard that `tauri.localhost` triggers — while `is_localhostish_host` 100 lines above already folded it. And an empty port made `localhost:` select https, producing a TLS failure against a plain-HTTP dev server.

Separately: closing a **docked** preview via the native titlebar X stranded the main window in the left column with no in-app control to recover — there is no `CloseRequested` handler anywhere in `src-tauri`, so only the `Destroyed` arm ran and it never restored geometry. It now mirrors `close_preview_window`.

## #158 — knowledge atlas

Allowlists `clients`, `partners`, `vendors`, `operations` alongside `patterns` / `practices` / `research`. Relationship folders render as diamonds vs circles for operational ones, with the distinction carried in the **accessible name**, not shape alone.

The folder set is now **config-driven but enum-bounded** — config may only narrow or reorder among compiled-in variants, so no config value can point the scanner at an arbitrary filesystem path. This makes the privacy decision reversible without a rebuild.

**`agents/` is deliberately excluded** despite the issue listing it as recommended: it is 63 of ~163 reachable files, holds third-party recruiting-candidate dossiers with personal contact details, and its 11 unfiltered `README.md` / `_TEMPLATE.md` files have duplicate basenames that poison the `by_title` / `by_basename` unique-lookup maps (`unique_lookup` returns `None`, so edges silently drop elsewhere in the graph).

Scoping notes: "filter chips" in the issue's acceptance criteria was loose phrasing — the shipped control is a `<select>` and stays one. The "folder type union mirror" does not exist to mirror (`types.ts` declares `folder: string` deliberately, so new backend folders need no frontend type change). Truncation messaging is vacuous at ~100 nodes against `MAX_NODES = 400`.

## Infrastructure

- **`src-tauri/src/acl_parity.rs`** enforces `generate_handler!` == `commands.allow` as a **set** (57↔57). Nothing enforced this before: a missed manifest line builds clean, passes clippy, passes CI, and fails at runtime the first time a user clicks the feature. Verified red in both symmetric-difference directions. It parses with **bracket-depth matching** — a non-greedy regex truncates the block and reports 46, so a wrong-but-green parser was the real hazard.
- **`.github/workflows/frontend.yml`** — there was no frontend CI at all; `svelte-check` and 103 vitest tests ran on local discipline only.

## Coverage proven by mutation, not by reading

Two features looked tested and were not:

- Gutting `resolve_wiki_folders` — the only line turning operator config into scanner behavior — left **515/515 green**. An operator narrowing the Atlas for privacy would silently have gotten every folder.
- Reverting the input to `type="url"`, which kills §1 entirely at runtime, left **99 frontend + 515 Rust tests green**.

Both now have locks verified by reverting the change and watching them fail.

## Review outcome

9 findings across 4 review lenses, each independently re-verified by an agent instructed to refute it. 8 confirmed and fixed; 1 correctly rejected (a reviewer wanted an empty folder config to mean "scan nothing", but that is deliberately grouped with other absent-equivalent inputs, documented in three places, and pinned by a passing test). A second adversarial pass — re-running every vector by execution and hunting for new bypasses including decimal-encoded loopback IPs, punycode hosts, and userinfo tricks — returned zero remaining findings.

## Validation

| gate | result |
|---|---|
| `cargo test --lib` | 522 passed, 0 failed, 1 ignored |
| `cargo check --tests` | clean |
| `npm run check` | 0 errors, 0 warnings |
| `npm test` | 103 passed (25 files) |
| `npm run build` | ok |
| ACL parity | 57 handler ↔ 57 manifest, set-equal |

`cargo clippy` and `cargo fmt` are CI-only in this environment (components not installed locally) — please confirm CI green rather than local green for those.

## Not verified here

The dock/pop-out geometry work has unit coverage for the split math (`dock_split_columns_are_flush_and_never_overlap`, `dock_split_refuses_displays_that_cannot_host_both_windows`, `remembered_positions_are_only_restored_onto_a_live_monitor`) but **has not been driven live** — the Tauri command surface compiles out under `cfg(test)`. Worth a manual pass on dock → pop-out → dock, titlebar-X while docked, and a mixed-DPI multi-monitor drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview windows now support session-specific URLs, dock/floating layouts, live status, copy, and reload/dock/undock/close controls.
  * Knowledge scanning can be narrowed via operator configuration, and the knowledge page expands folder coverage and ordering.
  * Relationship folders are shown with diamond-shaped nodes, improved tooltips, and updated legends/accessible labels.
* **Bug Fixes**
  * Tightened preview URL security rules and blocked unsafe/local and reserved API destinations.
  * Prevented stale/different-session preview actions and ensured excluded/private knowledge never appears in graph or page previews.
* **Tests**
  * Added/expanded automated coverage for preview behavior, knowledge scanning (including fail-closed narrowing), UI rendering, and permission/ACL alignment checks.
* **Chores**
  * Added a CI workflow to run frontend checks and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->