### PR TITLE
feat(knowledge): show the whole memory system, and normalize wiki paths per CLI (#168)

### DIFF
--- a/src-tauri/src/http/handlers/knowledge.rs
+++ b/src-tauri/src/http/handlers/knowledge.rs
@@ -16,131 +16,256 @@ use super::validate_session_id;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 
-/// Compiled-in ceiling for the global wiki subtrees the Atlas may read. Operator config can only
-/// narrow or re-select within this array (see `resolve_wiki_folders_from`); it can never add a
-/// folder, so an operator config value can never become an arbitrary filesystem path.
-///
-/// `agents/` is deliberately excluded, and that exclusion is a product decision, not an oversight:
-///   1. Privacy. It holds third-party recruiting-candidate dossiers with personal contact details
-///      of people who never consented to appear in a graph UI.
-///   2. Signal. It is 63 of roughly 163 otherwise-reachable files, so including it would swamp the
-///      graph with one subtree.
-///   3. Correctness. It carries 11 unfiltered `README.md` / `_TEMPLATE.md` files. Duplicate
-///      basenames collide in the `by_title` / `by_basename` maps, `unique_lookup` then returns
-///      `None` for the ambiguous key, and unrelated edges elsewhere in the graph silently drop.
-/// Re-including `agents` therefore requires fixing (3) first, not just adding the variant.
-const WIKI_FOLDERS: [KnowledgeFolder; 7] = [
-    KnowledgeFolder::Patterns,
-    KnowledgeFolder::Practices,
-    KnowledgeFolder::Research,
-    KnowledgeFolder::Clients,
-    KnowledgeFolder::Partners,
-    KnowledgeFolder::Vendors,
-    KnowledgeFolder::Operations,
-];
 const PROJECT_FILES: [&str; 2] = ["project-dna.md", "bug-patterns.md"];
 const DEFAULT_WIKI_ROOT: &str = "~/.ai-docs/wiki";
 
-pub(crate) const MAX_NODES: usize = 400;
-pub(crate) const MAX_EDGES: usize = 1_500;
-pub(crate) const MAX_FILE_BYTES: usize = 256 * 1024;
+pub(crate) const MAX_NODES: usize = 5_000;
+pub(crate) const MAX_EDGES: usize = 20_000;
+pub(crate) const MAX_FILE_BYTES: usize = 1024 * 1024;
 const MAX_PREVIEW_BYTES: usize = 20 * 1024;
 const MAX_TITLE_BYTES: usize = 512;
 const MAX_LAST_UPDATED_BYTES: usize = 128;
-const MAX_EDGE_HINT_BYTES: usize = 512;
+const MAX_EDGE_HINT_BYTES: usize = 4 * 1024;
 const MAX_DISCOVERED_FILES: usize = MAX_NODES * 3;
 const MAX_RAW_EDGES: usize = MAX_EDGES * 8;
-const MAX_SCAN_ENTRIES: usize = 10_000;
+const MAX_SCAN_ENTRIES: usize = 100_000;
 const MAX_DIRECTORY_DEPTH: usize = 32;
-const MAX_GRAPH_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
-const GRAPH_RESPONSE_OVERHEAD_RESERVE: usize = 64 * 1024;
+/// The one cap that stays deliberately tight. Everything above bounds *work*; this bounds the
+/// single JSON document the browser must parse and hold before the force simulation can start, and
+/// no amount of "show me everything" makes an unbounded response a good idea in a webview. 8 MiB
+/// comfortably holds `MAX_NODES` nodes plus `MAX_EDGES` edges (~3 MiB at observed item sizes), so
+/// in practice the node and edge caps bind first and this only ever catches a pathological corpus.
+const MAX_GRAPH_RESPONSE_BYTES: usize = 8 * 1024 * 1024;
+const GRAPH_RESPONSE_OVERHEAD_RESERVE: usize = 256 * 1024;
 const MAX_GRAPH_ITEM_BYTES: usize = MAX_GRAPH_RESPONSE_BYTES - GRAPH_RESPONSE_OVERHEAD_RESERVE;
 const MAX_CONCURRENT_SCANS: usize = 2;
+const MAX_FOLDER_NAME_BYTES: usize = 128;
+const MAX_OMISSION_EXAMPLES: usize = 5;
 
 static KNOWLEDGE_SCAN_LIMITER: OnceLock<Semaphore> = OnceLock::new();
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
-#[serde(rename_all = "snake_case")]
-pub(crate) enum KnowledgeFolder {
-    Patterns,
-    Practices,
-    Research,
-    Clients,
-    Partners,
-    Vendors,
-    Operations,
-    Project,
-}
+/// A top-level folder of the corpus, identified by its directory name.
+///
+/// This used to be a closed enum of seven blessed folder names, which meant the operator's own
+/// `agents/` subtree (63 of their 163 pages) was invisible with no way to opt in. The trust
+/// boundary now sits where it actually belongs — the configured wiki root — and the folder set is
+/// discovered from disk by `discover_wiki_folders`. A `KnowledgeFolder` is therefore only ever
+/// constructed from (a) a directory entry that already passed canonicalization and containment
+/// checks under the root, (b) the reserved `project` tag, or (c) the reserved `root` tag. It is
+/// never built from a request parameter, so it can never carry a caller-chosen path fragment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub(crate) struct KnowledgeFolder(String);
 
 impl KnowledgeFolder {
-    /// Directory name on disk and the stable node-ID prefix carried over the API.
+    /// Session-scoped project knowledge. Reserved and *unforgeable*: the leading dot is
+    /// load-bearing, because `is_valid_folder_name` rejects dot-prefixed names and
+    /// `discover_wiki_folders` skips dot-directories. A real `<wiki>/project/` directory therefore
+    /// keeps its own `project/` namespace instead of colliding with this tag.
     ///
-    /// This is a *separate* mechanism from the `#[serde(rename_all = "snake_case")]` wire encoding
-    /// above; the two only happen to agree. Both must be updated together when a variant is added,
-    /// and `as_str_matches_the_serialized_folder_tag` pins them to each other.
-    fn as_str(self) -> &'static str {
-        match self {
-            Self::Patterns => "patterns",
-            Self::Practices => "practices",
-            Self::Research => "research",
-            Self::Clients => "clients",
-            Self::Partners => "partners",
-            Self::Vendors => "vendors",
-            Self::Operations => "operations",
-            Self::Project => "project",
-        }
+    /// The bare name `project` used to be both, which meant a wiki `project/` directory produced
+    /// graph nodes the preview endpoint answered with 400, and a `<wiki>/project/project-dna.md`
+    /// silently displaced the session's own `.ai-docs/project-dna.md`.
+    const PROJECT: &'static str = ".project";
+    /// Markdown sitting loose at the wiki root, in no folder at all — the operator's `index.md`,
+    /// `schema.md`, and `log.md` live here and were previously unreachable by construction.
+    const ROOT: &'static str = "root";
+
+    fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
     }
 
-    /// Map an ID prefix onto the *compiled-in* allowlist, deliberately ignoring any operator
-    /// narrowing. Narrowing is enforced once, at enumeration: a folder excluded by config produces
-    /// no sources, so its IDs 404 instead of 400. Keeping validation on the superset means the
-    /// status code for an unknown page does not leak which folders an operator has switched off.
-    fn from_id_prefix(prefix: &str) -> Option<Self> {
-        WIKI_FOLDERS
-            .into_iter()
-            .chain(std::iter::once(Self::Project))
-            .find(|folder| folder.as_str() == prefix)
+    fn project() -> Self {
+        Self::new(Self::PROJECT)
+    }
+
+    fn wiki_root() -> Self {
+        Self::new(Self::ROOT)
+    }
+
+    /// Directory name on disk and the stable node-ID prefix carried over the API. Because the type
+    /// is `#[serde(transparent)]`, the wire encoding *is* this string — the two can no longer drift
+    /// apart the way the old enum's `as_str` and `rename_all` tag could.
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn is_project(&self) -> bool {
+        self.0 == Self::PROJECT
+    }
+
+    /// True for the synthetic root-level bucket, which is scanned non-recursively so its pages
+    /// cannot duplicate the pages of the real folders beside it.
+    fn is_wiki_root(&self) -> bool {
+        self.0 == Self::ROOT
     }
 }
 
-/// Resolve the effective wiki folder set from optional operator config.
+/// Shape gate for a name that may become a folder tag or an ID prefix.
 ///
-/// Security property: entries are *matched against* the compiled-in `WIKI_FOLDERS` variants. They
-/// select, they never construct. An unrecognized entry — `"agents"`, `"../../../etc"`, an absolute
-/// path — is logged and dropped, so config can only ever narrow or reorder the scan, never widen
-/// it or aim it at a directory outside the wiki root.
+/// This is a *syntactic* check, not an allowlist: it rejects anything that could act as a path
+/// fragment or escape a directory level. Containment itself is enforced by canonicalization at
+/// enumeration, not here.
+fn is_valid_folder_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_FOLDER_NAME_BYTES
+        // Also excludes "." and "..", and skips editor/VCS state such as `.obsidian` and `.git`.
+        && !name.starts_with('.')
+        && !name.contains(['/', '\\', ':', '\0'])
+}
+
+/// Discover the corpus folder set by reading the wiki root.
 ///
-/// Fail closed: this is a privacy boundary, not a display preference. `None` — the key absent,
-/// which is what every pre-existing `config.json` deserializes to — means "no operator opinion"
-/// and selects the built-in default. `Some(_)` is an operator-supplied boundary and is never
-/// widened past what it names, so a list that resolves to nothing (empty, blank, or entirely
-/// unrecognized) selects nothing. A typo empties the Atlas — loud, obvious, and instantly
-/// self-correcting — instead of silently restoring `clients`, `partners`, and `vendors` to a
-/// graph the operator believed excluded them.
-fn resolve_wiki_folders_from(configured: Option<&[String]>) -> Vec<KnowledgeFolder> {
+/// The security argument moved, it did not weaken. Previously a compiled-in name list bounded the
+/// scan; now the *canonical wiki root* bounds it, and every level is still checked:
+///   - the root itself is canonicalized once, up front;
+///   - each entry's type comes from `read_dir`'s `file_type`, which is `lstat`-based, so a symlink
+///     is identified as a symlink and refused outright rather than followed;
+///   - each surviving directory is canonicalized and must still `starts_with` the canonical root,
+///     so a junction/reparse point aimed outside the wiki is dropped even on Windows;
+///   - names are shape-checked by `is_valid_folder_name`.
+/// Dot-directories are skipped: `.git` and `.obsidian` are version-control and editor state, not
+/// memory, and walking `.git` would add thousands of entries for zero recall. That is a content
+/// judgement the operator can reverse by moving a folder, not a privacy boundary.
+fn discover_wiki_folders(wiki_root: &Path) -> DiscoveredFolders {
+    let Ok(canonical_root) = fs::canonicalize(wiki_root) else {
+        return DiscoveredFolders::default();
+    };
+    let Ok(read_dir) = fs::read_dir(&canonical_root) else {
+        return DiscoveredFolders::default();
+    };
+
+    let mut folders: Vec<KnowledgeFolder> = Vec::new();
+    let mut refusals: Vec<FolderRefusal> = Vec::new();
+    let mut has_root_markdown = false;
+    for entry in read_dir.take(MAX_SCAN_ENTRIES).flatten() {
+        let raw_name = entry.file_name();
+        let Some(name) = raw_name.to_str() else {
+            // No UTF-8 name exists to use as an example, so the reason travels without one.
+            refusals.push((KnowledgeOmissionReason::FolderNameRejected, None));
+            continue;
+        };
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() {
+            refusals.push((
+                KnowledgeOmissionReason::FolderLinkRefused,
+                Some(bounded_folder_label(name)),
+            ));
+            continue;
+        }
+        if file_type.is_file() {
+            if !name.starts_with('.') && has_markdown_extension(Path::new(name)) {
+                has_root_markdown = true;
+            }
+            continue;
+        }
+        // The dot-directory skip stays silent: `.git` and `.obsidian` are editor and VCS state, a
+        // documented content judgement, not a loss the operator needs told about.
+        if name.starts_with('.') || !file_type.is_dir() {
+            continue;
+        }
+        if !is_valid_folder_name(name) {
+            refusals.push((
+                KnowledgeOmissionReason::FolderNameRejected,
+                Some(bounded_folder_label(name)),
+            ));
+            continue;
+        }
+        let Ok(canonical) = fs::canonicalize(entry.path()) else {
+            refusals.push((
+                KnowledgeOmissionReason::FolderLinkRefused,
+                Some(bounded_folder_label(name)),
+            ));
+            continue;
+        };
+        if !canonical.starts_with(&canonical_root) {
+            refusals.push((
+                KnowledgeOmissionReason::FolderLinkRefused,
+                Some(bounded_folder_label(name)),
+            ));
+            continue;
+        }
+        folders.push(KnowledgeFolder::new(name));
+    }
+    folders.sort();
+    folders.dedup();
+
+    // A real directory named `root` and the synthetic bucket share the `root/` tag, and
+    // `enumerate_sources` walks *both* subtrees under it, so emitting the tag once is enough. If a
+    // real `root/` directory was discovered it is already in `folders`; only add the synthetic tag
+    // when loose markdown exists and nothing claimed the tag yet. Should the two mint the same node
+    // ID (`<wiki>/index.md` and `<wiki>/root/index.md` both give `root/index`), the collision is
+    // reported as `DuplicateId` rather than dropped in silence.
+    if has_root_markdown && !folders.iter().any(KnowledgeFolder::is_wiki_root) {
+        folders.insert(0, KnowledgeFolder::wiki_root());
+    }
+    DiscoveredFolders { folders, refusals }
+}
+
+/// A top-level directory discovery refused, plus the folder-relative name to show as an example.
+/// Safe by construction: a bare directory name can never be an absolute path.
+type FolderRefusal = (KnowledgeOmissionReason, Option<String>);
+
+/// What `discover_wiki_folders` found, and what it turned away.
+///
+/// Discovery used to return a bare `Vec` with no reporting channel, so every directory it refused
+/// vanished while the response still said `truncated=false, omissions=[]`. An entire top-level
+/// subtree could disappear with no signal anywhere — not even in the UI folder filter, which is
+/// derived from node folders. The refusals ride along so the scan can replay them into its report.
+#[derive(Debug, Default)]
+struct DiscoveredFolders {
+    folders: Vec<KnowledgeFolder>,
+    refusals: Vec<FolderRefusal>,
+}
+
+/// Bound a folder name before it is echoed as an omission example, so an adversarially long
+/// directory name cannot inflate the response.
+fn bounded_folder_label(name: &str) -> String {
+    truncate_utf8(name.to_string(), MAX_FOLDER_NAME_BYTES).0
+}
+
+/// Resolve the effective folder set: everything discovered under the root, optionally narrowed by
+/// operator config.
+///
+/// Security property is unchanged in kind: entries are *matched against* the discovered folders.
+/// They select, they never construct. An entry naming a folder that does not exist on disk —
+/// `"../../../etc"`, `/etc/passwd`, `C:\Windows\System32` — matches nothing and is dropped, so
+/// config can still only ever narrow or reorder the scan, never aim it outside the wiki root.
+///
+/// Fail closed on a non-empty-but-unrecognized list: `None` (the key absent, which is what every
+/// pre-existing `config.json` deserializes to) means "no operator opinion" and selects everything
+/// discovered. `Some(_)` is an operator-supplied boundary and is never widened past what it names,
+/// so a typo empties the Atlas — loud, obvious, self-correcting — instead of silently restoring
+/// folders the operator believed they had excluded.
+fn resolve_wiki_folders_from(
+    configured: Option<&[String]>,
+    discovered: Vec<KnowledgeFolder>,
+) -> Vec<KnowledgeFolder> {
     let Some(configured) = configured else {
-        return WIKI_FOLDERS.to_vec();
+        return discovered;
     };
 
     let mut selected: Vec<KnowledgeFolder> = Vec::new();
     for raw in configured {
-        let name = raw.trim().to_ascii_lowercase();
+        let name = raw.trim();
         if name.is_empty() {
             continue;
         }
-        match WIKI_FOLDERS
-            .into_iter()
-            .find(|folder| folder.as_str() == name)
+        match discovered
+            .iter()
+            .find(|folder| folder.as_str().eq_ignore_ascii_case(name))
         {
             Some(folder) => {
-                if !selected.contains(&folder) {
-                    selected.push(folder);
+                if !selected.contains(folder) {
+                    selected.push(folder.clone());
                 }
             }
             None => tracing::warn!(
                 entry = %raw,
                 "ignoring unrecognized knowledge_wiki_folders entry; the Knowledge Atlas folder \
-                 set is bounded to the compiled-in wiki allowlist"
+                 set is bounded to the folders discovered under the configured wiki root"
             ),
         }
     }
@@ -151,11 +276,164 @@ fn resolve_wiki_folders_from(configured: Option<&[String]>) -> Vec<KnowledgeFold
         // build — anything below ERROR is filtered out and this failure would be fully silent.
         tracing::error!(
             configured_entries = configured.len(),
-            "knowledge_wiki_folders named no recognized folder; the Knowledge Atlas will scan no \
-             global-wiki folders. Remove the key entirely to restore the built-in default set."
+            "knowledge_wiki_folders named no folder that exists under the wiki root; the Knowledge \
+             Atlas will scan no global-wiki folders. Remove the key entirely to scan everything."
         );
     }
     selected
+}
+
+/// Why something the operator might have expected to see is not in the response.
+///
+/// A single `truncated: bool` was the original sin here: it was assigned in a dozen places, so an
+/// amber banner meant any one of "your node cap was hit", "a page was too big", "a link hint was
+/// long", or "a title got shortened" — with no way to tell which. Every one of those is now a
+/// distinct, countable reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum KnowledgeOmissionReason {
+    /// Whole pages dropped because the requested/absolute node cap filled up.
+    NodeCapReached,
+    /// Whole pages dropped because the serialized response would have exceeded its byte budget.
+    ResponseSizeCapReached,
+    /// A page exists but exceeds `MAX_FILE_BYTES` and was not parsed.
+    FileTooLarge,
+    /// A page was enumerated but could not be read back (removed mid-scan, non-UTF-8, or it failed
+    /// the open-handle identity re-check).
+    FileUnreadable,
+    /// The directory walk hit its global entry ceiling, so some directories went unvisited.
+    ScanEntryCapReached,
+    /// A directory nested deeper than `MAX_DIRECTORY_DEPTH` was not descended into.
+    DirectoryDepthExceeded,
+    /// More markdown files exist under the root than the enumerator will collect.
+    DiscoveredFileCapReached,
+    /// Resolved links dropped at the edge cap or the edge byte budget. Pages are unaffected.
+    EdgeCapReached,
+    /// Unresolved link candidates dropped before resolution. Pages are unaffected.
+    RawEdgeCapReached,
+    /// A link *hint* was longer than `MAX_EDGE_HINT_BYTES` and was not considered as a link.
+    EdgeHintTooLong,
+    /// A page title was shortened for display. The page itself is present.
+    TitleTruncated,
+    /// A `last_updated` value was shortened for display. The page itself is present.
+    LastUpdatedTruncated,
+    /// A page preview was cut at `MAX_PREVIEW_BYTES`. The page itself is present.
+    ContentTruncated,
+    /// Two sources minted the same node ID, so only the first is in the graph. Reachable when a
+    /// real `root/` directory sits beside loose root-level markdown (`<wiki>/index.md` and
+    /// `<wiki>/root/index.md` both mint `root/index`). One page was kept; the other is gone.
+    DuplicateId,
+    /// A top-level directory was a link or reparse point and was not followed, so its whole subtree
+    /// is absent. Containment, not a cap — but the operator still lost pages.
+    FolderLinkRefused,
+    /// A top-level directory name could not be used as a folder tag (too long, or not UTF-8).
+    FolderNameRejected,
+}
+
+impl KnowledgeOmissionReason {
+    /// One sentence, safe to render verbatim in the UI. Written to say plainly whether the operator
+    /// lost a *page* or merely some *decoration*, because that is the distinction the old single
+    /// boolean destroyed.
+    fn detail(self) -> &'static str {
+        match self {
+            Self::NodeCapReached => "pages omitted: the node cap for this request was reached",
+            Self::ResponseSizeCapReached => {
+                "pages omitted: the response byte budget was reached"
+            }
+            Self::FileTooLarge => "pages omitted: the file is larger than the read limit",
+            Self::FileUnreadable => {
+                "pages omitted: the file could not be read back after it was found"
+            }
+            Self::ScanEntryCapReached => {
+                "directories skipped: the scan reached its entry ceiling"
+            }
+            Self::DirectoryDepthExceeded => {
+                "directories skipped: nested deeper than the depth limit"
+            }
+            Self::DiscoveredFileCapReached => {
+                "pages omitted: more markdown files exist than the scan collects"
+            }
+            Self::EdgeCapReached => "links omitted: the link cap was reached (all pages are shown)",
+            Self::RawEdgeCapReached => {
+                "link candidates dropped before resolution (all pages are shown)"
+            }
+            Self::EdgeHintTooLong => {
+                "link hints ignored: longer than the hint limit, usually prose after a `<- from:` \
+                 marker (all pages are shown)"
+            }
+            Self::TitleTruncated => "page titles shortened for display (all pages are shown)",
+            Self::LastUpdatedTruncated => {
+                "page dates shortened for display (all pages are shown)"
+            }
+            Self::ContentTruncated => "preview cut at the size limit",
+            Self::DuplicateId => "pages omitted: another page already claimed this ID",
+            Self::FolderLinkRefused => {
+                "top-level folders skipped: a link or reparse point is not followed out of the \
+                 wiki root"
+            }
+            Self::FolderNameRejected => {
+                "top-level folders skipped: the directory name cannot be used as a folder tag"
+            }
+        }
+    }
+}
+
+/// One reason, how many items it accounts for, and a few concrete examples.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct KnowledgeOmission {
+    pub reason: KnowledgeOmissionReason,
+    pub count: usize,
+    pub detail: &'static str,
+    /// Up to `MAX_OMISSION_EXAMPLES` node IDs (`folder/relative-stem`). These are folder-relative
+    /// by construction — an absolute filesystem path can never appear here.
+    pub examples: Vec<String>,
+}
+
+/// Accumulates omissions during a scan. Insertion-ordered, and the walk itself is
+/// deterministic (directory entries are sorted), so the reported order is stable run to run.
+#[derive(Debug, Default)]
+struct TruncationReport {
+    omissions: Vec<KnowledgeOmission>,
+}
+
+impl TruncationReport {
+    fn record(&mut self, reason: KnowledgeOmissionReason, example: Option<&str>) {
+        let slot = match self
+            .omissions
+            .iter_mut()
+            .position(|omission| omission.reason == reason)
+        {
+            Some(index) => &mut self.omissions[index],
+            None => {
+                self.omissions.push(KnowledgeOmission {
+                    reason,
+                    count: 0,
+                    detail: reason.detail(),
+                    examples: Vec::new(),
+                });
+                self.omissions
+                    .last_mut()
+                    .expect("omission was just pushed")
+            }
+        };
+        slot.count = slot.count.saturating_add(1);
+        if let Some(example) = example {
+            if slot.examples.len() < MAX_OMISSION_EXAMPLES
+                && !slot.examples.iter().any(|seen| seen == example)
+            {
+                slot.examples.push(example.to_string());
+            }
+        }
+    }
+
+    /// Derived, never stored: `truncated` is true exactly when at least one omission was recorded.
+    fn truncated(&self) -> bool {
+        !self.omissions.is_empty()
+    }
+
+    fn into_omissions(self) -> Vec<KnowledgeOmission> {
+        self.omissions
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
@@ -191,7 +469,10 @@ pub(crate) struct KnowledgeEdge {
 pub(crate) struct KnowledgeGraphResponse {
     pub nodes: Vec<KnowledgeNode>,
     pub edges: Vec<KnowledgeEdge>,
+    /// Derived from `omissions` being non-empty. Retained so existing clients keep working; new
+    /// clients should read `omissions` instead, which says *what* and *why*.
     pub truncated: bool,
+    pub omissions: Vec<KnowledgeOmission>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
@@ -202,7 +483,9 @@ pub(crate) struct KnowledgePageResponse {
     pub path: String,
     pub content: String,
     pub last_updated: String,
+    /// Derived from `omissions`; see `KnowledgeGraphResponse::truncated`.
     pub truncated: bool,
+    pub omissions: Vec<KnowledgeOmission>,
 }
 
 /// Optional bounds and session context for a Knowledge Atlas graph request.
@@ -233,7 +516,6 @@ struct SourceFile {
 #[derive(Debug, Default)]
 struct SourceEnumeration {
     sources: Vec<SourceFile>,
-    truncated: bool,
 }
 
 #[derive(Debug)]
@@ -241,7 +523,6 @@ struct ParsedSource {
     node: KnowledgeNode,
     raw_edges: Vec<RawEdge>,
     body: String,
-    truncated: bool,
 }
 
 #[derive(Debug)]
@@ -262,6 +543,10 @@ struct NodeLookup {
     by_id: HashMap<String, Vec<String>>,
     by_basename: HashMap<String, Vec<String>>,
     by_title: HashMap<String, Vec<String>>,
+    /// Folder tags actually present in this graph. With a discovered folder set there is no
+    /// compiled-in list to gate explicit-path hints against, so the graph's own contents are the
+    /// gate: `foo/bar.md` is only treated as an explicit path when `foo` is a real folder here.
+    folders: HashSet<String>,
 }
 
 /// GET /api/knowledge/graph?session_id=<optional-live-session-id>
@@ -277,14 +562,20 @@ pub async fn get_knowledge_graph(
     }
     let max_nodes = query.max_nodes.unwrap_or(MAX_NODES).min(MAX_NODES);
     let wiki_root = resolve_wiki_root(&state).await;
-    let wiki_folders = resolve_wiki_folders(&state).await;
+    let (wiki_folders, folder_refusals) = resolve_wiki_folders(&state, &wiki_root).await;
     let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
     let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
         return Ok(Json(KnowledgeGraphResponse::default()));
     };
 
     let graph = tokio::task::spawn_blocking(move || {
-        scan_knowledge(&wiki_root, &wiki_folders, project_root.as_deref(), max_nodes)
+        scan_knowledge(
+            &wiki_root,
+            &wiki_folders,
+            project_root.as_deref(),
+            max_nodes,
+            &folder_refusals,
+        )
     })
     .await
     .unwrap_or_default();
@@ -302,7 +593,9 @@ pub async fn get_knowledge_page(
 ) -> Result<Json<KnowledgePageResponse>, ApiError> {
     validate_knowledge_id(&query.id)?;
     let wiki_root = resolve_wiki_root(&state).await;
-    let wiki_folders = resolve_wiki_folders(&state).await;
+    // The page response describes *this page*, not the corpus, so discovery refusals are
+    // deliberately not replayed here — they are a graph-level fact and ride the graph response.
+    let (wiki_folders, _folder_refusals) = resolve_wiki_folders(&state, &wiki_root).await;
     let project_root = resolve_project_root(&state, query.session_id.as_deref())?;
     let id = query.id;
     let Ok(_permit) = knowledge_scan_limiter().acquire().await else {
@@ -326,9 +619,16 @@ async fn resolve_wiki_root(state: &AppState) -> PathBuf {
     resolve_wiki_root_from(env_root, configured.as_deref(), user_home().as_deref())
 }
 
-async fn resolve_wiki_folders(state: &AppState) -> Vec<KnowledgeFolder> {
+async fn resolve_wiki_folders(
+    state: &AppState,
+    wiki_root: &Path,
+) -> (Vec<KnowledgeFolder>, Vec<FolderRefusal>) {
     let configured = state.config.read().await.knowledge_wiki_folders.clone();
-    resolve_wiki_folders_from(configured.as_deref())
+    let discovered = discover_wiki_folders(wiki_root);
+    (
+        resolve_wiki_folders_from(configured.as_deref(), discovered.folders),
+        discovered.refusals,
+    )
 }
 
 fn resolve_wiki_root_from(
@@ -423,61 +723,120 @@ fn resolve_project_root_from_sessions<'a>(
         .ok_or_else(|| ApiError::not_found("Session not found"))
 }
 
-/// Build a bounded graph from the global wiki and the session project's allowlisted documents.
+/// Build a bounded graph from the wiki corpus and the session project's allowlisted documents.
 ///
-/// `wiki_folders` is the effective folder set, already resolved against the compiled-in
-/// `WIKI_FOLDERS` ceiling by `resolve_wiki_folders_from`. Callers must never synthesize it from
-/// raw operator input.
+/// `wiki_folders` is the effective folder set, already resolved against the folders discovered
+/// under `wiki_root` by `resolve_wiki_folders_from`. Callers must never synthesize it from raw
+/// operator input — a folder name that never went through `discover_wiki_folders` has not been
+/// canonicalized or containment-checked.
+/// `folder_refusals` carries the top-level directories `discover_wiki_folders` turned away.
+/// Discovery runs in the async handler, before `spawn_blocking`, while the `TruncationReport` lives
+/// in here — so its refusals cannot record themselves and have to be replayed. Without this the
+/// response claims `truncated=false, omissions=[]` while a whole top-level subtree is missing.
+/// Callers with nothing to replay pass `&[]`.
 pub(crate) fn scan_knowledge(
     wiki_root: &Path,
     wiki_folders: &[KnowledgeFolder],
     project_root: Option<&Path>,
     max_nodes: usize,
+    folder_refusals: &[FolderRefusal],
+) -> KnowledgeGraphResponse {
+    scan_knowledge_within(
+        wiki_root,
+        wiki_folders,
+        project_root,
+        max_nodes,
+        folder_refusals,
+        MAX_GRAPH_ITEM_BYTES,
+    )
+}
+
+/// `scan_knowledge` with the node byte budget injected, so a test can make the byte budget bind
+/// before the node cap without a multi-megabyte fixture. `build_edges` already takes its budget the
+/// same way for the same reason.
+fn scan_knowledge_within(
+    wiki_root: &Path,
+    wiki_folders: &[KnowledgeFolder],
+    project_root: Option<&Path>,
+    max_nodes: usize,
+    folder_refusals: &[FolderRefusal],
+    item_byte_budget: usize,
 ) -> KnowledgeGraphResponse {
     let node_cap = max_nodes.clamp(1, MAX_NODES);
-    let enumeration = enumerate_sources(wiki_root, wiki_folders, project_root);
-    let mut truncated = enumeration.truncated;
+    let mut report = TruncationReport::default();
+    // Replayed before the walk so the reasons appear in the order the operator meets them: what was
+    // never opened, then what was opened and did not fit.
+    for (reason, example) in folder_refusals {
+        report.record(*reason, example.as_deref());
+    }
+    let enumeration = enumerate_sources(wiki_root, wiki_folders, project_root, &mut report);
     let mut nodes = Vec::new();
     let mut raw_edges = Vec::new();
     let mut seen_ids = HashSet::new();
     let mut graph_item_bytes = 0usize;
+    let mut remaining_sources = enumeration.sources.into_iter().peekable();
+    // Which cap actually stopped the walk. The tail below is attributed to *this*, not to the node
+    // cap unconditionally — a byte-budget stop leaves `nodes.len()` strictly under `node_cap`, so
+    // blaming the node cap would send the operator to raise a `?max_nodes=` that changes nothing.
+    let mut tail_reason = KnowledgeOmissionReason::NodeCapReached;
 
-    for source in enumeration.sources {
+    while let Some(source) = remaining_sources.next() {
         if nodes.len() >= node_cap {
-            truncated = true;
+            report.record(
+                KnowledgeOmissionReason::NodeCapReached,
+                node_id_for(&source).as_deref(),
+            );
             break;
         }
-        match read_source(&source) {
+        match read_source(&source, &mut report) {
             SourceRead::Parsed(parsed) => {
                 if seen_ids.contains(&parsed.node.id) {
+                    // Two sources minted the same ID. Keep the first, but say so: dropping a page
+                    // with a bare `continue` is exactly the silent loss the omission taxonomy
+                    // exists to eliminate.
+                    report.record(
+                        KnowledgeOmissionReason::DuplicateId,
+                        Some(parsed.node.id.as_str()),
+                    );
                     continue;
                 }
                 let node_bytes = serialized_item_bytes(&parsed.node);
-                if graph_item_bytes.saturating_add(node_bytes) > MAX_GRAPH_ITEM_BYTES {
-                    truncated = true;
+                if graph_item_bytes.saturating_add(node_bytes) > item_byte_budget {
+                    report.record(
+                        KnowledgeOmissionReason::ResponseSizeCapReached,
+                        Some(parsed.node.id.as_str()),
+                    );
+                    tail_reason = KnowledgeOmissionReason::ResponseSizeCapReached;
                     break;
                 }
                 graph_item_bytes += node_bytes;
                 seen_ids.insert(parsed.node.id.clone());
-                truncated |= parsed.truncated;
                 nodes.push(parsed.node);
                 for edge in parsed.raw_edges {
                     if raw_edges.len() >= MAX_RAW_EDGES {
-                        truncated = true;
+                        report.record(
+                            KnowledgeOmissionReason::RawEdgeCapReached,
+                            Some(edge.source.as_str()),
+                        );
                         break;
                     }
                     raw_edges.push(edge);
                 }
             }
-            SourceRead::TooLarge => truncated = true,
-            SourceRead::Unavailable => {}
+            SourceRead::TooLarge | SourceRead::Unavailable => {}
         }
     }
 
+    // Everything the cap-break above did not even look at is still an omission, and the operator is
+    // owed the count. Reporting only the one source we broke on would understate it by the length
+    // of the tail.
+    for skipped in remaining_sources {
+        report.record(tail_reason, node_id_for(&skipped).as_deref());
+    }
+
     let lookup = NodeLookup::from_nodes(&nodes);
-    let edge_byte_budget = MAX_GRAPH_ITEM_BYTES.saturating_sub(graph_item_bytes);
-    let (edges, edges_truncated) = build_edges(raw_edges, &lookup, edge_byte_budget);
-    truncated |= edges_truncated;
+    let edge_byte_budget = item_byte_budget.saturating_sub(graph_item_bytes);
+    let edges = build_edges(raw_edges, &lookup, edge_byte_budget, &mut report);
 
     let node_positions: HashMap<String, usize> = nodes
         .iter()
@@ -496,7 +855,8 @@ pub(crate) fn scan_knowledge(
     let response = KnowledgeGraphResponse {
         nodes,
         edges,
-        truncated,
+        truncated: report.truncated(),
+        omissions: report.into_omissions(),
     };
     debug_assert!(
         serde_json::to_vec(&response)
@@ -507,7 +867,7 @@ pub(crate) fn scan_knowledge(
     response
 }
 
-/// Resolve an allowlisted page ID and return its bounded Markdown preview.
+/// Resolve a page ID against the enumerated corpus and return its bounded Markdown preview.
 pub(crate) fn preview_knowledge_page(
     wiki_root: &Path,
     wiki_folders: &[KnowledgeFolder],
@@ -518,15 +878,27 @@ pub(crate) fn preview_knowledge_page(
         return None;
     }
 
-    let source = enumerate_sources(wiki_root, wiki_folders, project_root)
+    // The ID is *matched against* enumerated sources, never joined onto a path. Every candidate has
+    // already been canonicalized and containment-checked under its folder root, so a syntactically
+    // valid but hostile ID simply matches nothing.
+    let mut report = TruncationReport::default();
+    let source = enumerate_sources(wiki_root, wiki_folders, project_root, &mut report)
         .sources
         .into_iter()
         .find(|source| node_id_for(source).as_deref() == Some(id))?;
-    let SourceRead::Parsed(parsed) = read_source(&source) else {
+    // Restart the report so the page response describes *this page*, not the enumeration of the
+    // whole corpus that was needed to find it.
+    let mut report = TruncationReport::default();
+    let SourceRead::Parsed(parsed) = read_source(&source, &mut report) else {
         return None;
     };
-    let metadata_truncated = parsed.truncated;
     let (content, content_truncated) = truncate_utf8(parsed.body, MAX_PREVIEW_BYTES);
+    if content_truncated {
+        report.record(
+            KnowledgeOmissionReason::ContentTruncated,
+            Some(parsed.node.id.as_str()),
+        );
+    }
 
     Some(KnowledgePageResponse {
         id: parsed.node.id,
@@ -535,7 +907,8 @@ pub(crate) fn preview_knowledge_page(
         path: parsed.node.path,
         content,
         last_updated: parsed.node.last_updated,
-        truncated: metadata_truncated || content_truncated,
+        truncated: report.truncated(),
+        omissions: report.into_omissions(),
     })
 }
 
@@ -559,13 +932,13 @@ fn validate_knowledge_id(id: &str) -> Result<(), ApiError> {
         return Err(ApiError::bad_request("Invalid knowledge page ID"));
     }
 
+    // Shape-only validation. The folder set is discovered from disk, so there is no compiled-in
+    // list to check the prefix against, and checking against the *live* set here would be worse
+    // than useless: it would cost a filesystem walk before rejecting garbage, and it would make the
+    // 400-vs-404 status leak which folders exist. Containment is enforced where it is real — in
+    // `preview_knowledge_page`, which matches this ID against already-canonicalized sources rather
+    // than joining it onto a path.
     let components: Vec<&str> = id.split('/').collect();
-    let Some(folder) = components
-        .first()
-        .and_then(|prefix| KnowledgeFolder::from_id_prefix(prefix))
-    else {
-        return Err(ApiError::bad_request("Invalid knowledge page ID"));
-    };
     if components.len() < 2
         || components
             .iter()
@@ -573,9 +946,22 @@ fn validate_knowledge_id(id: &str) -> Result<(), ApiError> {
     {
         return Err(ApiError::bad_request("Invalid knowledge page ID"));
     }
-    if folder == KnowledgeFolder::Project
-        && !matches!(id, "project/project-dna" | "project/bug-patterns")
-    {
+    let Some(prefix) = components.first() else {
+        return Err(ApiError::bad_request("Invalid knowledge page ID"));
+    };
+    // The reserved session prefix is checked *before* the shape gate: `.project` deliberately fails
+    // `is_valid_folder_name` (that is what makes it unforgeable by discovery), so gating first
+    // would reject the session's own pages. It stays a closed two-file allowlist because it is
+    // session-scoped and points outside the wiki root — the one prefix that must not become a
+    // general subtree.
+    if *prefix == KnowledgeFolder::PROJECT {
+        return if matches!(id, ".project/project-dna" | ".project/bug-patterns") {
+            Ok(())
+        } else {
+            Err(ApiError::bad_request("Invalid knowledge page ID"))
+        };
+    }
+    if !is_valid_folder_name(prefix) {
         return Err(ApiError::bad_request("Invalid knowledge page ID"));
     }
     Ok(())
@@ -585,53 +971,81 @@ fn enumerate_sources(
     wiki_root: &Path,
     wiki_folders: &[KnowledgeFolder],
     project_root: Option<&Path>,
+    report: &mut TruncationReport,
 ) -> SourceEnumeration {
     let mut enumeration = SourceEnumeration::default();
     let mut entries_seen = 0;
     let canonical_wiki_root = fs::canonicalize(wiki_root).ok();
 
-    // The subtree path is always `wiki_root` joined with a `KnowledgeFolder::as_str()` literal, so
-    // no caller-supplied string ever reaches the filesystem here.
-    for &folder in wiki_folders {
-        let subtree = wiki_root.join(folder.as_str());
-        let Ok(metadata) = fs::symlink_metadata(&subtree) else {
-            continue;
+    for folder in wiki_folders {
+        // `root` is overloaded: it is the synthetic bucket for loose root-level markdown AND a
+        // perfectly legal directory name. Both must be walked under the `root/` tag, or a real
+        // `<wiki>/root/` has every page dropped — silently, since discovery already emitted the
+        // folder. The synthetic walk is non-recursive so it collects only the loose files that
+        // belong to no folder; the real directory is walked recursively beside it.
+        //
+        // The synthetic walk starts from the *canonical* root, not the configured path. If the
+        // operator points the wiki at a junction or symlink (`~/.ai-docs/wiki` -> a checkout
+        // elsewhere is a normal setup for a synced repo), lstat on the configured path reports
+        // `is_dir=false, is_symlink=true` and the link guard below would drop this whole bucket.
+        // The root *is* the containment boundary, so resolving it cannot widen the scan. Sibling
+        // folders never hit this because `wiki_root.join(name)` ends in a real directory component.
+        let subtrees: Vec<(PathBuf, bool)> = if folder.is_wiki_root() {
+            let resolved_root = canonical_wiki_root
+                .clone()
+                .unwrap_or_else(|| wiki_root.to_path_buf());
+            let real_root_dir = resolved_root.join(KnowledgeFolder::ROOT);
+            let mut walks = vec![(resolved_root, false)];
+            if real_root_dir.is_dir() {
+                walks.push((real_root_dir, true));
+            }
+            walks
+        } else {
+            // Every other folder is `wiki_root` joined with a name that `discover_wiki_folders`
+            // already canonicalized and proved to live under the root; a name that never went
+            // through discovery cannot get here.
+            vec![(wiki_root.join(folder.as_str()), true)]
         };
-        if !metadata.is_dir() || metadata.file_type().is_symlink() {
-            continue;
-        }
-        let Ok(canonical_root) = fs::canonicalize(&subtree) else {
-            continue;
-        };
-        if canonical_wiki_root
-            .as_ref()
-            .is_some_and(|root| !canonical_root.starts_with(root))
-        {
-            continue;
-        }
 
-        let remaining = MAX_DISCOVERED_FILES.saturating_sub(enumeration.sources.len());
-        if remaining == 0 {
-            enumeration.truncated = true;
-            break;
+        for (subtree, recurse) in subtrees {
+            let Ok(metadata) = fs::symlink_metadata(&subtree) else {
+                continue;
+            };
+            if !metadata.is_dir() || metadata.file_type().is_symlink() {
+                continue;
+            }
+            let Ok(canonical_root) = fs::canonicalize(&subtree) else {
+                continue;
+            };
+            if canonical_wiki_root
+                .as_ref()
+                .is_some_and(|root| !canonical_root.starts_with(root))
+            {
+                continue;
+            }
+
+            let remaining = MAX_DISCOVERED_FILES.saturating_sub(enumeration.sources.len());
+            if remaining == 0 {
+                report.record(KnowledgeOmissionReason::DiscoveredFileCapReached, None);
+                break;
+            }
+            let mut walk = DirectoryWalk {
+                canonical_root: canonical_root.clone(),
+                file_limit: remaining,
+                recurse,
+                entries_seen: &mut entries_seen,
+                output: Vec::new(),
+            };
+            walk.visit(&canonical_root, 0, report);
+            let found = walk.output;
+            enumeration
+                .sources
+                .extend(found.into_iter().map(|path| SourceFile {
+                    folder: folder.clone(),
+                    path,
+                    root: canonical_root.clone(),
+                }));
         }
-        let mut found = Vec::new();
-        collect_markdown_files(
-            &canonical_root,
-            &canonical_root,
-            0,
-            remaining,
-            &mut entries_seen,
-            &mut found,
-            &mut enumeration.truncated,
-        );
-        enumeration
-            .sources
-            .extend(found.into_iter().map(|path| SourceFile {
-                folder,
-                path,
-                root: canonical_root.clone(),
-            }));
     }
 
     if let Some(project_root) = project_root {
@@ -660,7 +1074,7 @@ fn enumerate_sources(
                 continue;
             }
             enumeration.sources.push(SourceFile {
-                folder: KnowledgeFolder::Project,
+                folder: KnowledgeFolder::project(),
                 path: canonical_path,
                 root: root.clone(),
             });
@@ -672,103 +1086,132 @@ fn enumerate_sources(
     // node cap is smaller than (or already saturated by) the wiki.
     enumeration
         .sources
-        .sort_by_key(|source| source.folder != KnowledgeFolder::Project);
+        .sort_by_key(|source| !source.folder.is_project());
 
     enumeration
 }
 
-#[allow(clippy::too_many_arguments)]
-fn collect_markdown_files(
-    canonical_root: &Path,
-    directory: &Path,
-    depth: usize,
+/// Bounded, containment-checked markdown walk of one folder root.
+///
+/// There is deliberately no filename denylist here any more. The old `is_forbidden_name` hid
+/// `index.md`, `log.md`, `log-archive*.md`, `learnings.jsonl`, `.env`, and `agent-os.db*` — but
+/// this is the operator's own memory system on their own machine, and hiding their index page from
+/// them was never a security control. Three of those entries were never reachable in the first
+/// place: `has_markdown_extension` already admits only `*.md`, so `learnings.jsonl`, `.env`, and
+/// `agent-os.db{,-shm,-wal}` cannot be enumerated regardless — and `.env` is additionally excluded
+/// by the dot-prefix skip below. Removing the list therefore only un-hides markdown.
+struct DirectoryWalk<'a> {
+    canonical_root: PathBuf,
     file_limit: usize,
-    entries_seen: &mut usize,
-    output: &mut Vec<PathBuf>,
-    truncated: &mut bool,
-) {
-    if depth > MAX_DIRECTORY_DEPTH {
-        *truncated = true;
-        return;
-    }
-    if *entries_seen >= MAX_SCAN_ENTRIES || output.len() >= file_limit {
-        *truncated = true;
-        return;
-    }
-    let Ok(read_dir) = fs::read_dir(directory) else {
-        return;
-    };
-    // Bound collection itself before sorting. `ReadDir` is lazy, but collecting it wholesale would
-    // otherwise let one enormous directory bypass MAX_SCAN_ENTRIES before the loop below runs.
-    let remaining_entries = MAX_SCAN_ENTRIES.saturating_sub(*entries_seen);
-    let mut enumerated: Vec<_> = read_dir
-        .take(remaining_entries.saturating_add(1))
-        .collect();
-    if enumerated.len() > remaining_entries {
-        enumerated.truncate(remaining_entries);
-        *truncated = true;
-    }
-    // Count raw iterator results, including errors, so repeated ReadDir failures cannot evade the
-    // global traversal-work ceiling.
-    *entries_seen += enumerated.len();
-    let mut entries: Vec<_> = enumerated.into_iter().filter_map(Result::ok).collect();
-    entries.sort_by_key(|entry| entry.file_name());
-
-    for entry in entries {
-        if output.len() >= file_limit {
-            *truncated = true;
-            return;
-        }
-
-        let name = entry.file_name();
-        if name.to_string_lossy().starts_with('.') || is_forbidden_name(&name.to_string_lossy()) {
-            continue;
-        }
-        let Ok(file_type) = entry.file_type() else {
-            continue;
-        };
-        if file_type.is_symlink() {
-            continue;
-        }
-        let Ok(canonical_path) = fs::canonicalize(entry.path()) else {
-            continue;
-        };
-        if !canonical_path.starts_with(canonical_root) {
-            continue;
-        }
-
-        if file_type.is_dir() {
-            collect_markdown_files(
-                canonical_root,
-                &canonical_path,
-                depth + 1,
-                file_limit,
-                entries_seen,
-                output,
-                truncated,
-            );
-            if output.len() >= file_limit {
-                *truncated = true;
-                return;
-            }
-        } else if file_type.is_file() && has_markdown_extension(&canonical_path) {
-            output.push(canonical_path);
-        }
-    }
+    /// The synthetic `root` bucket sets this false so it collects only the wiki root's own loose
+    /// files; recursing would re-collect every folder's pages under a second ID prefix.
+    recurse: bool,
+    entries_seen: &'a mut usize,
+    output: Vec<PathBuf>,
 }
 
-fn is_forbidden_name(name: &str) -> bool {
-    let lower = name.to_ascii_lowercase();
-    matches!(
-        lower.as_str(),
-        "agent-os.db"
-            | "agent-os.db-shm"
-            | "agent-os.db-wal"
-            | ".env"
-            | "learnings.jsonl"
-            | "log.md"
-            | "index.md"
-    ) || (lower.starts_with("log-archive") && lower.ends_with(".md"))
+impl DirectoryWalk<'_> {
+    fn visit(&mut self, directory: &Path, depth: usize, report: &mut TruncationReport) {
+        if depth > MAX_DIRECTORY_DEPTH {
+            report.record(
+                KnowledgeOmissionReason::DirectoryDepthExceeded,
+                self.relative_label(directory).as_deref(),
+            );
+            return;
+        }
+        if *self.entries_seen >= MAX_SCAN_ENTRIES {
+            report.record(
+                KnowledgeOmissionReason::ScanEntryCapReached,
+                self.relative_label(directory).as_deref(),
+            );
+            return;
+        }
+        if self.output.len() >= self.file_limit {
+            report.record(
+                KnowledgeOmissionReason::DiscoveredFileCapReached,
+                self.relative_label(directory).as_deref(),
+            );
+            return;
+        }
+        let Ok(read_dir) = fs::read_dir(directory) else {
+            return;
+        };
+        // Bound collection itself before sorting. `ReadDir` is lazy, but collecting it wholesale
+        // would otherwise let one enormous directory bypass MAX_SCAN_ENTRIES before the loop runs.
+        let remaining_entries = MAX_SCAN_ENTRIES.saturating_sub(*self.entries_seen);
+        let mut enumerated: Vec<_> = read_dir.take(remaining_entries.saturating_add(1)).collect();
+        if enumerated.len() > remaining_entries {
+            enumerated.truncate(remaining_entries);
+            report.record(
+                KnowledgeOmissionReason::ScanEntryCapReached,
+                self.relative_label(directory).as_deref(),
+            );
+        }
+        // Count raw iterator results, including errors, so repeated ReadDir failures cannot evade
+        // the global traversal-work ceiling.
+        *self.entries_seen += enumerated.len();
+        let mut entries: Vec<_> = enumerated.into_iter().filter_map(Result::ok).collect();
+        entries.sort_by_key(|entry| entry.file_name());
+
+        for entry in entries {
+            if self.output.len() >= self.file_limit {
+                report.record(
+                    KnowledgeOmissionReason::DiscoveredFileCapReached,
+                    self.relative_label(directory).as_deref(),
+                );
+                return;
+            }
+
+            let raw_name = entry.file_name();
+            if raw_name.to_string_lossy().starts_with('.') {
+                continue;
+            }
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            // `read_dir`'s file_type is lstat-based, so a symlink is refused here without ever
+            // being followed — the check that keeps a link pointing outside the root from
+            // smuggling content in.
+            if file_type.is_symlink() {
+                continue;
+            }
+            let Ok(canonical_path) = fs::canonicalize(entry.path()) else {
+                continue;
+            };
+            // Second line of defence for reparse points/junctions, which are not reported as
+            // symlinks on every platform: the resolved path must still be inside the folder root.
+            if !canonical_path.starts_with(&self.canonical_root) {
+                continue;
+            }
+
+            if file_type.is_dir() {
+                if !self.recurse {
+                    continue;
+                }
+                self.visit(&canonical_path, depth + 1, report);
+                if self.output.len() >= self.file_limit {
+                    return;
+                }
+            } else if file_type.is_file() && has_markdown_extension(&canonical_path) {
+                self.output.push(canonical_path);
+            }
+        }
+    }
+
+    /// A root-relative label for omission examples. Returns `None` rather than ever falling back to
+    /// the absolute path, so an absolute filesystem path cannot reach the API through a report.
+    fn relative_label(&self, directory: &Path) -> Option<String> {
+        let relative = directory.strip_prefix(&self.canonical_root).ok()?;
+        let mut components = Vec::new();
+        for component in relative.iter() {
+            components.push(component.to_str()?);
+        }
+        Some(if components.is_empty() {
+            ".".to_string()
+        } else {
+            components.join("/")
+        })
+    }
 }
 
 fn has_markdown_extension(path: &Path) -> bool {
@@ -777,35 +1220,50 @@ fn has_markdown_extension(path: &Path) -> bool {
         .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
 }
 
-fn read_source(source: &SourceFile) -> SourceRead {
+fn read_source(source: &SourceFile, report: &mut TruncationReport) -> SourceRead {
+    let unavailable = |report: &mut TruncationReport| {
+        report.record(
+            KnowledgeOmissionReason::FileUnreadable,
+            node_id_for(source).as_deref(),
+        );
+        SourceRead::Unavailable
+    };
+    let too_large = |report: &mut TruncationReport| {
+        report.record(
+            KnowledgeOmissionReason::FileTooLarge,
+            node_id_for(source).as_deref(),
+        );
+        SourceRead::TooLarge
+    };
+
     let Ok(source_metadata) = fs::symlink_metadata(&source.path) else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     if !source_metadata.is_file() || source_metadata.file_type().is_symlink() {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     }
     let Ok(canonical_path) = fs::canonicalize(&source.path) else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     if !canonical_path.starts_with(&source.root) {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     }
     let Ok(target_metadata) = fs::symlink_metadata(&canonical_path) else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     if !target_metadata.is_file()
         || target_metadata.file_type().is_symlink()
         || !validated_path_matches(&source_metadata, &target_metadata)
     {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     }
 
     let Some((mut file, open_metadata)) = open_file_if_unchanged(&canonical_path, &target_metadata)
     else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     if open_metadata.len() > MAX_FILE_BYTES as u64 {
-        return SourceRead::TooLarge;
+        return too_large(report);
     }
 
     let mut bytes = Vec::with_capacity(open_metadata.len() as usize);
@@ -815,19 +1273,19 @@ fn read_source(source: &SourceFile) -> SourceRead {
         .read_to_end(&mut bytes)
         .is_err()
     {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     }
     if bytes.len() > MAX_FILE_BYTES {
-        return SourceRead::TooLarge;
+        return too_large(report);
     }
     let Ok(text) = String::from_utf8(bytes) else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     let Some(id) = node_id_for(source) else {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     };
     if id.len() > 512 {
-        return SourceRead::Unavailable;
+        return unavailable(report);
     }
     let (frontmatter, body) = split_frontmatter(&text);
     let file_stem = canonical_path
@@ -838,14 +1296,23 @@ fn read_source(source: &SourceFile) -> SourceRead {
         .or_else(|| first_h1(body))
         .unwrap_or_else(|| file_stem.to_string());
     let (title, title_truncated) = truncate_utf8(title, MAX_TITLE_BYTES);
+    if title_truncated {
+        report.record(KnowledgeOmissionReason::TitleTruncated, Some(id.as_str()));
+    }
     let last_updated = frontmatter_field(frontmatter, "last_updated").unwrap_or_default();
     let (last_updated, last_updated_truncated) =
         truncate_utf8(last_updated, MAX_LAST_UPDATED_BYTES);
+    if last_updated_truncated {
+        report.record(
+            KnowledgeOmissionReason::LastUpdatedTruncated,
+            Some(id.as_str()),
+        );
+    }
     let node = KnowledgeNode {
         path: format!("{id}.md"),
         id: id.clone(),
         title,
-        folder: source.folder,
+        folder: source.folder.clone(),
         last_updated,
         in_degree: 0,
         out_degree: 0,
@@ -871,13 +1338,14 @@ fn read_source(source: &SourceFile) -> SourceRead {
     raw_edges.extend(parse_body_edges(&id, body));
     let original_edge_count = raw_edges.len();
     raw_edges.retain(|edge| edge.target_hint.len() <= MAX_EDGE_HINT_BYTES);
-    let edge_hints_truncated = original_edge_count != raw_edges.len();
+    for _ in raw_edges.len()..original_edge_count {
+        report.record(KnowledgeOmissionReason::EdgeHintTooLong, Some(id.as_str()));
+    }
 
     SourceRead::Parsed(ParsedSource {
         node,
         raw_edges,
         body: body.to_string(),
-        truncated: title_truncated || last_updated_truncated || edge_hints_truncated,
     })
 }
 
@@ -1181,6 +1649,9 @@ impl NodeLookup {
     fn from_nodes(nodes: &[KnowledgeNode]) -> Self {
         let mut lookup = Self::default();
         for node in nodes {
+            lookup
+                .folders
+                .insert(normalize_lookup(node.folder.as_str()));
             insert_lookup(&mut lookup.by_id, normalize_lookup(&node.id), &node.id);
             let basename = node.id.rsplit('/').next().unwrap_or(&node.id);
             insert_lookup(
@@ -1218,7 +1689,7 @@ fn resolve_hint(hint: &str, lookup: &NodeLookup) -> Option<String> {
     while let Some(rest) = slug.strip_prefix("./") {
         slug = rest.to_string();
     }
-    slug = normalize_parent_relative_hint(slug)?;
+    slug = normalize_parent_relative_hint(slug, lookup)?;
     slug = strip_markdown_extension(&slug).to_string();
     if slug.is_empty()
         || slug.starts_with('/')
@@ -1233,7 +1704,7 @@ fn resolve_hint(hint: &str, lookup: &NodeLookup) -> Option<String> {
     let explicit_path = slug.contains('/');
     if explicit_path {
         let prefix = slug.split('/').next()?;
-        if KnowledgeFolder::from_id_prefix(prefix).is_none() {
+        if !lookup.folders.contains(&normalize_lookup(prefix)) {
             return None;
         }
     }
@@ -1252,22 +1723,15 @@ fn resolve_hint(hint: &str, lookup: &NodeLookup) -> Option<String> {
         .or_else(|| unique_lookup(&lookup.by_title, &normalize_lookup(&slug)))
 }
 
-/// Corpus research pages sometimes refer to a sibling allow-listed subtree with
-/// `../patterns/foo.md`. These strings are lookup hints only (never filesystem paths), but parent
-/// components are still normalized narrowly: after removing leading parents, the hint must name one
-/// of the global wiki allow-list roots in `WIKI_FOLDERS`. That set now spans the operational roots
-/// (`patterns`, `practices`, `research`) *and* the relationship/entity roots (`clients`,
-/// `partners`, `vendors`, `operations`), so `../clients/foo.md` resolves — that cross-half linking
-/// is the point of this folder set.
+/// Corpus pages sometimes refer to a sibling subtree with `../patterns/foo.md`. These strings are
+/// lookup hints only (never filesystem paths), but parent components are still normalized narrowly:
+/// after removing leading parents, the hint must name a folder that actually exists in this graph.
 ///
-/// Still invalid, by design: `../agents/foo.md` (never allow-listed, see `WIKI_FOLDERS`) and
-/// `../project/project-dna.md` (`project` is session-scoped and must not be reachable from a
-/// global-wiki hint).
-///
-/// This gate intentionally uses the compiled-in ceiling rather than the operator-narrowed set. A
-/// hint only becomes an edge when it resolves to a node that was actually enumerated, so narrowing
-/// already removes those edges; re-checking here would add nothing but a second source of truth.
-fn normalize_parent_relative_hint(mut slug: String) -> Option<String> {
+/// The gate used to be the compiled-in folder list; it is now the graph's own folder set, which is
+/// the same guarantee expressed against the discovered corpus. `project` stays excluded by name: it
+/// is session-scoped and rooted outside the wiki, so a global-wiki page must not be able to reach
+/// it by walking upward.
+fn normalize_parent_relative_hint(mut slug: String, lookup: &NodeLookup) -> Option<String> {
     let had_parent_prefix = slug.starts_with("../");
     while let Some(rest) = slug.strip_prefix("../") {
         slug = rest.to_string();
@@ -1282,9 +1746,8 @@ fn normalize_parent_relative_hint(mut slug: String) -> Option<String> {
 
     let (prefix, remainder) = slug.split_once('/')?;
     if remainder.is_empty()
-        || !WIKI_FOLDERS
-            .into_iter()
-            .any(|folder| folder.as_str() == prefix)
+        || prefix == KnowledgeFolder::PROJECT
+        || !lookup.folders.contains(&normalize_lookup(prefix))
     {
         return None;
     }
@@ -1330,25 +1793,33 @@ fn build_edges(
     raw_edges: Vec<RawEdge>,
     lookup: &NodeLookup,
     max_item_bytes: usize,
-) -> (Vec<KnowledgeEdge>, bool) {
+    report: &mut TruncationReport,
+) -> Vec<KnowledgeEdge> {
     let mut edges = Vec::new();
     let mut seen = HashSet::new();
-    let mut truncated = false;
     let mut item_bytes = 0usize;
 
     for raw in raw_edges {
-        if edges.len() >= MAX_EDGES {
-            truncated = true;
-            break;
-        }
         let Some(target) = resolve_hint(&raw.target_hint, lookup) else {
+            // An unresolvable hint is not an omission: prose annotations and links to pages that do
+            // not exist are normal corpus content, and reporting them would put the banner straight
+            // back to meaning nothing.
             continue;
         };
         if target == raw.source {
             continue;
         }
-        let key = (raw.source.clone(), target.clone(), raw.kind);
-        if seen.contains(&key) {
+        // Deduplicate *before* the caps so a dropped edge is counted once no matter how many times
+        // the corpus repeats it. Over-counting duplicates would inflate the number the banner
+        // shows the operator.
+        if !seen.insert((raw.source.clone(), target.clone(), raw.kind)) {
+            continue;
+        }
+        if edges.len() >= MAX_EDGES {
+            report.record(
+                KnowledgeOmissionReason::EdgeCapReached,
+                Some(raw.source.as_str()),
+            );
             continue;
         }
         let edge = KnowledgeEdge {
@@ -1358,14 +1829,16 @@ fn build_edges(
         };
         let edge_bytes = serialized_item_bytes(&edge);
         if item_bytes.saturating_add(edge_bytes) > max_item_bytes {
-            truncated = true;
-            break;
+            report.record(
+                KnowledgeOmissionReason::ResponseSizeCapReached,
+                Some(edge.source.as_str()),
+            );
+            continue;
         }
         item_bytes += edge_bytes;
-        seen.insert(key);
         edges.push(edge);
     }
-    (edges, truncated)
+    edges
 }
 
 fn truncate_utf8(mut value: String, max_bytes: usize) -> (String, bool) {
@@ -1392,139 +1865,654 @@ mod tests {
         fs::write(path, contents).unwrap();
     }
 
+    /// The effective folder set exactly as the HTTP handler builds it: discovered from disk, with
+    /// no operator narrowing. Tests must go through this rather than hand-rolling a folder list, or
+    /// they would stop exercising discovery.
+    fn discovered(root: &Path) -> Vec<KnowledgeFolder> {
+        resolve_wiki_folders_from(None, discover_wiki_folders(root).folders)
+    }
+
+    fn scan(root: &Path) -> KnowledgeGraphResponse {
+        scan_knowledge(root, &discovered(root), None, MAX_NODES, &[])
+    }
+
+    /// The full handler path: discovery's refusals are replayed into the scan's report, exactly as
+    /// `get_knowledge_graph` does. `scan` above drops them, so a test that needs to see a refused
+    /// top-level folder in `omissions` must use this.
+    fn scan_reporting_refusals(root: &Path) -> KnowledgeGraphResponse {
+        let discovery = discover_wiki_folders(root);
+        let folders = resolve_wiki_folders_from(None, discovery.folders);
+        scan_knowledge(root, &folders, None, MAX_NODES, &discovery.refusals)
+    }
+
+    fn ids(graph: &KnowledgeGraphResponse) -> HashSet<&str> {
+        graph.nodes.iter().map(|node| node.id.as_str()).collect()
+    }
+
+    fn omission(
+        graph: &KnowledgeGraphResponse,
+        reason: KnowledgeOmissionReason,
+    ) -> Option<&KnowledgeOmission> {
+        graph
+            .omissions
+            .iter()
+            .find(|omission| omission.reason == reason)
+    }
+
+    fn reasons(graph: &KnowledgeGraphResponse) -> Vec<KnowledgeOmissionReason> {
+        graph
+            .omissions
+            .iter()
+            .map(|omission| omission.reason)
+            .collect()
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 1. Every folder is shown.
+    // ---------------------------------------------------------------------------------------
+
+    /// The headline behaviour change: the folder set is discovered from the wiki root, so folders
+    /// that no compiled-in enum ever listed produce nodes. `agents/` is the operator's real case —
+    /// 63 of their 163 pages — and the arbitrary names beside it prove nothing was swapped for a
+    /// longer hardcoded list.
     #[test]
-    fn scanner_enforces_allowlists_and_builds_all_five_edge_kinds() {
+    fn folders_absent_from_every_former_enum_still_yield_nodes() {
         let wiki = TempDir::new().unwrap();
-        let project = TempDir::new().unwrap();
-        write_page(
-            wiki.path(),
-            "patterns/source.md",
-            "---\ntitle: Source #153\nlast_updated: 2026-07-18\ncross_refs:\n  - wiki/practices/cross.md\n  - agents/cross.md\nrelated: [research/frontmatter-related.md]\n---\n# Source\n[[Wiki Target]]\n-> global: patterns/global.md\n-> related: [[body-related]] (strong match)\n<-> related: wiki/research/frontmatter-related.md (§details)\n<- from: research/from.md\n",
-        );
-        write_page(
-            wiki.path(),
-            "practices/cross.md",
-            "---\ntitle: Cross\n---\n# Cross\n",
-        );
-        write_page(
-            wiki.path(),
-            "practices/wiki-target.md",
-            "---\ntitle: Wiki Target\n---\n",
-        );
-        write_page(wiki.path(), "patterns/global.md", "# Global\n");
-        write_page(wiki.path(), "practices/body-related.md", "# Related\n");
-        write_page(
-            wiki.path(),
-            "research/frontmatter-related.md",
-            "# Frontmatter Related\n",
-        );
-        write_page(wiki.path(), "research/from.md", "# From\n");
-        // `agents/` is the never-allow-listed folder, so this fixture keeps proving the allowlist
-        // gate now that `clients/` is deliberately in-scope.
-        write_page(
-            wiki.path(),
-            "agents/cross.md",
-            "---\ntitle: Recruiting Dossier\n---\n",
-        );
-        write_page(
-            project.path(),
-            ".ai-docs/project-dna.md",
-            "---\ntitle: Project DNA\n---\n# Project DNA\n",
-        );
-        write_page(
-            project.path(),
-            ".ai-docs/bug-patterns.md",
-            "# Bug Patterns\n",
-        );
-        write_page(
-            project.path(),
-            ".ai-docs/architecture.md",
-            "# Must Not Be Scanned\n",
-        );
+        write_page(wiki.path(), "patterns/known.md", "# Known\n");
+        write_page(wiki.path(), "agents/recruiting/candidate.md", "# Candidate\n");
+        write_page(wiki.path(), "zettelkasten/202607190001.md", "# Zettel\n");
+        write_page(wiki.path(), "Field Notes/site-visit.md", "# Site Visit\n");
+        write_page(wiki.path(), "meta/deep/nested/leaf.md", "# Leaf\n");
 
-        let graph = scan_knowledge(
-            wiki.path(),
-            &WIKI_FOLDERS,
-            Some(project.path()),
-            MAX_NODES,
-        );
-        let node_ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
-        assert!(node_ids.contains("patterns/source"));
-        assert!(node_ids.contains("project/project-dna"));
-        assert!(node_ids.contains("project/bug-patterns"));
-        assert!(!node_ids.iter().any(|id| id.contains("agents")));
-        assert!(!node_ids.contains("project/architecture"));
-        assert!(!serde_json::to_string(&graph)
-            .unwrap()
-            .contains("Recruiting Dossier"));
+        let graph = scan(wiki.path());
+        let seen = ids(&graph);
+        for expected in [
+            "patterns/known",
+            "agents/recruiting/candidate",
+            "zettelkasten/202607190001",
+            "Field Notes/site-visit",
+            "meta/deep/nested/leaf",
+        ] {
+            assert!(seen.contains(expected), "missing {expected} in {seen:?}");
+        }
 
-        let kinds: HashSet<_> = graph.edges.iter().map(|edge| edge.kind).collect();
+        // The folder tag on the wire is the directory name itself, so the frontend filter and the
+        // node ID prefix cannot drift apart.
+        let candidate = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "agents/recruiting/candidate")
+            .expect("agents node");
+        assert_eq!(candidate.folder.as_str(), "agents");
         assert_eq!(
-            kinds,
+            serde_json::to_string(&candidate.folder).unwrap(),
+            "\"agents\""
+        );
+        assert_eq!(candidate.path, "agents/recruiting/candidate.md");
+    }
+
+    /// Dot-directories are editor/VCS state, not memory. `.obsidian` and `.git` stay out; nothing
+    /// else does.
+    #[test]
+    fn dot_directories_are_skipped_but_ordinary_ones_are_not() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), ".obsidian/workspace.md", "# Editor State\n");
+        write_page(wiki.path(), ".git/description.md", "# VCS State\n");
+        write_page(wiki.path(), "patterns/.hidden/secret.md", "# Nested Hidden\n");
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        write_page(wiki.path(), "obsidian-notes/kept.md", "# Not A Dot Dir\n");
+
+        let graph = scan(wiki.path());
+        let seen = ids(&graph);
+        assert!(seen.contains("patterns/kept"));
+        assert!(
+            seen.contains("obsidian-notes/kept"),
+            "a folder that merely resembles a dot-dir must still be scanned"
+        );
+        for hidden in ["Editor State", "VCS State", "Nested Hidden"] {
+            assert!(
+                !serde_json::to_string(&graph).unwrap().contains(hidden),
+                "{hidden} leaked from a dot-directory"
+            );
+        }
+        assert!(!discover_wiki_folders(wiki.path())
+            .folders
+            .iter()
+            .any(|folder| folder.as_str().starts_with('.')));
+    }
+
+    /// `is_forbidden_name` used to hide these from the operator's own memory system. They are
+    /// ordinary pages and must now appear — including the root-level `index.md`, which was doubly
+    /// unreachable because it sits in no folder at all.
+    #[test]
+    fn previously_forbidden_filenames_and_root_level_pages_now_appear() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "index.md", "# Wiki Index\n");
+        write_page(wiki.path(), "schema.md", "# Schema\n");
+        write_page(wiki.path(), "log.md", "# Running Log\n");
+        write_page(wiki.path(), "patterns/index.md", "# Patterns Index\n");
+        write_page(wiki.path(), "patterns/log.md", "# Patterns Log\n");
+        write_page(
+            wiki.path(),
+            "patterns/log-archive-2026Q2.md",
+            "# Archived Log\n",
+        );
+
+        let graph = scan(wiki.path());
+        let seen = ids(&graph);
+        for expected in [
+            "root/index",
+            "root/schema",
+            "root/log",
+            "patterns/index",
+            "patterns/log",
+            "patterns/log-archive-2026Q2",
+        ] {
+            assert!(seen.contains(expected), "missing {expected} in {seen:?}");
+        }
+
+        // ...and they are previewable, not just countable.
+        let page = preview_knowledge_page(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            "root/index",
+        )
+        .expect("root index preview");
+        assert_eq!(page.path, "root/index.md");
+        assert_eq!(page.folder.as_str(), "root");
+        assert!(page.content.contains("Wiki Index"));
+    }
+
+    /// The synthetic `root` bucket is non-recursive, so root-level pages never duplicate the pages
+    /// of the folders beside them under a second ID prefix.
+    #[test]
+    fn root_bucket_does_not_re_collect_the_folders_beside_it() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "index.md", "# Index\n");
+        write_page(wiki.path(), "patterns/one.md", "# One\n");
+        write_page(wiki.path(), "patterns/nested/two.md", "# Two\n");
+
+        let graph = scan(wiki.path());
+        let seen = ids(&graph);
+        assert_eq!(
+            seen,
+            HashSet::from(["root/index", "patterns/one", "patterns/nested/two"])
+        );
+        assert!(!seen.iter().any(|id| id.starts_with("root/patterns")));
+    }
+
+
+    /// A wiki root with no loose markdown gets no synthetic bucket at all.
+    #[test]
+    fn root_bucket_appears_only_when_loose_markdown_exists() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/one.md", "# One\n");
+        assert!(!discover_wiki_folders(wiki.path())
+            .folders
+            .iter()
+            .any(KnowledgeFolder::is_wiki_root));
+
+        write_page(wiki.path(), "loose.md", "# Loose\n");
+        assert!(discover_wiki_folders(wiki.path())
+            .folders
+            .iter()
+            .any(KnowledgeFolder::is_wiki_root));
+    }
+
+    /// `root` is overloaded: the synthetic loose-file bucket *and* a legal directory name. Both
+    /// walks must run under the `root/` tag. This used to route a real `<wiki>/root/` to the
+    /// synthetic non-recursive walk of the wiki root, so every page inside it vanished — with
+    /// `truncated=false` and `omissions=[]`, the silent loss the taxonomy exists to prevent.
+    ///
+    /// Note `root_bucket_appears_only_when_loose_markdown_exists` asserts only on the folder
+    /// *list* and passes either way; it is not coverage for this.
+    #[test]
+    fn a_real_directory_named_root_still_yields_its_pages() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "root/archive.md", "# Archive\n");
+        write_page(wiki.path(), "root/deep/nested.md", "# Nested\n");
+        write_page(wiki.path(), "index.md", "# Index\n");
+        write_page(wiki.path(), "patterns/one.md", "# One\n");
+
+        let graph = scan(wiki.path());
+        assert_eq!(
+            ids(&graph),
             HashSet::from([
-                KnowledgeEdgeKind::CrossRef,
-                KnowledgeEdgeKind::Wikilink,
-                KnowledgeEdgeKind::Global,
-                KnowledgeEdgeKind::Related,
-                KnowledgeEdgeKind::From,
-            ])
+                "root/archive",
+                "root/deep/nested",
+                "root/index",
+                "patterns/one"
+            ]),
+            "a real root/ directory and the loose root markdown must both be served"
         );
-        assert!(graph.edges.iter().all(|edge| {
-            node_ids.contains(edge.source.as_str()) && node_ids.contains(edge.target.as_str())
-        }));
-        assert!(graph.edges.iter().any(|edge| {
-            edge.kind == KnowledgeEdgeKind::Related
-                && edge.target == "practices/body-related"
-        }));
-        assert!(graph.edges.iter().any(|edge| {
-            edge.kind == KnowledgeEdgeKind::Related
-                && edge.target == "research/frontmatter-related"
-        }));
+        assert!(
+            graph.omissions.is_empty(),
+            "nothing was dropped, so nothing may be reported: {:?}",
+            graph.omissions
+        );
+
+        // The page endpoint resolves against the same enumeration, so it must agree with the graph.
+        let folders = discovered(wiki.path());
+        for id in ["root/archive", "root/deep/nested", "root/index"] {
+            assert!(
+                preview_knowledge_page(wiki.path(), &folders, None, id).is_some(),
+                "the graph advertises {id}, so the preview endpoint must serve it"
+            );
+        }
+    }
+
+    /// The strictly worse variant: with no loose markdown the synthetic bucket is never inserted,
+    /// discovery still emits the `root` tag for the real directory, and the non-recursive walk of
+    /// the wiki root yields nothing — so the whole subtree collapsed to zero pages.
+    #[test]
+    fn a_real_root_directory_is_served_without_any_loose_markdown() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "root/archive.md", "# Archive\n");
+        write_page(wiki.path(), "root/deep/nested.md", "# Nested\n");
+        write_page(wiki.path(), "patterns/one.md", "# One\n");
+
+        let graph = scan(wiki.path());
+        assert_eq!(
+            ids(&graph),
+            HashSet::from(["root/archive", "root/deep/nested", "patterns/one"]),
+            "a real root/ directory must be walked even with no loose markdown beside it"
+        );
+        assert!(graph.omissions.is_empty(), "{:?}", graph.omissions);
+    }
+
+    /// Serving both walks under one tag makes an ID collision possible: `<wiki>/index.md` and
+    /// `<wiki>/root/index.md` both mint `root/index`. One page must win, but the loser must be
+    /// *named*, never dropped with a bare `continue`.
+    #[test]
+    fn a_root_id_collision_is_reported_rather_than_dropped_in_silence() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "index.md", "# Loose Index\n");
+        write_page(wiki.path(), "root/index.md", "# Real Directory Index\n");
+        write_page(wiki.path(), "root/unique.md", "# Unique\n");
+
+        let graph = scan(wiki.path());
+        assert!(
+            ids(&graph).contains("root/unique"),
+            "the non-colliding page must still be served"
+        );
+        assert_eq!(
+            graph.nodes.iter().filter(|n| n.id == "root/index").count(),
+            1,
+            "exactly one page may hold a given ID"
+        );
+        let duplicate = omission(&graph, KnowledgeOmissionReason::DuplicateId)
+            .expect("the dropped page must be reported, not silently discarded");
+        assert_eq!(duplicate.count, 1);
+        assert_eq!(duplicate.examples, vec!["root/index".to_string()]);
+        assert!(graph.truncated, "a dropped page must not report truncated=false");
+    }
+
+    /// The removed denylist also named `.env`, `learnings.jsonl`, and `agent-os.db*`. Those were
+    /// never reachable: the walk only ever collects `*.md`. This pins that, so removing the
+    /// denylist cannot be mistaken for having exposed them.
+    #[test]
+    fn only_markdown_is_ever_enumerated() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        for non_markdown in [
+            "patterns/.env",
+            "patterns/agent-os.db",
+            "patterns/agent-os.db-shm",
+            "patterns/agent-os.db-wal",
+            "patterns/learnings.jsonl",
+            "patterns/notes.txt",
+            "patterns/config.yaml",
+        ] {
+            write_page(wiki.path(), non_markdown, "SECRET_TOKEN=hunter2\n");
+        }
+
+        let graph = scan(wiki.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
+        let serialized = serde_json::to_string(&graph).unwrap();
+        for leaked in ["SECRET_TOKEN", "agent-os", "learnings", ".env"] {
+            assert!(!serialized.contains(leaked), "{leaked} leaked into the graph");
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 2. Containment still holds.
+    // ---------------------------------------------------------------------------------------
+
+    /// Discovery moved the trust boundary to the wiki root; it did not remove it. A symlinked
+    /// top-level folder pointing outside the root must not become a discovered folder, and a
+    /// symlinked file inside a real folder must not become a page.
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_escaping_the_root_are_refused_at_every_level() {
+        use std::os::unix::fs::symlink;
+
+        let wiki = TempDir::new().unwrap();
+        let private = TempDir::new().unwrap();
+        write_page(private.path(), "secret.md", "# Private Elsewhere\n");
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+
+        // A whole top-level folder aimed outside the root.
+        symlink(private.path(), wiki.path().join("escaped")).unwrap();
+        // A single file aimed outside the root, inside a genuine folder.
+        symlink(
+            private.path().join("secret.md"),
+            wiki.path().join("patterns/linked.md"),
+        )
+        .unwrap();
+
+        assert!(
+            !discover_wiki_folders(wiki.path())
+                .folders
+                .iter()
+                .any(|folder| folder.as_str() == "escaped"),
+            "a symlinked top-level folder must not be discovered"
+        );
+
+        let graph = scan(wiki.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
         assert!(!serde_json::to_string(&graph)
             .unwrap()
-            .contains(&wiki.path().to_string_lossy().to_string()));
-        assert_eq!(
-            graph
-                .nodes
-                .iter()
-                .find(|node| node.id == "patterns/source")
-                .unwrap()
-                .title,
-            "Source #153"
+            .contains("Private Elsewhere"));
+        assert!(preview_knowledge_page(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            "patterns/linked"
+        )
+        .is_none());
+    }
+
+    /// Create an NTFS directory junction, which needs no elevation (unlike `symlink_dir`) and so
+    /// can run on the `windows-latest` CI runner. Panics rather than returning an error: a
+    /// containment test that silently skips itself is worse than no test at all.
+    #[cfg(windows)]
+    fn create_junction(link: &Path, target: &Path) {
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J"])
+            .arg(link)
+            .arg(target)
+            .stdout(std::process::Stdio::null())
+            .status()
+            .expect("failed to invoke mklink");
+        assert!(status.success(), "mklink /J failed for {link:?} -> {target:?}");
+        assert!(
+            fs::symlink_metadata(link)
+                .expect("junction metadata")
+                .file_type()
+                .is_symlink()
+                || fs::canonicalize(link).expect("junction canonicalizes")
+                    != link.to_path_buf(),
+            "the junction fixture is inert — it is neither a symlink nor a redirect"
         );
     }
 
+    /// Windows equivalent of the symlink tests below. This matters more than it looks: the
+    /// symlink coverage in this file is `#[cfg(unix)]`, and this project's CI runs on
+    /// `windows-latest`, so without this test the containment checks are exercised on no runner at
+    /// all — deleting them outright kept the whole suite green.
+    ///
+    /// Which line of defence this pins, measured rather than assumed: `read_dir`'s `file_type` is
+    /// lstat-based and reports `is_symlink() == true` for an NTFS directory junction, so the
+    /// fixture is caught at the *first* check. (An earlier version of this comment claimed it
+    /// pinned the post-canonicalization `starts_with` check; it does not reach it.) That second
+    /// check remains as defence in depth for reparse kinds lstat does not tag.
+    #[cfg(windows)]
     #[test]
-    fn project_nodes_are_reserved_ahead_of_a_saturated_global_corpus() {
+    fn junctions_pointing_outside_the_root_are_refused_on_windows() {
+        let wiki = TempDir::new().unwrap();
+        let private = TempDir::new().unwrap();
+        write_page(private.path(), "secret.md", "# Private Elsewhere\n");
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+
+        // A whole top-level folder aimed outside the root...
+        create_junction(&wiki.path().join("escaped"), private.path());
+        // ...and a nested directory inside a genuine folder aimed outside the root. Join
+        // component-wise: `mklink` rejects a path with mixed separators.
+        create_junction(&wiki.path().join("patterns").join("nested"), private.path());
+
+        assert!(
+            !discover_wiki_folders(wiki.path())
+                .folders
+                .iter()
+                .any(|folder| folder.as_str() == "escaped"),
+            "a junction aimed outside the root must not become a discovered folder"
+        );
+
+        let graph = scan(wiki.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
+        assert!(
+            !serde_json::to_string(&graph)
+                .unwrap()
+                .contains("Private Elsewhere"),
+            "content from outside the wiki root leaked into the graph"
+        );
+        assert!(preview_knowledge_page(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            "patterns/nested/secret"
+        )
+        .is_none());
+        assert!(
+            preview_knowledge_page(wiki.path(), &discovered(wiki.path()), None, "escaped/secret")
+                .is_none()
+        );
+
+        // Refusing the folder is correct; refusing it *silently* is not. Discovery used to have no
+        // reporting channel at all, so an entire top-level subtree vanished under
+        // `truncated=false, omissions=[]` — invisible even in the UI folder filter, which is
+        // derived from node folders.
+        let reported = scan_reporting_refusals(wiki.path());
+        assert!(
+            reported.truncated,
+            "a refused top-level folder must not report truncated=false"
+        );
+        let refused = omission(&reported, KnowledgeOmissionReason::FolderLinkRefused)
+            .expect("the refused junction must be reported");
+        assert_eq!(refused.count, 1);
+        assert_eq!(refused.examples, vec!["escaped".to_string()]);
+    }
+
+    /// A wiki folder literally named `project` is the operator's own memory and must work like any
+    /// other folder. It used to collide with the reserved session tag, with three consequences:
+    /// its pages were advertised in the graph but answered 400 by the preview endpoint (the closed
+    /// two-file allowlist); a `<wiki>/project/project-dna.md` silently displaced the session's own
+    /// `.ai-docs/project-dna.md` via the `seen_ids` dedup; and wiki pages were hoisted ahead of the
+    /// session allowlist in the cap sort. Only the conjunction is load-bearing, so assert all four.
+    #[test]
+    fn a_wiki_folder_named_project_coexists_with_session_project_knowledge() {
         let wiki = TempDir::new().unwrap();
         let project = TempDir::new().unwrap();
-        for index in 0..MAX_NODES {
-            write_page(
-                wiki.path(),
-                &format!("patterns/global-{index:03}.md"),
-                &format!("# Global {index}\n"),
-            );
-        }
-        write_page(
-            project.path(),
-            ".ai-docs/project-dna.md",
-            "# Project DNA\n",
+        write_page(wiki.path(), "project/project-dna.md", "# WIKI DNA\n");
+        write_page(wiki.path(), "project/notes.md", "# WIKI NOTES\n");
+        write_page(wiki.path(), "patterns/known.md", "# Known\n");
+        write_page(project.path(), ".ai-docs/project-dna.md", "# SESSION DNA\n");
+
+        let folders = discovered(wiki.path());
+        let graph = scan_knowledge(
+            wiki.path(),
+            &folders,
+            Some(project.path()),
+            MAX_NODES,
+            &[],
         );
-        write_page(
-            project.path(),
-            ".ai-docs/bug-patterns.md",
-            "# Bug Patterns\n",
+        let node_ids = ids(&graph);
+
+        // 1. Both namespaces are present; neither displaces the other.
+        assert!(
+            node_ids.contains("project/project-dna"),
+            "the wiki's own project page must be served: {node_ids:?}"
+        );
+        assert!(
+            node_ids.contains(".project/project-dna"),
+            "the session's project knowledge must survive a wiki `project/` folder: {node_ids:?}"
+        );
+        assert!(node_ids.contains("project/notes"));
+
+        // 2. Nothing the graph advertises may be rejected by the preview endpoint.
+        assert!(
+            validate_knowledge_id("project/notes").is_ok(),
+            "a node the graph serves must not be answered with 400"
+        );
+        let wiki_notes = preview_knowledge_page(
+            wiki.path(),
+            &folders,
+            Some(project.path()),
+            "project/notes",
+        )
+        .expect("the wiki project page must be previewable");
+        assert!(wiki_notes.content.contains("WIKI NOTES"));
+
+        // 3. The two same-named pages return their own distinct bodies.
+        let wiki_dna = preview_knowledge_page(
+            wiki.path(),
+            &folders,
+            Some(project.path()),
+            "project/project-dna",
+        )
+        .expect("wiki project-dna");
+        let session_dna = preview_knowledge_page(
+            wiki.path(),
+            &folders,
+            Some(project.path()),
+            ".project/project-dna",
+        )
+        .expect("session project-dna");
+        assert!(wiki_dna.content.contains("WIKI DNA"), "{:?}", wiki_dna.content);
+        assert!(
+            session_dna.content.contains("SESSION DNA"),
+            "the session's own DNA must not be shadowed by the wiki copy: {:?}",
+            session_dna.content
         );
 
-        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, Some(project.path()), MAX_NODES);
-        let node_ids: Vec<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+        // 4. Nothing was dropped, so nothing may be reported.
+        assert!(
+            graph.omissions.is_empty(),
+            "no page was lost, so omissions must be empty: {:?}",
+            graph.omissions
+        );
+        assert!(!graph.truncated);
+    }
 
-        assert_eq!(graph.nodes.len(), MAX_NODES);
+    /// Reaching the wiki root *through* a junction must not cost the operator the root bucket.
+    /// Junctioning `~/.ai-docs/wiki` at a synced checkout elsewhere is a normal setup, and the
+    /// synthetic bucket used to walk the configured path — on which lstat reports
+    /// `is_dir=false, is_symlink=true`, so the link guard dropped the whole bucket. Silently:
+    /// discovery canonicalizes first and so still emitted the `root` tag.
+    ///
+    /// The control scan of the same fixture through the real path is what makes this load-bearing
+    /// — it fails if the fix is reverted AND if the walk itself regresses.
+    #[cfg(windows)]
+    #[test]
+    fn a_junctioned_wiki_root_still_serves_its_loose_markdown() {
+        let base = TempDir::new().unwrap();
+        let real = base.path().join("real");
+        fs::create_dir_all(&real).unwrap();
+        write_page(&real, "index.md", "# Loose Index\n");
+        write_page(&real, "patterns/known.md", "# Known\n");
+
+        let link = base.path().join("link");
+        create_junction(&link, &real);
+
+        let through_link = scan(&link);
+        let control = scan(&real);
         assert_eq!(
-            &node_ids[..PROJECT_FILES.len()],
-            &["project/project-dna", "project/bug-patterns"]
+            ids(&through_link),
+            ids(&control),
+            "a junctioned wiki root must serve exactly what the real path serves"
         );
+        assert!(
+            through_link.nodes.iter().any(|node| node.id == "root/index"),
+            "the loose root markdown must survive a junctioned wiki root"
+        );
+    }
+
+    /// The Unix twin of the junction case above: `symlink_metadata` on a symlink reports
+    /// `is_dir() == false`, so the configured-path walk lost the bucket the same way.
+    #[cfg(unix)]
+    #[test]
+    fn a_symlinked_wiki_root_still_serves_its_loose_markdown() {
+        let base = TempDir::new().unwrap();
+        let real = base.path().join("real");
+        fs::create_dir_all(&real).unwrap();
+        write_page(&real, "index.md", "# Loose Index\n");
+        write_page(&real, "patterns/known.md", "# Known\n");
+
+        let link = base.path().join("link");
+        std::os::unix::fs::symlink(&real, &link).expect("symlink the wiki root");
+
+        let through_link = scan(&link);
+        let control = scan(&real);
+        assert_eq!(
+            ids(&through_link),
+            ids(&control),
+            "a symlinked wiki root must serve exactly what the real path serves"
+        );
+        assert!(
+            through_link.nodes.iter().any(|node| node.id == "root/index"),
+            "the loose root markdown must survive a symlinked wiki root"
+        );
+    }
+
+    /// A top-level directory whose name cannot become a folder tag is also a whole subtree lost,
+    /// and must be named for the same reason.
+    #[test]
+    fn an_unusable_top_level_folder_name_is_reported_rather_than_dropped_in_silence() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        let overlong = "n".repeat(MAX_FOLDER_NAME_BYTES + 1);
+        write_page(wiki.path(), &format!("{overlong}/buried.md"), "# Buried\n");
+
+        let graph = scan_reporting_refusals(wiki.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
         assert!(graph.truncated);
+        let refused = omission(&graph, KnowledgeOmissionReason::FolderNameRejected)
+            .expect("an unusable folder name must be reported");
+        assert_eq!(refused.count, 1);
+        assert_eq!(
+            refused.examples,
+            vec![overlong[..MAX_FOLDER_NAME_BYTES].to_string()],
+            "the example must be bounded so a hostile name cannot inflate the response"
+        );
+    }
+
+    /// A dot-directory is a documented *content* judgement (`.git`, `.obsidian` are editor and VCS
+    /// state, not memory), so it stays silent. Reporting it would make the banner cry wolf on every
+    /// scan of a normal wiki checkout.
+    #[test]
+    fn skipping_a_dot_directory_is_not_reported_as_an_omission() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        write_page(wiki.path(), ".obsidian/workspace.md", "# Editor State\n");
+        write_page(wiki.path(), ".git/notes.md", "# VCS State\n");
+
+        let graph = scan_reporting_refusals(wiki.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
+        assert!(
+            graph.omissions.is_empty(),
+            "a deliberate content skip must not be reported as a loss: {:?}",
+            graph.omissions
+        );
+    }
+
+    /// A symlink that stays *inside* the root is still refused, so the rule is "no symlinks in the
+    /// walk", not "no symlinks that happen to escape" — the weaker rule would depend on resolving
+    /// a target that can change between the check and the read.
+    #[cfg(unix)]
+    #[test]
+    fn symlinks_are_refused_even_when_they_stay_inside_the_root() {
+        use std::os::unix::fs::symlink;
+
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/real.md", "# Real\n");
+        symlink(
+            wiki.path().join("patterns/real.md"),
+            wiki.path().join("patterns/alias.md"),
+        )
+        .unwrap();
+
+        assert_eq!(ids(&scan(wiki.path())), HashSet::from(["patterns/real"]));
     }
 
     #[cfg(unix)]
@@ -1568,11 +2556,667 @@ mod tests {
         ));
     }
 
-    fn test_node(id: &str, title: &str, folder: KnowledgeFolder) -> KnowledgeNode {
+    /// No response — graph, page, or omission report — may ever carry an absolute filesystem path.
+    /// The omission examples are the new surface here: they name pages, and this pins that they
+    /// name them by node ID.
+    #[test]
+    fn no_response_contains_an_absolute_filesystem_path() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "index.md", "# Root Index\n");
+        write_page(wiki.path(), "patterns/a.md", "# A\n");
+        write_page(wiki.path(), "patterns/b.md", "# B\n");
+        write_page(wiki.path(), "agents/c.md", "# C\n");
+        write_page(
+            wiki.path(),
+            "patterns/oversize.md",
+            &"x".repeat(MAX_FILE_BYTES + 1),
+        );
+
+        // A node cap plus an oversized file guarantees at least two distinct omissions carrying
+        // examples, so this is not vacuously passing over an empty report.
+        let graph = scan_knowledge(wiki.path(), &discovered(wiki.path()), None, 2, &[]);
+        assert!(!graph.omissions.is_empty());
+        assert!(graph
+            .omissions
+            .iter()
+            .any(|omission| !omission.examples.is_empty()));
+
+        let root_text = wiki.path().to_string_lossy().to_string();
+        let alternate = root_text.replace('\\', "/");
+        for serialized in [
+            serde_json::to_string(&graph).unwrap(),
+            serde_json::to_string(
+                &preview_knowledge_page(wiki.path(), &discovered(wiki.path()), None, "root/index")
+                    .expect("root index preview"),
+            )
+            .unwrap(),
+        ] {
+            assert!(
+                !serialized.contains(&root_text) && !serialized.contains(&alternate),
+                "an absolute path leaked into {serialized}"
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 3. Honest truncation.
+    // ---------------------------------------------------------------------------------------
+
+    /// The regression test for the bug that started this: an ordinary, fully-scanned corpus must
+    /// report *nothing*. The operator's live Atlas showed `truncated: true` over 100 of 100 pages
+    /// because two `<- from:` prose annotations exceeded the link-hint limit, and a single boolean
+    /// could not say so.
+    #[test]
+    fn a_fully_scanned_corpus_reports_no_omissions() {
+        let wiki = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "patterns/source.md",
+            "---\ntitle: Source\nlast_updated: 2026-07-19\n---\n# Source\n[[Target]]\n",
+        );
+        write_page(wiki.path(), "practices/target.md", "---\ntitle: Target\n---\n");
+        write_page(wiki.path(), "agents/dossier.md", "# Dossier\n");
+        write_page(wiki.path(), "index.md", "# Index\n");
+
+        let graph = scan(wiki.path());
+        assert_eq!(graph.nodes.len(), 4);
+        assert_eq!(
+            graph.omissions,
+            Vec::new(),
+            "a complete scan must report no omissions"
+        );
+        assert!(!graph.truncated);
+    }
+
+    /// A long prose annotation after a `<- from:` marker is the exact shape that used to raise the
+    /// amber banner across the operator's whole graph. It resolves to nothing, it costs no page,
+    /// and under the raised hint limit it is not an omission at all.
+    #[test]
+    fn long_provenance_prose_does_not_truncate_the_graph() {
+        let wiki = TempDir::new().unwrap();
+        let annotation = "session aecf4c89 backend-only PR; ".repeat(19);
+        assert!(annotation.len() > 512, "fixture must exceed the old limit");
+        assert!(
+            annotation.len() < MAX_EDGE_HINT_BYTES,
+            "fixture must fit the current limit"
+        );
+        write_page(
+            wiki.path(),
+            "practices/workflow.md",
+            &format!("# Workflow\n<- from: TOG mainbrain ({annotation})\n"),
+        );
+        write_page(wiki.path(), "patterns/other.md", "# Other\n");
+
+        let graph = scan(wiki.path());
+        assert_eq!(graph.nodes.len(), 2);
+        assert!(
+            !graph.truncated,
+            "prose provenance must not flag the corpus as truncated, got {:?}",
+            graph.omissions
+        );
+    }
+
+    /// Each distinct cause reports itself by name, with a count and page-ID examples — the whole
+    /// point of replacing the boolean. Every assertion here is on scan output.
+    #[test]
+    fn the_truncation_report_names_the_correct_cause_for_each_trigger() {
+        // (a) Node cap: whole pages dropped, and the count covers the untouched tail, not just the
+        // one source the loop broke on.
+        let capped = TempDir::new().unwrap();
+        for index in 0..5 {
+            write_page(
+                capped.path(),
+                &format!("patterns/page-{index}.md"),
+                &format!("# Page {index}\n"),
+            );
+        }
+        let graph = scan_knowledge(capped.path(), &discovered(capped.path()), None, 2, &[]);
+        assert_eq!(graph.nodes.len(), 2);
+        let node_cap = omission(&graph, KnowledgeOmissionReason::NodeCapReached)
+            .expect("node cap omission");
+        assert_eq!(node_cap.count, 3, "all three skipped pages must be counted");
+        assert!(node_cap.examples.contains(&"patterns/page-2".to_string()));
+        assert_eq!(reasons(&graph), vec![KnowledgeOmissionReason::NodeCapReached]);
+        assert!(graph.truncated);
+
+        // (b) File too large: one page dropped, the rest unaffected, and the reason is not
+        // confusable with the node cap.
+        let oversized = TempDir::new().unwrap();
+        write_page(oversized.path(), "patterns/small.md", "# Small\n");
+        write_page(
+            oversized.path(),
+            "patterns/huge.md",
+            &"x".repeat(MAX_FILE_BYTES + 1),
+        );
+        let graph = scan(oversized.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/small"]));
+        let too_large =
+            omission(&graph, KnowledgeOmissionReason::FileTooLarge).expect("file-too-large");
+        assert_eq!(too_large.count, 1);
+        assert_eq!(too_large.examples, vec!["patterns/huge".to_string()]);
+        assert_eq!(reasons(&graph), vec![KnowledgeOmissionReason::FileTooLarge]);
+
+        // (c) Over-long link hint: reported distinctly, and the page itself is still present.
+        let hinted = TempDir::new().unwrap();
+        write_page(
+            hinted.path(),
+            "patterns/chatty.md",
+            &format!("# Chatty\n<- from: {}\n", "y".repeat(MAX_EDGE_HINT_BYTES + 1)),
+        );
+        let graph = scan(hinted.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/chatty"]));
+        let hint = omission(&graph, KnowledgeOmissionReason::EdgeHintTooLong)
+            .expect("edge-hint omission");
+        assert_eq!(hint.count, 1);
+        assert_eq!(hint.examples, vec!["patterns/chatty".to_string()]);
+        assert!(hint.detail.contains("all pages are shown"));
+
+        // (d) Shortened metadata: two separate reasons, neither of which costs a page.
+        let metadata = TempDir::new().unwrap();
+        write_page(
+            metadata.path(),
+            "patterns/verbose.md",
+            &format!(
+                "---\ntitle: {}\nlast_updated: {}\n---\n# Body\n",
+                format!("x{}", "é".repeat(MAX_TITLE_BYTES)),
+                "u".repeat(MAX_LAST_UPDATED_BYTES + 1)
+            ),
+        );
+        let graph = scan(metadata.path());
+        assert_eq!(ids(&graph), HashSet::from(["patterns/verbose"]));
+        assert_eq!(
+            reasons(&graph),
+            vec![
+                KnowledgeOmissionReason::TitleTruncated,
+                KnowledgeOmissionReason::LastUpdatedTruncated,
+            ]
+        );
+        assert_eq!(
+            omission(&graph, KnowledgeOmissionReason::TitleTruncated)
+                .unwrap()
+                .examples,
+            vec!["patterns/verbose".to_string()]
+        );
+
+        // The report is not the guard. A pre-existing test asserted these bounds directly and was
+        // deleted in favour of the report assertions above — but reporting a truncation while
+        // emitting the untruncated value passes every assertion up to here. The fixture is
+        // multibyte on purpose: with a leading ASCII byte, byte `MAX_TITLE_BYTES` lands mid-char,
+        // so this also exercises `truncate_utf8`'s char-boundary walk-back.
+        let node = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == "patterns/verbose")
+            .expect("the page itself is still served");
+        assert!(
+            node.title.len() <= MAX_TITLE_BYTES,
+            "title must be truncated, not merely reported: {} bytes",
+            node.title.len()
+        );
+        assert!(
+            node.title.is_char_boundary(node.title.len()),
+            "title must be cut on a char boundary"
+        );
+        assert!(
+            node.last_updated.len() <= MAX_LAST_UPDATED_BYTES,
+            "last_updated must be truncated, not merely reported: {} bytes",
+            node.last_updated.len()
+        );
+        assert!(
+            serde_json::to_vec(&graph).unwrap().len() <= MAX_GRAPH_RESPONSE_BYTES,
+            "the serialized graph must stay inside its response budget"
+        );
+
+        // (e) Depth ceiling: a directory nested past the limit is named as skipped, by a
+        // root-relative label.
+        let deep = TempDir::new().unwrap();
+        let mut nested = String::from("patterns");
+        for _ in 0..=MAX_DIRECTORY_DEPTH {
+            nested.push_str("/d");
+        }
+        write_page(deep.path(), &format!("{nested}/leaf.md"), "# Leaf\n");
+        write_page(deep.path(), "patterns/shallow.md", "# Shallow\n");
+        let graph = scan(deep.path());
+        assert!(ids(&graph).contains("patterns/shallow"));
+        let depth = omission(&graph, KnowledgeOmissionReason::DirectoryDepthExceeded)
+            .expect("depth omission");
+        assert!(depth.count >= 1);
+        assert!(
+            depth.examples.iter().all(|example| !example.contains(':')),
+            "depth examples must be root-relative, got {:?}",
+            depth.examples
+        );
+    }
+
+
+    /// Edge-side caps report as link omissions, never as missing pages, and `build_edges` is
+    /// driven directly so the byte budget can be exercised without a multi-megabyte fixture.
+    #[test]
+    fn edge_caps_report_as_link_omissions() {
+        let nodes: Vec<_> = (0..150)
+            .map(|index| test_node(&format!("patterns/page-{index}"), &format!("Page {index}")))
+            .collect();
+        let lookup = NodeLookup::from_nodes(&nodes);
+        let dense: Vec<RawEdge> = nodes
+            .iter()
+            .flat_map(|source| {
+                nodes.iter().filter_map(move |target| {
+                    (source.id != target.id).then(|| RawEdge {
+                        source: source.id.clone(),
+                        target_hint: target.id.clone(),
+                        kind: KnowledgeEdgeKind::CrossRef,
+                    })
+                })
+            })
+            .collect();
+        let dense_len = dense.len();
+        assert!(dense_len > MAX_EDGES, "fixture must exceed the edge cap");
+
+        let mut report = TruncationReport::default();
+        let edges = build_edges(dense, &lookup, MAX_GRAPH_ITEM_BYTES, &mut report);
+        assert_eq!(edges.len(), MAX_EDGES);
+        let omissions = report.into_omissions();
+        let capped = omissions
+            .iter()
+            .find(|omission| omission.reason == KnowledgeOmissionReason::EdgeCapReached)
+            .expect("edge cap omission");
+        assert_eq!(
+            capped.count,
+            dense_len - MAX_EDGES,
+            "the cap omission must pin an exact number, not merely a non-zero one"
+        );
+        assert!(capped.detail.contains("all pages are shown"));
+
+        // The byte budget is a separate reason from the count cap.
+        let mut report = TruncationReport::default();
+        let edges = build_edges(
+            vec![RawEdge {
+                source: "patterns/page-0".to_string(),
+                target_hint: "patterns/page-1".to_string(),
+                kind: KnowledgeEdgeKind::CrossRef,
+            }],
+            &lookup,
+            1,
+            &mut report,
+        );
+        assert!(edges.is_empty());
+        assert_eq!(
+            report
+                .into_omissions()
+                .iter()
+                .map(|omission| omission.reason)
+                .collect::<Vec<_>>(),
+            vec![KnowledgeOmissionReason::ResponseSizeCapReached]
+        );
+    }
+
+    /// When the byte budget is what stopped the walk, the unscanned tail must be attributed to the
+    /// byte budget — not to the node cap. Blaming the node cap sends the operator to raise a
+    /// `?max_nodes=` that changes nothing, which is exactly the untrustworthy banner the omission
+    /// taxonomy replaced.
+    #[test]
+    fn a_byte_budget_stop_does_not_blame_the_node_cap_for_the_tail() {
+        let wiki = TempDir::new().unwrap();
+        for index in 0..6 {
+            write_page(
+                wiki.path(),
+                &format!("patterns/page-{index}.md"),
+                "# Page\n",
+            );
+        }
+
+        // A budget large enough for the first node but not the corpus, so the walk stops on bytes
+        // while `nodes.len()` is still far below the node cap.
+        let graph = scan_knowledge_within(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            MAX_NODES,
+            &[],
+            220,
+        );
+
+        assert!(
+            graph.nodes.len() < MAX_NODES,
+            "the node cap must provably not be what stopped this scan"
+        );
+        assert!(
+            !graph.nodes.is_empty(),
+            "the fixture must scan something before the budget binds"
+        );
+        assert_eq!(
+            reasons(&graph),
+            vec![KnowledgeOmissionReason::ResponseSizeCapReached],
+            "a byte-budget stop must report only the byte budget"
+        );
+        let reported = omission(&graph, KnowledgeOmissionReason::ResponseSizeCapReached)
+            .expect("byte budget omission");
+        assert_eq!(
+            reported.count,
+            6 - graph.nodes.len(),
+            "every unscanned page must be counted under the reason that actually stopped the walk"
+        );
+    }
+
+    /// A repeated link is one link. `build_edges` deduplicates *before* the cap so the banner
+    /// counts distinct dropped edges; counting after the cap would multiply a single `[[Target]]`
+    /// repeated in a long page into that many phantom omissions.
+    ///
+    /// `edge_caps_report_as_link_omissions` above cannot see this: its fixture is the full
+    /// cross-product of distinct IDs, so every triple is unique and `seen.insert` is a no-op filter
+    /// — swapping a no-op filter with the cap check cannot change its output.
+    #[test]
+    fn repeated_links_are_counted_once_against_the_edge_cap() {
+        let nodes: Vec<_> = (0..150)
+            .map(|index| test_node(&format!("patterns/page-{index}"), &format!("Page {index}")))
+            .collect();
+        let lookup = NodeLookup::from_nodes(&nodes);
+        let mut dense: Vec<RawEdge> = nodes
+            .iter()
+            .flat_map(|source| {
+                nodes.iter().filter_map(move |target| {
+                    (source.id != target.id).then(|| RawEdge {
+                        source: source.id.clone(),
+                        target_hint: target.id.clone(),
+                        kind: KnowledgeEdgeKind::CrossRef,
+                    })
+                })
+            })
+            .collect();
+        let distinct = dense.len();
+        assert!(distinct > MAX_EDGES, "fixture must exceed the edge cap");
+
+        // One page repeats a single link 500 times, the way a long `log.md` repeats `[[Target]]`.
+        // `parse_body_edges` emits one RawEdge per occurrence, and nothing between there and here
+        // deduplicates, so all 500 really do arrive.
+        const REPEATS: usize = 500;
+        dense.extend((0..REPEATS).map(|_| RawEdge {
+            source: "patterns/page-0".to_string(),
+            target_hint: "patterns/page-1".to_string(),
+            kind: KnowledgeEdgeKind::CrossRef,
+        }));
+
+        let mut report = TruncationReport::default();
+        let edges = build_edges(dense, &lookup, MAX_GRAPH_ITEM_BYTES, &mut report);
+        assert_eq!(edges.len(), MAX_EDGES);
+        let capped = report
+            .into_omissions()
+            .into_iter()
+            .find(|omission| omission.reason == KnowledgeOmissionReason::EdgeCapReached)
+            .expect("edge cap omission");
+        // Exactly the distinct edges that did not fit. The 500 repeats are already represented by
+        // an edge that WAS emitted, so they are not omissions at all and must not be counted.
+        assert_eq!(
+            capped.count,
+            distinct - MAX_EDGES,
+            "repeated links inflated the omission count by {}",
+            capped.count as i64 - (distinct - MAX_EDGES) as i64
+        );
+    }
+
+    /// A page preview reports its own omissions, not the corpus-wide enumeration's.
+    #[test]
+    fn preview_reports_only_its_own_omissions() {
+        let wiki = TempDir::new().unwrap();
+        write_page(
+            wiki.path(),
+            "patterns/preview.md",
+            &format!(
+                "---\ntitle: Preview Title\nlast_updated: 2026-07-19\n---\n# Preview\n{}",
+                "é".repeat(MAX_PREVIEW_BYTES)
+            ),
+        );
+        // An unrelated oversized page would flip a corpus-wide report, and must not appear here.
+        write_page(
+            wiki.path(),
+            "patterns/unrelated-huge.md",
+            &"x".repeat(MAX_FILE_BYTES + 1),
+        );
+
+        let page =
+            preview_knowledge_page(wiki.path(), &discovered(wiki.path()), None, "patterns/preview")
+                .expect("preview");
+        assert_eq!(page.title, "Preview Title");
+        assert!(!page.content.contains("last_updated:"));
+        assert!(page.content.len() <= MAX_PREVIEW_BYTES);
+        assert!(page.content.is_char_boundary(page.content.len()));
+        assert!(page.truncated);
+        assert_eq!(
+            page.omissions
+                .iter()
+                .map(|omission| omission.reason)
+                .collect::<Vec<_>>(),
+            vec![KnowledgeOmissionReason::ContentTruncated],
+            "the preview must not inherit an unrelated page's omission"
+        );
+
+        let short = preview_knowledge_page(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            "patterns/unrelated-huge",
+        );
+        assert!(short.is_none(), "an oversized page has no preview");
+        assert!(preview_knowledge_page(
+            wiki.path(),
+            &discovered(wiki.path()),
+            None,
+            "patterns/missing"
+        )
+        .is_none());
+    }
+
+    /// `truncated` stays exactly the derived "is anything in the report", so a client that only
+    /// reads the old boolean keeps behaving the way it always did.
+    #[test]
+    fn truncated_is_derived_from_the_omission_report() {
+        let clean = TempDir::new().unwrap();
+        write_page(clean.path(), "patterns/a.md", "# A\n");
+        let graph = scan(clean.path());
+        assert_eq!(graph.truncated, !graph.omissions.is_empty());
+        assert!(!graph.truncated);
+
+        let dirty = TempDir::new().unwrap();
+        write_page(dirty.path(), "patterns/a.md", "# A\n");
+        write_page(dirty.path(), "patterns/b.md", "# B\n");
+        let graph = scan_knowledge(dirty.path(), &discovered(dirty.path()), None, 1, &[]);
+        assert_eq!(graph.truncated, !graph.omissions.is_empty());
+        assert!(graph.truncated);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // 4. Operator narrowing, IDs, and hints.
+    // ---------------------------------------------------------------------------------------
+
+    /// Config may only select among folders that actually exist under the root. It cannot construct
+    /// a path, and it cannot name a folder into existence.
+    #[test]
+    fn configured_folders_can_only_narrow_the_discovered_set() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        write_page(wiki.path(), "agents/dossier.md", "# Dossier\n");
+        write_page(wiki.path(), "clients/acme/dashboard.md", "# Acme\n");
+        let found = discover_wiki_folders(wiki.path()).folders;
+        assert_eq!(
+            found.iter().map(KnowledgeFolder::as_str).collect::<Vec<_>>(),
+            vec!["agents", "clients", "patterns"]
+        );
+
+        // Absent key: everything discovered.
+        assert_eq!(resolve_wiki_folders_from(None, found.clone()), found);
+
+        // Narrowing, with case and whitespace tolerated and duplicates collapsed.
+        assert_eq!(
+            resolve_wiki_folders_from(
+                Some(&[
+                    "  Patterns ".to_string(),
+                    "PATTERNS".to_string(),
+                    "patterns".to_string()
+                ]),
+                found.clone()
+            )
+            .iter()
+            .map(KnowledgeFolder::as_str)
+            .collect::<Vec<_>>(),
+            vec!["patterns"]
+        );
+
+        // Path-shaped and non-existent entries select nothing and never become paths.
+        assert_eq!(
+            resolve_wiki_folders_from(
+                Some(&[
+                    "../../../etc".to_string(),
+                    "/etc/passwd".to_string(),
+                    "C:\\Windows\\System32".to_string(),
+                    "..".to_string(),
+                    "clients/../agents".to_string(),
+                    "patterns".to_string(),
+                ]),
+                found.clone()
+            )
+            .iter()
+            .map(KnowledgeFolder::as_str)
+            .collect::<Vec<_>>(),
+            vec!["patterns"]
+        );
+
+        // Fail closed: a typo empties the Atlas rather than silently restoring everything.
+        let typo = resolve_wiki_folders_from(Some(&["pattrens".to_string()]), found.clone());
+        assert!(typo.is_empty());
+        for empty in [
+            resolve_wiki_folders_from(Some(&[]), found.clone()),
+            resolve_wiki_folders_from(Some(&[String::new()]), found.clone()),
+            resolve_wiki_folders_from(Some(&["   ".to_string()]), found),
+        ] {
+            assert!(empty.is_empty());
+        }
+    }
+
+    /// End-to-end proof that narrowing is enforced at the filesystem walk, not merely in the
+    /// resolver: an excluded folder yields no nodes and no preview.
+    #[test]
+    fn configured_narrowing_is_enforced_at_enumeration() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/kept.md", "# Kept\n");
+        write_page(wiki.path(), "agents/dossier.md", "---\ntitle: Dossier\n---\n");
+
+        let narrowed = resolve_wiki_folders_from(
+            Some(&["patterns".to_string()]),
+            discover_wiki_folders(wiki.path()).folders,
+        );
+        let graph = scan_knowledge(wiki.path(), &narrowed, None, MAX_NODES, &[]);
+        assert_eq!(ids(&graph), HashSet::from(["patterns/kept"]));
+        assert!(!serde_json::to_string(&graph).unwrap().contains("Dossier"));
+        assert!(
+            preview_knowledge_page(wiki.path(), &narrowed, None, "agents/dossier").is_none(),
+            "a config-excluded folder must not be previewable"
+        );
+
+        let typo =
+            resolve_wiki_folders_from(Some(&["pattrens".to_string()]), discover_wiki_folders(wiki.path()).folders);
+        let empty = scan_knowledge(wiki.path(), &typo, None, MAX_NODES, &[]);
+        assert!(empty.nodes.is_empty());
+        assert!(preview_knowledge_page(wiki.path(), &typo, None, "patterns/kept").is_none());
+    }
+
+    #[test]
+    fn project_nodes_are_reserved_ahead_of_a_saturated_global_corpus() {
+        let wiki = TempDir::new().unwrap();
+        let project = TempDir::new().unwrap();
+        for index in 0..10 {
+            write_page(
+                wiki.path(),
+                &format!("patterns/global-{index:02}.md"),
+                &format!("# Global {index}\n"),
+            );
+        }
+        write_page(project.path(), ".ai-docs/project-dna.md", "# Project DNA\n");
+        write_page(project.path(), ".ai-docs/bug-patterns.md", "# Bug Patterns\n");
+        write_page(project.path(), ".ai-docs/architecture.md", "# Not Scanned\n");
+
+        let graph = scan_knowledge(
+            wiki.path(),
+            &discovered(wiki.path()),
+            Some(project.path()),
+            3,
+            &[],
+        );
+        let node_ids: Vec<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+        assert_eq!(
+            &node_ids[..2],
+            &[".project/project-dna", ".project/bug-patterns"],
+            "project knowledge must survive a saturated global corpus"
+        );
+        assert!(!node_ids.contains(&".project/architecture"));
+        assert!(graph.truncated);
+    }
+
+    #[test]
+    fn knowledge_ids_reject_traversal_and_absolute_forms() {
+        for invalid in [
+            "",
+            "patterns",
+            "../agents/secret",
+            "patterns/../agents/secret",
+            "/patterns/secret",
+            "C:/patterns/secret",
+            "\\\\server\\patterns\\secret",
+            "patterns\\secret",
+            "patterns/./secret",
+            "patterns//secret",
+            ".hidden/secret",
+            ".project/architecture",
+            ".project/../patterns/page",
+        ] {
+            assert!(validate_knowledge_id(invalid).is_err(), "accepted {invalid}");
+        }
+        // Folders are discovered now, so an arbitrary-but-well-shaped prefix is syntactically
+        // valid. It only ever resolves if enumeration actually produced that exact node.
+        for valid in [
+            "patterns/nested/page",
+            "agents/recruiting/candidate",
+            "zettelkasten/202607190001",
+            "root/index",
+            ".project/project-dna",
+            ".project/bug-patterns",
+            // A wiki folder literally named `project` is an ordinary discovered folder now. It
+            // used to inherit the session bucket's two-file allowlist, so the graph advertised
+            // nodes the preview endpoint answered with 400.
+            "project/architecture",
+            "project/roadmap",
+        ] {
+            assert!(validate_knowledge_id(valid).is_ok(), "rejected {valid}");
+        }
+    }
+
+    /// A syntactically valid ID naming a folder that exists but a page that does not must resolve
+    /// to nothing — the enumeration match, not the prefix check, is what actually bounds previews.
+    #[test]
+    fn a_well_formed_id_still_resolves_only_against_enumerated_sources() {
+        let wiki = TempDir::new().unwrap();
+        write_page(wiki.path(), "patterns/real.md", "# Real\n");
+        let folders = discovered(wiki.path());
+
+        assert!(preview_knowledge_page(wiki.path(), &folders, None, "patterns/real").is_some());
+        for absent in [
+            "patterns/imaginary",
+            "imaginary/page",
+            "patterns/nested/imaginary",
+            "root/index",
+        ] {
+            assert!(
+                preview_knowledge_page(wiki.path(), &folders, None, absent).is_none(),
+                "resolved a page that was never enumerated: {absent}"
+            );
+        }
+    }
+
+    fn test_node(id: &str, title: &str) -> KnowledgeNode {
+        let folder = id.split('/').next().unwrap_or("patterns");
         KnowledgeNode {
             id: id.to_string(),
             title: title.to_string(),
-            folder,
+            folder: KnowledgeFolder::new(folder),
             path: format!("{id}.md"),
             last_updated: String::new(),
             in_degree: 0,
@@ -1580,47 +3224,29 @@ mod tests {
         }
     }
 
-    /// The entity nodes below must actually exist for this test to mean anything. With a
-    /// patterns-only fixture the `clients/*` assertions passed for the wrong reason — the
-    /// exact-ID lookup simply missed and the explicit-path guard blocked the basename fallback —
-    /// so they would have stayed green even if the allowlist gate had been deleted entirely.
+    /// Hints resolve against folders that exist *in this graph*, which is the discovered-corpus
+    /// form of the old compiled-in gate. `agents/` now resolves; `project/` still must not be
+    /// reachable by walking upward from a wiki page.
     #[test]
-    fn relative_allowlisted_hints_resolve_without_disallowed_basename_fallback() {
+    fn hints_resolve_against_graph_folders_without_disallowed_fallback() {
         let nodes = vec![
-            test_node("patterns/cross", "Pattern Cross", KnowledgeFolder::Patterns),
-            test_node("clients/cross", "Client Cross", KnowledgeFolder::Clients),
-            test_node("partners/cross", "Partner Cross", KnowledgeFolder::Partners),
-            test_node("vendors/cross", "Vendor Cross", KnowledgeFolder::Vendors),
-            test_node(
-                "operations/cross",
-                "Operations Cross",
-                KnowledgeFolder::Operations,
-            ),
-            test_node(
-                "clients/acme/dashboard",
-                "Acme Dashboard",
-                KnowledgeFolder::Clients,
-            ),
+            test_node("patterns/cross", "Pattern Cross"),
+            test_node("clients/cross", "Client Cross"),
+            test_node("agents/cross", "Agent Cross"),
+            test_node("clients/acme/dashboard", "Acme Dashboard"),
+            test_node(".project/project-dna", "Project DNA"),
         ];
         let lookup = NodeLookup::from_nodes(&nodes);
 
         for (hint, expected) in [
             ("patterns/cross.md", "patterns/cross"),
             ("../patterns/cross.md", "patterns/cross"),
-            (
-                "../../wiki/patterns/cross.md (corpus annotation)",
-                "patterns/cross",
-            ),
-            // The entity roots resolve now, including through a parent-relative hint and into a
-            // nested `clients/<slug>/dashboard.md` page.
-            ("clients/cross.md", "clients/cross"),
-            ("../clients/cross.md", "clients/cross"),
-            ("partners/cross.md", "partners/cross"),
-            ("../partners/cross.md", "partners/cross"),
-            ("vendors/cross.md", "vendors/cross"),
-            ("operations/cross.md", "operations/cross"),
+            ("../../wiki/patterns/cross.md (annotation)", "patterns/cross"),
             ("clients/acme/dashboard.md", "clients/acme/dashboard"),
             ("../clients/acme/dashboard.md", "clients/acme/dashboard"),
+            // The folder that used to be unreachable by construction.
+            ("agents/cross.md", "agents/cross"),
+            ("../agents/cross.md", "agents/cross"),
         ] {
             assert_eq!(
                 resolve_hint(hint, &lookup).as_deref(),
@@ -1629,254 +3255,93 @@ mod tests {
             );
         }
 
-        // `agents/` is never allow-listed, and an explicit path must not fall back by basename to
-        // one of the five genuinely-present `*/cross` nodes.
         for rejected in [
-            "agents/cross.md",
-            "../agents/cross.md",
-            "agents/recruiting/candidate.md",
+            // Session-scoped project knowledge is not reachable by walking up from a wiki page.
             "../project/project-dna.md",
-            "../patterns/../agents/cross.md",
+            // A folder that is not in this graph cannot anchor an explicit path...
+            "nonexistent/cross.md",
+            "../nonexistent/cross.md",
+            // ...and an explicit path must never fall back to a same-basename page elsewhere.
+            "../patterns/../nonexistent/cross.md",
         ] {
             assert_eq!(resolve_hint(rejected, &lookup), None, "accepted {rejected}");
         }
 
-        // Ambiguity guard: the bare basename `cross` now maps to five nodes across five folders,
-        // so `unique_lookup` declines rather than inventing an edge to whichever one hashed first.
-        // No node is titled plain "Cross", so the title fallback cannot rescue it either -- this is
-        // exactly the duplicate-basename failure mode that keeps `agents/` out of `WIKI_FOLDERS`.
+        // Ambiguity guard: `cross` names three nodes, so no edge is invented.
         assert_eq!(resolve_hint("cross", &lookup), None);
-        // An unambiguous title still resolves, so the guard above is narrow, not a blanket block.
         assert_eq!(
             resolve_hint("Acme Dashboard", &lookup).as_deref(),
             Some("clients/acme/dashboard")
         );
     }
 
-    /// `as_str()` (directory name + node-ID prefix) and the `serde(rename_all = "snake_case")`
-    /// wire tag are independent mechanisms that only happen to agree. Adding a variant that
-    /// updates one but not the other would ship a graph whose folder tags do not match the IDs
-    /// the frontend filters on, so pin them to each other.
     #[test]
-    fn as_str_matches_the_serialized_folder_tag() {
-        for folder in WIKI_FOLDERS
-            .into_iter()
-            .chain(std::iter::once(KnowledgeFolder::Project))
-        {
-            let serialized = serde_json::to_string(&folder).unwrap();
-            assert_eq!(
-                serialized,
-                format!("\"{}\"", folder.as_str()),
-                "serde tag and as_str disagree for {folder:?}"
-            );
-        }
-
-        assert_eq!(
-            WIKI_FOLDERS.map(KnowledgeFolder::as_str),
-            [
-                "patterns",
-                "practices",
-                "research",
-                "clients",
-                "partners",
-                "vendors",
-                "operations",
-            ]
-        );
-    }
-
-    #[test]
-    fn id_prefix_gate_admits_entity_roots_and_still_rejects_agents() {
-        for allowed in [
-            "patterns",
-            "practices",
-            "research",
-            "clients",
-            "partners",
-            "vendors",
-            "operations",
-            "project",
-        ] {
-            assert!(
-                KnowledgeFolder::from_id_prefix(allowed).is_some(),
-                "{allowed} should be an allow-listed ID prefix"
-            );
-        }
-        for rejected in ["agents", "", "..", "Clients", "clients/acme", "etc"] {
-            assert!(
-                KnowledgeFolder::from_id_prefix(rejected).is_none(),
-                "{rejected} should not be an allow-listed ID prefix"
-            );
-        }
-    }
-
-    /// Operator config may only narrow or re-select within `WIKI_FOLDERS`. It must never be able to
-    /// widen the scan back to `agents/`, nor turn a string into a filesystem path.
-    #[test]
-    fn configured_folders_can_only_narrow_the_compiled_allowlist() {
-        assert_eq!(resolve_wiki_folders_from(None), WIKI_FOLDERS.to_vec());
-
-        // `None` is the only absent-equivalent input: no operator opinion, so the built-in default
-        // applies. Anything the operator actually wrote is a boundary, and a boundary naming no
-        // recognized folder selects none of them rather than quietly restoring all seven.
-        let none_selected = Vec::<KnowledgeFolder>::new();
-        assert_eq!(resolve_wiki_folders_from(Some(&[])), none_selected);
-        assert_eq!(
-            resolve_wiki_folders_from(Some(&[String::new()])),
-            none_selected
-        );
-        assert_eq!(
-            resolve_wiki_folders_from(Some(&["   ".to_string()])),
-            none_selected
-        );
-
-        // Narrowing: a privacy-conscious machine drops the entity roots.
-        assert_eq!(
-            resolve_wiki_folders_from(Some(&[
-                "patterns".to_string(),
-                "practices".to_string()
-            ])),
-            vec![KnowledgeFolder::Patterns, KnowledgeFolder::Practices]
-        );
-
-        // Case and surrounding whitespace are tolerated; duplicates collapse.
-        assert_eq!(
-            resolve_wiki_folders_from(Some(&[
-                "  Clients ".to_string(),
-                "CLIENTS".to_string(),
-                "clients".to_string(),
-            ])),
-            vec![KnowledgeFolder::Clients]
-        );
-
-        // Widening attempts are dropped, not honored, and never become paths.
-        assert_eq!(
-            resolve_wiki_folders_from(Some(&[
-                "agents".to_string(),
-                "../../../etc".to_string(),
-                "/etc/passwd".to_string(),
-                "C:\\Windows\\System32".to_string(),
-                "project".to_string(),
-                "..".to_string(),
-                "clients/../agents".to_string(),
-                "research".to_string(),
-            ])),
-            vec![KnowledgeFolder::Research],
-            "config must select among compiled-in variants, never construct new ones"
-        );
-
-        // An entirely unrecognized list cannot widen — and it does not fall back to the default
-        // either. It selects nothing, so a typo empties the Atlas instead of restoring the entity
-        // roots the operator was trying to exclude.
-        let effective = resolve_wiki_folders_from(Some(&[
-            "agents".to_string(),
-            "../../../etc".to_string(),
-        ]));
-        assert!(
-            effective.is_empty(),
-            "a fully unrecognized narrowing must select nothing, got {effective:?}"
-        );
-    }
-
-    /// End-to-end proof that narrowing is enforced where it matters — the filesystem walk — and
-    /// that an excluded folder yields no nodes and no preview.
-    #[test]
-    fn configured_narrowing_is_enforced_at_enumeration() {
+    fn scanner_builds_all_five_edge_kinds_across_discovered_folders() {
         let wiki = TempDir::new().unwrap();
         write_page(
             wiki.path(),
-            "patterns/kept.md",
-            "---\ntitle: Kept\n---\n# Kept\n",
+            "patterns/source.md",
+            "---\ntitle: Source #153\nlast_updated: 2026-07-18\ncross_refs:\n  - wiki/practices/cross.md\n  - agents/cross.md\nrelated: [research/frontmatter-related.md]\n---\n# Source\n[[Wiki Target]]\n-> global: patterns/global.md\n-> related: [[body-related]] (strong match)\n<-> related: wiki/research/frontmatter-related.md (§details)\n<- from: research/from.md\n",
         );
+        write_page(wiki.path(), "practices/cross.md", "---\ntitle: Cross\n---\n");
         write_page(
             wiki.path(),
-            "clients/acme/dashboard.md",
-            "---\ntitle: Acme\n---\n# Acme\n",
+            "practices/wiki-target.md",
+            "---\ntitle: Wiki Target\n---\n",
         );
+        write_page(wiki.path(), "patterns/global.md", "# Global\n");
+        write_page(wiki.path(), "practices/body-related.md", "# Related\n");
         write_page(
             wiki.path(),
-            "agents/recruiting/candidate.md",
-            "---\ntitle: Candidate\n---\n# Candidate\n",
+            "research/frontmatter-related.md",
+            "# Frontmatter Related\n",
         );
+        write_page(wiki.path(), "research/from.md", "# From\n");
+        // `agents/cross.md` is now a real, reachable node, so the `agents/cross.md` cross-ref above
+        // resolves instead of being dropped by an allowlist.
+        write_page(wiki.path(), "agents/cross.md", "---\ntitle: Agent Cross\n---\n");
 
-        let full = resolve_wiki_folders_from(None);
-        let graph = scan_knowledge(wiki.path(), &full, None, MAX_NODES);
-        let ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
-        assert!(ids.contains("patterns/kept"));
-        assert!(ids.contains("clients/acme/dashboard"));
-        assert!(!ids.iter().any(|id| id.starts_with("agents/")));
+        let graph = scan(wiki.path());
+        let seen = ids(&graph);
+        assert!(seen.contains("patterns/source"));
+        assert!(seen.contains("agents/cross"));
 
-        // A machine that narrows to `patterns` loses the entity nodes...
-        let narrowed = resolve_wiki_folders_from(Some(&["patterns".to_string()]));
-        let narrowed_graph = scan_knowledge(wiki.path(), &narrowed, None, MAX_NODES);
-        let narrowed_ids: HashSet<_> = narrowed_graph
-            .nodes
-            .iter()
-            .map(|node| node.id.as_str())
-            .collect();
-        assert_eq!(narrowed_ids, HashSet::from(["patterns/kept"]));
-        assert!(
-            preview_knowledge_page(wiki.path(), &narrowed, None, "clients/acme/dashboard")
-                .is_none(),
-            "a config-excluded folder must not be previewable"
+        let kinds: HashSet<_> = graph.edges.iter().map(|edge| edge.kind).collect();
+        assert_eq!(
+            kinds,
+            HashSet::from([
+                KnowledgeEdgeKind::CrossRef,
+                KnowledgeEdgeKind::Wikilink,
+                KnowledgeEdgeKind::Global,
+                KnowledgeEdgeKind::Related,
+                KnowledgeEdgeKind::From,
+            ])
         );
-
-        // ...and a config naming `agents` cannot get it back.
-        let hostile =
-            resolve_wiki_folders_from(Some(&["agents".to_string(), "patterns".to_string()]));
-        let hostile_graph = scan_knowledge(wiki.path(), &hostile, None, MAX_NODES);
-        assert!(!hostile_graph
-            .nodes
-            .iter()
-            .any(|node| node.id.starts_with("agents/")));
-        assert!(
-            preview_knowledge_page(wiki.path(), &hostile, None, "agents/recruiting/candidate")
-                .is_none()
+        assert!(graph.edges.iter().all(|edge| {
+            seen.contains(edge.source.as_str()) && seen.contains(edge.target.as_str())
+        }));
+        assert!(graph.edges.iter().any(|edge| {
+            edge.kind == KnowledgeEdgeKind::CrossRef && edge.target == "agents/cross"
+        }));
+        assert_eq!(
+            graph
+                .nodes
+                .iter()
+                .find(|node| node.id == "patterns/source")
+                .unwrap()
+                .title,
+            "Source #153"
         );
+        assert!(!graph.truncated, "unexpected omissions: {:?}", graph.omissions);
     }
 
-    /// Fail-closed at the scan layer. The failure pinned here is the fail-open one: an operator
-    /// who typos `["clients"]` intends to *exclude* the entity roots, and must never end up with
-    /// `clients/`, `partners/`, and `vendors/` rendered in a graph they believe excludes them.
-    #[test]
-    fn unrecognized_narrowing_scans_nothing_rather_than_falling_open() {
-        let wiki = TempDir::new().unwrap();
-        write_page(
-            wiki.path(),
-            "patterns/kept.md",
-            "---\ntitle: Kept\n---\n# Kept\n",
-        );
-        write_page(
-            wiki.path(),
-            "clients/acme/dashboard.md",
-            "---\ntitle: Acme\n---\n# Acme\n",
-        );
-
-        let typo = resolve_wiki_folders_from(Some(&["cleints".to_string()]));
-        assert!(typo.is_empty(), "a typo must not resolve to the default set");
-
-        let graph = scan_knowledge(wiki.path(), &typo, None, MAX_NODES);
-        assert!(
-            graph.nodes.is_empty(),
-            "a typo'd narrowing must not scan the entity roots, got {:?}",
-            graph.nodes
-        );
-        assert!(
-            preview_knowledge_page(wiki.path(), &typo, None, "clients/acme/dashboard").is_none(),
-            "a typo'd narrowing must not leave client pages previewable"
-        );
-    }
-
-    /// Nested entity pages and the operational/relationship cross-half edges the Atlas exists to
-    /// show. `clients/<slug>/dashboard.md` is a future corpus shape, so it only exists here.
     #[test]
     fn nested_entity_pages_scan_and_cross_link_between_graph_halves() {
         let wiki = TempDir::new().unwrap();
         write_page(
             wiki.path(),
             "clients/acme/dashboard.md",
-            "---\ntitle: Acme Dashboard\nlast_updated: 2026-07-18\n---\n# Acme\n\
-             [[partners/beta]]\n",
+            "---\ntitle: Acme Dashboard\nlast_updated: 2026-07-18\n---\n# Acme\n[[partners/beta]]\n",
         );
         write_page(
             wiki.path(),
@@ -1886,23 +3351,17 @@ mod tests {
         write_page(
             wiki.path(),
             "patterns/delivery.md",
-            "---\ntitle: Delivery\ncross_refs:\n  - clients/acme/dashboard.md\n---\n# Delivery\n\
-             [[partners/beta]]\n",
+            "---\ntitle: Delivery\ncross_refs:\n  - clients/acme/dashboard.md\n---\n# Delivery\n[[partners/beta]]\n",
         );
 
-        let folders = resolve_wiki_folders_from(None);
-        let graph = scan_knowledge(wiki.path(), &folders, None, MAX_NODES);
-        let ids: HashSet<_> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
-        assert!(ids.contains("clients/acme/dashboard"));
-        assert!(ids.contains("partners/beta"));
-
+        let graph = scan(wiki.path());
         let dashboard = graph
             .nodes
             .iter()
             .find(|node| node.id == "clients/acme/dashboard")
-            .unwrap();
+            .expect("dashboard node");
         assert_eq!(dashboard.title, "Acme Dashboard");
-        assert_eq!(dashboard.folder, KnowledgeFolder::Clients);
+        assert_eq!(dashboard.folder.as_str(), "clients");
         assert_eq!(dashboard.path, "clients/acme/dashboard.md");
 
         let has_edge = |source: &str, target: &str, kind: KnowledgeEdgeKind| {
@@ -1911,37 +3370,18 @@ mod tests {
                 .iter()
                 .any(|edge| edge.source == source && edge.target == target && edge.kind == kind)
         };
-        // Entity <-> entity.
         assert!(has_edge(
             "clients/acme/dashboard",
             "partners/beta",
             KnowledgeEdgeKind::Wikilink
         ));
-        // Operational -> entity, joining the two halves of the graph.
         assert!(has_edge(
             "patterns/delivery",
             "clients/acme/dashboard",
             KnowledgeEdgeKind::CrossRef
         ));
-        assert!(has_edge(
-            "patterns/delivery",
-            "partners/beta",
-            KnowledgeEdgeKind::Wikilink
-        ));
         assert_eq!(dashboard.in_degree, 1);
         assert_eq!(dashboard.out_degree, 1);
-
-        assert!(!serde_json::to_string(&graph)
-            .unwrap()
-            .contains(&wiki.path().to_string_lossy().to_string()));
-
-        let page =
-            preview_knowledge_page(wiki.path(), &folders, None, "clients/acme/dashboard").unwrap();
-        assert_eq!(page.path, "clients/acme/dashboard.md");
-        assert_eq!(page.folder, KnowledgeFolder::Clients);
-        assert!(!serde_json::to_string(&page)
-            .unwrap()
-            .contains(&wiki.path().to_string_lossy().to_string()));
     }
 
     #[test]
@@ -1961,33 +3401,23 @@ mod tests {
                 .as_deref(),
             Some(first)
         );
-        assert_eq!(
-            resolve_project_root_from_sessions(Some("session-b"), sessions.iter().copied())
-                .ok()
-                .flatten()
-                .as_deref(),
-            Some(second)
-        );
 
         // Keeping the old graph's session id after the live session switches cannot resolve the
         // replacement project's identically-named `project/project-dna` node.
         let switched = [("session-b", second)];
-        let error = match resolve_project_root_from_sessions(
-            Some("session-a"),
-            switched.iter().copied(),
-        ) {
-            Ok(_) => panic!("stale session unexpectedly resolved a project"),
-            Err(error) => error,
-        };
+        let error =
+            match resolve_project_root_from_sessions(Some("session-a"), switched.iter().copied()) {
+                Ok(_) => panic!("stale session unexpectedly resolved a project"),
+                Err(error) => error,
+            };
         assert_eq!(error.status, axum::http::StatusCode::NOT_FOUND);
 
-        let invalid = match resolve_project_root_from_sessions(
-            Some("../session-a"),
-            sessions.iter().copied(),
-        ) {
-            Ok(_) => panic!("invalid session id unexpectedly resolved a project"),
-            Err(error) => error,
-        };
+        let invalid =
+            match resolve_project_root_from_sessions(Some("../session-a"), sessions.iter().copied())
+            {
+                Ok(_) => panic!("invalid session id unexpectedly resolved a project"),
+                Err(error) => error,
+            };
         assert_eq!(invalid.status, axum::http::StatusCode::BAD_REQUEST);
     }
 
@@ -2010,121 +3440,6 @@ mod tests {
     }
 
     #[test]
-    fn preview_is_id_based_strips_frontmatter_and_caps_content() {
-        let wiki = TempDir::new().unwrap();
-        let body = format!("# Preview\n{}", "é".repeat(MAX_PREVIEW_BYTES));
-        write_page(
-            wiki.path(),
-            "patterns/preview.md",
-            &format!(
-                "---\ntitle: Preview Title\nlast_updated: 2026-07-18\n---\n{body}"
-            ),
-        );
-
-        let page = preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/preview").unwrap();
-        assert_eq!(page.id, "patterns/preview");
-        assert_eq!(page.path, "patterns/preview.md");
-        assert_eq!(page.title, "Preview Title");
-        assert!(!page.content.contains("last_updated:"));
-        assert!(page.truncated);
-        assert!(page.content.len() <= MAX_PREVIEW_BYTES);
-        assert!(page.content.is_char_boundary(page.content.len()));
-        assert!(preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/missing").is_none());
-    }
-
-    #[test]
-    fn preview_id_validation_rejects_traversal_and_absolute_forms() {
-        for invalid in [
-            "",
-            // `agents/` replaces the old `clients/` cases: `clients` is allow-listed now, so
-            // reusing it here would assert nothing about the folder gate.
-            "../agents/secret",
-            "patterns/../agents/secret",
-            "clients/../agents/secret",
-            "/patterns/secret",
-            "C:/patterns/secret",
-            "\\\\server\\patterns\\secret",
-            "patterns\\secret",
-            "clients\\acme\\dashboard",
-            "agents/secret",
-            "agents/recruiting/candidate",
-            "clients",
-            "project/architecture",
-        ] {
-            assert!(validate_knowledge_id(invalid).is_err(), "accepted {invalid}");
-        }
-        for valid in [
-            "patterns/nested/page",
-            "project/project-dna",
-            "clients/acme",
-            "clients/acme/dashboard",
-            "partners/beta",
-            "vendors/gamma",
-            "operations/runbook",
-        ] {
-            assert!(validate_knowledge_id(valid).is_ok(), "rejected {valid}");
-        }
-    }
-
-    #[test]
-    fn node_and_file_bounds_degrade_safely() {
-        let wiki = TempDir::new().unwrap();
-        write_page(wiki.path(), "patterns/a.md", "# A\n");
-        write_page(wiki.path(), "patterns/b.md", "# B\n");
-        write_page(wiki.path(), "patterns/c.md", "# C\n");
-        write_page(
-            wiki.path(),
-            "patterns/oversize.md",
-            &"x".repeat(MAX_FILE_BYTES + 1),
-        );
-
-        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, 2);
-        assert_eq!(graph.nodes.len(), 2);
-        assert!(graph.truncated);
-
-        let uncapped = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
-        assert!(uncapped.truncated);
-        assert!(!uncapped
-            .nodes
-            .iter()
-            .any(|node| node.id.ends_with("oversize")));
-
-        let missing = scan_knowledge(&wiki.path().join("missing"), &WIKI_FOLDERS, None, MAX_NODES);
-        assert!(missing.nodes.is_empty());
-        assert!(missing.edges.is_empty());
-    }
-
-    #[test]
-    fn metadata_and_serialized_graph_size_are_bounded() {
-        let wiki = TempDir::new().unwrap();
-        let oversized_title = "é".repeat(MAX_TITLE_BYTES);
-        let oversized_updated = "x".repeat(MAX_LAST_UPDATED_BYTES + 50);
-        write_page(
-            wiki.path(),
-            "patterns/metadata.md",
-            &format!(
-                "---\ntitle: {oversized_title}\nlast_updated: {oversized_updated}\n---\n# Body\n"
-            ),
-        );
-
-        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
-        let node = graph
-            .nodes
-            .iter()
-            .find(|node| node.id == "patterns/metadata")
-            .unwrap();
-        assert!(node.title.len() <= MAX_TITLE_BYTES);
-        assert!(node.title.is_char_boundary(node.title.len()));
-        assert!(node.last_updated.len() <= MAX_LAST_UPDATED_BYTES);
-        assert!(graph.truncated);
-        assert!(serde_json::to_vec(&graph).unwrap().len() <= MAX_GRAPH_RESPONSE_BYTES);
-
-        let page = preview_knowledge_page(wiki.path(), &WIKI_FOLDERS, None, "patterns/metadata").unwrap();
-        assert!(page.title.len() <= MAX_TITLE_BYTES);
-        assert!(page.truncated);
-    }
-
-    #[test]
     fn directory_entry_collection_is_bounded_before_sorting() {
         let root = TempDir::new().unwrap();
         for index in 0..12 {
@@ -2132,88 +3447,47 @@ mod tests {
         }
         let canonical_root = fs::canonicalize(root.path()).unwrap();
         let mut entries_seen = MAX_SCAN_ENTRIES - 3;
-        let mut output = Vec::new();
-        let mut truncated = false;
+        let mut report = TruncationReport::default();
+        let mut walk = DirectoryWalk {
+            canonical_root: canonical_root.clone(),
+            file_limit: MAX_DISCOVERED_FILES,
+            recurse: true,
+            entries_seen: &mut entries_seen,
+            output: Vec::new(),
+        };
+        walk.visit(&canonical_root, 0, &mut report);
 
-        collect_markdown_files(
-            &canonical_root,
-            &canonical_root,
-            0,
-            MAX_DISCOVERED_FILES,
-            &mut entries_seen,
-            &mut output,
-            &mut truncated,
-        );
-
+        assert_eq!(walk.output.len(), 3);
         assert_eq!(entries_seen, MAX_SCAN_ENTRIES);
-        assert_eq!(output.len(), 3);
-        assert!(truncated);
+        assert_eq!(
+            report
+                .into_omissions()
+                .iter()
+                .map(|omission| omission.reason)
+                .collect::<Vec<_>>(),
+            vec![KnowledgeOmissionReason::ScanEntryCapReached]
+        );
     }
 
     #[test]
-    fn resolved_edges_are_hard_capped() {
-        let nodes: Vec<_> = (0..51)
-            .map(|index| KnowledgeNode {
-                id: format!("patterns/page-{index}"),
-                title: format!("Page {index}"),
-                folder: KnowledgeFolder::Patterns,
-                path: format!("patterns/page-{index}.md"),
-                last_updated: String::new(),
-                in_degree: 0,
-                out_degree: 0,
-            })
-            .collect();
-        let lookup = NodeLookup::from_nodes(&nodes);
-        let raw_edges = nodes
-            .iter()
-            .flat_map(|source| {
-                nodes.iter().filter_map(move |target| {
-                    (source.id != target.id).then(|| RawEdge {
-                        source: source.id.clone(),
-                        target_hint: target.id.clone(),
-                        kind: KnowledgeEdgeKind::CrossRef,
-                    })
-                })
-            })
-            .collect();
-
-        let (edges, truncated) = build_edges(raw_edges, &lookup, MAX_GRAPH_ITEM_BYTES);
-        assert_eq!(edges.len(), MAX_EDGES);
-        assert!(truncated);
-    }
-
-    #[test]
-    fn resolved_edges_respect_the_serialized_response_budget() {
-        let nodes = vec![
-            KnowledgeNode {
-                id: "patterns/source".to_string(),
-                title: "Source".to_string(),
-                folder: KnowledgeFolder::Patterns,
-                path: "patterns/source.md".to_string(),
-                last_updated: String::new(),
-                in_degree: 0,
-                out_degree: 0,
-            },
-            KnowledgeNode {
-                id: "patterns/target".to_string(),
-                title: "Target".to_string(),
-                folder: KnowledgeFolder::Patterns,
-                path: "patterns/target.md".to_string(),
-                last_updated: String::new(),
-                in_degree: 0,
-                out_degree: 0,
-            },
-        ];
-        let lookup = NodeLookup::from_nodes(&nodes);
-        let raw_edges = vec![RawEdge {
-            source: "patterns/source".to_string(),
-            target_hint: "patterns/target".to_string(),
-            kind: KnowledgeEdgeKind::CrossRef,
-        }];
-
-        let (edges, truncated) = build_edges(raw_edges, &lookup, 1);
-        assert!(edges.is_empty());
-        assert!(truncated);
+    fn folder_name_shape_gate_rejects_path_fragments() {
+        for valid in ["patterns", "Field Notes", "agents", "a", "202607-notes"] {
+            assert!(is_valid_folder_name(valid), "rejected {valid}");
+        }
+        for invalid in [
+            "",
+            ".",
+            "..",
+            ".obsidian",
+            ".git",
+            "a/b",
+            "a\\b",
+            "C:",
+            "with\0null",
+            &"x".repeat(MAX_FOLDER_NAME_BYTES + 1),
+        ] {
+            assert!(!is_valid_folder_name(invalid), "accepted {invalid}");
+        }
     }
 
     #[test]
@@ -2239,23 +3513,16 @@ mod tests {
         assert_eq!(strip_markdown_extension("é.md"), "é");
     }
 
-    #[cfg(unix)]
     #[test]
-    fn scanner_skips_symlinked_subtrees_and_files() {
-        use std::os::unix::fs::symlink;
-
+    fn a_missing_wiki_root_degrades_to_an_empty_graph() {
         let wiki = TempDir::new().unwrap();
-        let private = TempDir::new().unwrap();
-        write_page(private.path(), "secret.md", "# Private\n");
-        fs::create_dir_all(wiki.path().join("practices")).unwrap();
-        symlink(private.path(), wiki.path().join("patterns")).unwrap();
-        symlink(
-            private.path().join("secret.md"),
-            wiki.path().join("practices/secret.md"),
-        )
-        .unwrap();
-
-        let graph = scan_knowledge(wiki.path(), &WIKI_FOLDERS, None, MAX_NODES);
+        let missing = wiki.path().join("does-not-exist");
+        let discovered = discover_wiki_folders(&missing);
+        assert!(discovered.folders.is_empty());
+        assert!(discovered.refusals.is_empty());
+        let graph = scan_knowledge(&missing, &[], None, MAX_NODES, &[]);
         assert!(graph.nodes.is_empty());
+        assert!(graph.edges.is_empty());
+        assert!(!graph.truncated);
     }
 }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -1098,7 +1098,7 @@ title: Public Source
 last_updated: 2026-07-18
 cross_refs:
   - wiki/practices/cross.md
-  - agents/private-dossier.md
+  - agents/dossier.md
 ---
 # Source body
 [[Wiki Target]]
@@ -1120,17 +1120,23 @@ cross_refs:
         "---\ntitle: Body Related\n---\n# Related\n",
     );
     write_knowledge_fixture(wiki.path(), "research/from.md", "# From\n");
-    // `clients/` is allow-listed as of #158, so the non-allow-listed folder in this fixture must
-    // be `agents/` — otherwise these exclusion assertions would pass vacuously.
+    // `agents/` used to be excluded by a compiled-in folder enum. The folder set is now discovered
+    // from the wiki root, so this page is part of the operator's memory system like any other —
+    // and the `agents/private-dossier.md` cross-ref above must now resolve to a real edge.
     write_knowledge_fixture(
         wiki.path(),
-        "agents/private-dossier.md",
-        "---\ntitle: Private Recruiting Dossier\n---\n# Never expose this\n",
+        "agents/dossier.md",
+        "---\ntitle: Agent Dossier\n---\n# Dossier body\n",
     );
+    // Root-level markdown sits in no folder and was unreachable by construction; it now arrives
+    // under the synthetic `root` prefix.
+    write_knowledge_fixture(wiki.path(), "index.md", "# Wiki Index\n");
+    // Previously hidden by `is_forbidden_name`.
+    write_knowledge_fixture(wiki.path(), "patterns/log.md", "# Patterns Log\n");
     write_knowledge_fixture(
         wiki.path(),
         "patterns/oversized.md",
-        vec![b'x'; 256 * 1024 + 1],
+        vec![b'x'; 1024 * 1024 + 1],
     );
     write_knowledge_fixture(
         project.path(),
@@ -1171,10 +1177,40 @@ cross_refs:
         .filter_map(|node| node["id"].as_str())
         .collect();
     assert!(node_ids.contains("patterns/source"));
-    assert!(node_ids.contains("project/project-dna"));
-    assert!(!node_ids.contains("project/architecture"));
+    assert!(node_ids.contains(".project/project-dna"));
+    assert!(!node_ids.contains(".project/architecture"));
+    // Everything the old allowlist and denylist hid is now reachable over the API.
+    assert!(node_ids.contains("agents/dossier"));
+    assert!(node_ids.contains("root/index"));
+    assert!(node_ids.contains("patterns/log"));
+    // Still omitted, but now for a reason the client can name and explain.
     assert!(!node_ids.contains("patterns/oversized"));
     assert!(graph["truncated"].as_bool().unwrap());
+
+    let omissions = graph["omissions"].as_array().unwrap();
+    assert_eq!(
+        omissions
+            .iter()
+            .filter_map(|omission| omission["reason"].as_str())
+            .collect::<Vec<_>>(),
+        vec!["file_too_large"],
+        "the only omission here is the oversized page, and the report must say exactly that"
+    );
+    let too_large = &omissions[0];
+    assert_eq!(too_large["count"], 1);
+    assert_eq!(
+        too_large["examples"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|example| example.as_str())
+            .collect::<Vec<_>>(),
+        vec!["patterns/oversized"]
+    );
+    assert!(too_large["detail"]
+        .as_str()
+        .unwrap()
+        .contains("larger than the read limit"));
 
     let edges = graph["edges"].as_array().unwrap();
     let edge_kinds: std::collections::HashSet<_> = edges
@@ -1200,9 +1236,14 @@ cross_refs:
                 .is_some_and(|id| node_ids.contains(id))
     }));
 
+    // The `agents/` cross-ref resolves now that the folder is reachable.
+    assert!(edges.iter().any(|edge| {
+        edge["source"] == "patterns/source"
+            && edge["target"] == "agents/dossier"
+            && edge["kind"] == "cross_ref"
+    }));
+
     let serialized_graph = serde_json::to_string(&graph).unwrap();
-    assert!(!serialized_graph.contains("Private Recruiting Dossier"));
-    assert!(!serialized_graph.contains("agents/private-dossier"));
     assert!(!serialized_graph.contains(wiki.path().to_string_lossy().as_ref()));
     assert!(!serialized_graph.contains(project.path().to_string_lossy().as_ref()));
 
@@ -1228,11 +1269,37 @@ cross_refs:
         .unwrap()
         .contains(wiki.path().to_string_lossy().as_ref()));
 
+    // A previously-hidden page is now previewable end to end.
+    let agents_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/page?id=agents%2Fdossier&session_id=session-knowledge")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(agents_response.status(), StatusCode::OK);
+    let agents_preview = read_json_body(agents_response).await;
+    assert_eq!(agents_preview["folder"], "agents");
+    assert!(agents_preview["content"]
+        .as_str()
+        .unwrap()
+        .contains("Dossier body"));
+    assert!(agents_preview["omissions"].as_array().unwrap().is_empty());
+    assert!(!agents_preview["truncated"].as_bool().unwrap());
+
+    // Traversal and absolute forms are still rejected before any filesystem work happens. These
+    // are shape violations, not folder-membership violations, so discovery does not weaken them.
     for invalid_id in [
-        "patterns%2F..%2Fagents%2Fprivate-dossier",
+        "patterns%2F..%2Fagents%2Fdossier",
         "%2Fpatterns%2Fsource",
-        "agents%2Fprivate-dossier",
-        "clients%2F..%2Fagents%2Fprivate-dossier",
+        "clients%2F..%2Fagents%2Fdossier",
+        "patterns%5Csource",
+        "C%3A%2Fpatterns%2Fsource",
+        "patterns%2F.%2Fsource",
+        ".project%2Farchitecture",
     ] {
         let response = app
             .clone()
@@ -1302,11 +1369,12 @@ async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_ha
         "---\ntitle: Engagement Pattern\ncross_refs:\n  - clients/acme/dashboard.md\n---\n\
          # Engagement\n[[partners/beta]]\n",
     );
-    // Still never scanned.
+    // Discovered like every other folder now — the folder set comes from the wiki root, not from
+    // a compiled-in list of blessed names.
     write_knowledge_fixture(
         wiki.path(),
         "agents/recruiting/candidate.md",
-        "---\ntitle: Candidate Dossier\n---\n# Personal contact details\n",
+        "---\ntitle: Candidate Dossier\n---\n# Candidate notes\n",
     );
 
     let (_storage_dir, app, _controller, _storage) =
@@ -1336,11 +1404,12 @@ async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_ha
         "vendors/gamma",
         "operations/runbook",
         "patterns/engagement",
+        "agents/recruiting/candidate",
     ] {
         assert!(node_ids.contains(expected), "missing node {expected}");
     }
-    assert!(!node_ids.iter().any(|id| id.starts_with("agents/")));
     assert!(!graph["truncated"].as_bool().unwrap());
+    assert!(graph["omissions"].as_array().unwrap().is_empty());
 
     let dashboard = nodes
         .iter()
@@ -1411,7 +1480,7 @@ async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_ha
     assert!(page["content"].as_str().unwrap().contains("# Acme"));
     assert!(!page["content"].as_str().unwrap().contains("title: Acme"));
 
-    // The never-allow-listed folder stays unreachable through the preview path too.
+    // The formerly-excluded folder is reachable through the preview path too.
     let agents_response = app
         .clone()
         .oneshot(
@@ -1422,7 +1491,10 @@ async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_ha
         )
         .await
         .unwrap();
-    assert_eq!(agents_response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(agents_response.status(), StatusCode::OK);
+    let agents_page = read_json_body(agents_response).await;
+    assert_eq!(agents_page["folder"], "agents");
+    assert_eq!(agents_page["path"], "agents/recruiting/candidate.md");
 
     // No absolute filesystem path may appear in any response body. Compare against both the raw
     // path and its JSON-escaped form -- on Windows the raw backslashes are re-escaped on the wire,
@@ -1435,13 +1507,13 @@ async fn test_knowledge_entity_folders_scan_nested_pages_and_cross_link_graph_ha
     for body in [
         serde_json::to_string(&graph).unwrap(),
         serde_json::to_string(&page).unwrap(),
+        serde_json::to_string(&agents_page).unwrap(),
     ] {
         assert!(!body.contains(&wiki_display), "leaked wiki path: {body}");
         assert!(
             !body.contains(&wiki_json_escaped),
             "leaked escaped wiki path: {body}"
         );
-        assert!(!body.contains("Candidate Dossier"));
     }
 }
 
@@ -1716,7 +1788,7 @@ async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
             .as_array()
             .unwrap()
             .iter()
-            .find(|node| node["id"] == "project/project-dna")
+            .find(|node| node["id"] == ".project/project-dna")
             .expect("session-scoped project node");
         assert_eq!(project_node["title"], expected_title);
 
@@ -1725,7 +1797,7 @@ async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
             .oneshot(
                 Request::builder()
                     .uri(format!(
-                        "/api/knowledge/page?id=project%2Fproject-dna&session_id={session_id}"
+                        "/api/knowledge/page?id=.project%2Fproject-dna&session_id={session_id}"
                     ))
                     .body(Body::empty())
                     .unwrap(),
@@ -1754,7 +1826,7 @@ async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
         .as_array()
         .unwrap()
         .iter()
-        .all(|node| node["folder"] != "project"));
+        .all(|node| node["folder"] != ".project"));
 
     let unknown_session = app
         .oneshot(
@@ -1768,15 +1840,18 @@ async fn test_knowledge_project_pages_are_bound_to_the_requested_session() {
     assert_eq!(unknown_session.status(), StatusCode::NOT_FOUND);
 }
 
+/// A corpus larger than the *old* 400-node ceiling must now come back whole and unflagged, and the
+/// cap must still bind — with a named reason and an accurate count — when a caller asks for one.
 #[tokio::test]
-async fn test_knowledge_graph_enforces_hard_node_cap() {
+async fn test_knowledge_graph_serves_a_corpus_past_the_old_cap_and_reports_a_requested_cap() {
     let _environment_lock = KNOWLEDGE_ENV_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
     let wiki = TempDir::new().unwrap();
     let _wiki_root = ScopedEnvironmentVariable::set("HIVE_WIKI_ROOT", wiki.path());
 
-    for index in 0..405 {
+    let corpus = 450;
+    for index in 0..corpus {
         write_knowledge_fixture(
             wiki.path(),
             &format!("patterns/page-{index:03}.md"),
@@ -1786,6 +1861,7 @@ async fn test_knowledge_graph_enforces_hard_node_cap() {
 
     let app = setup_test_app().await;
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/api/knowledge/graph")
@@ -1796,8 +1872,38 @@ async fn test_knowledge_graph_enforces_hard_node_cap() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
     let graph = read_json_body(response).await;
-    assert_eq!(graph["nodes"].as_array().unwrap().len(), 400);
-    assert!(graph["truncated"].as_bool().unwrap());
+    assert_eq!(
+        graph["nodes"].as_array().unwrap().len(),
+        corpus,
+        "a growing personal wiki must not be silently cut"
+    );
+    assert!(!graph["truncated"].as_bool().unwrap());
+    assert!(graph["omissions"].as_array().unwrap().is_empty());
+
+    let capped_response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/knowledge/graph?max_nodes=50")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(capped_response.status(), StatusCode::OK);
+    let capped = read_json_body(capped_response).await;
+    assert_eq!(capped["nodes"].as_array().unwrap().len(), 50);
+    assert!(capped["truncated"].as_bool().unwrap());
+    let omissions = capped["omissions"].as_array().unwrap();
+    assert_eq!(omissions.len(), 1);
+    assert_eq!(omissions[0]["reason"], "node_cap_reached");
+    assert_eq!(
+        omissions[0]["count"], 400,
+        "the count must cover every skipped page, not just the one the scan stopped on"
+    );
+    assert!(!omissions[0]["examples"]
+        .as_array()
+        .unwrap()
+        .is_empty());
 }
 
 #[tokio::test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -2690,7 +2690,7 @@ impl SessionController {
     /// Add prompt argument to args based on CLI type
     /// Each CLI has different syntax for accepting initial prompts
     fn add_prompt_to_args(cli: &str, args: &mut Vec<String>, prompt_path: &str) {
-        let prompt_path = if matches!(cli, "cursor" | "wsl") {
+        let prompt_path = if Self::cli_runs_under_wsl(cli) {
             Self::to_wsl_path(prompt_path)
         } else {
             prompt_path.to_string()
@@ -3517,16 +3517,26 @@ Last updated: {timestamp}
     /// Insert the `global_wiki_path` prompt variable plus the `{{#if}}` gate flags
     /// that wrap the "Prior Wiki Context" load phase in the debate templates.
     ///
-    /// The flags exist so an unset/blank wiki path renders a prompt containing no
+    /// **Every** template that renders `{{global_wiki_path}}` — `queen-research`,
+    /// `debater`, and `debate-judge` — MUST get the variable from here. All three embed
+    /// it in quoted shell commands, so all three need the same separator/WSL handling;
+    /// normalizing per-site is exactly the sibling divergence that produced the
+    /// trailing-dot split fixed in #159 and the missing outer loop fixed in #169.
+    /// `cli` is the CLI that will execute the rendered prompt (see
+    /// [`Self::normalize_wiki_path_for_cli`]).
+    ///
+    /// The gate flags exist so an unset/blank wiki path renders a prompt containing no
     /// read of an empty path: the whole `cat "<path>/index.md"` block is dropped
     /// and a short skip notice renders in its place. A debate must still run to
     /// completion with no wiki configured.
-    fn insert_debate_wiki_variables(
+    fn insert_wiki_path_variables(
         variables: &mut HashMap<String, String>,
         global_wiki_path: &str,
+        cli: &str,
     ) {
-        let configured = !global_wiki_path.trim().is_empty();
-        variables.insert("global_wiki_path".to_string(), global_wiki_path.to_string());
+        let normalized = Self::normalize_wiki_path_for_cli(global_wiki_path, cli);
+        let configured = !normalized.trim().is_empty();
+        variables.insert("global_wiki_path".to_string(), normalized);
         variables.insert("has_global_wiki".to_string(), configured.to_string());
         variables.insert("no_global_wiki".to_string(), (!configured).to_string());
     }
@@ -3580,7 +3590,8 @@ Last updated: {timestamp}
         );
         variables.insert("opponent_files".to_string(), opponent_files.to_string());
         variables.insert("task_file".to_string(), Self::prompt_path(task_file));
-        Self::insert_debate_wiki_variables(&mut variables, global_wiki_path);
+        // The debater's own CLI executes this prompt, so it decides the wiki path form.
+        Self::insert_wiki_path_variables(&mut variables, global_wiki_path, &debater.config.cli);
 
         let engine = TemplateEngine::default();
         let context = PromptContext {
@@ -3599,10 +3610,14 @@ Last updated: {timestamp}
         })
     }
 
+    /// `judge_cli` is the **resolved** CLI the judge will run under (i.e. after the
+    /// session-default fallback for a blank `metadata.judge_config.cli`), because it
+    /// decides how the wiki path must be spelled in the prompt's shell blocks.
     fn build_debate_judge_prompt(
         session_id: &str,
         metadata: &DebateSessionMetadata,
         global_wiki_path: &str,
+        judge_cli: &str,
     ) -> String {
         let mut variables = HashMap::new();
         variables.insert(
@@ -3622,7 +3637,7 @@ Last updated: {timestamp}
         );
         variables.insert("rounds".to_string(), metadata.rounds.to_string());
         variables.insert("verdict_file".to_string(), metadata.verdict_file.clone());
-        Self::insert_debate_wiki_variables(&mut variables, global_wiki_path);
+        Self::insert_wiki_path_variables(&mut variables, global_wiki_path, judge_cli);
 
         let debater_list = metadata
             .debaters
@@ -3668,6 +3683,45 @@ Last updated: {timestamp}
 
     fn prompt_path(path: &Path) -> String {
         path.to_string_lossy().replace('\\', "/")
+    }
+
+    /// Does `cli` execute its prompt inside WSL rather than on the Windows host?
+    ///
+    /// `build_command` maps `cli == "cursor"` to the `wsl` executable, and call sites
+    /// pass the *remapped* command name (`&cmd`) to `add_prompt_to_args`, so both
+    /// spellings must answer yes. Centralized so the "runs under WSL" set is defined
+    /// once instead of being re-`matches!`-ed at every site that needs to translate a
+    /// host path (the divergence class behind #159 and #169).
+    fn cli_runs_under_wsl(cli: &str) -> bool {
+        matches!(cli.trim(), "cursor" | "wsl")
+    }
+
+    /// Normalize a configured global wiki path for embedding in the **quoted shell
+    /// commands** of a rendered prompt, for the CLI that will actually execute it.
+    ///
+    /// `expand_tilde` resolves `~` from `USERPROFILE` on Windows, so the value reaching
+    /// a prompt is mixed-separator — `C:\Users\RDuff/.ai-docs/wiki` for the default
+    /// `~/.ai-docs/wiki`. Inside bash double quotes a backslash is only special before
+    /// `$`, a backtick, `"`, `\`, or a newline, so `\U` survives literally and Git Bash's
+    /// MSYS layer usually still resolves it — which is why this never visibly broke.
+    ///
+    /// It genuinely breaks under WSL: neither `C:\Users\...` **nor** `C:/Users/...`
+    /// resolves there, only `/mnt/c/Users/...`. A separator swap alone would therefore
+    /// look fixed while leaving the one adapter that needs real translation still broken,
+    /// so WSL-backed CLIs are routed through [`Self::to_wsl_path`] — the same translation
+    /// `add_prompt_to_args` already applies to the prompt file path for cursor.
+    ///
+    /// A blank path is returned unchanged so the `{{#if has_global_wiki}}` gates and the
+    /// queen-research "if empty, skip gracefully" prose keep seeing an empty string.
+    fn normalize_wiki_path_for_cli(global_wiki_path: &str, cli: &str) -> String {
+        if global_wiki_path.trim().is_empty() {
+            return global_wiki_path.to_string();
+        }
+        if Self::cli_runs_under_wsl(cli) {
+            Self::to_wsl_path(global_wiki_path)
+        } else {
+            global_wiki_path.replace('\\', "/")
+        }
     }
 
     fn to_wsl_path(path: &str) -> String {
@@ -8212,18 +8266,12 @@ Last updated: {timestamp}
         // template's quoted shell commands (`cd "{{global_wiki_path}}"`).
         let global_wiki_path = expand_tilde(&global_wiki_path);
 
-        let mut extra_queen_vars = HashMap::new();
-        extra_queen_vars.insert("global_wiki_path".to_string(), global_wiki_path);
-        // `smoke_directive` is rendered near the top of the queen-research prompt. It is
-        // empty for a normal run and a hard override for a smoke run (spawn ONE
-        // researcher, trivial canned task, no wiki load/capture).
-        extra_queen_vars.insert(
-            "smoke_directive".to_string(),
-            if smoke_test {
-                Self::research_smoke_directive()
-            } else {
-                String::new()
-            },
+        // The Queen executes this prompt, so the Queen's CLI decides how the wiki path
+        // must be spelled in its shell blocks.
+        let extra_queen_vars = Self::research_queen_extra_vars(
+            &global_wiki_path,
+            &hive_config.queen_config.cli,
+            smoke_test,
         );
 
         // Research never touches git: no worktrees, no branches, and no pre-spawned
@@ -8236,6 +8284,36 @@ Last updated: {timestamp}
             false,
             false,
         )
+    }
+
+    /// Assemble the `queen-research`-specific template variables.
+    ///
+    /// Extracted from [`Self::launch_research`] so the rendered research Queen prompt is
+    /// reachable from a test without standing up storage and a PTY — a
+    /// template-constant assertion would prove nothing about what the Queen receives.
+    ///
+    /// `queen_cli` is the CLI that will execute the prompt; the wiki path goes through
+    /// the same [`Self::insert_wiki_path_variables`] the debate templates use, so the
+    /// two insert sites cannot drift.
+    fn research_queen_extra_vars(
+        global_wiki_path: &str,
+        queen_cli: &str,
+        smoke_test: bool,
+    ) -> HashMap<String, String> {
+        let mut extra_queen_vars = HashMap::new();
+        Self::insert_wiki_path_variables(&mut extra_queen_vars, global_wiki_path, queen_cli);
+        // `smoke_directive` is rendered near the top of the queen-research prompt. It is
+        // empty for a normal run and a hard override for a smoke run (spawn ONE
+        // researcher, trivial canned task, no wiki load/capture).
+        extra_queen_vars.insert(
+            "smoke_directive".to_string(),
+            if smoke_test {
+                Self::research_smoke_directive()
+            } else {
+                String::new()
+            },
+        );
+        extra_queen_vars
     }
 
     /// Hard-override banner injected at the top of the queen-research prompt for a
@@ -11478,16 +11556,10 @@ phases and do EXACTLY this, then stop:
             .and_then(|cfg| cfg.global_wiki_path)
             .unwrap_or_default();
         let global_wiki_path = expand_tilde(&global_wiki_path);
-        let judge_prompt =
-            Self::build_debate_judge_prompt(session_id, &metadata, &global_wiki_path);
-        let prompt_file = Self::write_prompt_file(
-            &session.project_path,
-            session_id,
-            "debate-judge-prompt.md",
-            &judge_prompt,
-        )?;
-        let prompt_path = prompt_file.to_string_lossy().to_string();
 
+        // Resolve the judge's effective CLI/model BEFORE rendering: the prompt spells the
+        // wiki path differently for a WSL-backed CLI, so it must see the post-fallback
+        // value, not a blank `judge_config.cli`.
         let mut judge_config = metadata.judge_config.clone();
         if judge_config.cli.trim().is_empty() {
             judge_config.cli = session.default_cli.clone();
@@ -11495,6 +11567,20 @@ phases and do EXACTLY this, then stop:
         if judge_config.model.is_none() {
             judge_config.model = session.default_model.clone();
         }
+
+        let judge_prompt = Self::build_debate_judge_prompt(
+            session_id,
+            &metadata,
+            &global_wiki_path,
+            &judge_config.cli,
+        );
+        let prompt_file = Self::write_prompt_file(
+            &session.project_path,
+            session_id,
+            "debate-judge-prompt.md",
+            &judge_prompt,
+        )?;
+        let prompt_path = prompt_file.to_string_lossy().to_string();
 
         let (cmd, mut args) = Self::build_command(&judge_config);
         Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
@@ -16333,7 +16419,7 @@ mod tests {
 
     const DEBATE_TEST_WIKI_PATH: &str = "/home/tester/.ai-docs/wiki";
 
-    fn debate_test_debater() -> DebateDebaterMetadata {
+    fn debate_test_debater_with_cli(cli: &str) -> DebateDebaterMetadata {
         DebateDebaterMetadata {
             index: 1,
             name: "Debater 1".to_string(),
@@ -16341,8 +16427,15 @@ mod tests {
             slug: "debater-1".to_string(),
             branch: "debate/session-wiki-debater-1".to_string(),
             worktree_path: "/projects/app/debater-1".to_string(),
-            config: AgentConfig::default(),
+            config: AgentConfig {
+                cli: cli.to_string(),
+                ..AgentConfig::default()
+            },
         }
+    }
+
+    fn debate_test_debater() -> DebateDebaterMetadata {
+        debate_test_debater_with_cli("claude")
     }
 
     fn debate_test_metadata() -> DebateSessionMetadata {
@@ -16356,10 +16449,10 @@ mod tests {
         }
     }
 
-    fn render_debate_test_debater_prompt(global_wiki_path: &str) -> String {
+    fn render_debate_test_debater_prompt_for_cli(global_wiki_path: &str, cli: &str) -> String {
         SessionController::build_debate_debater_prompt(
             "session-wiki",
-            &debate_test_debater(),
+            &debate_test_debater_with_cli(cli),
             "Monolith versus microservices",
             1,
             2,
@@ -16369,6 +16462,10 @@ mod tests {
             Path::new("/projects/app/debater-1/task.md"),
             global_wiki_path,
         )
+    }
+
+    fn render_debate_test_debater_prompt(global_wiki_path: &str) -> String {
+        render_debate_test_debater_prompt_for_cli(global_wiki_path, "claude")
     }
 
     /// Any leftover mustache control token means the render silently produced a
@@ -16459,6 +16556,7 @@ mod tests {
             "session-wiki",
             &debate_test_metadata(),
             DEBATE_TEST_WIKI_PATH,
+            "claude",
         );
 
         assert!(
@@ -16492,6 +16590,7 @@ mod tests {
                 "session-wiki",
                 &debate_test_metadata(),
                 unset,
+                "claude",
             );
 
             assert_no_dangling_wiki_read(&prompt, "judge");
@@ -16506,6 +16605,201 @@ mod tests {
             assert!(prompt.contains("Monolith versus microservices"));
             assert!(prompt.contains("## Verdict Format"));
             assert!(prompt.contains(".hive-manager/session-wiki/debate/verdict.md"));
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // `global_wiki_path` separator / WSL normalization (issue #168)
+    //
+    // `expand_tilde` resolves `~` from `USERPROFILE` on Windows, so what reaches a
+    // prompt is MIXED-separator. Every assertion below is on the string a builder
+    // actually returns: a template-constant assertion would prove nothing about
+    // what the agent receives, which is the whole point of the issue.
+    // ---------------------------------------------------------------------
+
+    /// Exactly what `expand_tilde("~/.ai-docs/wiki")` yields on Windows: `USERPROFILE`
+    /// contributes backslashes, the configured remainder keeps its forward slashes.
+    const MIXED_SEPARATOR_WIKI_PATH: &str = r"C:\Users\RDuff/.ai-docs/wiki";
+    /// The Git-Bash/MSYS-safe spelling every non-WSL CLI must receive.
+    const FORWARD_SLASH_WIKI_PATH: &str = "C:/Users/RDuff/.ai-docs/wiki";
+    /// The only spelling that resolves under WSL. `C:/Users/...` does NOT.
+    const WSL_WIKI_PATH: &str = "/mnt/c/Users/RDuff/.ai-docs/wiki";
+
+    fn render_research_queen_prompt(global_wiki_path: &str, queen_cli: &str) -> String {
+        let extra_vars =
+            SessionController::research_queen_extra_vars(global_wiki_path, queen_cli, false);
+        SessionController::build_templated_queen_prompt(
+            "queen-research",
+            "session-wiki",
+            &[AgentConfig::default()],
+            Some("Investigate prompt path handling"),
+            extra_vars,
+        )
+    }
+
+    /// A backslash surviving into the prompt is the defect. Asserting on the drive
+    /// prefix catches it wherever in the prompt it appears -- the load block, the
+    /// prose line naming the path, or the Phase 4 / Wiki Capture `cd`.
+    fn assert_no_windows_separators(prompt: &str, label: &str) {
+        assert!(
+            !prompt.contains(r"C:\"),
+            "{} prompt still carries a backslash-separated Windows wiki path:\n{}",
+            label,
+            prompt
+        );
+    }
+
+    #[test]
+    fn research_queen_prompt_renders_a_forward_slash_wiki_path() {
+        let prompt = render_research_queen_prompt(MIXED_SEPARATOR_WIKI_PATH, "claude");
+
+        assert!(
+            prompt.contains(&format!("cat \"{}/index.md\"", FORWARD_SLASH_WIKI_PATH)),
+            "queen-research prompt is missing the normalized index read:\n{}",
+            prompt
+        );
+        // Phase 4's capture block quotes the same variable and must agree.
+        assert!(
+            prompt.contains(&format!("cd \"{}\"", FORWARD_SLASH_WIKI_PATH)),
+            "queen-research wiki capture `cd` was not normalized:\n{}",
+            prompt
+        );
+        assert_no_windows_separators(&prompt, "queen-research");
+        assert_no_unrendered_template_syntax(&prompt, "queen-research");
+    }
+
+    /// A separator swap alone would leave `C:/Users/...` here, which is just as
+    /// unresolvable under WSL as `C:\Users\...` -- solved-looking but not solved.
+    #[test]
+    fn research_queen_prompt_translates_the_wiki_path_for_a_wsl_backed_queen() {
+        let prompt = render_research_queen_prompt(MIXED_SEPARATOR_WIKI_PATH, "cursor");
+
+        assert!(
+            prompt.contains(&format!("cat \"{}/index.md\"", WSL_WIKI_PATH)),
+            "cursor-backed queen-research prompt did not get a /mnt-translated path:\n{}",
+            prompt
+        );
+        assert!(
+            prompt.contains(&format!("cd \"{}\"", WSL_WIKI_PATH)),
+            "cursor-backed queen-research capture `cd` was not translated:\n{}",
+            prompt
+        );
+        assert!(
+            !prompt.contains("C:"),
+            "cursor-backed queen-research prompt still names a drive letter WSL cannot \
+             resolve:\n{}",
+            prompt
+        );
+        assert_no_unrendered_template_syntax(&prompt, "queen-research");
+    }
+
+    #[test]
+    fn debate_prompts_render_a_forward_slash_wiki_path() {
+        let debater =
+            render_debate_test_debater_prompt_for_cli(MIXED_SEPARATOR_WIKI_PATH, "claude");
+        assert!(
+            debater.contains(&format!("cat \"{}/index.md\"", FORWARD_SLASH_WIKI_PATH)),
+            "debater prompt is missing the normalized index read:\n{}",
+            debater
+        );
+        assert_no_windows_separators(&debater, "debater");
+        assert_no_unrendered_template_syntax(&debater, "debater");
+
+        let judge = SessionController::build_debate_judge_prompt(
+            "session-wiki",
+            &debate_test_metadata(),
+            MIXED_SEPARATOR_WIKI_PATH,
+            "claude",
+        );
+        assert!(
+            judge.contains(&format!("cat \"{}/index.md\"", FORWARD_SLASH_WIKI_PATH)),
+            "judge prompt is missing the normalized index read:\n{}",
+            judge
+        );
+        assert!(
+            judge.contains(&format!("cd \"{}\"", FORWARD_SLASH_WIKI_PATH)),
+            "judge wiki capture `cd` was not normalized:\n{}",
+            judge
+        );
+        assert_no_windows_separators(&judge, "judge");
+        assert_no_unrendered_template_syntax(&judge, "judge");
+    }
+
+    #[test]
+    fn debate_prompts_translate_the_wiki_path_for_wsl_backed_clis() {
+        let debater =
+            render_debate_test_debater_prompt_for_cli(MIXED_SEPARATOR_WIKI_PATH, "cursor");
+        assert!(
+            debater.contains(&format!("cat \"{}/index.md\"", WSL_WIKI_PATH)),
+            "cursor-backed debater prompt did not get a /mnt-translated path:\n{}",
+            debater
+        );
+        assert!(
+            !debater.contains("C:"),
+            "cursor-backed debater prompt still names a drive letter WSL cannot resolve:\n{}",
+            debater
+        );
+
+        let judge = SessionController::build_debate_judge_prompt(
+            "session-wiki",
+            &debate_test_metadata(),
+            MIXED_SEPARATOR_WIKI_PATH,
+            "cursor",
+        );
+        assert!(
+            judge.contains(&format!("cat \"{}/index.md\"", WSL_WIKI_PATH)),
+            "cursor-backed judge prompt did not get a /mnt-translated path:\n{}",
+            judge
+        );
+        assert!(
+            judge.contains(&format!("cd \"{}\"", WSL_WIKI_PATH)),
+            "cursor-backed judge capture `cd` was not translated:\n{}",
+            judge
+        );
+        assert!(
+            !judge.contains("C:"),
+            "cursor-backed judge prompt still names a drive letter WSL cannot resolve:\n{}",
+            judge
+        );
+    }
+
+    /// A failed `cat` currently degrades to "no prior context" with no signal to
+    /// anyone. Every prompt that instructs the read must also instruct the report.
+    #[test]
+    fn wiki_loading_prompts_require_reporting_a_failed_read() {
+        let prompts = [
+            (
+                "queen-research",
+                render_research_queen_prompt(MIXED_SEPARATOR_WIKI_PATH, "claude"),
+            ),
+            (
+                "debater",
+                render_debate_test_debater_prompt(DEBATE_TEST_WIKI_PATH),
+            ),
+            (
+                "judge",
+                SessionController::build_debate_judge_prompt(
+                    "session-wiki",
+                    &debate_test_metadata(),
+                    DEBATE_TEST_WIKI_PATH,
+                    "claude",
+                ),
+            ),
+        ];
+
+        for (label, prompt) in prompts {
+            assert!(
+                prompt.contains("WIKI INDEX UNREADABLE"),
+                "{} prompt does not make a failed wiki read observable:\n{}",
+                label,
+                prompt
+            );
+            assert!(
+                prompt.contains("Verify the read actually succeeded"),
+                "{} prompt does not instruct the agent to check the read:\n{}",
+                label,
+                prompt
+            );
         }
     }
 }

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -16550,6 +16550,40 @@ mod tests {
         }
     }
 
+    /// The sibling the debate templates had and `queen-research` did not.
+    ///
+    /// Its Phase 1 was gated by PROSE alone ("If the path is non-empty... / If it is
+    /// empty..."), so an unset wiki rendered a literal `cat "/index.md"` — and the
+    /// "verify the read succeeded, this is a defect the user needs to see" instruction
+    /// then fired for a wiki that was never configured, turning a supported flow into a
+    /// reported failure. The `{{#if}}` gate the debater and judge already used is what
+    /// makes the empty case a real skip rather than a promise in prose.
+    #[test]
+    fn research_queen_prompt_skips_wiki_load_gracefully_when_path_unset() {
+        for unset in ["", "   "] {
+            let prompt = render_research_queen_prompt(unset, "claude");
+
+            assert_no_dangling_wiki_read(&prompt, "queen-research");
+            assert_no_unrendered_template_syntax(&prompt, "queen-research");
+            assert!(
+                prompt.contains("No global wiki path is configured"),
+                "queen-research prompt is missing the explicit skip notice:\n{}",
+                prompt
+            );
+            // The contradictory half: an unconfigured wiki must NOT be reported as an
+            // unreadable one.
+            assert!(
+                !prompt.contains("WIKI INDEX UNREADABLE"),
+                "queen-research tells the queen to report an unreadable wiki when none \
+                 is configured at all:\n{}",
+                prompt
+            );
+            // ...and it is still a usable research brief.
+            assert!(prompt.contains("Investigate prompt path handling"));
+            assert!(prompt.contains("Phase 2"));
+        }
+    }
+
     #[test]
     fn debate_judge_prompt_loads_prior_wiki_context_when_path_configured() {
         let prompt = SessionController::build_debate_judge_prompt(

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1446,19 +1446,19 @@ pub struct AppConfig {
     pub global_wiki_path: Option<String>,
     /// Optional operator narrowing of the Knowledge Atlas global-wiki folder set.
     ///
-    /// Entries are *matched against* the compiled-in allowlist in
-    /// `http::handlers::knowledge::WIKI_FOLDERS` — they select, they never construct. An
-    /// unrecognized entry is logged and ignored, so this field can only narrow or reorder the
-    /// scan; it can never widen it or point the scanner at an arbitrary directory. `None` (the
-    /// default, and what every pre-existing `config.json` deserializes to) means the built-in
-    /// folder set.
+    /// Entries are *matched against* the folders `http::handlers::knowledge::discover_wiki_folders`
+    /// actually finds under the wiki root — they select, they never construct. An entry naming a
+    /// folder that does not exist there is logged and ignored, so this field can only narrow or
+    /// reorder the scan; it can never widen it past the root or point the scanner at an arbitrary
+    /// directory. `None` (the default, and what every pre-existing `config.json` deserializes to)
+    /// means "scan every discovered folder".
     ///
-    /// **`Some(..)` fails closed.** This is a privacy boundary — its purpose is keeping entity
-    /// folders (`clients`, `partners`, `vendors`) out of a browsable graph — so a present-but-
-    /// unusable value scans *nothing* rather than reverting to the full default. A typo such as
-    /// `["pattern"]` therefore yields an empty Atlas and an error-level log, not a silent scan of
-    /// every folder the operator was trying to exclude. An empty Atlas is loud and self-correcting;
-    /// silently rendering data the operator believed was excluded is neither.
+    /// **`Some(..)` fails closed.** This is a privacy boundary — its purpose is keeping chosen
+    /// folders out of a browsable graph — so a present-but-unusable value scans *nothing* rather
+    /// than reverting to the full default. A typo such as `["pattern"]` therefore yields an empty
+    /// Atlas and an error-level log, not a silent scan of every folder the operator was trying to
+    /// exclude. An empty Atlas is loud and self-correcting; silently rendering data the operator
+    /// believed was excluded is neither.
     #[serde(default)]
     pub knowledge_wiki_folders: Option<Vec<String>>,
 }

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -1455,14 +1455,18 @@ The system assigns the worker its ID (`{{session_id}}-worker-N`) and a read-only
 
 Ground your research in existing institutional knowledge before delegating.
 
+{{#if has_global_wiki}}
 - The global wiki path is: `{{global_wiki_path}}`
-- **If `{{global_wiki_path}}` is non-empty**: read the wiki index and the topic-relevant pages directly with your own CLI filesystem access:
+- Read the wiki index and the topic-relevant pages directly with your own CLI filesystem access:
   ```bash
   cat "{{global_wiki_path}}/index.md" || echo "WIKI INDEX UNREADABLE: {{global_wiki_path}}/index.md"
   ```
   Then read the pages from the index that are relevant to the research objective. Use this prior knowledge to frame sharper sub-questions and avoid re-deriving what is already documented.
 - **Verify the read actually succeeded.** If the index does not print — or `WIKI INDEX UNREADABLE` does — do NOT silently continue as if no wiki were configured. Post a short note to the conversation naming the path you tried, then proceed without prior context. A wiki that was configured but unreadable is a defect the user needs to see, not a silent downgrade.
-- **If `{{global_wiki_path}}` is empty**: skip this phase gracefully and proceed with no prior-wiki context.
+{{/if}}
+{{#if no_global_wiki}}
+- No global wiki path is configured. Skip this phase gracefully and proceed with no prior-wiki context.
+{{/if}}
 
 ## Phase 2 — Coordinate Researchers
 

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -1178,9 +1178,10 @@ Ground your argument in existing institutional knowledge before writing this rou
 - The global wiki path is: `{{global_wiki_path}}`
 - Read the wiki index and the topic-relevant pages directly with your own CLI filesystem access:
   ```bash
-  cat "{{global_wiki_path}}/index.md"
+  cat "{{global_wiki_path}}/index.md" || echo "WIKI INDEX UNREADABLE: {{global_wiki_path}}/index.md"
   ```
   Then read the pages from the index that are relevant to the debate topic. Use this prior knowledge to sharpen your argument and to avoid re-deriving what is already documented.
+- **Verify the read actually succeeded.** If the index does not print — or `WIKI INDEX UNREADABLE` does — do NOT silently continue with no prior context. Say so explicitly at the top of this round's argument file, so the missing grounding is visible to the judge instead of invisible to everyone.
 {{/if}}
 {{#if no_global_wiki}}
 - No global wiki path is configured. Skip this phase gracefully and argue with no prior-wiki context.
@@ -1236,9 +1237,10 @@ Ground your verdict in existing institutional knowledge before evaluating the ar
 - The global wiki path is: `{{global_wiki_path}}`
 - Read the wiki index and the topic-relevant pages directly with your own CLI filesystem access:
   ```bash
-  cat "{{global_wiki_path}}/index.md"
+  cat "{{global_wiki_path}}/index.md" || echo "WIKI INDEX UNREADABLE: {{global_wiki_path}}/index.md"
   ```
   Then read the pages from the index that are relevant to the debate topic. Weigh the arguments against what is already documented, and note where a position contradicts or extends prior knowledge.
+- **Verify the read actually succeeded.** If the index does not print — or `WIKI INDEX UNREADABLE` does — do NOT silently continue with no prior context. Record that fact in the verdict's Summary section, so a verdict reached without prior grounding is visibly labelled as such.
 {{/if}}
 {{#if no_global_wiki}}
 - No global wiki path is configured. Skip this phase gracefully and judge with no prior-wiki context.
@@ -1456,9 +1458,10 @@ Ground your research in existing institutional knowledge before delegating.
 - The global wiki path is: `{{global_wiki_path}}`
 - **If `{{global_wiki_path}}` is non-empty**: read the wiki index and the topic-relevant pages directly with your own CLI filesystem access:
   ```bash
-  cat "{{global_wiki_path}}/index.md"
+  cat "{{global_wiki_path}}/index.md" || echo "WIKI INDEX UNREADABLE: {{global_wiki_path}}/index.md"
   ```
   Then read the pages from the index that are relevant to the research objective. Use this prior knowledge to frame sharper sub-questions and avoid re-deriving what is already documented.
+- **Verify the read actually succeeded.** If the index does not print — or `WIKI INDEX UNREADABLE` does — do NOT silently continue as if no wiki were configured. Post a short note to the conversation naming the path you tried, then proceed without prior context. A wiki that was configured but unreadable is a defect the user needs to see, not a silent downgrade.
 - **If `{{global_wiki_path}}` is empty**: skip this phase gracefully and proceed with no prior-wiki context.
 
 ## Phase 2 — Coordinate Researchers

--- a/src/lib/components/knowledge/KnowledgePagePreview.svelte
+++ b/src/lib/components/knowledge/KnowledgePagePreview.svelte
@@ -3,7 +3,7 @@
   import { X } from 'phosphor-svelte';
   import MarkdownInline from './MarkdownInline.svelte';
   import { parseMarkdown } from '$lib/knowledge/markdown';
-  import { folderColor, formatLastUpdated } from '$lib/knowledge/graphUtils';
+  import { describeOmission, folderColor, formatLastUpdated } from '$lib/knowledge/graphUtils';
   import type { KnowledgePage } from '$lib/knowledge/types';
 
   interface FocusTarget {
@@ -84,7 +84,11 @@
       <div class="page-meta">
         <code>{page.path}</code>
         <span>Updated {formatLastUpdated(page.last_updated)}</span>
-        {#if page.truncated}<span class="truncated">Preview capped for safety</span>{/if}
+        {#each page.omissions ?? [] as omission (omission.reason)}
+          <span class="truncated">{describeOmission(omission)}</span>
+        {:else}
+          {#if page.truncated}<span class="truncated">Preview capped for safety</span>{/if}
+        {/each}
       </div>
     </div>
 

--- a/src/lib/knowledge/graphUtils.test.ts
+++ b/src/lib/knowledge/graphUtils.test.ts
@@ -3,27 +3,29 @@ import {
   FOLDER_COLORS,
   RELATIONSHIP_FOLDERS,
   compareKnowledgeNodes,
+  describeOmission,
   filterKnowledgeGraph,
   folderColor,
   folderKindLabel,
   isRelationshipFolder,
   normalizeKnowledgeGraph,
+  normalizeOmissions,
   nodeDegree,
 } from './graphUtils';
 import type { KnowledgeGraph, KnowledgeNode } from './types';
 
-const EXPECTED_FOLDERS = [
+/** The folders that keep a hand-picked swatch. The set of folders is otherwise open. */
+const CURATED_FOLDERS = [
   'patterns',
   'practices',
   'research',
-  'project',
+  '.project',
   'clients',
   'partners',
   'vendors',
   'operations',
+  'root',
 ] as const;
-
-const UNKNOWN_FOLDER_COLOR = folderColor('folder-with-no-mapping');
 
 function node(
   id: string,
@@ -98,7 +100,7 @@ describe('knowledge graph utilities', () => {
   });
 
   it('filters both endpoints together so the visible graph cannot contain dangling edges', () => {
-    const filtered = filterKnowledgeGraph(graph, 'alpha', 'all');
+    const filtered = filterKnowledgeGraph(graph, 'alpha', null);
     expect(filtered.nodes.map((entry) => entry.id)).toEqual(['alpha']);
     expect(filtered.edges).toEqual([]);
 
@@ -110,30 +112,257 @@ describe('knowledge graph utilities', () => {
   it('carries the truncation flag through filtering so the cap notice cannot be filtered away', () => {
     const truncatedGraph: KnowledgeGraph = { ...graph, truncated: true };
 
-    expect(filterKnowledgeGraph(truncatedGraph, '', 'all').truncated).toBe(true);
+    expect(filterKnowledgeGraph(truncatedGraph, '', null).truncated).toBe(true);
     expect(filterKnowledgeGraph(truncatedGraph, 'alpha', 'patterns').truncated).toBe(true);
     // A query that matches nothing must still report the corpus as truncated.
-    expect(filterKnowledgeGraph(truncatedGraph, 'no-such-page', 'all')).toMatchObject({
+    expect(filterKnowledgeGraph(truncatedGraph, 'no-such-page', null)).toMatchObject({
       nodes: [],
       edges: [],
       truncated: true,
     });
-    expect(filterKnowledgeGraph({ ...graph, truncated: false }, '', 'all').truncated).toBe(false);
-    expect(filterKnowledgeGraph(graph, '', 'all').truncated).toBeUndefined();
+    expect(filterKnowledgeGraph({ ...graph, truncated: false }, '', null).truncated).toBe(false);
+    expect(filterKnowledgeGraph(graph, '', null).truncated).toBeUndefined();
   });
 
-  it('resolves a distinct color for every supported folder', () => {
-    expect(Object.keys(FOLDER_COLORS).sort()).toEqual([...EXPECTED_FOLDERS].sort());
+  it('resolves a distinct color for every curated folder', () => {
+    expect(Object.keys(FOLDER_COLORS).sort()).toEqual([...CURATED_FOLDERS].sort());
 
-    for (const name of EXPECTED_FOLDERS) {
+    for (const name of CURATED_FOLDERS) {
       expect(folderColor(name)).toBe(FOLDER_COLORS[name]);
-      expect(folderColor(name)).not.toBe(UNKNOWN_FOLDER_COLOR);
+    }
+    expect(folderColor('Clients')).toBe(folderColor('clients'));
+    // Every curated folder must be its own swatch — no two share one.
+    expect(new Set(Object.values(FOLDER_COLORS)).size).toBe(CURATED_FOLDERS.length);
+  });
+
+  it('gives discovered folders stable, distinguishable colors instead of one shared fallback', () => {
+    // The backend now discovers folders from the wiki root, so these names are
+    // representative of what actually shows up, not hypothetical.
+    const discovered = [
+      'agents',
+      'zettelkasten',
+      'Field Notes',
+      'meta',
+      'archive',
+      'inbox',
+      'people',
+      'projects-2026',
+    ];
+    const colors = discovered.map(folderColor);
+
+    // Every one is a real color, and no two collapse onto the same swatch — the
+    // old behavior gave all of these one identical fallback pink.
+    for (const color of colors) {
+      expect(color).toMatch(/^hsl\(/);
+    }
+    expect(new Set(colors).size).toBe(discovered.length);
+
+    // Stable across calls and case-insensitive, so a reload does not reshuffle
+    // the legend.
+    expect(folderColor('agents')).toBe(folderColor('agents'));
+    expect(folderColor('AGENTS')).toBe(folderColor(' agents '));
+
+    // ...and none of them is byte-identical to a curated swatch. This alone is a
+    // weak check — curated swatches are hex and generated ones are hsl(), so it
+    // can never fire. The hue-separation test below is the real guard.
+    for (const color of colors) {
+      expect(Object.values(FOLDER_COLORS)).not.toContain(color);
+    }
+  });
+
+  it('keeps every generated folder color a readable distance from the curated hues', () => {
+    // Independent oracle: derive the curated hues from the swatches themselves
+    // rather than trusting the module's own reserved-hue list, so a drifted list
+    // fails here instead of silently guarding the wrong point on the wheel.
+    function hexHue(hex: string): number {
+      const red = parseInt(hex.slice(1, 3), 16) / 255;
+      const green = parseInt(hex.slice(3, 5), 16) / 255;
+      const blue = parseInt(hex.slice(5, 7), 16) / 255;
+      const max = Math.max(red, green, blue);
+      const delta = max - Math.min(red, green, blue);
+      if (delta === 0) return 0;
+      let hue: number;
+      if (max === red) {
+        hue = 60 * (((green - blue) / delta) % 6);
+      } else if (max === green) {
+        hue = 60 * ((blue - red) / delta + 2);
+      } else {
+        hue = 60 * ((red - green) / delta + 4);
+      }
+      return hue < 0 ? hue + 360 : hue;
+    }
+    function separation(left: number, right: number): number {
+      const raw = Math.abs(left - right) % 360;
+      return raw > 180 ? 360 - raw : raw;
     }
 
-    expect(folderColor('clients')).not.toBe(UNKNOWN_FOLDER_COLOR);
-    expect(folderColor('Clients')).toBe(folderColor('clients'));
-    // Every folder must be its own hue — no two share a swatch.
-    expect(new Set(Object.values(FOLDER_COLORS)).size).toBe(EXPECTED_FOLDERS.length);
+    // Ordinary wiki folder names, not adversarial ones — several of these landed
+    // within 6 degrees of a curated swatch before the reserved-hue guard was fixed.
+    const discovered = [
+      'archive',
+      'ideas',
+      'zettelkasten',
+      'books',
+      'journal',
+      'travel',
+      'work',
+      'reading',
+      'school',
+      'legal',
+      'agents',
+      'meta',
+      'inbox',
+      'people',
+      'projects-2026',
+      'Field Notes',
+    ];
+
+    for (const name of discovered) {
+      const color = folderColor(name);
+      const match = /^hsl\((\d+(?:\.\d+)?) /.exec(color);
+      expect(match, `${name} produced an unparseable color: ${color}`).not.toBeNull();
+      const hue = Number(match?.[1]);
+
+      for (const [curated, hex] of Object.entries(FOLDER_COLORS)) {
+        expect(
+          separation(hue, hexHue(hex)),
+          `folder "${name}" -> ${color} reads as curated "${curated}" (${hex})`,
+        ).toBeGreaterThanOrEqual(14);
+      }
+    }
+  });
+
+  it('normalizes the structured omission report and derives truncated from it', () => {
+    const normalized = normalizeKnowledgeGraph({
+      nodes: [],
+      edges: [],
+      omissions: [
+        {
+          reason: 'file_too_large',
+          count: 3,
+          detail: 'pages omitted: the file is larger than the read limit',
+          examples: ['patterns/huge', 'agents/bigger'],
+        },
+        { reason: 'edge_cap_reached' },
+        // Malformed entries are dropped rather than rendered.
+        { count: 4 },
+        'not-an-object',
+      ],
+    });
+
+    expect(normalized.omissions).toEqual([
+      {
+        reason: 'file_too_large',
+        count: 3,
+        detail: 'pages omitted: the file is larger than the read limit',
+        examples: ['patterns/huge', 'agents/bigger'],
+      },
+      { reason: 'edge_cap_reached', count: 1, detail: 'edge cap reached', examples: [] },
+    ]);
+    // `truncated` is derived, so a backend that only sends omissions still raises the banner.
+    expect(normalized.truncated).toBe(true);
+
+    const clean = normalizeKnowledgeGraph({ nodes: [], edges: [], omissions: [] });
+    expect(clean.truncated).toBe(false);
+    // An older backend sending only the boolean is still honored.
+    expect(normalizeKnowledgeGraph({ nodes: [], edges: [], truncated: true }).truncated).toBe(true);
+  });
+
+  it('describes each omission with its count, reason, and examples', () => {
+    expect(
+      describeOmission({
+        reason: 'file_too_large',
+        count: 3,
+        detail: 'pages omitted: the file is larger than the read limit',
+        examples: ['patterns/huge', 'agents/bigger'],
+      }),
+    ).toBe(
+      '3 pages omitted: the file is larger than the read limit (patterns/huge, agents/bigger, +1 more)',
+    );
+
+    expect(
+      describeOmission({
+        reason: 'edge_cap_reached',
+        count: 12,
+        detail: 'links omitted: the link cap was reached (all pages are shown)',
+        examples: [],
+      }),
+    ).toBe('12 links omitted: the link cap was reached (all pages are shown)');
+  });
+
+  it('accounts for every omitted item when the backend supplies more examples than are shown', () => {
+    // The backend sends up to MAX_OMISSION_EXAMPLES = 5 but only 3 are named inline. The
+    // remainder used to be computed against examples.length, so `named + implied` fell short of
+    // `count` — the one arithmetic the banner exists to get right.
+    expect(
+      describeOmission({
+        reason: 'node_cap_reached',
+        count: 8,
+        detail: 'pages omitted: the node cap for this request was reached',
+        examples: [
+          'patterns/page-2',
+          'patterns/page-3',
+          'patterns/page-4',
+          'patterns/page-5',
+          'patterns/page-6',
+        ],
+      }),
+    ).toBe(
+      '8 pages omitted: the node cap for this request was reached (patterns/page-2, patterns/page-3, patterns/page-4, +5 more)',
+    );
+
+    // count === examples.length: the suffix must NOT disappear, or two supplied IDs vanish with
+    // no indicator at all from a line that reads as complete.
+    expect(
+      describeOmission({
+        reason: 'node_cap_reached',
+        count: 5,
+        detail: 'pages omitted',
+        examples: ['a', 'b', 'c', 'd', 'e'],
+      }),
+    ).toBe('5 pages omitted (a, b, c, +2 more)');
+
+    // The shape the backend's own cap test produces: 400 omitted, 5 examples.
+    expect(
+      describeOmission({
+        reason: 'node_cap_reached',
+        count: 400,
+        detail: 'pages omitted: the node cap for this request was reached',
+        examples: ['p/000', 'p/001', 'p/002', 'p/003', 'p/004'],
+      }),
+    ).toBe(
+      '400 pages omitted: the node cap for this request was reached (p/000, p/001, p/002, +397 more)',
+    );
+  });
+
+  it('lets a folder literally named "all" be filtered in isolation', () => {
+    // The folder set is discovered from the wiki root, so `all` is a legal directory name. While
+    // the no-filter sentinel was the string 'all', selecting that folder returned the whole graph
+    // — a dropdown entry that silently did nothing.
+    const allFolderGraph: KnowledgeGraph = {
+      nodes: [
+        node('a1', 'Inbox One', 'all', 0, 0, '2026-07-01T00:00:00Z'),
+        node('a2', 'Inbox Two', 'all', 0, 0, '2026-07-02T00:00:00Z'),
+        node('p1', 'Pattern', 'patterns', 0, 0, '2026-07-03T00:00:00Z'),
+      ],
+      edges: [],
+    };
+
+    expect(filterKnowledgeGraph(allFolderGraph, '', 'all').nodes.map((n) => n.id)).toEqual([
+      'a1',
+      'a2',
+    ]);
+    expect(filterKnowledgeGraph(allFolderGraph, '', null).nodes).toHaveLength(3);
+  });
+
+  it('passes omissions through filtering so a folder filter cannot imply pages were dropped', () => {
+    const omissions = normalizeOmissions([
+      { reason: 'node_cap_reached', count: 2, detail: 'pages omitted', examples: ['a'] },
+    ]);
+    const withOmissions: KnowledgeGraph = { ...graph, truncated: true, omissions };
+
+    expect(filterKnowledgeGraph(withOmissions, 'alpha', 'patterns').omissions).toEqual(omissions);
+    expect(filterKnowledgeGraph(withOmissions, 'no-such-page', null).omissions).toEqual(omissions);
   });
 
   it('classifies relationship folders apart from operational ones with a text equivalent', () => {
@@ -144,7 +373,7 @@ describe('knowledge graph utilities', () => {
       expect(isRelationshipFolder(name)).toBe(true);
       expect(folderKindLabel(name)).toBe('relationship entity');
     }
-    for (const name of ['patterns', 'practices', 'research', 'project', 'operations']) {
+    for (const name of ['patterns', 'practices', 'research', '.project', 'operations']) {
       expect(isRelationshipFolder(name)).toBe(false);
       expect(folderKindLabel(name)).toBe('operational knowledge');
     }

--- a/src/lib/knowledge/graphUtils.ts
+++ b/src/lib/knowledge/graphUtils.ts
@@ -201,10 +201,39 @@ function normalizeOmission(value: unknown): KnowledgeOmission | null {
   };
 }
 
+/**
+ * Normalizes and — critically — upholds the backend's one-entry-per-reason contract.
+ *
+ * `TruncationReport::record` dedupes by reason, incrementing an existing entry rather
+ * than pushing a second, so a well-formed response never repeats one. The UI relies on
+ * that: both banners key their `{#each}` on `omission.reason`, and Svelte throws at
+ * runtime on a duplicate key. Since this function accepts arbitrary JSON, enforcing the
+ * invariant here is what makes that key safe — merging is the right answer rather than
+ * weakening the key to an index, which would discard identity across updates.
+ *
+ * Single pass: `normalizeOmission` is called once per entry, not once in a filter and
+ * again in a map.
+ */
 export function normalizeOmissions(value: unknown): KnowledgeOmission[] {
   if (!Array.isArray(value)) return [];
-  return value.filter((entry): entry is KnowledgeOmission => normalizeOmission(entry) !== null)
-    .map((entry) => normalizeOmission(entry) as KnowledgeOmission);
+  const byReason = new Map<string, KnowledgeOmission>();
+  for (const entry of value) {
+    const normalized = normalizeOmission(entry);
+    if (normalized === null) continue;
+    const existing = byReason.get(normalized.reason);
+    if (existing === undefined) {
+      byReason.set(normalized.reason, { ...normalized });
+      continue;
+    }
+    // Merge, mirroring the backend accumulator: counts add, examples concatenate
+    // up to the same inline budget the banner shows.
+    existing.count += normalized.count;
+    for (const example of normalized.examples) {
+      if (existing.examples.length >= MAX_SHOWN_EXAMPLES) break;
+      if (!existing.examples.includes(example)) existing.examples.push(example);
+    }
+  }
+  return [...byReason.values()];
 }
 
 /** How many example IDs the banner names inline before collapsing to `+N more`. */

--- a/src/lib/knowledge/graphUtils.ts
+++ b/src/lib/knowledge/graphUtils.ts
@@ -4,27 +4,62 @@ import {
   type KnowledgeEdgeKind,
   type KnowledgeGraph,
   type KnowledgeNode,
+  type KnowledgeOmission,
   type KnowledgeSortKey,
   type SortDirection,
 } from './types';
 
 /**
- * Hues are spread around the wheel so all eight folders stay separable in the
- * dark UI: cyan 186, green 144, amber 37, silver 212 (low chroma), violet 274,
- * coral 5, lime 81, indigo 227. `operations` (227) is the closest neighbour to
- * `project` (212) by hue, but `project` is a 27%-saturation neutral while
- * `operations` is fully saturated, so they never read as the same swatch.
+ * Hues are spread around the wheel so these folders stay separable in the
+ * dark UI: cyan 186, green 144, amber 37, silver 209 (low chroma), violet 274,
+ * coral 5, lime 81, indigo 227, mint 164. `operations` (227) is the closest
+ * neighbour to `.project` (209) by hue, but `.project` is a 29%-saturation neutral
+ * while `operations` is fully saturated, so they never read as the same swatch.
+ *
+ * This map is no longer exhaustive: the backend discovers folders from the wiki
+ * root, so any name can arrive. Unlisted folders get a deterministic colour from
+ * {@link folderColor} rather than all collapsing onto one fallback swatch.
  */
 export const FOLDER_COLORS: Record<string, string> = {
   patterns: '#00e5ff',
   practices: '#00ff66',
   research: '#ff9d00',
-  project: '#a3b8cc',
+  '.project': '#a3b8cc',
   clients: '#c77dff',
   partners: '#ff5f52',
   vendors: '#b6f24a',
   operations: '#6f8dff',
+  root: '#8ce8d0',
 };
+
+/** Hue in degrees of a `#rrggbb` swatch. */
+function hexHue(hex: string): number {
+  const red = parseInt(hex.slice(1, 3), 16) / 255;
+  const green = parseInt(hex.slice(3, 5), 16) / 255;
+  const blue = parseInt(hex.slice(5, 7), 16) / 255;
+  const max = Math.max(red, green, blue);
+  const delta = max - Math.min(red, green, blue);
+  if (delta === 0) return 0;
+  let hue: number;
+  if (max === red) {
+    hue = 60 * (((green - blue) / delta) % 6);
+  } else if (max === green) {
+    hue = 60 * ((blue - red) / delta + 2);
+  } else {
+    hue = 60 * ((red - green) / delta + 4);
+  }
+  return hue < 0 ? hue + 360 : hue;
+}
+
+/**
+ * Hues reserved by {@link FOLDER_COLORS}, in degrees. Generated colours keep a
+ * wide berth from these so a discovered folder never reads as a known one.
+ *
+ * Derived from the swatches themselves rather than hand-maintained: a
+ * transcribed list drifts the moment a swatch is retuned, and even rounding it
+ * to whole degrees eats into the separation margin.
+ */
+const RESERVED_HUES = Object.values(FOLDER_COLORS).map(hexHue);
 
 /**
  * Relationship entities — *who* we work with. Everything else in
@@ -52,8 +87,6 @@ export const EDGE_LABELS: Record<KnowledgeEdgeKind, string> = {
   related: 'Related',
   from: 'Provenance',
 };
-
-const DEFAULT_FOLDER_COLOR = '#ff6bcb';
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -138,7 +171,63 @@ export function normalizeKnowledgeGraph(value: unknown): KnowledgeGraph {
         )
     : [];
 
-  return { nodes, edges, truncated: value.truncated === true };
+  const omissions = normalizeOmissions(value.omissions);
+  return {
+    nodes,
+    edges,
+    // Prefer the structured report when the backend sends one; fall back to the
+    // legacy boolean so an older backend still raises the banner.
+    truncated: omissions.length > 0 || value.truncated === true,
+    omissions,
+  };
+}
+
+function normalizeOmission(value: unknown): KnowledgeOmission | null {
+  if (!isRecord(value)) return null;
+  const reason = stringValue(value.reason);
+  if (!reason) return null;
+  const count =
+    typeof value.count === 'number' && Number.isFinite(value.count) && value.count > 0
+      ? Math.floor(value.count)
+      : 1;
+  const examples = Array.isArray(value.examples)
+    ? value.examples.filter((example): example is string => typeof example === 'string')
+    : [];
+  return {
+    reason,
+    count,
+    detail: stringValue(value.detail) ?? reason.replace(/_/g, ' '),
+    examples,
+  };
+}
+
+export function normalizeOmissions(value: unknown): KnowledgeOmission[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((entry): entry is KnowledgeOmission => normalizeOmission(entry) !== null)
+    .map((entry) => normalizeOmission(entry) as KnowledgeOmission);
+}
+
+/** How many example IDs the banner names inline before collapsing to `+N more`. */
+const MAX_SHOWN_EXAMPLES = 3;
+
+/**
+ * One banner line per reason, e.g. `3 pages omitted: the file is larger than the
+ * read limit (patterns/huge, patterns/other)`. This is the whole point of the
+ * structured report: the operator learns what they lost and why, instead of an
+ * amber bar that could mean any of a dozen things.
+ */
+export function describeOmission(omission: KnowledgeOmission): string {
+  const head = `${omission.count} ${omission.detail}`;
+  if (omission.examples.length === 0) return head;
+  const shownExamples = omission.examples.slice(0, MAX_SHOWN_EXAMPLES);
+  const shown = shownExamples.join(', ');
+  // Subtract what was actually rendered, not how many the backend supplied. It sends up to
+  // MAX_OMISSION_EXAMPLES = 5 (knowledge.rs) but only MAX_SHOWN_EXAMPLES are named, so subtracting
+  // examples.length made `named + implied` fall short of `count` — and when count === examples
+  // .length it dropped the `+N more` suffix entirely, silently discarding two named pages.
+  const rest = omission.count - shownExamples.length;
+  const more = rest > 0 ? `, +${rest} more` : '';
+  return `${head} (${shown}${more})`;
 }
 
 export function normalizeKnowledgePage(value: unknown): import('./types').KnowledgePage | null {
@@ -149,6 +238,7 @@ export function normalizeKnowledgePage(value: unknown): import('./types').Knowle
   const path = stringValue(value.path);
   if (!id || !title || !folder || !path || typeof value.content !== 'string') return null;
 
+  const omissions = normalizeOmissions(value.omissions);
   return {
     id,
     title,
@@ -156,12 +246,54 @@ export function normalizeKnowledgePage(value: unknown): import('./types').Knowle
     path,
     content: value.content,
     last_updated: updatedValue(value.last_updated),
-    truncated: value.truncated === true,
+    truncated: omissions.length > 0 || value.truncated === true,
+    omissions,
   };
 }
 
+/** FNV-1a. Small, dependency-free, and well spread for short ASCII-ish keys. */
+function hashFolderName(folder: string): number {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < folder.length; index += 1) {
+    hash ^= folder.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+/**
+ * Stable colour for a folder tag.
+ *
+ * Known folders keep their curated swatch. Every other folder — the backend now
+ * discovers them from the wiki root, so the set is open — gets a colour derived
+ * from its name, which makes it (a) stable across reloads, and (b) distinct from
+ * its neighbours, instead of every unknown folder sharing one fallback pink.
+ *
+ * The generated hue is placed in a gap between the reserved hues, and saturation
+ * and lightness are pinned to a legible band for the dark UI rather than being
+ * hashed too, so no folder can land on an unreadable near-black or a washed-out
+ * grey.
+ */
 export function folderColor(folder: string): string {
-  return FOLDER_COLORS[folder.toLowerCase()] ?? DEFAULT_FOLDER_COLOR;
+  const key = folder.trim().toLowerCase();
+  const known = FOLDER_COLORS[key];
+  if (known) return known;
+
+  const hash = hashFolderName(key);
+  // Walk the hue circle in a coprime step so successive folders land far apart,
+  // then nudge away from any reserved hue.
+  let hue = (hash * 47) % 360;
+  for (let attempt = 0; attempt < RESERVED_HUES.length; attempt += 1) {
+    const clash = RESERVED_HUES.find((reserved) => {
+      const distance = Math.abs(((hue - reserved + 540) % 360) - 180);
+      return distance < 14;
+    });
+    if (clash === undefined) break;
+    hue = (hue + 17) % 360;
+  }
+  const saturation = 62 + ((hash >>> 8) % 26); // 62–87%
+  const lightness = 58 + ((hash >>> 16) % 14); // 58–71%
+  return `hsl(${hue} ${saturation}% ${lightness}%)`;
 }
 
 /** Case-folded so a folder string from the API cannot slip past the set. */
@@ -222,14 +354,19 @@ export function compareKnowledgeNodes(
   return direction === 'asc' ? comparison : -comparison;
 }
 
+/**
+ * `folder` is `null` for "no filter". A string sentinel cannot work here: the backend discovers
+ * folders from the wiki root, so `all` is a legal directory name and a folder literally named
+ * `all` would be unselectable — the dropdown would offer a control that silently did nothing.
+ */
 export function filterKnowledgeGraph(
   graph: KnowledgeGraph,
   query: string,
-  folder: string,
+  folder: string | null,
 ): KnowledgeGraph {
   const normalizedQuery = query.trim().toLocaleLowerCase();
   const nodes = graph.nodes.filter((node) => {
-    if (folder !== 'all' && node.folder !== folder) return false;
+    if (folder !== null && node.folder !== folder) return false;
     if (!normalizedQuery) return true;
     return [node.title, node.path, node.folder].some((value) =>
       value.toLocaleLowerCase().includes(normalizedQuery),
@@ -239,5 +376,7 @@ export function filterKnowledgeGraph(
   const edges = graph.edges.filter(
     (edge) => visibleIds.has(edge.source) && visibleIds.has(edge.target),
   );
-  return { nodes, edges, truncated: graph.truncated };
+  // Omissions describe the corpus scan, not the client-side filter, so they pass
+  // through untouched — filtering to one folder must not imply pages were dropped.
+  return { nodes, edges, truncated: graph.truncated, omissions: graph.omissions };
 }

--- a/src/lib/knowledge/types.ts
+++ b/src/lib/knowledge/types.ts
@@ -24,10 +24,26 @@ export interface KnowledgeEdge {
   kind: KnowledgeEdgeKind;
 }
 
+/**
+ * Why something the operator might have expected is missing. The backend replaced a single
+ * `truncated: boolean` — which was assigned in a dozen unrelated places and so meant nothing
+ * actionable — with a countable list of these.
+ */
+export interface KnowledgeOmission {
+  reason: string;
+  count: number;
+  /** One sentence, safe to render verbatim. */
+  detail: string;
+  /** Up to a handful of affected page IDs. Never absolute filesystem paths. */
+  examples: string[];
+}
+
 export interface KnowledgeGraph {
   nodes: KnowledgeNode[];
   edges: KnowledgeEdge[];
+  /** Derived from `omissions` being non-empty; kept for backward compatibility. */
   truncated?: boolean;
+  omissions?: KnowledgeOmission[];
 }
 
 export interface KnowledgePage {
@@ -38,6 +54,7 @@ export interface KnowledgePage {
   content: string;
   last_updated: string | number | null;
   truncated?: boolean;
+  omissions?: KnowledgeOmission[];
 }
 
 export type KnowledgeView = 'graph' | 'table';

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -13,6 +13,7 @@
   import KnowledgePagePreview from '$lib/components/knowledge/KnowledgePagePreview.svelte';
   import KnowledgeTable from '$lib/components/knowledge/KnowledgeTable.svelte';
   import {
+    describeOmission,
     EDGE_COLORS,
     EDGE_LABELS,
     filterKnowledgeGraph,
@@ -30,36 +31,38 @@
 
   let sessionId = $derived($routePage.url.searchParams.get('session_id') || null);
   let query = $state('');
-  let folder = $state('all');
+  let folder = $state<string | null>(null);
   let view = $state<KnowledgeView>('graph');
   let previewReturnFocus = $state.raw<FocusTarget | null>(null);
 
+  // The backend discovers folders from the wiki root, so this list is open-ended.
+  // `preferredOrder` is a *hint* for the familiar folders only: anything it does
+  // not name still appears, sorted alphabetically after them, and is selectable.
+  // Comparison is case-folded so a folder named `Field Notes` cannot be silently
+  // shunted to the tail by a casing mismatch.
+  const PREFERRED_FOLDER_ORDER = [
+    'patterns',
+    'practices',
+    'research',
+    '.project',
+    'clients',
+    'partners',
+    'vendors',
+    'operations',
+    'root',
+  ];
+
   let folders = $derived.by(() => {
-    // Must stay lowercase and exact — indexOf does not case-fold, and a
-    // mismatch silently sorts the folder to the tail with no error.
-    const preferredOrder = [
-      'patterns',
-      'practices',
-      'research',
-      'project',
-      'clients',
-      'partners',
-      'vendors',
-      'operations',
-    ];
+    const rank = (name: string) => {
+      const index = PREFERRED_FOLDER_ORDER.indexOf(name.trim().toLowerCase());
+      return index === -1 ? PREFERRED_FOLDER_ORDER.length : index;
+    };
     return [...new Set($knowledgeStore.graph.nodes.map((node) => node.folder))].sort(
-      (left, right) => {
-        const leftIndex = preferredOrder.indexOf(left);
-        const rightIndex = preferredOrder.indexOf(right);
-        if (leftIndex !== -1 || rightIndex !== -1) {
-          return (leftIndex === -1 ? preferredOrder.length : leftIndex) -
-            (rightIndex === -1 ? preferredOrder.length : rightIndex);
-        }
-        return left.localeCompare(right);
-      },
+      (left, right) => rank(left) - rank(right) || left.localeCompare(right),
     );
   });
   let filteredGraph = $derived(filterKnowledgeGraph($knowledgeStore.graph, query, folder));
+  let omissions = $derived($knowledgeStore.graph.omissions ?? []);
 
   $effect(() => {
     const currentSessionId = sessionId;
@@ -113,7 +116,7 @@
     <label class="folder-field">
       <span class="sr-only">Filter by folder</span>
       <select bind:value={folder} aria-label="Filter by folder">
-        <option value="all">All folders ({$knowledgeStore.graph.nodes.length})</option>
+        <option value={null}>All folders ({$knowledgeStore.graph.nodes.length})</option>
         {#each folders as name (name)}
           <option value={name}>{name} ({folderCount(name)})</option>
         {/each}
@@ -157,9 +160,19 @@
       Refresh failed: {$knowledgeStore.error}. Showing the last loaded graph.
     </div>
   {/if}
-  {#if $knowledgeStore.graph.truncated}
+  {#if omissions.length > 0}
     <div class="notice cap-notice">
-      This atlas reached its safety cap. Refine the corpus to see pages beyond the current bounded scan.
+      <strong>Not everything is shown.</strong>
+      <ul>
+        {#each omissions as omission (omission.reason)}
+          <li>{describeOmission(omission)}</li>
+        {/each}
+      </ul>
+    </div>
+  {:else if $knowledgeStore.graph.truncated}
+    <!-- Older backend: the boolean without the report behind it. -->
+    <div class="notice cap-notice">
+      This atlas reached a scan limit, but this backend does not report which one.
     </div>
   {/if}
 
@@ -183,8 +196,8 @@
           <Brain size={32} weight="light" />
           <strong>No knowledge pages found</strong>
           <p>
-            Add markdown under the wiki folders — patterns, practices, research, clients,
-            partners, vendors, operations — or the project’s .ai-docs folder.
+            Add markdown anywhere under the wiki root — every top-level folder is scanned, plus
+            loose pages at the root itself — or in the project’s .ai-docs folder.
           </p>
           <button type="button" onclick={() => knowledgeStore.loadGraph(sessionId)}>Scan again</button>
         </div>
@@ -193,7 +206,7 @@
           <MagnifyingGlass size={30} weight="light" />
           <strong>No matching pages</strong>
           <p>Try a broader search or choose another folder.</p>
-          <button type="button" onclick={() => { query = ''; folder = 'all'; }}>Clear filters</button>
+          <button type="button" onclick={() => { query = ''; folder = null; }}>Clear filters</button>
         </div>
       {:else}
         <div class="view-frame">
@@ -464,6 +477,17 @@
 
   .error-notice { color: var(--status-warning); }
   .cap-notice { color: var(--accent-amber); }
+  .cap-notice strong { font-weight: 600; }
+  .cap-notice ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2px var(--space-3);
+    margin: 2px 0 0;
+    padding: 0;
+    list-style: none;
+  }
+  .cap-notice li { color: var(--text-secondary); }
+  .cap-notice li::before { content: '· '; color: var(--accent-amber); }
 
   .workspace {
     flex: 1;

--- a/src/routes/knowledge/knowledge-page.svelte.test.ts
+++ b/src/routes/knowledge/knowledge-page.svelte.test.ts
@@ -31,6 +31,18 @@ function jsonResponse(payload: unknown): Response {
   } as unknown as Response;
 }
 
+function graphNode(id: string, folder: string) {
+  return {
+    id,
+    title: id,
+    folder,
+    path: `${id}.md`,
+    last_updated: '2026-07-19',
+    in_degree: 0,
+    out_degree: 0,
+  };
+}
+
 describe('Knowledge route scope', () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -39,6 +51,15 @@ describe('Knowledge route scope', () => {
     pageStore.set({ url: new URL('http://localhost/knowledge?session_id=session-a') });
     fetchMock = vi.fn().mockResolvedValue(jsonResponse({ nodes: [], edges: [] }));
     vi.stubGlobal('fetch', fetchMock);
+    // The graph view mounts once nodes exist; jsdom has no ResizeObserver.
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
   });
 
   afterEach(() => {
@@ -61,5 +82,115 @@ describe('Knowledge route scope', () => {
     const secondUrl = new URL(String(fetchMock.mock.calls[1][0]));
     expect(secondUrl.pathname).toBe('/api/knowledge/graph');
     expect(secondUrl.searchParams.get('session_id')).toBe('session-b');
+  });
+
+  it('offers every discovered folder in the filter, including names it has never seen', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        nodes: [
+          graphNode('patterns/known', 'patterns'),
+          graphNode('agents/dossier', 'agents'),
+          graphNode('zettelkasten/note', 'zettelkasten'),
+          graphNode('root/index', 'root'),
+          // A directory name as the operator actually typed it. Ranking must be
+          // case-folded, or a capitalised curated name would silently sort to the
+          // tail with no error.
+          graphNode('Patterns Archive/old', 'Patterns Archive'),
+          graphNode('Operations/runbook', 'Operations'),
+        ],
+        edges: [],
+        omissions: [],
+      }),
+    );
+
+    const { container } = render(KnowledgePage);
+    await waitFor(() =>
+      expect(container.querySelectorAll('.folder-field option').length).toBe(7),
+    );
+
+    const options = [...container.querySelectorAll('.folder-field option')].map(
+      (option) => (option as HTMLOptionElement).value,
+    );
+    // Curated folders keep their preferred position regardless of casing;
+    // unlisted ones follow, sorted, and are selectable rather than silently
+    // missing from the filter.
+    // The no-filter sentinel is `null`, which the DOM reflects as an empty value. It must NOT be
+    // the string 'all': the folder set is discovered from the wiki root, so a real folder named
+    // `all` would otherwise collide with the sentinel and be unselectable.
+    expect(options[0]).toBe('');
+    expect(options).not.toContain('all');
+    expect(options).toEqual([
+      '',
+      'patterns',
+      'Operations',
+      'root',
+      'agents',
+      'Patterns Archive',
+      'zettelkasten',
+    ]);
+
+    // Each folder's legend swatch is a real, distinct colour — the discovered
+    // folders must not collapse onto one shared fallback.
+    const swatches = [
+      ...container.querySelectorAll('[aria-label="Folder colors and shapes"] i'),
+    ].map((swatch) => (swatch as HTMLElement).style.background);
+    expect(swatches.length).toBe(6);
+    expect(swatches.every((background) => background.length > 0)).toBe(true);
+    expect(new Set(swatches).size).toBe(6);
+  });
+
+  it('names what was omitted instead of showing one ambiguous cap banner', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        nodes: [graphNode('patterns/known', 'patterns')],
+        edges: [],
+        truncated: true,
+        omissions: [
+          {
+            reason: 'file_too_large',
+            count: 3,
+            detail: 'pages omitted: the file is larger than the read limit',
+            examples: ['patterns/huge'],
+          },
+          {
+            reason: 'edge_hint_too_long',
+            count: 2,
+            detail: 'link hints ignored: longer than the hint limit (all pages are shown)',
+            examples: ['practices/workflow'],
+          },
+        ],
+      }),
+    );
+
+    const { container } = render(KnowledgePage);
+    await waitFor(() => expect(container.querySelector('.cap-notice')).not.toBeNull());
+
+    const lines = [...container.querySelectorAll('.cap-notice li')].map(
+      (line) => line.textContent?.trim() ?? '',
+    );
+    expect(lines).toEqual([
+      '3 pages omitted: the file is larger than the read limit (patterns/huge, +2 more)',
+      '2 link hints ignored: longer than the hint limit (all pages are shown) (practices/workflow, +1 more)',
+    ]);
+    // The old banner said only this, for any of a dozen causes.
+    expect(container.querySelector('.cap-notice')?.textContent).not.toContain(
+      'Refine the corpus',
+    );
+  });
+
+  it('still warns when an older backend sends the bare boolean', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        nodes: [graphNode('patterns/known', 'patterns')],
+        edges: [],
+        truncated: true,
+      }),
+    );
+
+    const { container } = render(KnowledgePage);
+    await waitFor(() => expect(container.querySelector('.cap-notice')).not.toBeNull());
+    expect(container.querySelector('.cap-notice')?.textContent).toContain(
+      'does not report which one',
+    );
   });
 });


### PR DESCRIPTION
Closes #168. Also removes the Atlas restrictions so the operator's whole memory system is visible.

## The Atlas showed 100 of 167 pages, and the banner never said why

The operator noticed `100` was "a suspiciously round number." It was — but not for the reason either of us first guessed.

Diagnosed by instrumenting the real corpus **before** changing any limit. `truncated: true` over 100-of-100 nodes was **not** a cap: exactly two files carry a `<- from:` provenance annotation longer than the 512-byte `MAX_EDGE_HINT_BYTES` (647 and 657 bytes). Those flipped the per-file flag, which `scan_knowledge` OR'd into one global boolean.

```
DIAG sources=100 enumeration_truncated=false
DIAG parsed_truncated id=practices/multi-agent-workflows   long_hint len=647
DIAG parsed_truncated id=practices/procedural-art-direction long_hint len=657
DIAG parsed=100 too_large=0 unavailable=0 raw_edges=993 / 12000
DIAG graph nodes=100 edges=480 truncated=true  bytes=67500 / 2MB
```

So for the entire life of this feature, the amber banner has meant *"two unresolvable link hints were slightly long."* Never a missing page. Every other candidate was ruled out by measurement rather than argument.

After the change, same corpus:

```
DIAG folders=["root","agents","clients","operations","partners","patterns","practices","research","vendors"]
DIAG nodes=167 edges=520 truncated=false omissions=[] bytes=85068
```

## Nothing is forbidden any more

The wiki is the operator's own memory system, on their own machine, served on loopback in an app only they run. Defaults now show everything.

- **Folder discovery is dynamic.** The trust boundary moves from a compiled enum of folder names to the *configured wiki root* — which is what actually bounds the scan. Canonicalization, containment checks and symlink refusal are preserved at every level. `agents/` (63 files) appears for the first time.
- **`is_forbidden_name` is gone.** It hid `index.md`, `log.md`, `log-archive*.md`. `.env` and `agent-os.db*` were never reachable in the first place — `has_markdown_extension` admits `*.md` only — and that's now pinned by a test that writes `SECRET_TOKEN=` fixtures and asserts none reach the graph.
- **Root-level markdown is reachable** under a synthetic `root/` tag. `index.md`, the documented spine of the wiki, was previously unreachable by *two* independent mechanisms.
- **Dot-directories stay skipped.** `.git` and `.obsidian` are VCS and editor state, not memory, and walking `.git` adds thousands of entries for zero recall. A content judgement the operator can reverse by moving a folder — not a privacy boundary. `obsidian-notes/` (which merely resembles one) is scanned, and that's asserted.

| cap | before | after | why |
|---|---|---|---|
| `MAX_NODES` | 400 | 5,000 | a 163-file corpus had no headroom |
| `MAX_EDGES` | 1,500 | 20,000 | |
| `MAX_EDGE_HINT_BYTES` | 512 | 4,096 | **this was the bug** |
| `MAX_FILE_BYTES` | 256 KB | 1 MB | the operator's root `log.md` is 372 KB and would otherwise be dropped |
| `MAX_SCAN_ENTRIES` | 10,000 | 100,000 | |
| `MAX_GRAPH_RESPONSE_BYTES` | 2 MB | 8 MB | **kept bounded deliberately** |

The response cap is the one limit not removed: "show me everything" doesn't make an unbounded JSON document safe for the webview to parse and hold before the force sim starts. At 8 MB the node and edge caps bind first in any realistic corpus, so it only catches a pathological one — and now it says so by name.

## Truncation is honest now

`truncated: bool` becomes a `KnowledgeOmission[]` of `{reason, count, detail, examples}` across 13 distinct reasons, with the boolean derived for backward compatibility. Examples are node IDs, never paths. Each `detail` states whether a **page** or merely **decoration** was lost, so an edge-hint overflow no longer reads like missing knowledge. The banner renders one line per reason.

## #168 — one normalization, and real WSL translation

`expand_tilde` resolves `~` from `USERPROFILE`, so the value is mixed-separator (`C:\Users\RDuff/.ai-docs/wiki`). Three templates embedded it raw. In bash double quotes `\U` passes through literally and Git Bash's MSYS layer usually copes — but under WSL neither `C:\...` nor `C:/...` resolves, so a cursor-backed agent failed to `cat` the wiki and degraded **silently** to "no prior context".

The issue asked whether the builder knows the target CLI at render time. **It does, at all three sites** — which made real translation possible instead of declaring WSL unsupported. One shared `normalize_wiki_path_for_cli` now serves every render site (including `queen-research`, so the two sites named in the issue cannot drift), routing WSL-backed CLIs through the existing `to_wsl_path`. `cli_runs_under_wsl` centralizes the `cursor | wsl` set that `add_prompt_to_args` had duplicated.

One latent bug surfaced: the judge's session-default CLI fallback was applied **after** the prompt rendered, so a blank configured CLI rendered as non-WSL and mis-spelled the path for a cursor judge. Hoisted above the render.

## Symlink protection had never run on any CI runner

Every symlink test in this handler was `#[cfg(unix)]`, and CI runs `windows-latest`. Deleting **all** symlink *and* containment checks across all four layers left the suite fully green — 36 passed, 0 failed. That protection was verified on no runner at all.

Added `junctions_pointing_outside_the_root_are_refused_on_windows` using `mklink /J` (no elevation, so it runs on the CI runner), with a fixture assertion that panics if the junction is inert. Proven load-bearing. Incidentally: Rust reports an NTFS junction as `is_symlink()=true, is_dir()=false`, which is why single-layer mutations stayed green — the layers are genuinely redundant, which is good, but nothing had verified them here.

## Review

**13 findings confirmed, 2 refuted.** The most serious were self-inflicted by the dynamic-folder change:

- a real top-level directory named `root` was misrouted to the non-recursive walk and lost its **entire subtree**, with an empty omission report;
- a folder named `project` collided with the session-project namespace, so its pages returned 400 on preview and could shadow real project pages.

Also cleaned destructive review debris: an agent left a **live production mutation** (`// MUTANT-F3` in `build_edges`, cap check moved before `seen.insert`) and four probe tests in the working tree. Verified clean.

## Validation

| gate | result |
|---|---|
| `cargo check` | clean, zero warnings |
| `cargo check --tests` | clean, zero warnings |
| `cargo test --lib` | 579 passed, 0 failed, 1 ignored (was 556) |
| `npm run check` | 0 errors, 0 warnings |
| `npm test` | 117 passed (was 107) |

## Not verified here

The 167-node render has not been driven in the live app — the counts above come from instrumenting the scanner against the real corpus, not from the UI. Worth confirming the force-directed graph stays usable at 167 nodes and 520 edges, since it was previously only ever exercised at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge Atlas now discovers knowledge folders anywhere under the wiki root and reports missing content with structured omission reasons, counts, and examples for both the graph and page previews.
  * Folder filtering now covers all discovered folders, with improved ordering and distinct legend colors.
* **Bug Fixes**
  * Improved wiki-path normalization across environments (including WSL) so prompts render correctly without dangling/blank wiki reads.
* **UI/UX Improvements**
  * Knowledge previews now display omission details (and fall back gracefully for older truncation-only responses).
  * Updated “Global Wiki” prompt instructions to explicitly surface unreadable wiki index conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->