### PR TITLE
chore(release): bump to 0.38.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.37.0"
+version = "0.38.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Minor bump for [PR #171](https://github.com/rdfitted/hive-manager/pull/171).

| change | effect |
|---|---|
| Knowledge Atlas unrestricted | 100 → **167 nodes**; dynamic folder discovery, `agents/` visible, no forbidden filenames, root-level `index.md` reachable |
| Structured truncation | one boolean OR'd from 13 causes → a per-reason report distinguishing a lost **page** from lost **decoration** |
| #168 | one shared `normalize_wiki_path_for_cli` across all three render sites, with real WSL translation via `to_wsl_path` |

`x.Y.0` because the Atlas change is a feature, not a fix.

Four files in lockstep: `package.json`, `src-tauri/Cargo.toml`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)