### PR TITLE
chore(release): bump to 0.37.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.36.1"
+version = "0.37.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.36.1"
+version = "0.37.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Minor bump for the batch since 0.36.1.

| PR | issue | change |
|---|---|---|
| #166 | #163 | preview maximized state modelled across dock, undock and reopen |
| #167 | #120 | debater and judge prompts load prior wiki context |
| #169 | #141 | heartbeat cadence reaches every CLI behavior, derived from `STUCK_CUTOFF_MS` |

`x.Y.0` rather than a patch: #120 is a feature (Debate mode gains prior-wiki grounding it did not have), which outranks the patch bumps #163 and #141 would each imply alone.

Four files in lockstep: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)