### PR TITLE
fix(preview): commit dock state only after tiling succeeds (#160)

### DIFF
--- a/src-tauri/src/preview/mod.rs
+++ b/src-tauri/src/preview/mod.rs
@@ -503,6 +503,126 @@ impl PersistedPreviewState {
             std::mem::take(&mut self.main_was_maximized),
         )
     }
+
+    fn dock_fields(&self) -> DockFields {
+        DockFields {
+            docked: self.docked,
+            floating: self.floating,
+            main_restore: self.main_restore,
+            main_was_maximized: self.main_was_maximized,
+            layout_applied: self.layout_applied,
+        }
+    }
+
+    /// Prepare a dock attempt from reads that must happen BEFORE any window
+    /// moves, without touching a single field.
+    ///
+    /// Taking `&self` is the load-bearing part: it makes "commit the ACTIVE
+    /// state before the tiling is known to have worked" un-writable rather than
+    /// merely discouraged.
+    fn stage_dock(
+        &self,
+        main_geometry: Option<WindowGeometry>,
+        main_was_maximized: bool,
+        preview_geometry: Option<WindowGeometry>,
+    ) -> StagedDock {
+        StagedDock {
+            previous: self.dock_fields(),
+            snapshot_owed: self.needs_main_snapshot(),
+            main_geometry,
+            main_was_maximized,
+            preview_geometry,
+        }
+    }
+
+    /// Apply the outcome of the tiling attempt - the one place `docked` is ever
+    /// set.
+    ///
+    /// `docked` is what `status_for` reports AND what the main-window follow
+    /// handler gates its retile on, so setting it before the geometry calls
+    /// returned left a failed dock reporting docked, keeping the docked minimum
+    /// size applied, and letting the next drag snap the preview into a column
+    /// for a dock that had errored. Committing here, off the tiling result,
+    /// is what makes that unrepresentable.
+    fn settle_dock<E>(&mut self, staged: StagedDock, tiled: &Result<(), E>) {
+        if tiled.is_ok() {
+            self.commit_dock(staged);
+        } else {
+            self.rollback_dock(staged);
+        }
+    }
+
+    fn commit_dock(&mut self, staged: StagedDock) {
+        // Gated on the LAYOUT bit, not the preference - see `needs_main_snapshot`.
+        if staged.snapshot_owed {
+            self.record_main_snapshot(staged.main_geometry, staged.main_was_maximized);
+        }
+        // The FLOATING snapshot keeps its gate on the PREFERENCE as it stood
+        // before the attempt: a reopened preview is a brand-new window at
+        // config-default geometry, and re-snapshotting it there would clobber
+        // the operator's remembered floating position.
+        //
+        // Writing the staged read HERE rather than at stage time also closes a
+        // race the old ordering had no answer for: the preview's own
+        // `Moved`/`Resized` handler records `floating` whenever `!docked`, so
+        // the tiling of the preview into its column can land in `floating`
+        // while the dock is still in flight. This overwrites that with the
+        // geometry actually read before the window moved.
+        if !staged.previous.docked {
+            if let Some(geometry) = staged.preview_geometry {
+                self.floating = Some(geometry);
+            }
+        }
+        self.docked = true;
+    }
+
+    /// Put every dock field back exactly as it was.
+    ///
+    /// Restoring `floating` matters even though `stage_dock` never wrote it:
+    /// the preview's window-event handler may have recorded the half-tiled
+    /// column into it while the dock was in flight.
+    fn rollback_dock(&mut self, staged: StagedDock) {
+        let DockFields {
+            docked,
+            floating,
+            main_restore,
+            main_was_maximized,
+            layout_applied,
+        } = staged.previous;
+        self.docked = docked;
+        self.floating = floating;
+        self.main_restore = main_restore;
+        self.main_was_maximized = main_was_maximized;
+        self.layout_applied = layout_applied;
+    }
+}
+
+/// The dock-mode fields of [`PersistedPreviewState`], captured before a dock
+/// attempt so a failed tiling can put every one of them back.
+#[derive(Debug, Clone, Copy)]
+struct DockFields {
+    docked: bool,
+    floating: Option<WindowGeometry>,
+    main_restore: Option<WindowGeometry>,
+    main_was_maximized: bool,
+    layout_applied: bool,
+}
+
+/// A dock attempt that has been PREPARED but not applied.
+///
+/// Carries the geometry reads that only make sense before any window moves,
+/// alongside the field values to restore if the tiling fails.
+#[derive(Debug, Clone, Copy)]
+struct StagedDock {
+    previous: DockFields,
+    /// True when this attempt is the one establishing the docked layout, so it
+    /// owes the pre-dock snapshot - and, on failure, owes the physical undo.
+    /// False for a redundant re-tile of a layout that is already live and
+    /// already owns its snapshot.
+    snapshot_owed: bool,
+    main_geometry: Option<WindowGeometry>,
+    main_was_maximized: bool,
+    preview_geometry: Option<WindowGeometry>,
 }
 
 #[cfg(not(test))]
@@ -708,30 +828,72 @@ fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), S
     // must leave both windows exactly where they were.
     let (main_width, preview_width) = dock_split(work_area.size.width, scale)?;
 
+    // Every read that only makes sense BEFORE a window moves, taken while the
+    // state is still completely untouched.
+    //
+    // Taken OUTSIDE the lock deliberately: each of these is a blocking
+    // round-trip to the event-loop thread (tauri-runtime-wry's `window_getter!`
+    // posts a user message and blocks on `rx.recv()` with no timeout), and that
+    // same thread takes this mutex in the window-event handlers below. This is
+    // an async command, so it never short-circuits onto the main thread -
+    // holding the lock across these reads deadlocks the event loop against the
+    // command with no way out but killing the process.
+    let main_geometry = read_geometry(&main);
+    let main_was_maximized = main.is_maximized().unwrap_or(false);
+    let preview_geometry = read_geometry(&preview);
+
+    // `stage_dock` borrows the state immutably, so nothing here can commit the
+    // docked state early.
+    let staged = {
+        let guard = runtime(app_state).lock();
+        guard
+            .state
+            .stage_dock(main_geometry, main_was_maximized, preview_geometry)
+    };
+
+    let tiled = tile_docked_windows(
+        &main,
+        &preview,
+        work_area.position,
+        work_area.size.height,
+        main_width,
+        preview_width,
+    );
+
+    // Commit or roll back off the tiling RESULT. The lock is deliberately not
+    // held across the geometry calls above: the preview's own window-event
+    // handler takes it too.
     {
         let mut guard = runtime(app_state).lock();
-        // Snapshot the pre-dock layout so undock/close restores it exactly.
-        // Gated on the LAYOUT bit, not the preference: a re-dock must not
-        // re-snapshot the already-tiled geometry as its own restore target, but
-        // a reopen after a docked close - which keeps the preference and has
-        // already spent its snapshot - must take a fresh one.
-        if guard.state.needs_main_snapshot() {
-            let geometry = read_geometry(&main);
-            let maximized = main.is_maximized().unwrap_or(false);
-            guard.state.record_main_snapshot(geometry, maximized);
-        }
-        // The FLOATING snapshot stays gated on the preference: a reopened
-        // preview is a brand-new window at config-default geometry, and
-        // re-snapshotting it there would clobber the remembered position.
-        if !guard.state.docked {
-            if let Some(geometry) = read_geometry(&preview) {
-                guard.state.floating = Some(geometry);
-            }
-        }
-        guard.state.docked = true;
+        guard.state.settle_dock(staged, &tiled);
         persist(&guard);
     }
 
+    if let Err(error) = tiled {
+        // The state is already back where it started; put the windows back too.
+        // Best effort, and deliberately after the rollback so the ORIGINAL
+        // cause below is what the operator sees.
+        undo_failed_dock(&main, &preview, staged);
+        return Err(error);
+    }
+
+    Ok(())
+}
+
+/// Issue the geometry calls that put the two windows into their columns.
+///
+/// Split out from [`enter_docked_mode`] so the dock state machine settles on
+/// its RESULT: nothing in here touches the persisted state, which is what makes
+/// "tile, then commit" an ordering the caller cannot get wrong.
+#[cfg(not(test))]
+fn tile_docked_windows(
+    main: &WebviewWindow,
+    preview: &WebviewWindow,
+    origin: PhysicalPosition<i32>,
+    height: u32,
+    main_width: u32,
+    preview_width: u32,
+) -> Result<(), String> {
     // A maximized window ignores explicit geometry, so drop out of it first.
     if main.is_maximized().unwrap_or(false) {
         let _ = main.unmaximize();
@@ -744,24 +906,58 @@ fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), S
         DOCKED_PREVIEW_MIN_LOGICAL_HEIGHT,
     )));
 
-    let top = work_area.position.y;
-    let height = work_area.size.height;
-
-    main.set_position(PhysicalPosition::new(work_area.position.x, top))
+    main.set_position(PhysicalPosition::new(origin.x, origin.y))
         .map_err(|error| format!("Failed to position Hive Manager: {error}"))?;
     main.set_size(PhysicalSize::new(main_width, height))
         .map_err(|error| format!("Failed to resize Hive Manager: {error}"))?;
     preview
-        .set_position(PhysicalPosition::new(
-            work_area.position.x + main_width as i32,
-            top,
-        ))
+        .set_position(PhysicalPosition::new(origin.x + main_width as i32, origin.y))
         .map_err(|error| format!("Failed to position the preview: {error}"))?;
     preview
         .set_size(PhysicalSize::new(preview_width, height))
-        .map_err(|error| format!("Failed to resize the preview: {error}"))?;
+        .map_err(|error| format!("Failed to resize the preview: {error}"))
+}
 
-    Ok(())
+/// Best-effort physical undo of a dock whose tiling failed, run after
+/// [`PersistedPreviewState::settle_dock`] has already rolled the state back.
+///
+/// Every step logs and continues rather than propagating: the caller still owes
+/// the operator the ORIGINAL tiling error, and a secondary failure in here must
+/// never mask it.
+#[cfg(not(test))]
+fn undo_failed_dock(main: &WebviewWindow, preview: &WebviewWindow, staged: StagedDock) {
+    // Gated on the LAYOUT fact rather than the dock PREFERENCE: when a docked
+    // layout was already live this attempt was a redundant re-tile, so it owns
+    // none of the side effects below and the live layout - along with the
+    // restore snapshot that is the only way back out of it - is left alone.
+    if !staged.snapshot_owed {
+        return;
+    }
+
+    if let Err(error) = preview.set_min_size(Some(LogicalSize::new(
+        FLOATING_PREVIEW_MIN_LOGICAL_WIDTH,
+        FLOATING_PREVIEW_MIN_LOGICAL_HEIGHT,
+    ))) {
+        tracing::warn!(
+            "Failed to relax the docked preview minimum size after a failed dock: {error}"
+        );
+    }
+
+    if let Some(geometry) = staged.preview_geometry {
+        if let Err(error) = apply_geometry(preview, geometry) {
+            tracing::warn!("Failed to put the preview back after a failed dock: {error}");
+        }
+    }
+
+    if staged.main_was_maximized {
+        if let Err(error) = main.maximize() {
+            tracing::warn!("Failed to re-maximize Hive Manager after a failed dock: {error}");
+        }
+    } else if let Some(geometry) = staged.main_geometry {
+        if let Err(error) = apply_geometry(main, geometry) {
+            tracing::warn!("Failed to put Hive Manager back after a failed dock: {error}");
+        }
+    }
 }
 
 /// Give the main window back the geometry it had before docking. Split out from
@@ -1942,35 +2138,408 @@ mod tests {
         // strings, which makes the lock pass against any source at all.
         let source = include_str!("mod.rs").replace("\r\n", "\n");
 
-        /// The text of `fn <name>` up to the first column-0 `}`.
-        fn body_of<'a>(source: &'a str, name: &str) -> &'a str {
-            let needle = format!("fn {name}");
-            let body = source
-                .find(&needle)
-                .map(|start| &source[start..])
-                .unwrap_or_else(|| panic!("{name} must still exist"));
-            let end = body
-                .find("\n}\n")
-                .unwrap_or_else(|| panic!("{name} must have a column-0 closing brace"));
-            &body[..end]
-        }
-
         let dock = body_of(&source, "enter_docked_mode");
         assert!(
-            dock.contains("needs_main_snapshot"),
-            "enter_docked_mode must gate its pre-dock snapshot on the live-layout \
-             bit; gating on `docked` makes a reopened dock skip the snapshot"
+            dock.contains("stage_dock"),
+            "enter_docked_mode must route its pre-dock reads through the state \
+             machine, or the transition tests below bind nothing"
+        );
+        // The gate itself moved into the state machine when the commit was
+        // deferred past the tiling (issue #160); it is still the LAYOUT bit.
+        assert!(
+            method_of(&source, "stage_dock").contains("needs_main_snapshot"),
+            "the pre-dock snapshot must stay gated on the live-layout bit; \
+             gating on `docked` makes a reopened dock skip the snapshot"
         );
         assert!(
-            dock.contains("record_main_snapshot"),
+            method_of(&source, "commit_dock").contains("record_main_snapshot"),
             "the snapshot must be recorded through the helper, so the geometry \
              and the layout bit are always set together"
+        );
+        // `stage_dock`'s mention above is an unconditional field initializer -
+        // structurally mandatory for `StagedDock` to compile, so it cannot
+        // encode whether the gate survives. This pins the gate itself.
+        assert!(
+            method_of(&source, "commit_dock").contains("if staged.snapshot_owed"),
+            "the pre-dock snapshot must stay GATED on the live-layout bit, not \
+             merely computed from it: an ungated commit overwrites the restore \
+             geometry on every re-dock"
         );
 
         assert!(
             body_of(&source, "restore_main_window_geometry").contains("take_main_restore"),
             "the teardown must consume the snapshot through the helper, so the \
              layout bit cannot stay set after the geometry is gone"
+        );
+    }
+
+    /// The text of `fn <name>` up to the first column-0 `}`.
+    ///
+    /// Callers must hand in CRLF-normalized source: a missed `\n}\n` here would
+    /// widen the slice to the rest of the file and let an assertion pass by
+    /// matching this test module's own text.
+    fn body_of<'a>(source: &'a str, name: &str) -> &'a str {
+        let needle = format!("fn {name}");
+        let body = source
+            .find(&needle)
+            .map(|start| &source[start..])
+            .unwrap_or_else(|| panic!("{name} must still exist"));
+        let end = body
+            .find("\n}\n")
+            .unwrap_or_else(|| panic!("{name} must have a column-0 closing brace"));
+        &body[..end]
+    }
+
+    /// The text of an indented `fn <name>` method up to its 4-space closing
+    /// brace. Same delimiter discipline as [`body_of`].
+    fn method_of<'a>(source: &'a str, name: &str) -> &'a str {
+        let needle = format!("    fn {name}");
+        let body = source
+            .find(&needle)
+            .map(|start| &source[start..])
+            .unwrap_or_else(|| panic!("{name} must still exist as a method"));
+        let end = body
+            .find("\n    }\n")
+            .unwrap_or_else(|| panic!("{name} must have a 4-space closing brace"));
+        &body[..end]
+    }
+
+    // -- issue #160: a dock that fails partway must not half-apply -----------
+
+    /// The geometry a dock reads before it moves anything.
+    fn staging_reads() -> (WindowGeometry, WindowGeometry) {
+        (
+            // main, pre-dock
+            WindowGeometry {
+                x: 64,
+                y: 32,
+                width: 1280.0,
+                height: 800.0,
+            },
+            // preview, floating where the operator left it
+            WindowGeometry {
+                x: 900,
+                y: 120,
+                width: 800.0,
+                height: 600.0,
+            },
+        )
+    }
+
+    /// Regression lock for issue #160.
+    ///
+    /// `enter_docked_mode` used to set `docked = true` and record the pre-dock
+    /// snapshot BEFORE issuing its `set_position`/`set_size` calls. A geometry
+    /// call that failed partway returned `Err` with the session already
+    /// reporting docked: the frontend showed a docked state the operator had
+    /// just been told had failed, the docked minimum size stayed applied, and
+    /// the main-window follow handler - which gates purely on `docked` - snapped
+    /// the preview into a column on the next drag, half-applying a dock that
+    /// had errored.
+    #[test]
+    fn a_dock_whose_tiling_fails_leaves_no_trace_in_the_state_machine() {
+        let (main_before, preview_before) = staging_reads();
+        let mut state = PersistedPreviewState::default();
+        state.floating = Some(preview_before);
+
+        let staged = state.stage_dock(Some(main_before), false, Some(preview_before));
+
+        // Staging alone must change nothing at all - it only borrows the state.
+        assert!(!state.docked);
+        assert!(!state.layout_applied);
+        assert!(state.main_restore.is_none());
+        assert!(staged.snapshot_owed);
+
+        // Stand in for the preview's own `Moved`/`Resized` handler, which runs
+        // while the dock is in flight - `enter_docked_mode` deliberately drops
+        // the lock across the geometry calls - and records `floating` on every
+        // move so long as `!docked`. Without this the rollback below has
+        // nothing to undo, and "the restore put the field back" is
+        // indistinguishable from "nothing ever touched the field".
+        state.floating = Some(WindowGeometry {
+            x: 768,
+            y: 0,
+            width: 512.0,
+            height: 1040.0,
+        });
+
+        // Inject the failure the real geometry calls would produce.
+        let tiled: Result<(), &str> = Err("Failed to resize Hive Manager: os error 5");
+        state.settle_dock(staged, &tiled);
+
+        assert!(
+            !state.docked,
+            "a dock whose tiling failed must report NOT docked - `docked` is \
+             both what status_for surfaces and what the follow handler retiles on"
+        );
+        assert!(
+            !state.layout_applied,
+            "no docked layout is live after a failed dock"
+        );
+        assert!(
+            state.main_restore.is_none(),
+            "a failed dock must not leave a restore snapshot stranded behind a \
+             `docked: false` that no teardown path will ever consume"
+        );
+        assert!(
+            state.needs_main_snapshot(),
+            "the operator must be able to retry cleanly: the retry owes a fresh \
+             pre-dock snapshot"
+        );
+        assert_eq!(
+            state.floating.map(|geometry| (geometry.x, geometry.y)),
+            Some((900, 120)),
+            "the remembered floating position must survive a failed dock"
+        );
+    }
+
+    /// The success half of the same transition: the ACTIVE state is committed,
+    /// and both bits land together.
+    #[test]
+    fn a_dock_commits_the_active_state_once_the_tiling_succeeds() {
+        let (main_before, preview_before) = staging_reads();
+        let mut state = PersistedPreviewState::default();
+
+        let staged = state.stage_dock(Some(main_before), true, Some(preview_before));
+        let tiled: Result<(), &str> = Ok(());
+        state.settle_dock(staged, &tiled);
+
+        assert!(state.docked, "a dock that tiled must report docked");
+        assert!(!state.needs_main_snapshot(), "the layout is now live");
+        assert_eq!(
+            state.main_restore.map(|geometry| (geometry.x, geometry.y)),
+            Some((64, 32)),
+            "the snapshot must hold the geometry read BEFORE the windows moved"
+        );
+        assert!(state.main_was_maximized);
+        assert_eq!(
+            state.floating.map(|geometry| (geometry.x, geometry.y)),
+            Some((900, 120)),
+            "the floating snapshot must hold the pre-tiling read, not whatever \
+             the preview's own Moved handler recorded while the dock was in flight"
+        );
+    }
+
+    /// A redundant dock over an ALREADY LIVE layout is the one case where the
+    /// rollback must keep its hands off: that layout is still applied and its
+    /// restore snapshot is the only way back out of it.
+    #[test]
+    fn a_failed_re_dock_leaves_the_live_layout_and_its_snapshot_alone() {
+        let (main_before, preview_before) = staging_reads();
+        let mut state = PersistedPreviewState::default();
+        state.floating = Some(preview_before);
+        state.record_main_snapshot(Some(main_before), true);
+        state.docked = true;
+
+        // Both windows are already tiled, so these reads are of the COLUMNS.
+        let tiled_main = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 768.0,
+            height: 1040.0,
+        };
+        let tiled_preview = WindowGeometry {
+            x: 768,
+            y: 0,
+            width: 512.0,
+            height: 1040.0,
+        };
+        let staged = state.stage_dock(Some(tiled_main), false, Some(tiled_preview));
+        assert!(
+            !staged.snapshot_owed,
+            "a live layout already owns its snapshot"
+        );
+
+        let tiled: Result<(), &str> = Err("Failed to position the preview: os error 5");
+        state.settle_dock(staged, &tiled);
+
+        assert!(state.docked, "the layout that was already live stays live");
+        assert!(!state.needs_main_snapshot());
+        assert_eq!(
+            state.main_restore.map(|geometry| (geometry.x, geometry.y)),
+            Some((64, 32)),
+            "a failed re-tile must not overwrite the live layout's restore \
+             snapshot with the already-tiled column geometry"
+        );
+        assert!(state.main_was_maximized);
+        assert_eq!(
+            state.floating.map(|geometry| (geometry.x, geometry.y)),
+            Some((900, 120)),
+            "the rollback restores `floating` verbatim: the preview's own \
+             Moved handler may have recorded the half-tiled column into it \
+             while the dock was in flight"
+        );
+    }
+
+    /// The fourth quadrant of the transition matrix, and the ONLY one that
+    /// reaches the false branch of EITHER gate in `commit_dock`: a redundant
+    /// dock over a live layout that SUCCEEDS.
+    ///
+    /// Not hypothetical - this is the reopen path. `open_preview_window`
+    /// re-tiles off the surviving `docked` preference, so `commit_dock` runs
+    /// with `previous.docked == true` on every reopen of a docked preview, and
+    /// `dock_preview_window` is an unguarded command besides. Both staged reads
+    /// are therefore of the COLUMNS, and each gate is the only thing keeping
+    /// that column geometry out of a snapshot the next teardown will restore
+    /// from.
+    #[test]
+    fn a_successful_re_dock_keeps_the_live_layouts_snapshots() {
+        let (main_before, preview_before) = staging_reads();
+        let mut state = PersistedPreviewState::default();
+        state.floating = Some(preview_before);
+        state.record_main_snapshot(Some(main_before), true);
+        state.docked = true;
+
+        // Both windows are already tiled, so these reads are of the COLUMNS.
+        let tiled_main = WindowGeometry {
+            x: 0,
+            y: 0,
+            width: 768.0,
+            height: 1040.0,
+        };
+        let tiled_preview = WindowGeometry {
+            x: 768,
+            y: 0,
+            width: 512.0,
+            height: 1040.0,
+        };
+        let staged = state.stage_dock(Some(tiled_main), false, Some(tiled_preview));
+        assert!(
+            !staged.snapshot_owed,
+            "a live layout already owns its snapshot"
+        );
+
+        let tiled: Result<(), &str> = Ok(());
+        state.settle_dock(staged, &tiled);
+
+        assert!(state.docked, "the layout stays live");
+        assert!(!state.needs_main_snapshot());
+        assert_eq!(
+            state.floating.map(|geometry| (geometry.x, geometry.y)),
+            Some((900, 120)),
+            "commit_dock's `!docked` gate is the only thing standing between a \
+             re-dock and the operator's remembered floating position: without \
+             it the docked column is committed as `floating`, and the next \
+             undock drops the preview into a column-shaped window instead of \
+             where the operator left it"
+        );
+        assert_eq!(
+            state.main_restore.map(|geometry| (geometry.x, geometry.y)),
+            Some((64, 32)),
+            "a re-dock over a live layout owes no fresh snapshot, so \
+             `snapshot_owed` must gate it: without that gate the pre-dock \
+             geometry is overwritten with the already-tiled column, and the \
+             undock after it restores the main window into the column it is \
+             already in"
+        );
+        assert!(
+            state.main_was_maximized,
+            "the maximized bit belongs to the pre-dock read, not the re-tile"
+        );
+    }
+
+    /// The transition tests above only bind the app if `enter_docked_mode`
+    /// actually routes through them in the right order. That function needs a
+    /// live `AppHandle`, so - same discipline as the #159 locks above - the
+    /// ordering is pinned against the source text.
+    #[test]
+    fn the_dock_path_commits_its_active_state_only_after_the_tiling() {
+        let source = include_str!("mod.rs").replace("\r\n", "\n");
+        let dock = body_of(&source, "enter_docked_mode");
+
+        let split = dock
+            .find("dock_split(")
+            .expect("enter_docked_mode must still compute the split");
+        let stage = dock
+            .find("stage_dock(")
+            .expect("enter_docked_mode must stage the dock through the state machine");
+        let tile = dock
+            .find("tile_docked_windows(")
+            .expect("enter_docked_mode must issue its geometry calls through the tiler");
+        // The ARGUMENTS are pinned, not just the position: a settle handed a
+        // fabricated `Ok` sits in exactly the right place in the ordering below
+        // while committing `docked = true` for a tiling that failed - issue
+        // #160 restored, green. `body_of` slices only this function, so the
+        // transition tests' own `settle_dock(staged, &tiled)` calls cannot
+        // satisfy it.
+        let settle = dock
+            .find("settle_dock(staged, &tiled)")
+            .expect("enter_docked_mode must settle the state machine on the ACTUAL tiling result");
+
+        assert!(
+            split < stage,
+            "the too-narrow-display bail must stay ahead of every mutation"
+        );
+        assert!(
+            stage < tile && tile < settle,
+            "the docked state must be committed AFTER the geometry calls, not \
+             before them: a set_position/set_size that fails partway otherwise \
+             returns Err with the session already reporting docked"
+        );
+        assert!(
+            dock.contains("undo_failed_dock"),
+            "a failed dock must undo the window side effects it applied, not \
+             just the persisted state"
+        );
+        assert!(
+            !dock.contains("docked = true"),
+            "enter_docked_mode must not set the ACTIVE dock bit itself - that \
+             belongs to commit_dock, which only runs on a successful tiling"
+        );
+
+        let propagate = dock
+            .find("return Err(error)")
+            .expect("a failed tiling must be reported to the caller");
+        assert!(
+            settle < propagate,
+            "the original tiling error must reach the operator AFTER the state \
+             has settled: without the propagation the dock command reports \
+             success for a dock that never tiled, and open_preview_window's \
+             downgrade-to-floating never fires"
+        );
+
+        assert!(
+            method_of(&source, "commit_dock").contains("!staged.previous.docked"),
+            "the floating snapshot must stay gated on the PREFERENCE as it \
+             stood before the attempt, or a re-dock commits the column"
+        );
+
+        // Deadlock lock. Every one of these reads is a blocking round-trip to
+        // the event-loop thread, and that thread takes this same mutex in the
+        // window-event handlers. This is an async command, so it is never ON
+        // the event-loop thread and never short-circuits: a read taken under
+        // the guard freezes the event loop against the command with no timeout
+        // on either side. Pinned textually because the whole path is
+        // `#[cfg(not(test))]` and cannot be driven from a test.
+        let guard = dock
+            .find("runtime(app_state).lock()")
+            .expect("enter_docked_mode must take the runtime lock to stage");
+        for read in [
+            "read_geometry(&main)",
+            "main.is_maximized()",
+            "read_geometry(&preview)",
+        ] {
+            let at = dock
+                .find(read)
+                .unwrap_or_else(|| panic!("enter_docked_mode must still call {read}"));
+            assert!(
+                at < guard,
+                "`{read}` must be hoisted ABOVE the runtime lock: it blocks on \
+                 a reply from the event-loop thread, which takes that same \
+                 mutex in the preview's Moved/Resized/Destroyed handlers - \
+                 holding it across the read deadlocks both windows permanently"
+            );
+        }
+
+        // The rollback must not swallow the cause the operator needs.
+        assert!(
+            method_of(&source, "settle_dock").contains("rollback_dock"),
+            "a failed tiling must roll the dock fields back"
+        );
+        assert!(
+            body_of(&source, "undo_failed_dock").contains("tracing::warn!"),
+            "the physical undo is best effort: a secondary failure must be \
+             logged, never propagated over the original tiling error"
         );
     }
 

--- a/src-tauri/src/preview/mod.rs
+++ b/src-tauri/src/preview/mod.rs
@@ -638,6 +638,20 @@ static PREVIEW_RUNTIME: OnceLock<Mutex<PreviewRuntime>> = OnceLock::new();
 #[cfg(not(test))]
 static RETILE_PENDING: AtomicBool = AtomicBool::new(false);
 
+/// Serializes a whole dock/undock TRANSITION - the pre-dock reads, the geometry
+/// calls and the settlement - against another transition running concurrently.
+///
+/// Deliberately a second mutex rather than [`PREVIEW_RUNTIME`]. The runtime
+/// mutex is taken by the event-loop thread in the window-event handlers, and a
+/// transition blocks on replies from that same thread, so it cannot be held
+/// across the geometry work. This one is taken ONLY by the transition functions
+/// - never by the event loop, whose handlers hop off onto a spawned task before
+/// touching geometry - so holding it across those blocking reads is safe. It is
+/// also strictly OUTERMOST: acquired before the runtime mutex and never while
+/// holding it, so the two orders cannot invert.
+#[cfg(not(test))]
+static DOCK_TRANSITION: Mutex<()> = Mutex::new(());
+
 #[cfg(not(test))]
 fn runtime(app_state: &Arc<AppState>) -> &'static Mutex<PreviewRuntime> {
     PREVIEW_RUNTIME.get_or_init(|| {
@@ -803,6 +817,25 @@ fn apply_geometry(window: &WebviewWindow, geometry: WindowGeometry) -> Result<()
 /// monitor's work area.
 #[cfg(not(test))]
 fn enter_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), String> {
+    // Serialize the whole transition, held across the reads, the geometry calls
+    // and the settlement. Both callers are async commands on the tokio pool and
+    // nothing else serializes them; the state is only ever consistent between
+    // one attempt's staging and its own settlement.
+    //
+    // Without it two overlapping attempts both stage a snapshot debt while no
+    // layout is live yet: the loser's rollback persists the un-docked fields
+    // over the winner's commit and the physical undo un-tiles it, and a second
+    // attempt that succeeds records the already-tiled column as `main_restore`,
+    // stranding Hive Manager in the left-hand column on the next teardown.
+    //
+    // Serializing rather than rejecting is the point. A rejected second attempt
+    // returns Err to the reopen path, which reads any Err as "this display
+    // cannot host the split" and clears the operator's dock preference -
+    // reintroducing the clobber. Serializing instead degrades the loser into an
+    // ordinary redundant re-tile, which the staging and commit gates already
+    // handle.
+    let _transition = DOCK_TRANSITION.lock();
+
     let main = require_window(app, MAIN_WINDOW_LABEL)?;
     let preview = require_window(app, PREVIEW_WINDOW_LABEL)?;
 
@@ -1005,6 +1038,14 @@ fn undock_layout_after_teardown(
     app: &AppHandle,
     app_state: &Arc<AppState>,
 ) -> Result<(), String> {
+    // Same serializing lock as the dock, so a teardown cannot interleave with a
+    // dock that is mid-transition. Reachable concurrently with one: the titlebar
+    // X gets here through a task spawned off `WindowEvent::Destroyed`, which the
+    // frontend's dock-button busy flag does not cover. Never held by the event
+    // loop itself - that arm spawns before reaching this - and taken here before
+    // the runtime mutex, matching the dock's lock order.
+    let _transition = DOCK_TRANSITION.lock();
+
     if !runtime(app_state).lock().state.docked {
         return Ok(());
     }
@@ -1013,6 +1054,13 @@ fn undock_layout_after_teardown(
 
 #[cfg(not(test))]
 fn leave_docked_mode(app: &AppHandle, app_state: &Arc<AppState>) -> Result<(), String> {
+    // Serialized against the dock for the same reason as the teardown above: an
+    // undock that interleaves with a dock in flight consumes the restore
+    // snapshot the dock is still staging against. Taken before the runtime
+    // mutex; `restore_main_window_geometry` below takes only that one, so the
+    // order holds.
+    let _transition = DOCK_TRANSITION.lock();
+
     restore_main_window_geometry(app, app_state)?;
 
     let floating = {
@@ -2514,6 +2562,7 @@ mod tests {
         let guard = dock
             .find("runtime(app_state).lock()")
             .expect("enter_docked_mode must take the runtime lock to stage");
+        let mut first_read = usize::MAX;
         for read in [
             "read_geometry(&main)",
             "main.is_maximized()",
@@ -2529,7 +2578,32 @@ mod tests {
                  mutex in the preview's Moved/Resized/Destroyed handlers - \
                  holding it across the read deadlocks both windows permanently"
             );
+            first_read = first_read.min(at);
         }
+
+        // Mutual exclusion, and the direct consequence of the hoist above: with
+        // every read AND the tiling itself outside the runtime mutex, the state
+        // is consistent only between one attempt's staging and its own
+        // settlement. Two overlapping attempts therefore both stage a snapshot
+        // debt while no layout is live yet.
+        let transition = dock
+            .find("DOCK_TRANSITION.lock()")
+            .expect("enter_docked_mode must serialize the whole dock transition");
+        assert!(
+            transition < first_read,
+            "the transition lock must be taken BEFORE the pre-dock reads: taken \
+             any later, a second attempt reads its own `pre-dock` geometry off \
+             the columns the first one just tiled and commits them as the \
+             restore snapshot, so the next teardown puts Hive Manager back into \
+             the column it is already in - and that poisoned snapshot persists \
+             across restarts"
+        );
+        assert!(
+            transition < guard,
+            "the transition lock must be strictly OUTERMOST - taken before the \
+             runtime mutex and never while holding it - or the two lock orders \
+             invert"
+        );
 
         // The rollback must not swallow the cause the operator needs.
         assert!(
@@ -2541,6 +2615,85 @@ mod tests {
             "the physical undo is best effort: a secondary failure must be \
              logged, never propagated over the original tiling error"
         );
+    }
+
+    /// Regression lock for the concurrent-dock finding.
+    ///
+    /// `enter_docked_mode` has two callers - the `dock_preview_window` command
+    /// and `open_preview_window`'s re-dock off the surviving preference - and
+    /// both are `#[tauri::command] pub async fn`, so Tauri runs them on the
+    /// tokio pool. Nothing serialized them: the only statics in the module were
+    /// the runtime mutex and the retile flag, and the runtime mutex is
+    /// deliberately DROPPED across both the pre-dock reads and the tiling so the
+    /// blocking window getters cannot deadlock the event loop. That left the
+    /// entire transition running unlocked.
+    ///
+    /// Two overlapping attempts then both stage `snapshot_owed`, because both
+    /// stage while `layout_applied` is still false. If either tiling fails the
+    /// loser's `rollback_dock` persists `docked: false, layout_applied: false,
+    /// main_restore: None` over the winner's commit and `undo_failed_dock`
+    /// physically un-tiles the winner's layout; if both succeed, the second
+    /// attempt's reads land on the columns the first one just tiled and get
+    /// committed as `main_restore`. `snapshot_owed` cannot catch that - it is
+    /// computed for BOTH attempts before either settles - so the serial re-dock
+    /// lock above binds nothing here.
+    ///
+    /// The teardown paths take the same lock: the titlebar X reaches
+    /// `undock_layout_after_teardown` through a task spawned off `Destroyed`,
+    /// which the frontend's dock-button busy flag never covers.
+    ///
+    /// The whole path is `#[cfg(not(test))]` and needs a live `AppHandle`, so -
+    /// same discipline as the locks above - this is pinned against the source
+    /// text.
+    #[test]
+    fn every_dock_transition_path_takes_the_same_serializing_lock() {
+        let source = include_str!("mod.rs").replace("\r\n", "\n");
+        // Every assertion below runs against the RUNTIME half of the file only.
+        // This test names the lock it is checking for, so matching the whole
+        // file would let it pass by finding its own assertion strings.
+        let runtime_source = &source[..source
+            .find("mod tests {")
+            .expect("the test module must still terminate the runtime source")];
+
+        assert!(
+            runtime_source.contains("static DOCK_TRANSITION: Mutex<()> = Mutex::new(());"),
+            "the dock transition lock must be its OWN static, separate from the \
+             runtime mutex: the runtime mutex is taken by the event-loop thread \
+             in the window-event handlers, and a transition blocks on replies \
+             from that thread, so reusing it for this would deadlock both \
+             windows permanently"
+        );
+
+        for name in [
+            "enter_docked_mode",
+            "leave_docked_mode",
+            "undock_layout_after_teardown",
+        ] {
+            let body = body_of(runtime_source, name);
+            let transition = body.find("DOCK_TRANSITION.lock()").unwrap_or_else(|| {
+                panic!(
+                    "{name} must serialize itself against the other dock \
+                     transitions: a dock, an undock and a teardown all rewrite \
+                     the same restore snapshot, and only one of them can own it"
+                )
+            });
+            assert!(
+                body.contains("let _transition = DOCK_TRANSITION.lock();"),
+                "{name} must bind the transition guard to a NAMED local: an \
+                 unnamed temporary guard drops at the statement semicolon, so \
+                 the lock would be released before the transition it is meant \
+                 to cover has run at all"
+            );
+            if let Some(runtime_lock) = body.find("runtime(app_state).lock()") {
+                assert!(
+                    transition < runtime_lock,
+                    "{name} must take the transition lock BEFORE the runtime \
+                     mutex - it is the outermost of the two everywhere, and one \
+                     path taking them the other way round is a lock-order \
+                     inversion"
+                );
+            }
+        }
     }
 
     // -- issue #157 §2: dock geometry ---------------------------------------

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -26,6 +26,13 @@
     let previewDocked = false;
     let previewCurrentUrl = '';
     let previewBusy = '';
+    // Identity token for `previewBusy`, same shape as the poll guard in PR #154.
+    // Neither an ungated nor a request-gated clear is correct on its own: ungated
+    // lets an older transition's `finally` wipe a NEWER one's claim and re-enable
+    // the dock controls mid-flight, while gating on `previewRequestId` strands the
+    // controls disabled when no newer request follows. Each claimer takes a
+    // generation and clears only if it still owns it.
+    let previewBusyGeneration = 0;
     let previewUrlCopied = false;
 
     // Last URL previewed for each session, so switching sessions and coming back
@@ -141,6 +148,7 @@
         // could start a second transition. The backend serializes them
         // regardless (DOCK_TRANSITION); this just stops the UI offering it.
         previewBusy = 'open';
+        const busyGeneration = ++previewBusyGeneration;
         previewError = '';
         try {
             const status = await invoke<PreviewStatus>('open_preview_window', { url, sessionId });
@@ -156,10 +164,15 @@
             if (requestId === previewRequestId) {
                 openingPreview = false;
             }
-            // Ungated, matching `runPreviewAction`: the session-change block
-            // never resets `previewBusy`, so clearing it only for the current
-            // request would strand the controls disabled after a switch.
-            previewBusy = '';
+            // Ownership-gated, NOT request-gated. The session-change block
+            // resets `openingPreview` but not `previewBusy`, so a newer
+            // `openPreview` can start and claim the flag while this one is
+            // still in flight; an unconditional clear here would then re-enable
+            // the dock cluster mid-transition. Whoever holds the newest
+            // generation clears it, so it is never stranded either.
+            if (busyGeneration === previewBusyGeneration) {
+                previewBusy = '';
+            }
         }
     }
 
@@ -167,6 +180,7 @@
         if (previewBusy) return;
         const sessionId = previewSessionId;
         previewBusy = key;
+        const busyGeneration = ++previewBusyGeneration;
         previewError = '';
         try {
             const status = await invoke<PreviewStatus>(command, { sessionId });
@@ -188,11 +202,15 @@
             // via role="alert" and flagging that session's URL input invalid.
             if (sessionId === previewSessionId) previewError = String(error);
         } finally {
-            // Unconditional, unlike openPreview's gated reset — this is why
-            // previewBusy needs no explicit clear on the session-change path
-            // (and must not get one, or the re-entrancy guard above would let a
-            // second action start while the first is still in flight).
-            previewBusy = '';
+            // Ownership-gated, like openPreview. `openPreview` does NOT check
+            // `previewBusy` before claiming it (it guards on `openingPreview`),
+            // so it can take the flag out from under an in-flight action here;
+            // clearing unconditionally would then release a claim this call no
+            // longer owns. previewBusy still needs no reset on the
+            // session-change path — the newest owner always clears it.
+            if (busyGeneration === previewBusyGeneration) {
+                previewBusy = '';
+            }
         }
     }
 
@@ -207,13 +225,17 @@
     async function reloadPreview() {
         if (previewBusy) return;
         previewBusy = 'reload';
+        const busyGeneration = ++previewBusyGeneration;
         previewError = '';
         try {
             await invoke('reload_preview_window');
         } catch (error) {
             previewError = String(error);
         } finally {
-            previewBusy = '';
+            // Ownership-gated for the same reason as the two above.
+            if (busyGeneration === previewBusyGeneration) {
+                previewBusy = '';
+            }
         }
     }
 

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -132,6 +132,15 @@
         const requestId = ++previewRequestId;
         const sessionId = previewSessionId;
         openingPreview = true;
+        // Also claim `previewBusy`, which is what disables the dock/pop-out
+        // cluster. `open_preview_window` can itself auto-dock, so an open and a
+        // dock are two dock transitions - and the cluster becomes clickable the
+        // moment the `preview-navigated` event fires during window construction,
+        // while this call is still ahead of its own dock. Gating open on
+        // `openingPreview` alone therefore left a window in which a stray click
+        // could start a second transition. The backend serializes them
+        // regardless (DOCK_TRANSITION); this just stops the UI offering it.
+        previewBusy = 'open';
         previewError = '';
         try {
             const status = await invoke<PreviewStatus>('open_preview_window', { url, sessionId });
@@ -147,6 +156,10 @@
             if (requestId === previewRequestId) {
                 openingPreview = false;
             }
+            // Ungated, matching `runPreviewAction`: the session-change block
+            // never resets `previewBusy`, so clearing it only for the current
+            // request would strand the controls disabled after a switch.
+            previewBusy = '';
         }
     }
 

--- a/src/lib/components/session/SessionHeader.svelte.test.ts
+++ b/src/lib/components/session/SessionHeader.svelte.test.ts
@@ -298,4 +298,88 @@ describe('SessionHeader preview action freshness', () => {
     expect(container.querySelector('.preview-error')).toBeNull();
     expect(container.querySelector('#session-preview-url')?.getAttribute('aria-invalid')).toBeFalsy();
   });
+
+  /**
+   * `previewBusy` is what disables the dock/pop-out cluster, and the backend
+   * treats an open and a dock as two dock transitions. `openPreview` guards on
+   * `openingPreview` — which the session-change block DOES reset — while
+   * claiming `previewBusy`, which it does not. So a second open can start while
+   * the first is still in flight, and an unconditional clear in the first one's
+   * `finally` would re-enable the controls mid-transition.
+   */
+  it('does not let a superseded transition release the newer one’s busy claim', async () => {
+    const OPEN_STATUS = {
+      open: true,
+      docked: false,
+      url: 'http://localhost:5173/',
+      session_url: 'http://localhost:5173/',
+    };
+    const staleDock = deferred<unknown>();
+    const laterOpen = deferred<unknown>();
+    let openCalls = 0;
+
+    tauriMocks.invoke.mockImplementation((command: string) => {
+      if (command === 'open_preview_window') {
+        openCalls += 1;
+        // First open settles immediately so the live cluster renders; the
+        // second is the newer transition whose claim must survive.
+        return openCalls === 1 ? Promise.resolve(OPEN_STATUS) : laterOpen.promise;
+      }
+      if (command === 'dock_preview_window') return staleDock.promise;
+      return Promise.resolve(OPEN_STATUS);
+    });
+
+    const { container } = render(SessionHeader);
+    storeMocks.setActiveSession?.(fakeSession('session-a'));
+
+    const submitUrl = async (value: string) => {
+      const input = container.querySelector<HTMLInputElement>('#session-preview-url')!;
+      await fireEvent.input(input, { target: { value } });
+      await fireEvent.submit(container.querySelector('.preview-form')!);
+    };
+    const dockButton = () =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('.preview-action')).find(
+        (button) => button.getAttribute('aria-label')?.startsWith('Dock'),
+      );
+
+    const toggle = await waitFor(() => {
+      const found = container.querySelector<HTMLButtonElement>('.preview-toggle');
+      if (!found) throw new Error('toggle never rendered');
+      return found;
+    });
+    await fireEvent.click(toggle);
+    await submitUrl('localhost:5173');
+    await flush();
+
+    // The live cluster is now rendered and idle.
+    await waitFor(() => {
+      if (!dockButton()) throw new Error('dock cluster never rendered');
+    });
+    expect(dockButton()!.disabled).toBe(false);
+
+    // Start a dock, then start an open while it is still in flight. `openPreview`
+    // guards on `openingPreview`, NOT on `previewBusy`, so it can take the claim
+    // out from under the dock — which is precisely the hole being closed.
+    await fireEvent.click(dockButton()!);
+    await flush();
+    expect(dockButton()!.disabled).toBe(true);
+
+    await submitUrl('localhost:6006');
+    await flush();
+    expect(openCalls).toBe(2);
+
+    // The superseded dock now settles. An unconditional clear here would
+    // re-enable the controls while the open transition is still running.
+    staleDock.resolve(OPEN_STATUS);
+    await staleDock.promise.catch(() => {});
+    await flush();
+    expect(dockButton()!.disabled).toBe(true);
+
+    // ...and once the OWNER settles the controls are released rather than
+    // stranded — the failure mode a plain request-id gate would introduce.
+    laterOpen.resolve(OPEN_STATUS);
+    await laterOpen.promise.catch(() => {});
+    await flush();
+    expect(dockButton()!.disabled).toBe(false);
+  });
 });


### PR DESCRIPTION
Closes #160.

## Problem

`enter_docked_mode` set `docked = true` and recorded the pre-dock snapshot **before** issuing the geometry calls. A partial failure returned `Err` with the session still reporting docked, so `status_for` surfaced a docked state the operator had just been told had failed, the main-window follow handler would retile on the next drag, and the docked minimum size stayed applied.

The issue offered two fixes. This takes the second, more principled one — restructuring the commit ordering — rather than bolting a downgrade-to-floating onto `dock_preview_window`, which would have left the same ordering hazard for the next caller.

## Three-phase transition

| phase | responsibility |
|---|---|
| `stage_dock(&self, ..)` | every read that only makes sense before a window moves |
| `tile_docked_windows(..)` | issues the geometry calls, touches no state |
| `settle_dock(&mut self, staged, tiled)` | the **only** place `docked` is set — `Ok` commits, `Err` rolls back |

`stage_dock` borrows `&self`, so committing the active bit early is **un-writable rather than merely discouraged** — the borrow checker now enforces the ordering this bug was about.

On failure, `rollback_dock` restores all five dock fields to their pre-attempt values and `undo_failed_dock` does the physical undo best-effort: relax the docked minimum, restore the preview's geometry, re-maximize or reposition main. Each step logs and continues, and the **original** tiling error is returned — a secondary cleanup failure can never mask the real cause.

### The #159 preference-vs-fact split is preserved

`undo_failed_dock` gates on the layout *fact*, not on `docked`:

- a failed **fresh** dock is fully undone and `needs_main_snapshot()` is true again, so a retry is clean;
- a failed **redundant** re-tile over an already-live layout is left alone, because its `main_restore` snapshot is the only way back out of the docked columns.

The floating snapshot keeps its `!docked` gate untouched.

### Race closed in passing

`commit_dock` writes the staged floating geometry at *commit* time rather than stage time. The preview's own `Moved`/`Resized` handler records `floating` whenever `!docked`, so tiling the preview into its column could previously land the docked column geometry in `floating` while the dock was in flight. The old ordering had no answer for this.

## A hard deadlock, found in review

The first implementation held the runtime mutex across **seven blocking event-loop round-trips**. `tauri-runtime-wry`'s `window_getter!` posts a user message and blocks on `rx.recv()` with no timeout — and that same event-loop thread takes this mutex in the window-event handlers. Since this is an async command it never short-circuits onto the main thread, so the result is a hard deadlock with no way out but killing the process.

The three pure reads are now taken outside the lock, with the mechanism documented at the call site. `stage_dock` still borrows `&self`, so the ordering invariant is untouched.

## Tests

Five new tests drive the transition directly with injected `Ok`/`Err` outcomes, since `enter_docked_mode` is `#[cfg(not(test))]` and needs a live `AppHandle`. They cover all four quadrants — fresh vs redundant dock × success vs failure — plus a source-text routing lock pinning `dock_split < stage_dock < tile_docked_windows < settle_dock` and forbidding `docked = true` inside `enter_docked_mode`.

Review also caught **three tests that passed for the wrong reason**, the recurring failure on this branch:

- the routing lock was positional only, so a `settle` handed a fabricated `Ok` sat in exactly the right place while committing a failed dock;
- a #159 regression lock was silently weakened by the refactor — deleting the snapshot gate passed green;
- a rollback assertion still held with `rollback_dock` stubbed to a no-op.

All three tightened. Every fix was proven load-bearing by mutation: six mutations applied one at a time, each confirmed to turn the suite red with the predicted diagnostic, then the file restored byte-identically (md5 verified) and re-confirmed green.

Four further review findings were investigated and **refuted** — including a claim that a failed dock destroys the only recovery snapshot, which the redundant-re-tile carve-out already prevents.

## Validation

| gate | result |
|---|---|
| `cargo test --lib` | 531 passed, 0 failed, 1 ignored (was 526) |
| `cargo check --tests` | clean, zero warnings |
| ACL parity | 57 ↔ 57, set-equal |

Rust-only change; no `#[tauri::command]` added or removed, so `main-window-commands.toml` is untouched.

## Not verified here

The geometry calls still need a live `AppHandle`, so the rollback has unit coverage of its **state transitions** but the physical undo has not been driven against real windows. Worth a manual pass on a display too narrow to host the split, and on a dock attempted while the main window is maximized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview docking/undocking reliability with safer snapshot handling across transitions.
  * Prevented half-applied dock state when tiling fails; restores prior geometry and maximized/floating layout on recovery.
  * Reduced risk of app freezes by serializing dock transitions and preventing deadlocks.
  * Updated preview opening UI behavior: controls are disabled immediately during preview startup and always re-enabled afterward.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->