### PR TITLE
chore(release): bump to 0.36.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.36.0"
+version = "0.36.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.36.0"
+version = "0.36.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Patch bump for the two preview fixes merged since 0.36.0.

| PR | issue | change |
|---|---|---|
| #162 | #160 | dock state is committed only after tiling succeeds, with rollback; dock transitions serialized; `previewBusy` guard made identity-owned |
| #164 | #161 | both monitor lookups resolve through one shared helper with a single fallback policy |

Both are fixes rather than features, so `x.x.Z` per the project's versioning scheme.

Four files in lockstep: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.36.1 across supported platforms and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->