### PR TITLE
fix(heartbeat): deliver cadence to every CLI behavior and derive it from the stuck cutoff (#141)

### DIFF
--- a/src-tauri/src/coordination/queue_manager.rs
+++ b/src-tauri/src/coordination/queue_manager.rs
@@ -22,11 +22,88 @@ use crate::storage::StorageError;
 /// genuinely-working-but-quiet worker that keeps heartbeating is never reclaimed.
 pub const STUCK_CUTOFF_MS: i64 = 90_000;
 
+/// `STUCK_CUTOFF_MS` in whole seconds, for prompt prose.
+pub const STUCK_CUTOFF_SECS: u64 = (STUCK_CUTOFF_MS as u64) / 1_000;
+
+/// Rounding granularity for the derived cadence, so prompts read in round numbers.
+const HEARTBEAT_CADENCE_GRANULARITY_SECS: u64 = 5;
+
+/// Headroom multiplier between the cadence workers are INSTRUCTED to heartbeat at and
+/// `STUCK_CUTOFF_MS` (#141). A worker obeying the upper bound of its instruction fits at
+/// least this many beats inside one cutoff window, so it takes a genuinely missed beat —
+/// not ordinary jitter — before `reclaim_stuck` can requeue it. Raising the factor tightens
+/// the instructed cadence; it never relaxes the cutoff.
+pub const HEARTBEAT_SAFETY_FACTOR: u64 = 2;
+
+/// Upper bound of the instructed heartbeat cadence, in seconds. DERIVED from
+/// `STUCK_CUTOFF_MS` — do not hand-edit, and never hardcode a cadence into a prompt
+/// template. Prompts take this through [`heartbeat_cadence_label`], which is the only way
+/// the instruction and the reclaim cutoff stay pinned to each other.
+pub const HEARTBEAT_MAX_INTERVAL_SECS: u64 = derived_heartbeat_max_interval_secs();
+
+/// Lower bound of the instructed cadence. Exists only so workers do not hammer the
+/// heartbeat endpoint; the reclaim invariant rides on the upper bound.
+pub const HEARTBEAT_MIN_INTERVAL_SECS: u64 = derived_heartbeat_min_interval_secs();
+
+/// Largest cadence that still leaves `HEARTBEAT_SAFETY_FACTOR` beats STRICTLY inside the
+/// cutoff window, rounded down to `HEARTBEAT_CADENCE_GRANULARITY_SECS`.
+const fn derived_heartbeat_max_interval_secs() -> u64 {
+    let budget = STUCK_CUTOFF_SECS / HEARTBEAT_SAFETY_FACTOR;
+    let rounded =
+        (budget / HEARTBEAT_CADENCE_GRANULARITY_SECS) * HEARTBEAT_CADENCE_GRANULARITY_SECS;
+    // Exact division lands the worker ON the cutoff, which is the #141 defect. Step down one
+    // granularity so the product is strictly below it.
+    let strict = if rounded * HEARTBEAT_SAFETY_FACTOR < STUCK_CUTOFF_SECS {
+        rounded
+    } else {
+        rounded.saturating_sub(HEARTBEAT_CADENCE_GRANULARITY_SECS)
+    };
+
+    if strict == 0 {
+        1
+    } else {
+        strict
+    }
+}
+
+const fn derived_heartbeat_min_interval_secs() -> u64 {
+    let half = HEARTBEAT_MAX_INTERVAL_SECS / 2;
+    let rounded = (half / HEARTBEAT_CADENCE_GRANULARITY_SECS) * HEARTBEAT_CADENCE_GRANULARITY_SECS;
+
+    if rounded == 0 {
+        HEARTBEAT_MAX_INTERVAL_SECS
+    } else {
+        rounded
+    }
+}
+
+/// The one cadence phrase every prompt must use, e.g. `every 20-40s`. Single source of
+/// truth: prose in a template can no longer drift away from `STUCK_CUTOFF_MS`.
+pub fn heartbeat_cadence_label() -> String {
+    format!("every {HEARTBEAT_MIN_INTERVAL_SECS}-{HEARTBEAT_MAX_INTERVAL_SECS}s")
+}
+
 /// Finalize a run once it has produced this many continuations (distinct status changes).
 pub const MAX_CONTINUATIONS: i64 = 8;
 
+/// Wall-clock window a run may hold a single status before `finalize_no_progress` retires
+/// it. A liveness heartbeat carries a FIXED status per phase (see `heartbeat_snippet`), so
+/// consecutive beats ALWAYS take the no-progress branch in `record_heartbeat` — the budget
+/// must therefore be a wall-clock decision, not a beat count. Must exceed the longest
+/// legitimate quiet stretch: codex indexes 8-12 minutes before emitting any output.
+pub const NO_PROGRESS_WINDOW_SECS: u64 = 1_800;
+
 /// Finalize a run once it has produced this many consecutive no-progress heartbeats.
-pub const MAX_NO_PROGRESS_CONTINUATIONS: i64 = 5;
+/// DERIVED from the instructed cadence (#141): the cadence and this budget are coupled in
+/// OPPOSITE directions, so tightening `HEARTBEAT_SAFETY_FACTOR` must raise the beat count
+/// rather than shrink the wall-clock budget. Hardcoding it is how a healthy worker that
+/// simply beats faster gets flipped to the TERMINAL `finalized` state mid-run — after which
+/// `record_heartbeat` matches no rows and `reclaim_stuck` can never recover it.
+///
+/// Ceiling division so the realised budget is never shorter than the window.
+pub const MAX_NO_PROGRESS_CONTINUATIONS: i64 = NO_PROGRESS_WINDOW_SECS
+    .div_ceil(HEARTBEAT_MIN_INTERVAL_SECS)
+    as i64;
 
 /// Coordination-layer façade over the durable queue. Cheaply clonable.
 #[derive(Clone)]
@@ -307,6 +384,81 @@ mod tests {
         mgr.claim_and_spawn("r1", "s1", "s1-worker-1").await.unwrap();
         let e3 = rx.recv().await.unwrap();
         assert_eq!(e3.event_type, EventType::WorkerClaimFailed);
+    }
+
+    /// #141 follow-up: the instructed cadence and the no-progress budget are coupled in
+    /// OPPOSITE directions — a faster cadence spends the beat budget sooner. A liveness
+    /// heartbeat carries a fixed status per phase, so every beat after the first takes the
+    /// `last_status = ?4` branch in `record_heartbeat` and climbs `no_progress_count`. Pin
+    /// the budget in WALL-CLOCK terms so tightening the cadence can never flip a healthy
+    /// worker to the terminal `finalized` state mid-run.
+    #[test]
+    fn no_progress_budget_outlives_a_long_quiet_worker() {
+        // Route through a call so the assertions exercise real values rather than being
+        // const-folded into `assert!(true)`.
+        fn derived_budget() -> (u64, u64, u64) {
+            (
+                MAX_NO_PROGRESS_CONTINUATIONS as u64,
+                HEARTBEAT_MIN_INTERVAL_SECS,
+                NO_PROGRESS_WINDOW_SECS,
+            )
+        }
+
+        let (max_beats, min_interval, window) = derived_budget();
+
+        // The floor: a worker obeying the FAST end of the instructed cadence burns the beat
+        // budget quickest, so that product is the shortest survivable quiet stretch.
+        let shortest_budget_secs = max_beats * min_interval;
+
+        assert!(
+            shortest_budget_secs >= window,
+            "a worker obeying the instructed cadence is finalized after {shortest_budget_secs}s \
+             of legitimate quiet work, short of the {window}s no-progress window"
+        );
+        // 12 minutes is the observed codex indexing ceiling — a run must survive it silently.
+        assert!(
+            shortest_budget_secs > 12 * 60,
+            "budget {shortest_budget_secs}s is shorter than a normal codex indexing pass"
+        );
+    }
+
+    /// #141 defect B: the instructed cadence used to be prose ("every 60-90s") whose upper
+    /// bound landed EXACTLY on the 90s cutoff, so ordinary jitter reclaimed a healthy worker.
+    /// Assert the relationship between the two values, not the literals — the point is that
+    /// they cannot drift apart.
+    #[test]
+    fn instructed_cadence_keeps_safety_margin_under_stuck_cutoff() {
+        // Read the constants through a call so the assertions exercise real values instead
+        // of being folded into `assert!(true)`.
+        fn derived_cadence() -> (u64, u64, u64, u64) {
+            (
+                HEARTBEAT_MIN_INTERVAL_SECS,
+                HEARTBEAT_MAX_INTERVAL_SECS,
+                HEARTBEAT_SAFETY_FACTOR,
+                STUCK_CUTOFF_MS as u64,
+            )
+        }
+
+        let (min, max, factor, cutoff_ms) = derived_cadence();
+
+        assert!(
+            factor >= 2,
+            "a factor below 2 leaves no room for a single missed beat"
+        );
+        assert!(
+            max * factor * 1_000 < cutoff_ms,
+            "instructed max cadence {max}s x{factor} must stay strictly under \
+             STUCK_CUTOFF_MS ({cutoff_ms}ms)"
+        );
+        assert!(
+            min > 0 && min <= max,
+            "cadence bounds {min}-{max}s must describe a usable range"
+        );
+        assert_eq!(
+            heartbeat_cadence_label(),
+            format!("every {min}-{max}s"),
+            "the prompt-facing label must report the derived bounds verbatim"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use crate::artifacts::collector::ArtifactCollector;
 use crate::cli::{CliBehavior, CliRegistry};
+use crate::coordination::queue_manager::{heartbeat_cadence_label, STUCK_CUTOFF_SECS};
 use crate::coordination::{HierarchyNode, StateManager, WorkerStateInfo};
 use crate::domain::{ArtifactBundle, HiveExecutionPolicy, HiveLaunchKind, WorkspaceStrategy};
 use crate::events::{EventBus, EventEmitter};
@@ -764,9 +765,18 @@ fn get_polling_instructions(
     role_type: Option<&str>,
     heartbeat_command: Option<&str>,
 ) -> String {
+    // #141: the cadence is derived from the reclaim cutoff, and EVERY behavior gets it. A
+    // behavior that receives no cadence instruction produces a silent worker, and a silent
+    // worker is indistinguishable from a dead one to `reclaim_stuck`.
+    let cadence = heartbeat_cadence_label();
     let heartbeat_line = heartbeat_command
         .map(|command| format!("  {command}\n"))
         .unwrap_or_default();
+    // Behaviors that get no bash loop need the same instruction in their own register.
+    let heartbeat_block = |lead: &str| match heartbeat_command {
+        Some(command) => format!("\n{lead}\n```bash\n{command}\n```\n"),
+        None => String::new(),
+    };
 
     match CliRegistry::get_behavior_for_role(cli, role_type) {
         CliBehavior::ExplicitPolling => {
@@ -776,16 +786,20 @@ fn get_polling_instructions(
 Run this bash loop to wait for task activation:
 ```bash
 while true; do
-  STATUS=$(grep "^## Status:" "{}" | head -1)
+  STATUS=$(grep "^## Status:" "{task_file}" | head -1)
   if [[ "$STATUS" == *"ACTIVE"* ]]; then break; fi
-{}
-  sleep {}
+{heartbeat_line}
+  sleep {poll_secs}
 done
 ```
+The `sleep {poll_secs}` keeps you inside the required heartbeat cadence ({cadence}). Do not
+lengthen it: the orchestrator requeues a worker whose last heartbeat is over {cutoff_secs}s old.
 "#,
-                task_file,
-                heartbeat_line,
-                ACTIVATION_POLL_INTERVAL.as_secs()
+                task_file = task_file,
+                heartbeat_line = heartbeat_line,
+                poll_secs = ACTIVATION_POLL_INTERVAL.as_secs(),
+                cadence = cadence,
+                cutoff_secs = STUCK_CUTOFF_SECS,
             )
         }
         CliBehavior::ActionProne => {
@@ -794,30 +808,45 @@ done
 ## WAIT FOR ACTIVATION (CRITICAL)
 WARNING: You MUST wait for your task file Status to become ACTIVE.
 WARNING: Do NOT start working just because you received this prompt.
-WARNING: Read {} - if Status is STANDBY, WAIT.
-
-Check the file, then wait. Do not proceed until ACTIVE.
+WARNING: Read {task_file} - if Status is STANDBY, WAIT.
+WARNING: Waiting is NOT silence. You MUST send a heartbeat {cadence} the entire time you
+wait. The orchestrator requeues a worker whose last heartbeat is over {cutoff_secs}s old.
+{heartbeat_block}
+Check the file, heartbeat, then wait. Do not proceed until ACTIVE.
 "#,
-                task_file
+                task_file = task_file,
+                cadence = cadence,
+                cutoff_secs = STUCK_CUTOFF_SECS,
+                heartbeat_block = heartbeat_block("Send this heartbeat while waiting:"),
             )
         }
         CliBehavior::InstructionFollowing => {
             format!(
                 r#"
 ## Task Coordination
-Read {}. Begin work only when Status is ACTIVE.
-"#,
-                task_file
+Read {task_file}. Begin work only when Status is ACTIVE.
+While the status is still STANDBY, send a heartbeat {cadence}. A worker whose last heartbeat
+is over {cutoff_secs}s old is treated as stuck and its run is requeued.
+{heartbeat_block}"#,
+                task_file = task_file,
+                cadence = cadence,
+                cutoff_secs = STUCK_CUTOFF_SECS,
+                heartbeat_block = heartbeat_block("Heartbeat command:"),
             )
         }
         CliBehavior::Interactive => {
             format!(
                 r#"
 ## Task Coordination
-Read {}. Begin work only when Status is ACTIVE.
+Read {task_file}. Begin work only when Status is ACTIVE.
 Use the interactive interface to monitor your task file.
-"#,
-                task_file
+While you monitor, run this heartbeat {cadence} from the interactive shell. A worker whose
+last heartbeat is over {cutoff_secs}s old is treated as stuck and its run is requeued.
+{heartbeat_block}"#,
+                task_file = task_file,
+                cadence = cadence,
+                cutoff_secs = STUCK_CUTOFF_SECS,
+                heartbeat_block = heartbeat_block("Heartbeat command:"),
             )
         }
     }
@@ -6205,7 +6234,9 @@ Use only the native tools exposed by the configured harness. The Capability Card
 - Send progress, blockers, and completion evidence to POST /api/sessions/{session_id}/conversations/queen/append.
 - If the API is unavailable, append the same message to {queen_conversation}.
 
-Heartbeat while active:
+Heartbeat while active ({heartbeat_cadence} — REQUIRED). Long silent stretches (indexing, builds,
+long tool calls) still need it: a run whose last heartbeat is over {stuck_cutoff_secs}s old is
+treated as stuck and requeued.
 {working_heartbeat}
 
 {learnings_section}{project_context}After reporting completion, stop and continue monitoring the inbox without sending another heartbeat. Do not take a new task until its task file status is ACTIVE; once reactivated, send a working heartbeat."#,
@@ -6230,6 +6261,8 @@ Heartbeat while active:
             queen_conversation = queen_conversation,
             shared_conversation = shared_conversation,
             working_heartbeat = working_heartbeat,
+            heartbeat_cadence = heartbeat_cadence_label(),
+            stuck_cutoff_secs = STUCK_CUTOFF_SECS,
             learnings_section = learnings_section,
             project_context = project_context,
         )
@@ -14024,6 +14057,10 @@ mod tests {
         FusionVariantMetadata, QaWorkerConfig, Session, SessionController, SessionError,
         SessionState, SessionType,
     };
+    use super::{heartbeat_cadence_label, CliBehavior, CliRegistry, ACTIVATION_POLL_INTERVAL};
+    use crate::coordination::queue_manager::{
+        HEARTBEAT_MAX_INTERVAL_SECS, HEARTBEAT_MIN_INTERVAL_SECS,
+    };
     use crate::domain::{ArtifactBundle, HiveExecutionPolicy, WorkspaceStrategy};
     use crate::pty::{AgentRole, AgentStatus, PtyManager, WorkerRole};
     use crate::workspace::git::current_head;
@@ -14543,6 +14580,185 @@ mod tests {
             &restored.execution_policy,
         );
         assert!(prompt.contains(&SessionController::prompt_path(&task_path)));
+    }
+
+    /// Every `CliBehavior` must name a CLI here. Adding a variant breaks this match at
+    /// compile time, which forces the new behavior into the coverage test below instead of
+    /// letting it silently ship without a heartbeat instruction (#141 defect A).
+    fn representative_cli_for(behavior: &CliBehavior) -> &'static str {
+        match behavior {
+            CliBehavior::ActionProne => "claude",
+            CliBehavior::InstructionFollowing => "qwen",
+            CliBehavior::ExplicitPolling => "codex",
+            CliBehavior::Interactive => "droid",
+        }
+    }
+
+    /// Enumerate every `CliBehavior` EXHAUSTIVELY BY CONSTRUCTION. A hand-written `vec![]`
+    /// would compile unchanged when a variant is added, so the new behavior would never be
+    /// rendered by the coverage test below and its polling arm would ship uncovered — the
+    /// exhaustive match in `representative_cli_for` forces a variant to NAME a CLI, not to
+    /// enter the iterated collection. The successor chain below closes that gap: its match
+    /// is compiler-checked, so a fifth variant is a build error here (E0004) rather than a
+    /// silent hole. A `const ALL: [CliBehavior; N]` would NOT work — array arity is not tied
+    /// to variant count.
+    fn all_cli_behaviors() -> Vec<CliBehavior> {
+        let mut all = Vec::new();
+        let mut next = Some(CliBehavior::ActionProne);
+        while let Some(behavior) = next {
+            next = match behavior {
+                CliBehavior::ActionProne => Some(CliBehavior::InstructionFollowing),
+                CliBehavior::InstructionFollowing => Some(CliBehavior::ExplicitPolling),
+                CliBehavior::ExplicitPolling => Some(CliBehavior::Interactive),
+                CliBehavior::Interactive => None,
+            };
+            all.push(behavior);
+        }
+        all
+    }
+
+    fn worker_prompt_for_cli(cli: &str) -> String {
+        let temp = tempfile::tempdir().expect("temp project");
+        SessionController::build_worker_prompt(
+            1,
+            &AgentConfig {
+                cli: cli.to_string(),
+                role: Some(WorkerRole::new("backend", "Backend", cli)),
+                ..AgentConfig::default()
+            },
+            "session-141-queen",
+            "session-141",
+            temp.path(),
+            temp.path(),
+            &HiveExecutionPolicy::default(),
+        )
+    }
+
+    /// #141 defect A: `heartbeat_line` was interpolated only into the `ExplicitPolling` arm,
+    /// so workers on the other three behaviors were handed no heartbeat instruction at all
+    /// and went silent straight into `reclaim_stuck`. Asserted against the RENDERED prompt,
+    /// not a template constant.
+    #[test]
+    fn worker_prompt_instructs_heartbeat_cadence_for_every_cli_behavior() {
+        let cadence = heartbeat_cadence_label();
+
+        for behavior in all_cli_behaviors() {
+            let cli = representative_cli_for(&behavior);
+            assert_eq!(
+                CliRegistry::get_behavior(cli),
+                behavior,
+                "representative CLI {cli} no longer maps to the behavior it stands in for"
+            );
+
+            let prompt = worker_prompt_for_cli(cli);
+            assert!(
+                prompt.contains(&cadence),
+                "{behavior:?} ({cli}) prompt carries no heartbeat cadence instruction"
+            );
+            assert!(
+                prompt.contains(r#""status":"idle""#),
+                "{behavior:?} ({cli}) prompt drops the activation-wait heartbeat command"
+            );
+            assert!(
+                prompt.contains(r#""status":"working""#),
+                "{behavior:?} ({cli}) prompt drops the active-work heartbeat command"
+            );
+            assert!(
+                prompt.contains("/api/sessions/session-141/heartbeat"),
+                "{behavior:?} ({cli}) prompt has no heartbeat endpoint to call"
+            );
+
+            // The active-work heartbeat is the one that keeps a `running` queue row fresh,
+            // so its own instruction must state the cadence rather than leaving the worker
+            // to infer it from the activation-wait section.
+            let active_line = prompt
+                .lines()
+                .find(|line| line.starts_with("Heartbeat while active"))
+                .unwrap_or_else(|| {
+                    panic!("{behavior:?} ({cli}) prompt has no active-work heartbeat instruction")
+                });
+            assert!(
+                active_line.contains(&cadence),
+                "{behavior:?} ({cli}) active-work heartbeat states no cadence: {active_line}"
+            );
+
+            // #155/#156 on the status axis: the completed heartbeat is built outside the
+            // CliBehavior match, so it already reaches every behavior. Guard that — gating it
+            // the way `heartbeat_line` was gated would resurrect the same defect.
+            assert!(
+                prompt.contains("Completion Protocol (MANDATORY)")
+                    && prompt.contains(r#""status":"completed""#),
+                "{behavior:?} ({cli}) prompt drops the completed heartbeat instruction"
+            );
+
+            // The polling section must stand on its own: a worker parked in STANDBY never
+            // reaches the active-work section.
+            let polling = super::get_polling_instructions(
+                cli,
+                "worker-1-task.md",
+                Some("backend"),
+                Some("HEARTBEAT_COMMAND"),
+            );
+            assert!(
+                polling.contains(&cadence) && polling.contains("HEARTBEAT_COMMAND"),
+                "{behavior:?} ({cli}) polling section omits the heartbeat instruction: {polling}"
+            );
+        }
+    }
+
+    /// The behavior enum is only reachable in production through real CLI names, so cover
+    /// the allowlist too: a CLI whose behavior mapping changes must not lose its cadence.
+    #[test]
+    fn every_allowlisted_cli_receives_the_heartbeat_cadence() {
+        let cadence = heartbeat_cadence_label();
+
+        for cli in crate::adapters::VALID_CLIS {
+            let prompt = worker_prompt_for_cli(cli);
+            assert!(
+                prompt.contains(&cadence),
+                "cli {cli} prompt carries no heartbeat cadence instruction"
+            );
+            assert!(
+                prompt.contains(r#""status":"idle""#),
+                "cli {cli} prompt drops the activation-wait heartbeat command"
+            );
+
+            // Assert the POLLING SECTION on its own. The whole-prompt check above is ALSO
+            // satisfied by the unconditional "Heartbeat while active" line, which lives
+            // outside the `CliBehavior` match — so on its own it can never see a behavior arm
+            // that drops the cadence. This is also the assertion that covers the
+            // `get_behavior` catch-all: a CLI added to VALID_CLIS with no mapping arm
+            // silently inherits ActionProne, and only a VALID_CLIS-driven loop notices.
+            let polling = super::get_polling_instructions(
+                cli,
+                "worker-1-task.md",
+                Some("backend"),
+                Some("HEARTBEAT_COMMAND"),
+            );
+            assert!(
+                polling.contains(&cadence) && polling.contains("HEARTBEAT_COMMAND"),
+                "cli {cli} polling section omits the heartbeat instruction: {polling}"
+            );
+        }
+    }
+
+    /// The `ExplicitPolling` loop is one of several cadences enforced by code rather than by
+    /// the model obeying prose — the evaluator and prince poll loops in `templates/` are the
+    /// others, and they are guarded by `heartbeat_loops_sleep_within_the_instructed_cadence`.
+    /// Wherever a sleep sits between two heartbeats, it must satisfy the instruction it
+    /// ships with.
+    #[test]
+    fn activation_poll_loop_obeys_the_instructed_cadence() {
+        assert!(
+            ACTIVATION_POLL_INTERVAL.as_secs() <= HEARTBEAT_MAX_INTERVAL_SECS,
+            "polling loop sleeps {}s, longer than the instructed {HEARTBEAT_MAX_INTERVAL_SECS}s maximum",
+            ACTIVATION_POLL_INTERVAL.as_secs()
+        );
+        assert!(
+            ACTIVATION_POLL_INTERVAL.as_secs() >= HEARTBEAT_MIN_INTERVAL_SECS,
+            "polling loop sleeps {}s, shorter than the instructed {HEARTBEAT_MIN_INTERVAL_SECS}s minimum",
+            ACTIVATION_POLL_INTERVAL.as_secs()
+        );
     }
 
     #[test]

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -497,6 +497,8 @@ implementation being evaluated.
    The first poll waits {{evaluator_first_poll_interval}} (`sleep {{evaluator_first_poll_secs}}`); after that, poll every {{idle_poll_interval}} (`sleep {{idle_poll_secs}}`).
    The heartbeat is nested INSIDE the wait so it keeps the required {{heartbeat_cadence}}
    cadence: the file check may be slow, but going quiet gets your run treated as stuck.
+   The sleep is clamped to whatever is LEFT of the wait, so a short poll window never
+   overshoots into a longer sleep than it asked for.
    ```bash
    FIRST_WAIT=1
    while [ ! -f ".hive-manager/{{session_id}}/peer/milestone-ready.json" ]; do
@@ -509,8 +511,12 @@ implementation being evaluated.
      WAITED=0
      while [ "$WAITED" -lt "$WAIT_FOR" ]; do
        {{evaluator_idle_heartbeat_snippet}}
-       sleep {{heartbeat_interval_secs}}
-       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+       SLEEP_TIME={{heartbeat_interval_secs}}
+       if [ $((WAIT_FOR - WAITED)) -lt "$SLEEP_TIME" ]; then
+         SLEEP_TIME=$((WAIT_FOR - WAITED))
+       fi
+       sleep "$SLEEP_TIME"
+       WAITED=$((WAITED + SLEEP_TIME))
      done
    done
    cat ".hive-manager/{{session_id}}/peer/milestone-ready.json"
@@ -535,7 +541,7 @@ Use these defaults when spawning QA workers unless the plan specifies otherwise.
 1. You MUST act as a coordinator, not a tester.
 2. You MUST spawn all {{qa_worker_count}} QA workers one at a time in this exact order:
 {{qa_worker_spawn_plan}}
-3. You MUST poll worker task files every {{active_poll_interval}} (`sleep {{active_poll_secs}}`) until every QA worker reaches `COMPLETED` or `BLOCKED`, and emit a heartbeat {{heartbeat_cadence}} while you wait. The heartbeat is nested INSIDE the poll interval on purpose — checking task files slowly is fine, going quiet is not:
+3. You MUST poll worker task files every {{active_poll_interval}} (`sleep {{active_poll_secs}}`) until every QA worker reaches `COMPLETED` or `BLOCKED`, and emit a heartbeat {{heartbeat_cadence}} while you wait. The heartbeat is nested INSIDE the poll interval on purpose — checking task files slowly is fine, going quiet is not. The sleep is clamped to whatever is LEFT of the poll interval, so a short interval never overshoots:
    ```bash
    while true; do
      # Check QA worker task files here; break when all are COMPLETED or BLOCKED.
@@ -544,8 +550,12 @@ Use these defaults when spawning QA workers unless the plan specifies otherwise.
        curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
          -H "Content-Type: application/json" \
          -d '{"agent_id":"{{session_id}}-evaluator","status":"working","summary":"Polling QA workers"}'
-       sleep {{heartbeat_interval_secs}}
-       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+       SLEEP_TIME={{heartbeat_interval_secs}}
+       if [ $(({{active_poll_secs}} - WAITED)) -lt "$SLEEP_TIME" ]; then
+         SLEEP_TIME=$(({{active_poll_secs}} - WAITED))
+       fi
+       sleep "$SLEEP_TIME"
+       WAITED=$((WAITED + SLEEP_TIME))
      done
    done
    ```
@@ -1005,6 +1015,7 @@ git, build, and test commands against that path.
 1. You MUST poll for the Evaluator's verdict. You MUST NOT use `/loop`.
    The heartbeat is nested INSIDE the {{idle_poll_secs}}s file poll so it keeps the required
    {{heartbeat_cadence}} cadence — a run that goes quiet longer than that is treated as stuck.
+   The sleep is clamped to whatever is LEFT of the file poll, so a short poll never overshoots.
    ```bash
    while [ ! -f ".hive-manager/{{session_id}}/peer/qa-verdict.json" ]; do
      WAITED=0
@@ -1012,8 +1023,12 @@ git, build, and test commands against that path.
        curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
          -H "Content-Type: application/json" \
          -d '{"agent_id":"{{session_id}}-prince","status":"idle","summary":"Waiting for QA verdict"}'
-       sleep {{heartbeat_interval_secs}}
-       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+       SLEEP_TIME={{heartbeat_interval_secs}}
+       if [ $(({{idle_poll_secs}} - WAITED)) -lt "$SLEEP_TIME" ]; then
+         SLEEP_TIME=$(({{idle_poll_secs}} - WAITED))
+       fi
+       sleep "$SLEEP_TIME"
+       WAITED=$((WAITED + SLEEP_TIME))
      done
    done
    cat ".hive-manager/{{session_id}}/peer/qa-verdict.json"
@@ -1044,15 +1059,21 @@ git, build, and test commands against that path.
    - You MUST put the full finding text to resolve, verbatim, in `initial_task`.
 2. You MUST poll your fixers' task files every {{active_poll_secs}}s until each reaches
    `COMPLETED` or `BLOCKED`. Poll the files on that interval, but send this heartbeat
-   {{heartbeat_cadence}} throughout — the file poll is slow by design, your heartbeat is not:
+   {{heartbeat_cadence}} throughout — the file poll is slow by design, your heartbeat is not.
+   The sleep is clamped to whatever is LEFT of the poll interval, so a short interval never
+   overshoots:
    ```bash
    WAITED=0
    while [ "$WAITED" -lt {{active_poll_secs}} ]; do
      curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
        -H "Content-Type: application/json" \
        -d '{"agent_id":"{{session_id}}-prince","status":"working","summary":"Driving fixers"}'
-     sleep {{heartbeat_interval_secs}}
-     WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+     SLEEP_TIME={{heartbeat_interval_secs}}
+     if [ $(({{active_poll_secs}} - WAITED)) -lt "$SLEEP_TIME" ]; then
+       SLEEP_TIME=$(({{active_poll_secs}} - WAITED))
+     fi
+     sleep "$SLEEP_TIME"
+     WAITED=$((WAITED + SLEEP_TIME))
    done
    ```
 3. You MUST verify each finding is actually resolved (inspect the diff / re-run the relevant check).
@@ -2327,6 +2348,173 @@ mod tests {
         }
     }
 
+    /// Poll-interval profiles a heartbeat loop has to survive: `(label, idle, active,
+    /// evaluator_first)`. `standard` and `smoke` mirror `polling_intervals.rs`; `tight` is
+    /// the degenerate case the #169 review named, where the poll window is far SHORTER than
+    /// the heartbeat cadence and an unclamped sleep overshoots it 8x.
+    const POLL_PROFILES: [(&str, &str, &str, &str); 3] = [
+        ("standard", "480", "480", "1200"),
+        ("smoke", "30", "15", "30"),
+        ("tight", "5", "5", "5"),
+    ];
+
+    fn heartbeat_loop_context(idle: &str, active: &str, evaluator_first: &str) -> PromptContext {
+        let mut variables = HashMap::new();
+        variables.insert("agent_id".to_string(), "session-141-worker-1".to_string());
+        variables.insert("heartbeat_status".to_string(), "working".to_string());
+        variables.insert("heartbeat_summary".to_string(), "Implementing".to_string());
+        variables.insert("idle_poll_secs".to_string(), idle.to_string());
+        variables.insert("active_poll_secs".to_string(), active.to_string());
+        variables.insert(
+            "evaluator_first_poll_secs".to_string(),
+            evaluator_first.to_string(),
+        );
+        PromptContext {
+            session_id: "session-141".to_string(),
+            project_path: ".".to_string(),
+            task: Some("Build API".to_string()),
+            variables,
+        }
+    }
+
+    /// Right-hand side of every `NAME=...` assignment in `block`, in source order.
+    fn shell_assignments<'a>(block: &'a str, name: &str) -> Vec<&'a str> {
+        let prefix = format!("{name}=");
+        block
+            .lines()
+            .filter_map(|line| line.trim().strip_prefix(prefix.as_str()))
+            .map(str::trim)
+            .collect()
+    }
+
+    /// `if [ EXPR -lt "$var" ]; then` -> `Some(EXPR)`. Any other line -> `None`.
+    fn downward_guard_expression<'a>(line: &'a str, var: &str) -> Option<&'a str> {
+        let rest = line.trim().strip_prefix("if [ ")?;
+        let quoted = format!("-lt \"${var}\" ]");
+        let bare = format!("-lt ${var} ]");
+        let cut = rest.find(&quoted).or_else(|| rest.find(&bare))?;
+        Some(rest[..cut].trim())
+    }
+
+    /// The poll window an inner `while [ "$WAITED" -lt <token> ]` loop is serving, as
+    /// `(ident, seconds)`. `None` means the block has no such loop. Panics rather than
+    /// returning `None` when a window exists but cannot be resolved — an unresolvable
+    /// window would silently drop this guard's coverage of that block.
+    fn resolve_poll_window(label: &str, block: &str) -> Option<(String, u64)> {
+        let mut window = None;
+        for line in block.lines() {
+            let Some(rest) = line.trim().strip_prefix("while [ \"$WAITED\" -lt ") else {
+                continue;
+            };
+            let token = rest.split(']').next().unwrap_or("").trim().trim_matches('"');
+            if let Ok(secs) = token.parse::<u64>() {
+                window = Some((token.to_string(), secs));
+                continue;
+            }
+            // A shell-variable window (the evaluator's `$WAIT_FOR`): the loop must fit
+            // inside the SMALLEST value the block ever assigns it, so bound on that.
+            let ident = token.trim_start_matches('$').to_string();
+            let tightest = shell_assignments(block, &ident)
+                .into_iter()
+                .filter_map(|rhs| rhs.parse::<u64>().ok())
+                .min()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{label}: poll window `{token}` has no literal assignment in its \
+                         block, so no sleep in it can be bounded — resolve the window or \
+                         this guard is scanning blind"
+                    )
+                });
+            window = Some((ident, tightest));
+        }
+        window
+    }
+
+    /// Prove that `sleep "$var"` can never exceed the cadence OR the poll window, without
+    /// evaluating shell arithmetic.
+    ///
+    /// A general shell-arithmetic evaluator is out of scope, and simply skipping `$`-tokens
+    /// would make this guard blind to the exact four loops the clamp lives in. So the SHAPE
+    /// is pinned instead — the only shape that is provably non-raising:
+    ///   1. the first assignment is a literal no larger than the instructed cadence, and
+    ///   2. every later assignment sits directly under an `if [ EXPR -lt "$var" ]` guard and
+    ///      assigns that same `EXPR` — a branch taken only when `EXPR` is already smaller,
+    ///      assigning exactly what was proven smaller, so `var` can only ever go DOWN, and
+    ///   3. `EXPR` is the time remaining in this loop's own window (`window - WAITED`), so
+    ///      the clamp restores the loop's polling semantics rather than some other bound.
+    fn assert_sleep_var_is_clamped(label: &str, block: &str, var: &str, window_ident: &str) {
+        let lines: Vec<&str> = block.lines().collect();
+        let prefix = format!("{var}=");
+        let mut initialised: Option<u64> = None;
+        let mut clamps = 0usize;
+
+        for (idx, line) in lines.iter().enumerate() {
+            let Some(rhs) = line.trim().strip_prefix(prefix.as_str()) else {
+                continue;
+            };
+            let rhs = rhs.trim();
+
+            if initialised.is_none() {
+                let init = rhs.parse::<u64>().unwrap_or_else(|_| {
+                    panic!(
+                        "{label}: `sleep \"${var}\"` — the first assignment is `{var}={rhs}`, \
+                         not a literal. {var} must start from the rendered heartbeat interval \
+                         or its bound is unprovable"
+                    )
+                });
+                assert!(
+                    init <= HEARTBEAT_MAX_INTERVAL_SECS,
+                    "{label}: {var} is initialised to {init}s, ABOVE the instructed \
+                     {HEARTBEAT_MAX_INTERVAL_SECS}s cadence — the loop would beat slower than \
+                     the prompt it ships with"
+                );
+                initialised = Some(init);
+                continue;
+            }
+
+            let guard = idx
+                .checked_sub(1)
+                .and_then(|prev| downward_guard_expression(lines[prev], var))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{label}: `{var}={rhs}` is not the body of an \
+                         `if [ ... -lt \"${var}\" ]` guard — an unguarded reassignment can \
+                         RAISE the sleep above the {HEARTBEAT_MAX_INTERVAL_SECS}s cadence"
+                    )
+                });
+            assert_eq!(
+                guard, rhs,
+                "{label}: the clamp tests `{guard}` but assigns `{rhs}` — only assigning the \
+                 very expression proven smaller can lower {var}"
+            );
+            // Operand ORDER, not just operand presence. `$((WAITED - 480))` mentions both
+            // idents and is textually identical on each side of the guard, so a containment
+            // check alone accepts it — while it evaluates negative, `sleep` rejects the
+            // argument, and the loop spins hot hammering the heartbeat endpoint. That is a
+            // worse failure than the overshoot this clamp exists to fix.
+            let remaining = format!("{window_ident} - WAITED");
+            assert!(
+                guard.contains(&remaining),
+                "{label}: the clamp tests `{guard}`, which is not the time REMAINING in this \
+                 loop's own window — that must be `{remaining}` in exactly that order. \
+                 Reversed operands evaluate negative, `sleep` rejects it, and the loop spins \
+                 without ever sleeping"
+            );
+            clamps += 1;
+        }
+
+        assert!(
+            initialised.is_some(),
+            "{label}: `sleep \"${var}\"` with no assignment to {var} anywhere in the block — \
+             an unbounded sleep in a heartbeat loop"
+        );
+        assert!(
+            clamps >= 1,
+            "{label}: `sleep \"${var}\"` is never clamped down to the remaining poll window, \
+             so a window shorter than {HEARTBEAT_MAX_INTERVAL_SECS}s overshoots it"
+        );
+    }
+
     /// #141 follow-up: a heartbeat nested in a bash loop is a cadence enforced by CODE, not
     /// by the model obeying prose — the loop's own `sleep` decides the real beat rate, and
     /// prose stating otherwise is decoration. The evaluator and prince polled files every
@@ -2335,72 +2523,156 @@ mod tests {
     /// Assert the structural rule instead of any literal: every `sleep` sitting between two
     /// heartbeats must stay within the instructed cadence. A literal sweep (the `60-90`
     /// check above) structurally cannot catch this.
+    ///
+    /// #169 review: #141 then over-corrected, sleeping the full cadence UNCONDITIONALLY
+    /// inside the poll loop, so a 15s smoke window slept 40s — an 8x overshoot in the other
+    /// direction. A sleep must therefore fit inside BOTH bounds: the cadence (going quiet is
+    /// fatal) and the loop's own poll window (overshooting it changes the loop's semantics).
+    /// Sleeping LESS than the cadence is always safe; sleeping more is not.
     #[test]
     fn heartbeat_loops_sleep_within_the_instructed_cadence() {
-        let engine = TemplateEngine::default();
-
-        let mut variables = HashMap::new();
-        variables.insert("agent_id".to_string(), "session-141-worker-1".to_string());
-        variables.insert("heartbeat_status".to_string(), "working".to_string());
-        variables.insert("heartbeat_summary".to_string(), "Implementing".to_string());
-        // The real STANDARD_* wiring from `polling_intervals.rs`: what every non-smoke
-        // session renders. Substituting them is what makes the sleeps parseable below.
-        variables.insert("idle_poll_secs".to_string(), "480".to_string());
-        variables.insert("active_poll_secs".to_string(), "480".to_string());
-        variables.insert("evaluator_first_poll_secs".to_string(), "1200".to_string());
-        let context = PromptContext {
-            session_id: "session-141".to_string(),
-            project_path: ".".to_string(),
-            task: Some("Build API".to_string()),
-            variables,
-        };
-
-        let names: Vec<String> = engine.builtin_templates.keys().cloned().collect();
+        // Counted across ALL profiles, and asserted only once every profile has been
+        // scanned: the per-sleep assertions are the substantive ones, and a profile-scoped
+        // count guard would short-circuit them before the short-window profiles ever ran.
         let mut heartbeat_blocks = 0usize;
+        let mut clamped_sleeps: Vec<String> = Vec::new();
 
-        for name in names {
-            let rendered = match engine.render_template(&name, &context) {
-                Ok(rendered) => rendered,
-                // A template needing variables this test does not supply is not the subject
-                // here; the ones that carry heartbeat loops all render from the set above.
-                Err(_) => continue,
-            };
+        for (profile, idle, active, evaluator_first) in POLL_PROFILES {
+            let engine = TemplateEngine::default();
+            let context = heartbeat_loop_context(idle, active, evaluator_first);
+            let names: Vec<String> = engine.builtin_templates.keys().cloned().collect();
 
-            for block in rendered.split("```bash").skip(1) {
-                let block = block.split("```").next().unwrap_or("");
-                if !block.contains("/heartbeat") {
-                    continue;
-                }
-                heartbeat_blocks += 1;
+            for name in names {
+                let rendered = engine
+                    .render_template(&name, &context)
+                    .unwrap_or_else(|err| panic!("{profile}/{name}: render failed: {err:?}"));
 
-                let tokens: Vec<&str> = block.split_whitespace().collect();
-                for pair in tokens.windows(2) {
-                    if pair[0] != "sleep" {
+                for block in rendered.split("```bash").skip(1) {
+                    let block = block.split("```").next().unwrap_or("");
+                    if !block.contains("/heartbeat") {
                         continue;
                     }
-                    let secs: u64 = pair[1].parse().unwrap_or_else(|_| {
-                        panic!(
-                            "{name}: `sleep {}` inside a heartbeat loop did not resolve to a \
-                             number — an unsubstituted placeholder would hide the real cadence",
-                            pair[1]
-                        )
-                    });
-                    assert!(
-                        secs <= HEARTBEAT_MAX_INTERVAL_SECS,
-                        "{name}: heartbeat loop sleeps {secs}s, far longer than the instructed \
-                         {HEARTBEAT_MAX_INTERVAL_SECS}s maximum — the prompt's stated cadence \
-                         is decoration if the loop it ships with beats slower"
-                    );
+                    heartbeat_blocks += 1;
+
+                    let label = format!("{profile}/{name}");
+                    let window = resolve_poll_window(&label, block);
+
+                    let tokens: Vec<&str> = block.split_whitespace().collect();
+                    for pair in tokens.windows(2) {
+                        if pair[0] != "sleep" {
+                            continue;
+                        }
+                        let token = pair[1].trim_matches('"');
+
+                        if let Some(var) = token.strip_prefix('$') {
+                            let (window_ident, _) = window.as_ref().unwrap_or_else(|| {
+                                panic!(
+                                    "{label}: `sleep {token}` is not inside a \
+                                     `while [ \"$WAITED\" -lt ... ]` poll loop, so there is no \
+                                     window to bound it against"
+                                )
+                            });
+                            assert_sleep_var_is_clamped(&label, block, var, window_ident);
+                            clamped_sleeps.push(format!("{profile}/{name}"));
+                            continue;
+                        }
+
+                        let secs: u64 = token.parse().unwrap_or_else(|_| {
+                            panic!(
+                                "{label}: `sleep {token}` inside a heartbeat loop resolved to \
+                                 neither a number nor a clamped variable — an unsubstituted \
+                                 placeholder would hide the real cadence"
+                            )
+                        });
+                        assert!(
+                            secs <= HEARTBEAT_MAX_INTERVAL_SECS,
+                            "{label}: heartbeat loop sleeps {secs}s, far longer than the \
+                             instructed {HEARTBEAT_MAX_INTERVAL_SECS}s maximum — the prompt's \
+                             stated cadence is decoration if the loop it ships with beats slower"
+                        );
+                        if let Some((_, bound)) = window.as_ref() {
+                            assert!(
+                                secs <= *bound,
+                                "{label}: heartbeat loop sleeps {secs}s to serve a {bound}s poll \
+                                 window — it overshoots the window it is waiting out and changes \
+                                 the loop's polling semantics. Clamp to the remaining window."
+                            );
+                        }
+                    }
                 }
             }
         }
 
         // Guard the guard: if the block-detection heuristic stops matching, this test would
-        // pass by scanning nothing.
+        // pass by scanning nothing. Name the two templates that actually carry the clamped
+        // loops per profile, so losing any one of them fails loudly rather than quietly
+        // shrinking the count.
+        let profiles = POLL_PROFILES.len();
         assert!(
-            heartbeat_blocks >= 4,
-            "expected to scan the evaluator and prince heartbeat loops, only found \
-             {heartbeat_blocks} heartbeat-bearing bash blocks"
+            heartbeat_blocks >= 4 * profiles,
+            "expected to scan the evaluator and prince heartbeat loops in every profile, only \
+             found {heartbeat_blocks} heartbeat-bearing bash blocks"
+        );
+        for (profile, ..) in POLL_PROFILES {
+            for owner in ["roles/evaluator", "roles/prince"] {
+                let expected = format!("{profile}/{owner}");
+                // Two clamped loops apiece: evaluator idle + QA poll, prince verdict + fixers.
+                let found = clamped_sleeps.iter().filter(|got| **got == expected).count();
+                assert_eq!(
+                    found, 2,
+                    "expected 2 clamped heartbeat sleeps in {expected}, found {found} — the \
+                     four loops this guard exists for are {clamped_sleeps:?}"
+                );
+            }
+        }
+    }
+
+    /// #169 review, rendered-output half: the constants are not the deliverable, the prompt
+    /// text is. With a poll window SHORTER than the cadence, the rendered prompt must not
+    /// instruct the longer sleep — and the clamp it does render must be bound to that
+    /// window's actual number.
+    #[test]
+    fn a_poll_window_shorter_than_the_cadence_renders_no_longer_sleep() {
+        let engine = TemplateEngine::default();
+        let context = heartbeat_loop_context("5", "5", "5");
+        let cadence_sleep = format!("sleep {HEARTBEAT_MAX_INTERVAL_SECS}");
+
+        // The evaluator's window is the shell var it just assigned from the 5s poll values;
+        // the prince's is the substituted literal. Both must clamp against their own window.
+        let expected_clamps = [
+            ("roles/evaluator", "SLEEP_TIME=$((WAIT_FOR - WAITED))"),
+            ("roles/prince", "SLEEP_TIME=$((5 - WAITED))"),
+        ];
+
+        for (name, expected_clamp) in expected_clamps {
+            let rendered = engine
+                .render_template(name, &context)
+                .expect("render heartbeat-loop template");
+
+            assert!(
+                !rendered.contains(&cadence_sleep),
+                "{name}: renders `{cadence_sleep}` for a 5s poll window — an 8x-over sleep \
+                 the window never asked for"
+            );
+            assert!(
+                rendered.contains(expected_clamp),
+                "{name}: the rendered clamp `{expected_clamp}` is not bound to the 5s window \
+                 it was rendered with"
+            );
+            assert!(
+                rendered.contains("sleep \"$SLEEP_TIME\""),
+                "{name}: rendered prompt no longer sleeps the clamped value"
+            );
+        }
+
+        // The evaluator's `$WAIT_FOR` is only a 5s bound because it was assigned from the 5s
+        // poll values — assert that link, or the clamp above proves nothing about the window.
+        let evaluator = engine
+            .render_template("roles/evaluator", &context)
+            .expect("render evaluator");
+        assert!(
+            evaluator.contains("WAIT_FOR=5"),
+            "roles/evaluator: `$WAIT_FOR` is not the 5s poll window it was rendered with"
         );
     }
 

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -1063,17 +1063,20 @@ git, build, and test commands against that path.
    The sleep is clamped to whatever is LEFT of the poll interval, so a short interval never
    overshoots:
    ```bash
-   WAITED=0
-   while [ "$WAITED" -lt {{active_poll_secs}} ]; do
-     curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
-       -H "Content-Type: application/json" \
-       -d '{"agent_id":"{{session_id}}-prince","status":"working","summary":"Driving fixers"}'
-     SLEEP_TIME={{heartbeat_interval_secs}}
-     if [ $(({{active_poll_secs}} - WAITED)) -lt "$SLEEP_TIME" ]; then
-       SLEEP_TIME=$(({{active_poll_secs}} - WAITED))
-     fi
-     sleep "$SLEEP_TIME"
-     WAITED=$((WAITED + SLEEP_TIME))
+   while true; do
+     # Check each fixer's task file here; break when all are COMPLETED or BLOCKED.
+     WAITED=0
+     while [ "$WAITED" -lt {{active_poll_secs}} ]; do
+       curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
+         -H "Content-Type: application/json" \
+         -d '{"agent_id":"{{session_id}}-prince","status":"working","summary":"Driving fixers"}'
+       SLEEP_TIME={{heartbeat_interval_secs}}
+       if [ $(({{active_poll_secs}} - WAITED)) -lt "$SLEEP_TIME" ]; then
+         SLEEP_TIME=$(({{active_poll_secs}} - WAITED))
+       fi
+       sleep "$SLEEP_TIME"
+       WAITED=$((WAITED + SLEEP_TIME))
+     done
    done
    ```
 3. You MUST verify each finding is actually resolved (inspect the diff / re-run the relevant check).

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -8,6 +8,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::coordination::queue_manager::{heartbeat_cadence_label, HEARTBEAT_MAX_INTERVAL_SECS};
 use crate::domain::{SessionMode, WorkspaceStrategy};
 use crate::pty::WorkerRole;
 use crate::session::SessionType;
@@ -327,7 +328,7 @@ You are a Backend Worker in a multi-agent coding session.
 - Report progress to `queen.md` after milestones
 - Read `shared.md` for broadcasts
 
-## Heartbeat (every 60-90s — REQUIRED)
+## Heartbeat ({{heartbeat_cadence}} — REQUIRED)
 ```bash
 {{generic_heartbeat_snippet}}
 ```
@@ -365,7 +366,7 @@ You are a Frontend Worker in a multi-agent coding session.
 - Report progress to `queen.md` after milestones
 - Read `shared.md` for broadcasts
 
-## Heartbeat (every 60-90s — REQUIRED)
+## Heartbeat ({{heartbeat_cadence}} — REQUIRED)
 ```bash
 {{generic_heartbeat_snippet}}
 ```
@@ -397,7 +398,7 @@ You are a Coherence Worker in a multi-agent coding session.
 - Report progress to `queen.md` after milestones
 - Read `shared.md` for broadcasts
 
-## Heartbeat (every 60-90s — REQUIRED)
+## Heartbeat ({{heartbeat_cadence}} — REQUIRED)
 ```bash
 {{generic_heartbeat_snippet}}
 ```
@@ -429,7 +430,7 @@ You are a Simplify Worker in a multi-agent coding session.
 - Report progress to `queen.md` after milestones
 - Read `shared.md` for broadcasts
 
-## Heartbeat (every 60-90s — REQUIRED)
+## Heartbeat ({{heartbeat_cadence}} — REQUIRED)
 ```bash
 {{generic_heartbeat_snippet}}
 ```
@@ -458,7 +459,7 @@ You are a Worker in a multi-agent coding session.
 - Report progress to `queen.md` after milestones
 - Read `shared.md` for broadcasts
 
-## Heartbeat (every 60-90s — REQUIRED)
+## Heartbeat ({{heartbeat_cadence}} — REQUIRED)
 ```bash
 {{generic_heartbeat_snippet}}
 ```
@@ -494,16 +495,23 @@ implementation being evaluated.
    ```
 2. You MUST use this inline bash polling loop. You MUST NOT use `/loop`.
    The first poll waits {{evaluator_first_poll_interval}} (`sleep {{evaluator_first_poll_secs}}`); after that, poll every {{idle_poll_interval}} (`sleep {{idle_poll_secs}}`).
+   The heartbeat is nested INSIDE the wait so it keeps the required {{heartbeat_cadence}}
+   cadence: the file check may be slow, but going quiet gets your run treated as stuck.
    ```bash
    FIRST_WAIT=1
    while [ ! -f ".hive-manager/{{session_id}}/peer/milestone-ready.json" ]; do
-     {{evaluator_idle_heartbeat_snippet}}
      if [ "$FIRST_WAIT" = "1" ]; then
        FIRST_WAIT=0
-       sleep {{evaluator_first_poll_secs}}
+       WAIT_FOR={{evaluator_first_poll_secs}}
      else
-       sleep {{idle_poll_secs}}
+       WAIT_FOR={{idle_poll_secs}}
      fi
+     WAITED=0
+     while [ "$WAITED" -lt "$WAIT_FOR" ]; do
+       {{evaluator_idle_heartbeat_snippet}}
+       sleep {{heartbeat_interval_secs}}
+       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+     done
    done
    cat ".hive-manager/{{session_id}}/peer/milestone-ready.json"
    ```
@@ -527,14 +535,18 @@ Use these defaults when spawning QA workers unless the plan specifies otherwise.
 1. You MUST act as a coordinator, not a tester.
 2. You MUST spawn all {{qa_worker_count}} QA workers one at a time in this exact order:
 {{qa_worker_spawn_plan}}
-3. You MUST poll worker task files every {{active_poll_interval}} (`sleep {{active_poll_secs}}`) until every QA worker reaches `COMPLETED` or `BLOCKED`, and emit a heartbeat inside each polling iteration:
+3. You MUST poll worker task files every {{active_poll_interval}} (`sleep {{active_poll_secs}}`) until every QA worker reaches `COMPLETED` or `BLOCKED`, and emit a heartbeat {{heartbeat_cadence}} while you wait. The heartbeat is nested INSIDE the poll interval on purpose — checking task files slowly is fine, going quiet is not:
    ```bash
    while true; do
-     curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
-       -H "Content-Type: application/json" \
-       -d '{"agent_id":"{{session_id}}-evaluator","status":"working","summary":"Polling QA workers"}'
      # Check QA worker task files here; break when all are COMPLETED or BLOCKED.
-     sleep {{active_poll_secs}}
+     WAITED=0
+     while [ "$WAITED" -lt {{active_poll_secs}} ]; do
+       curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
+         -H "Content-Type: application/json" \
+         -d '{"agent_id":"{{session_id}}-evaluator","status":"working","summary":"Polling QA workers"}'
+       sleep {{heartbeat_interval_secs}}
+       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+     done
    done
    ```
 4. You MUST wait for all {{qa_worker_count}} QA workers to finish before you render the verdict.
@@ -991,12 +1003,18 @@ git, build, and test commands against that path.
 ## Phase 1: Wait For The QA Verdict
 
 1. You MUST poll for the Evaluator's verdict. You MUST NOT use `/loop`.
+   The heartbeat is nested INSIDE the {{idle_poll_secs}}s file poll so it keeps the required
+   {{heartbeat_cadence}} cadence — a run that goes quiet longer than that is treated as stuck.
    ```bash
    while [ ! -f ".hive-manager/{{session_id}}/peer/qa-verdict.json" ]; do
-     curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
-       -H "Content-Type: application/json" \
-       -d '{"agent_id":"{{session_id}}-prince","status":"idle","summary":"Waiting for QA verdict"}'
-     sleep {{idle_poll_secs}}
+     WAITED=0
+     while [ "$WAITED" -lt {{idle_poll_secs}} ]; do
+       curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
+         -H "Content-Type: application/json" \
+         -d '{"agent_id":"{{session_id}}-prince","status":"idle","summary":"Waiting for QA verdict"}'
+       sleep {{heartbeat_interval_secs}}
+       WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+     done
    done
    cat ".hive-manager/{{session_id}}/peer/qa-verdict.json"
    ```
@@ -1025,11 +1043,17 @@ git, build, and test commands against that path.
    - You MUST give each fixer a precise, self-contained task derived from the QA finding.
    - You MUST put the full finding text to resolve, verbatim, in `initial_task`.
 2. You MUST poll your fixers' task files every {{active_poll_secs}}s until each reaches
-   `COMPLETED` or `BLOCKED`, emitting a heartbeat inside each iteration:
+   `COMPLETED` or `BLOCKED`. Poll the files on that interval, but send this heartbeat
+   {{heartbeat_cadence}} throughout — the file poll is slow by design, your heartbeat is not:
    ```bash
-   curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
-     -H "Content-Type: application/json" \
-     -d '{"agent_id":"{{session_id}}-prince","status":"working","summary":"Driving fixers"}'
+   WAITED=0
+   while [ "$WAITED" -lt {{active_poll_secs}} ]; do
+     curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
+       -H "Content-Type: application/json" \
+       -d '{"agent_id":"{{session_id}}-prince","status":"working","summary":"Driving fixers"}'
+     sleep {{heartbeat_interval_secs}}
+     WAITED=$((WAITED + {{heartbeat_interval_secs}}))
+   done
    ```
 3. You MUST verify each finding is actually resolved (inspect the diff / re-run the relevant check).
    You own the outcome — do not certify on a fixer's say-so alone.
@@ -1298,7 +1322,7 @@ curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?sinc
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
 ### Broadcast to all:
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
-### Heartbeat (every 60-90s):
+### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
 
 ## Learning Curation Protocol
@@ -1432,7 +1456,7 @@ curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?sinc
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
 #### Broadcast to all:
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
-#### Heartbeat (every 60-90s):
+#### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
 
 ### Communication Format
@@ -1514,7 +1538,7 @@ curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?sinc
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
 ### Broadcast to all:
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
-### Heartbeat (every 60-90s):
+### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
 
 ## Resolver Invocation
@@ -1924,6 +1948,17 @@ You are a Planner agent managing the {{domain}} domain in a Swarm session.
         );
         let api_base_url = normalize_api_base_url(context.variables.get("api_base_url"));
         rendered = rendered.replace("{{api_base_url}}", &api_base_url);
+        // #141: cadence is substituted from the constant derived off STUCK_CUTOFF_MS, never
+        // from the caller's variables — a caller that forgot to supply it would silently ship
+        // a prompt with no cadence at all.
+        rendered = rendered.replace("{{heartbeat_cadence}}", &heartbeat_cadence_label());
+        // #141: the numeric form, for templates that sleep on a code-enforced clock rather
+        // than asking the model to obey prose. A long FILE-poll interval is fine; a long
+        // HEARTBEAT interval is not, so these two cadences must be substituted separately.
+        rendered = rendered.replace(
+            "{{heartbeat_interval_secs}}",
+            &HEARTBEAT_MAX_INTERVAL_SECS.to_string(),
+        );
         rendered = rendered.replace(
             "{{queen_heartbeat_snippet}}",
             &heartbeat_snippet(
@@ -2111,9 +2146,9 @@ mod tests {
     use crate::pty::WorkerRole;
 
     use super::{
-        builtin_role_packs, builtin_session_templates, heartbeat_snippet, normalize_api_base_url,
-        PromptContext, SessionTemplate, TemplateCatalog, TemplateEngine, TemplateError,
-        DEFAULT_API_BASE_URL,
+        builtin_role_packs, builtin_session_templates, heartbeat_cadence_label, heartbeat_snippet,
+        normalize_api_base_url, PromptContext, SessionTemplate, TemplateCatalog, TemplateEngine,
+        TemplateError, DEFAULT_API_BASE_URL, HEARTBEAT_MAX_INTERVAL_SECS,
     };
 
     #[test]
@@ -2234,6 +2269,139 @@ mod tests {
             ));
             assert!(prompt.contains("UI completion checkoff and stall monitor depend on it"));
         }
+    }
+
+    /// #141 defect B: the cadence used to be prose typed into eight templates, free to drift
+    /// from `STUCK_CUTOFF_MS`. Assert the RENDERED prompts carry the derived label and that
+    /// no hand-typed cadence survives anywhere in the built-ins.
+    #[test]
+    fn rendered_prompts_take_their_heartbeat_cadence_from_the_stuck_cutoff() {
+        let cadence = heartbeat_cadence_label();
+        let engine = TemplateEngine::default();
+
+        let mut variables = HashMap::new();
+        variables.insert("agent_id".to_string(), "session-141-worker-1".to_string());
+        variables.insert("heartbeat_status".to_string(), "working".to_string());
+        variables.insert("heartbeat_summary".to_string(), "Implementing".to_string());
+        let context = PromptContext {
+            session_id: "session-141".to_string(),
+            project_path: ".".to_string(),
+            task: Some("Build API".to_string()),
+            variables,
+        };
+
+        for role_type in ["backend", "frontend", "coherence", "simplify", "custom"] {
+            let prompt = engine
+                .render_worker_prompt(&WorkerRole::new(role_type, role_type, "claude"), &context)
+                .expect("render worker role prompt");
+            assert!(
+                prompt.contains(&cadence),
+                "roles/{role_type} lost its derived heartbeat cadence"
+            );
+            assert!(
+                !prompt.contains("{{heartbeat_cadence}}"),
+                "roles/{role_type} leaked the cadence placeholder"
+            );
+        }
+
+        for template_name in ["queen-hive", "queen-research", "queen-fusion"] {
+            let prompt = engine
+                .render_template(template_name, &context)
+                .expect("render queen prompt");
+            assert!(
+                prompt.contains(&cadence),
+                "{template_name} lost its derived heartbeat cadence"
+            );
+            assert!(
+                !prompt.contains("{{heartbeat_cadence}}"),
+                "{template_name} leaked the cadence placeholder"
+            );
+        }
+
+        let engine_with_builtins = TemplateEngine::default();
+        for (name, body) in engine_with_builtins.builtin_templates.iter() {
+            assert!(
+                !body.contains("60-90"),
+                "{name} still hardcodes a cadence instead of deriving it from STUCK_CUTOFF_MS"
+            );
+        }
+    }
+
+    /// #141 follow-up: a heartbeat nested in a bash loop is a cadence enforced by CODE, not
+    /// by the model obeying prose — the loop's own `sleep` decides the real beat rate, and
+    /// prose stating otherwise is decoration. The evaluator and prince polled files every
+    /// 480s (first poll 1200s) with the heartbeat INSIDE that loop, so they beat 12x-30x
+    /// slower than the instruction they shipped with, while the whole suite stayed green.
+    /// Assert the structural rule instead of any literal: every `sleep` sitting between two
+    /// heartbeats must stay within the instructed cadence. A literal sweep (the `60-90`
+    /// check above) structurally cannot catch this.
+    #[test]
+    fn heartbeat_loops_sleep_within_the_instructed_cadence() {
+        let engine = TemplateEngine::default();
+
+        let mut variables = HashMap::new();
+        variables.insert("agent_id".to_string(), "session-141-worker-1".to_string());
+        variables.insert("heartbeat_status".to_string(), "working".to_string());
+        variables.insert("heartbeat_summary".to_string(), "Implementing".to_string());
+        // The real STANDARD_* wiring from `polling_intervals.rs`: what every non-smoke
+        // session renders. Substituting them is what makes the sleeps parseable below.
+        variables.insert("idle_poll_secs".to_string(), "480".to_string());
+        variables.insert("active_poll_secs".to_string(), "480".to_string());
+        variables.insert("evaluator_first_poll_secs".to_string(), "1200".to_string());
+        let context = PromptContext {
+            session_id: "session-141".to_string(),
+            project_path: ".".to_string(),
+            task: Some("Build API".to_string()),
+            variables,
+        };
+
+        let names: Vec<String> = engine.builtin_templates.keys().cloned().collect();
+        let mut heartbeat_blocks = 0usize;
+
+        for name in names {
+            let rendered = match engine.render_template(&name, &context) {
+                Ok(rendered) => rendered,
+                // A template needing variables this test does not supply is not the subject
+                // here; the ones that carry heartbeat loops all render from the set above.
+                Err(_) => continue,
+            };
+
+            for block in rendered.split("```bash").skip(1) {
+                let block = block.split("```").next().unwrap_or("");
+                if !block.contains("/heartbeat") {
+                    continue;
+                }
+                heartbeat_blocks += 1;
+
+                let tokens: Vec<&str> = block.split_whitespace().collect();
+                for pair in tokens.windows(2) {
+                    if pair[0] != "sleep" {
+                        continue;
+                    }
+                    let secs: u64 = pair[1].parse().unwrap_or_else(|_| {
+                        panic!(
+                            "{name}: `sleep {}` inside a heartbeat loop did not resolve to a \
+                             number — an unsubstituted placeholder would hide the real cadence",
+                            pair[1]
+                        )
+                    });
+                    assert!(
+                        secs <= HEARTBEAT_MAX_INTERVAL_SECS,
+                        "{name}: heartbeat loop sleeps {secs}s, far longer than the instructed \
+                         {HEARTBEAT_MAX_INTERVAL_SECS}s maximum — the prompt's stated cadence \
+                         is decoration if the loop it ships with beats slower"
+                    );
+                }
+            }
+        }
+
+        // Guard the guard: if the block-detection heuristic stops matching, this test would
+        // pass by scanning nothing.
+        assert!(
+            heartbeat_blocks >= 4,
+            "expected to scan the evaluator and prince heartbeat loops, only found \
+             {heartbeat_blocks} heartbeat-bearing bash blocks"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Resolves the **unambiguous half** of #141. The PTY-derived-heartbeat redesign, raising `STUCK_CUTOFF_MS`, and the queue dashboard are all deliberately out of scope — the first is an architectural decision for the repo owner, the second fixes the wrong side, and the third cannot pass its own acceptance criterion since `queueStore` has zero Svelte consumers.

## Defect A — the cadence reached 1 of 4 CLI behaviors

`get_polling_instructions` bound `heartbeat_line` but interpolated it **only** in the `ExplicitPolling` arm. `ActionProne`, `InstructionFollowing` and `Interactive` never referenced it — so 6 of the 8 allowlisted CLIs (claude, gemini, antigravity, qwen, droid, cursor) received no heartbeat instruction at all.

That isn't cosmetic. The prompt heartbeat **is** the queue's liveness signal: `POST /api/sessions/{id}/heartbeat` → `record_heartbeat` → the `heartbeat_at` that `reclaim_stuck` compares against the cutoff. Those workers were permanently one sweep away from being reclaimed while perfectly healthy.

Every arm now emits the command and a cadence, worded in that behavior's existing register rather than pasted uniformly — `ActionProne` gets it as a WARNING line, because "waiting is not silence" is precisely the mistake that behavior makes. The `Heartbeat while active:` line in `build_worker_prompt` also stated no cadence at all, and it is the beat that keeps a RUNNING row fresh, so it now carries one and names the cutoff.

## Defect B — zero margin, by coincidence

Templates instructed "every 60-90s" against `STUCK_CUTOFF_MS = 90_000`. A worker obeying the **upper bound of its own instruction** sat exactly at the cutoff, so ordinary jitter reclaimed it.

The cadence is now derived from the cutoff in one place via `HEARTBEAT_SAFETY_FACTOR` (=2), yielding "every 20-40s" — 40 × 2 = 80s, strictly inside 90s, so a worker can miss a full beat and stay healthy. The const fn deliberately steps down one 5s granularity when the division is exact, because exact division is *precisely* the old coincidence.

Templates carry `{{heartbeat_cadence}}`, substituted in `render_prompt_text` from the constant — **not** from `context.variables`, so a caller who forgets to supply it cannot silently ship a cadence-free prompt. No hardcoded cadence prose survives in any builtin template, and a sweep test fails if one reappears.

## The critical finding: the fix for #141 nearly broke what #141 protects

Review caught that the tighter beat collides with `MAX_NO_PROGRESS_CONTINUATIONS = 5`.

`record_heartbeat` increments `no_progress_count` whenever the incoming status equals the last one — and the prompts emit a **fixed status per phase**, so consecutive beats always take that branch. Six beats at the new 20s floor finalized a *healthy* worker in **100 seconds**. And terminally: once finalized, `record_heartbeat`'s `WHERE status IN ('queued','running')` matches zero rows and `reclaim_stuck` can never recover it.

Tightening the cadence — the entire point of Defect B — would have permanently disabled the recovery path this issue exists to protect. Fixed by deriving the no-progress budget from a wall-clock window rather than a raw beat count, applying the same derive-never-hardcode discipline as the cadence itself.

## Also checked: #155 / PR #156 needed no change

The completed-heartbeat instruction is built in `build_worker_prompt`'s completion-protocol block, which branches only on `is_research` and is concatenated **outside** the `CliBehavior` match; `build_fusion_worker_prompt` embeds it unconditionally. It was never gated the way `heartbeat_line` was, so no production code changed — only a guard assertion so that gating it later fails.

## Tests

Five new tests, every assertion against **rendered builder output** rather than template constants.

- The per-behavior test iterates all variants through an **exhaustive match**: a new `CliBehavior` fails to compile until it names a representative CLI, which drops it into coverage automatically.
- The margin test asserts the **relationship** between cadence and `STUCK_CUTOFF_MS`, not the literals — and reads both through a fn call so the assertions cannot be const-folded into `assert!(true)`.
- A test pins that `ACTIVATION_POLL_INTERVAL` sits inside the instructed window, since that loop is the only place cadence is enforced by code rather than by a model obeying prose.

Every change proven load-bearing by revert → red → restore → green, reported verbatim in the workflow log. One revert attempt failed to *compile* ("named argument never used"), which is itself evidence the args are consumed.

**Review confirmed 4 findings and refuted 3.** Three of the four confirmed were test-integrity holes: a hand-written variant list a new behavior would silently escape, a cadence assertion satisfiable by an unconditional line elsewhere in the prompt, and a poll-interval test that pinned the one interval already complying while three others did not.

## Validation

| gate | result |
|---|---|
| `cargo check` | clean, zero warnings |
| `cargo check --tests` | clean, zero warnings |
| `cargo test --lib` | 555 passed, 0 failed, 1 ignored (was 548) |

## Not verified here

The live end-to-end path — launch a session, spawn a worker, watch running → heartbeat → finalized, kill the app, resume, confirm reclaim — needs the Tauri shell and real CLI spend, and there is no e2e harness in this repo. It remains a human checklist item, and it is the only way to confirm real CLI startup fits inside the first-heartbeat window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * Improved stalled-work detection with consistent, dynamically derived heartbeat and no-progress timing across workers.
  * Reduced false “stuck” classifications during prolonged low-output periods.
* **Worker Experience**
  * Heartbeat instructions are now included consistently across all worker workflows, with clearer “Heartbeat while active” guidance.
  * Activation and waiting loops were adjusted to keep heartbeat updates aligned with polling windows.
* **Bug Fixes**
  * Fixed missing/uneven heartbeat cadence guidance in specific workflows and ensured heartbeat-adjacent sleeps are properly bounded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->