### PR TITLE
fix: QA timer poisoning, worker-claim leak, unguarded force-pass, and nested-worktree ESLint (#175, #176, #177)

### DIFF
--- a/.claude/resolvegitissue-loop.json
+++ b/.claude/resolvegitissue-loop.json
@@ -1,30 +1,38 @@
 {
-    "issue_number": 17,
-    "branch_name": "issue/17-session-scoped-learnings-api",
+    "issue_number": 175,
+    "also_resolving": [176, 177],
+    "branch_name": "issue/175-177-field-report-fixes",
     "iteration": 1,
     "max_iterations": 10,
-    "test_command": "cargo test",
+    "test_command": "cargo test --lib",
+    "test_baseline": "559 passed; 0 failed; 1 ignored",
+    "test_final": "587 passed; 0 failed; 1 ignored",
+    "pr_number": 178,
+    "chained_to_prcomments": false,
+    "partial_criteria_notes": {
+        "ac-175-untrap": "Visibility half shipped (warn + coordination-log entry + UI event). Re-entry into QaInProgress deferred: the freshness guard is broken as specified (PeerMessageRecord::timestamp has no serde default and the Queen handoff emits none). Satisfies the issue's explicit 'or at minimum log + surface' clause."
+    },
     "github": {
         "repo": "rdfitted/hive-manager",
         "fetch_on_iteration": true,
         "post_progress": true,
-        "last_fetched_at": "2026-02-05T19:15:00Z"
+        "last_fetched_at": "2026-07-28T00:00:00Z"
     },
     "acceptance_criteria": [
-        {"id": "ac-multi-hive", "text": "User can run two Hive sessions against different projects simultaneously", "status": "pending"},
-        {"id": "ac-worker-a", "text": "Workers in Session A submit learnings to Project A's .ai-docs/learnings.jsonl", "status": "pending"},
-        {"id": "ac-worker-b", "text": "Workers in Session B submit learnings to Project B's .ai-docs/learnings.jsonl", "status": "pending"},
-        {"id": "ac-queen-a", "text": "Queen in Session A reviews only Project A's learnings", "status": "pending"},
-        {"id": "ac-queen-b", "text": "Queen in Session B reviews only Project B's learnings", "status": "pending"},
-        {"id": "ac-dna-scoped", "text": "Project DNA retrieval is session-scoped", "status": "pending"},
-        {"id": "ac-backward-single", "text": "Old /api/learnings endpoints work when only one project is active", "status": "pending"},
-        {"id": "ac-backward-multi", "text": "Old endpoints return helpful error when multiple projects are active, suggesting new endpoints", "status": "pending"},
-        {"id": "ac-no-arbitrary-paths", "text": "No agent can write learnings to arbitrary filesystem paths", "status": "pending"},
-        {"id": "ac-404-invalid", "text": "Session_id validation returns 404 for non-existent sessions", "status": "pending"},
-        {"id": "ac-files-validation", "text": "File path validation in files_touched is preserved", "status": "pending"},
-        {"id": "ac-completed-sessions", "text": "Completed sessions don't interfere with active session path resolution", "status": "pending"},
-        {"id": "ac-resumption", "text": "Session resumption doesn't break learning endpoints for other active sessions", "status": "pending"},
-        {"id": "ac-concurrent", "text": "Concurrent learning submissions from multiple workers in same session work correctly", "status": "pending"}
+        {"id": "ac-175-timer", "text": "#175: Do not enter QaInProgress / arm the QA timer from the launch-time evaluator spawn; arm only on milestone handoff", "status": "verified"},
+        {"id": "ac-175-respawn", "text": "#175: on_milestone_ready dead-evaluator respawn branch still transitions+arms after arming is stripped from launch_evaluator", "status": "verified"},
+        {"id": "ac-175-noverdict", "text": "#175: No BLOCKED verdict emitted for a milestone that was never submitted", "status": "verified"},
+        {"id": "ac-175-untrap", "text": "#175: QaInconclusive un-trapped - a fresh milestone-ready is no longer silently dropped", "status": "verified"},
+        {"id": "ac-175-validate", "text": "#175: add_worker validates session state before enqueue/claim AND releases the claimed row on every post-claim failure path", "status": "verified"},
+        {"id": "ac-175-status", "text": "#175: state-validation failures map to 409/422 with the real reason, not a generic 500", "status": "verified"},
+        {"id": "ac-175-recovery", "text": "#175: recovery endpoint clears an orphaned claim; GET /workers and GET /queue agree afterwards", "status": "verified"},
+        {"id": "ac-175-heartbeat", "text": "#175: POST /heartbeat with an unrostered agent_id returns 404; every legitimate agent id shape still returns 200", "status": "verified"},
+        {"id": "ac-176-confirm", "text": "#176: force-pass/force-fail require confirm:true; empty body returns a clear 400 with no state change and no operator log entry", "status": "verified"},
+        {"id": "ac-176-rationale", "text": "#176: optional rationale accepted and included in the operator log line", "status": "verified"},
+        {"id": "ac-176-nostatus", "text": "#176: regression test pins that force-pass does not mutate individual worker AgentStatus", "status": "verified"},
+        {"id": "ac-176-callers", "text": "#176: every existing force-pass/force-fail caller (frontend, prompts, generated tool docs) updated for the new body", "status": "verified"},
+        {"id": "ac-177-lint", "text": "#177: ESLint cascade no longer escapes the worker worktree into the parent repo", "status": "verified"},
+        {"id": "ac-gate-tests", "text": "cargo test --lib passes (baseline 559) with new tests added and mutation-proven", "status": "verified"}
     ],
     "iteration_history": []
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.39.0"
+version = "0.39.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -306,6 +306,9 @@ impl Action for AddWorker {
                 config,
                 request.role.clone(),
                 request.parent_id,
+                // This surface does not reserve an index up front (it also does
+                // not enqueue a queue row), so there is nothing to race against.
+                None,
             )
             .map_err(|e| ActionError::internal(e.to_string()))?;
 

--- a/src-tauri/src/actions/git/mod.rs
+++ b/src-tauri/src/actions/git/mod.rs
@@ -411,6 +411,13 @@ impl Action for WorktreeAdd {
             &parsed.project_path,
         )
         .map_err(git_err)?;
+        // #177: deliberately NOT wired to `ensure_worktree_config_boundary`. Unlike
+        // the four managed worktree chokepoints, `worktree_path` here is
+        // caller-supplied and unvalidated, so deriving a boundary root from it
+        // could drop a `root: true` ESLint config into an arbitrary tracked
+        // directory of the operator's repo and silently disable every rule below
+        // it. Callers wanting the boundary should go through
+        // `workspace::git::create_session_worktree`.
         Ok(Value::Null)
     }
 }

--- a/src-tauri/src/coordination/mod.rs
+++ b/src-tauri/src/coordination/mod.rs
@@ -5,7 +5,7 @@ mod state;
 
 pub use contracts::*;
 pub use injection::*;
-pub use queue_manager::QueueManager;
+pub use queue_manager::{QueueManager, ReleaseAfterFailure, ReleaseOutcome};
 pub use state::*;
 
 use chrono::{DateTime, Utc};

--- a/src-tauri/src/coordination/queue_manager.rs
+++ b/src-tauri/src/coordination/queue_manager.rs
@@ -105,6 +105,32 @@ pub const MAX_NO_PROGRESS_CONTINUATIONS: i64 = NO_PROGRESS_WINDOW_SECS
     .div_ceil(HEARTBEAT_MIN_INTERVAL_SECS)
     as i64;
 
+/// How many times a single queue row may be claimed for a spawn that then fails
+/// before the row is retired as terminally `failed` (#175d). Bounds the retry
+/// loop that releasing the claim would otherwise make unbounded.
+pub const MAX_SPAWN_ATTEMPTS: i64 = 3;
+
+/// Outcome of releasing a claim after a failed spawn.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReleaseAfterFailure {
+    /// Row returned to `queued`; a retry may claim it.
+    Released,
+    /// Spawn budget exhausted; the row is terminally `failed` and only the
+    /// explicit release route can revive it.
+    Exhausted { attempts: i64 },
+    /// We no longer held the claim (someone else reclaimed it first).
+    NotHeld,
+}
+
+/// Outcome of an operator/agent claim release.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReleaseOutcome {
+    Released { previous: QueueStatus },
+    AlreadyQueued,
+    Terminal { status: QueueStatus },
+    NoRow,
+}
+
 /// Coordination-layer façade over the durable queue. Cheaply clonable.
 #[derive(Clone)]
 pub struct QueueManager {
@@ -166,16 +192,17 @@ impl QueueManager {
     /// Atomically claim a queued (or stale-running) row, flipping it to `running`. Returns
     /// `true` iff THIS call won the claim. Emits `WorkerClaimed` on a win and
     /// `WorkerClaimFailed` on a loss. The HTTP handler proceeds to spawn only on `true`.
+    /// Returns the claim epoch (`attempts`) on a win, `None` on a loss.
     pub async fn claim_and_spawn(
         &self,
         id: &str,
         session_id: &str,
         worker_id: &str,
-    ) -> Result<bool, StorageError> {
+    ) -> Result<Option<i64>, StorageError> {
         let now = Self::now_ms();
         let cutoff = now - STUCK_CUTOFF_MS;
-        let won = self.repo.try_claim(id, cutoff, now)?;
-        if won {
+        let epoch = self.repo.try_claim(id, cutoff, now)?;
+        if epoch.is_some() {
             self.emit(session_id, worker_id, EventType::WorkerClaimed, Severity::Info)
                 .await;
         } else {
@@ -187,7 +214,90 @@ impl QueueManager {
             )
             .await;
         }
-        Ok(won)
+        Ok(epoch)
+    }
+
+    /// Release a claim whose spawn failed (#175d).
+    ///
+    /// Without this, a spawn that failed after winning the claim left the row
+    /// `running` forever: retries inside the 90s freshness window lost the claim
+    /// (409), the 30s maintenance pass then reclaimed it, the next retry won and
+    /// failed again — a permanent 409/500 oscillation with the worker index
+    /// pinned, and no API to recover.
+    ///
+    /// Past [`MAX_SPAWN_ATTEMPTS`] the row is marked terminally `failed` instead.
+    /// Releasing without a cap converts a bounded oscillation into an unbounded
+    /// retry loop, and each iteration re-runs worktree creation and branch
+    /// deletion against the operator's real repository.
+    pub async fn release_after_failed_spawn(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        id: &str,
+        epoch: i64,
+    ) -> Result<ReleaseAfterFailure, StorageError> {
+        let now = Self::now_ms();
+        if epoch >= MAX_SPAWN_ATTEMPTS {
+            if self.repo.fail_claimed(id, epoch, now)? {
+                self.emit(
+                    session_id,
+                    worker_id,
+                    EventType::WorkerFinalized,
+                    Severity::Warning,
+                )
+                .await;
+                return Ok(ReleaseAfterFailure::Exhausted { attempts: epoch });
+            }
+            return Ok(ReleaseAfterFailure::NotHeld);
+        }
+
+        if self.repo.requeue_claimed(id, epoch, now)? {
+            // Reuse the event `reconcile` already emits for the identical repair.
+            self.emit(
+                session_id,
+                worker_id,
+                EventType::WorkerReclaimed,
+                Severity::Warning,
+            )
+            .await;
+            Ok(ReleaseAfterFailure::Released)
+        } else {
+            Ok(ReleaseAfterFailure::NotHeld)
+        }
+    }
+
+    /// Operator/agent recovery for an orphaned claim (#175e).
+    pub async fn release_claim(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+    ) -> Result<ReleaseOutcome, StorageError> {
+        let rows = self.repo.rows_for_session(session_id)?;
+        // `worker_id` has no UNIQUE constraint; `rows_for_session` orders by
+        // creation, so this deterministically takes the oldest duplicate.
+        let Some(row) = rows.into_iter().find(|r| r.worker_id == worker_id) else {
+            return Ok(ReleaseOutcome::NoRow);
+        };
+
+        match row.status {
+            QueueStatus::Running | QueueStatus::Failed => {
+                let previous = row.status;
+                if self.repo.release_claim_manual(&row.id, Self::now_ms())? {
+                    self.emit(
+                        session_id,
+                        worker_id,
+                        EventType::WorkerReclaimed,
+                        Severity::Warning,
+                    )
+                    .await;
+                    Ok(ReleaseOutcome::Released { previous })
+                } else {
+                    Ok(ReleaseOutcome::NoRow)
+                }
+            }
+            QueueStatus::Queued => Ok(ReleaseOutcome::AlreadyQueued),
+            other => Ok(ReleaseOutcome::Terminal { status: other }),
+        }
     }
 
     /// Record a heartbeat against the queue row, advancing continuation / no-progress
@@ -354,8 +464,8 @@ mod tests {
         assert_eq!(snap.queued, 1);
 
         // First claim wins, second loses (already running, fresh).
-        assert!(mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap());
-        assert!(!mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap());
+        assert!(mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap().is_some());
+        assert!(mgr.claim_and_spawn("s1-worker-1", "s1", "s1-worker-1").await.unwrap().is_none());
 
         let snap = mgr.queue_snapshot("s1").unwrap();
         assert_eq!(snap.running, 1);

--- a/src-tauri/src/http/error.rs
+++ b/src-tauri/src/http/error.rs
@@ -43,6 +43,19 @@ impl ApiError {
             details: Some(details),
         }
     }
+
+    /// Create an internal error with structured details, so a caller still gets
+    /// the identifiers it needs to recover (e.g. the worker id to release).
+    pub fn internal_with_details(
+        message: impl Into<String>,
+        details: HashMap<String, Value>,
+    ) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            message: message.into(),
+            details: Some(details),
+        }
+    }
 }
 
 impl IntoResponse for ApiError {

--- a/src-tauri/src/http/handlers/evaluator.rs
+++ b/src-tauri/src/http/handlers/evaluator.rs
@@ -412,8 +412,25 @@ fn require_qa_overridable(
         return Ok(());
     }
 
+    // #175(a): evaluator-backed sessions now sit in Running (or briefly
+    // SpawningEvaluator) until the milestone handoff, but they still cannot
+    // complete without reaching QaPassed. Without this the operator would have no
+    // way to unblock a session before its first handoff.
+    //
+    // The widening is conditioned on the session actually having an Evaluator or
+    // QA worker, which is exactly the set of sessions the timer change affects.
+    // A non-evaluator session keeps the old gate -- otherwise a swarm could be
+    // forced into QaPassed and permanently lose `add_planner`.
+    if matches!(
+        session.state,
+        SessionState::Running | SessionState::SpawningEvaluator
+    ) && SessionController::session_requires_internal_evaluator(&session)
+    {
+        return Ok(());
+    }
+
     Err(ApiError::bad_request(format!(
-        "Cannot {}: session is in {:?} state, expected QaInProgress, QaInconclusive, or PrinceRemediation",
+        "Cannot {}: session is in {:?} state, expected QaInProgress, QaInconclusive, PrinceRemediation, or an evaluator-backed Running session",
         action, session.state
     )))
 }
@@ -541,6 +558,35 @@ pub async fn post_verdict(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
+
+    // #175(a) self-heal. The QA window normally opens when the peer watcher
+    // observes milestone-ready, but that watcher does not exist when the session
+    // was launched without an app handle. Without this, such a session
+    // hard-deadlocks: the Evaluator's real verdict is rejected, and so is its
+    // documented BLOCKED fallback (this guard runs before the BLOCKED fork), while
+    // the Queen polls forever with no clock. This also rescues in-flight sessions
+    // that were launched under the old prompt.
+    {
+        let controller = state.session_controller.read();
+        let needs_window = controller.get_session(&session_id).is_some_and(|session| {
+            matches!(
+                session.state,
+                SessionState::Running | SessionState::SpawningEvaluator
+            ) && session
+                .agents
+                .iter()
+                .any(|agent| matches!(agent.role, AgentRole::Evaluator))
+        });
+        if needs_window {
+            tracing::info!(
+                session_id = %session_id,
+                "Opening a QA window from an incoming verdict: the milestone handoff was never observed"
+            );
+            controller
+                .begin_qa_window(&session_id)
+                .map_err(ApiError::internal)?;
+        }
+    }
 
     // Resolve peer identities + project path up front (needed for both BLOCKED and
     // PASS/FAIL paths). require_qa_in_progress rejects verdicts posted outside the
@@ -766,6 +812,39 @@ pub async fn post_prince_verdict(
         "rationale": rationale,
         "persisted": true,
         "peer_file_written": true,
+    })))
+}
+
+/// POST /api/sessions/{id}/milestone-ready
+///
+/// #175(a): the Queen signals that a milestone is ready for QA review. This opens
+/// the QA window and arms the QA timeout. Before this, the clock was armed at
+/// session launch, so any session whose first milestone took longer than the
+/// timeout was deterministically poisoned to `QaInconclusive` with a BLOCKED
+/// verdict for work that had never been submitted.
+pub async fn post_milestone_ready(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+) -> Result<Json<Value>, ApiError> {
+    validate_session_id(&session_id)?;
+
+    let controller = state.session_controller.read();
+    controller
+        .get_session(&session_id)
+        .ok_or_else(|| ApiError::not_found(format!("Session {} not found", session_id)))?;
+    controller
+        .on_milestone_ready(&session_id)
+        .map_err(ApiError::internal)?;
+    let new_state = controller
+        .get_session(&session_id)
+        .map(|s| format!("{:?}", s.state))
+        .unwrap_or_default();
+    drop(controller);
+
+    Ok(Json(json!({
+        "session_id": session_id,
+        "action": "milestone-ready",
+        "new_state": new_state,
     })))
 }
 

--- a/src-tauri/src/http/handlers/evaluator.rs
+++ b/src-tauri/src/http/handlers/evaluator.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::{Path, Query, State},
+    extract::{rejection::JsonRejection, Path, Query, State},
     http::StatusCode,
     Json,
 };
@@ -31,6 +31,51 @@ pub struct AddEvaluatorResponse {
     pub cli: String,
     pub status: String,
     pub prompt_file: String,
+}
+
+/// Body for the operator QA overrides (#176).
+///
+/// `force-pass` / `force-fail` are destructive session-level overrides that
+/// bypass the Evaluator entirely, so they must not be reachable by a bodyless
+/// POST -- which is exactly how one was tripped while an agent was enumerating
+/// the API surface.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ForceVerdictRequest {
+    /// Must be `true`. `#[serde(default)]` is load-bearing: it moves the
+    /// missing-field case out of serde's 422 and into our own 400 below, so
+    /// every rejection carries the same explanatory message.
+    #[serde(default)]
+    pub confirm: bool,
+    /// Optional operator note, recorded in the coordination audit log.
+    #[serde(default)]
+    pub rationale: Option<String>,
+}
+
+/// Funnel every malformed-body case -- absent `Content-Type`, `{}`,
+/// `{"confirm": false}`, malformed JSON -- into one repo-shaped 400.
+///
+/// Taking `Result<Json<T>, JsonRejection>` rather than a bare `Json<T>` is
+/// deliberate: a bare extractor answers the bodyless POST that today's UI sends
+/// with axum's plain-text 415, which is neither actionable nor in our error
+/// envelope.
+fn require_confirmation(
+    body: Result<Json<ForceVerdictRequest>, JsonRejection>,
+    action: &str,
+) -> Result<ForceVerdictRequest, ApiError> {
+    let req = match body {
+        Ok(Json(req)) => req,
+        Err(_) => ForceVerdictRequest::default(),
+    };
+
+    if !req.confirm {
+        return Err(ApiError::bad_request(format!(
+            "Refusing to {action}: this is a destructive operator override. \
+             Re-send with a JSON body {{\"confirm\": true}} (optionally with \
+             \"rationale\": \"<why>\") and Content-Type: application/json."
+        )));
+    }
+
+    Ok(req)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -373,11 +418,21 @@ fn require_qa_overridable(
     )))
 }
 
-fn append_operator_log(state: &AppState, session_id: &str, action: &str, detail: &str) {
-    let msg = crate::coordination::CoordinationMessage::system(
-        "OPERATOR",
-        &format!("[{}] Operator forced {} for session {}", action, detail, session_id),
+fn append_operator_log(
+    state: &AppState,
+    session_id: &str,
+    action: &str,
+    detail: &str,
+    rationale: Option<&str>,
+) {
+    let mut body = format!(
+        "[{}] Operator forced {} for session {}",
+        action, detail, session_id
     );
+    if let Some(rationale) = rationale.map(str::trim).filter(|r| !r.is_empty()) {
+        body.push_str(&format!(" — rationale: {}", rationale));
+    }
+    let msg = crate::coordination::CoordinationMessage::system("OPERATOR", &body);
     let _ = state.storage.append_coordination_log(session_id, &msg);
 }
 
@@ -440,6 +495,7 @@ pub(crate) fn apply_verdict(
     session_id: &str,
     verdict: &str,
     is_override: bool,
+    rationale: Option<&str>,
 ) -> Result<SessionState, ApiError> {
     let action = if is_override {
         let (action, _) = override_log_details(verdict)?;
@@ -461,7 +517,7 @@ pub(crate) fn apply_verdict(
 
     if is_override {
         let (log_action, detail) = override_log_details(verdict)?;
-        append_operator_log(state, session_id, log_action, detail);
+        append_operator_log(state, session_id, log_action, detail, rationale);
     }
 
     Ok(new_state)
@@ -713,33 +769,55 @@ pub async fn post_prince_verdict(
     })))
 }
 
+/// #176: the confirmation guard runs BEFORE the session lookup, so a bodyless
+/// POST to a nonexistent session answers with the confirm-400 rather than the
+/// 404 `require_qa_overridable` used to produce. That precedence is deliberate
+/// and pinned by a test.
 pub async fn force_pass(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
+    body: Result<Json<ForceVerdictRequest>, JsonRejection>,
 ) -> Result<Json<Value>, ApiError> {
     validate_session_id(&session_id)?;
+    let req = require_confirmation(body, "force-pass")?;
 
-    let new_state = apply_verdict(&state, &session_id, "QA_VERDICT: PASS", true)?;
+    let new_state = apply_verdict(
+        &state,
+        &session_id,
+        "QA_VERDICT: PASS",
+        true,
+        req.rationale.as_deref(),
+    )?;
 
     Ok(Json(json!({
         "session_id": session_id,
         "action": "force-pass",
-        "new_state": format!("{:?}", new_state)
+        "new_state": format!("{:?}", new_state),
+        "rationale": req.rationale,
     })))
 }
 
 pub async fn force_fail(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
+    body: Result<Json<ForceVerdictRequest>, JsonRejection>,
 ) -> Result<Json<Value>, ApiError> {
     validate_session_id(&session_id)?;
+    let req = require_confirmation(body, "force-fail")?;
 
-    let new_state = apply_verdict(&state, &session_id, "QA_VERDICT: FAIL", true)?;
+    let new_state = apply_verdict(
+        &state,
+        &session_id,
+        "QA_VERDICT: FAIL",
+        true,
+        req.rationale.as_deref(),
+    )?;
 
     Ok(Json(json!({
         "session_id": session_id,
         "action": "force-fail",
-        "new_state": format!("{:?}", new_state)
+        "new_state": format!("{:?}", new_state),
+        "rationale": req.rationale,
     })))
 }
 

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -82,24 +82,42 @@ pub async fn post_heartbeat(
     //
     // It still closes the hole: the harmful case is an id with no roster entry,
     // no live PTY and no queue row, and this runs BEFORE `record_heartbeat`.
-    let known_locally = {
+    // The Queen posts a bare `queen` alias while its roster entry is
+    // `{session}-queen`, so RESOLVE the posted id rather than rewriting it: an id
+    // that is already a member wins, and only an unknown bare alias is expanded.
+    // Rewriting unconditionally would break every agent whose roster id genuinely
+    // is unqualified.
+    let qualified = super::canonical_agent_id(&session_id, &req.agent_id);
+
+    let (raw_known, qualified_known) = {
         let controller = state.session_controller.read();
         let session = controller.get_session(&session_id).ok_or_else(|| {
             ApiError::not_found(format!("Session {} not found", session_id))
         })?;
-        session.agents.iter().any(|a| a.id == req.agent_id)
-            || state.pty_manager.read().is_alive(&req.agent_id)
+        let pty_manager = state.pty_manager.read();
+        let known = |id: &str| {
+            session.agents.iter().any(|a| a.id == id) || pty_manager.is_alive(id)
+        };
+        (known(&req.agent_id), known(&qualified))
     };
 
-    if !known_locally {
-        let has_queue_row = state
+    let agent_id = if raw_known {
+        req.agent_id.clone()
+    } else if qualified_known {
+        qualified
+    } else {
+        // Last resort: a durable queue row is proof of a real worker whose roster
+        // push has not landed yet.
+        let rows = state
             .queue_manager
             .repo()
             .rows_for_session(&session_id)
-            .map_err(|e| ApiError::internal(e.to_string()))?
-            .iter()
-            .any(|row| row.worker_id == req.agent_id);
-        if !has_queue_row {
+            .map_err(|e| ApiError::internal(e.to_string()))?;
+        if rows.iter().any(|row| row.worker_id == req.agent_id) {
+            req.agent_id.clone()
+        } else if rows.iter().any(|row| row.worker_id == qualified) {
+            qualified
+        } else {
             tracing::warn!(
                 session_id = %session_id,
                 agent_id = %req.agent_id,
@@ -110,18 +128,13 @@ pub async fn post_heartbeat(
                 req.agent_id, session_id
             )));
         }
-    }
+    };
 
     // Scope the (non-Send) parking_lot guard so it is dropped before the await below.
     {
         let controller = state.session_controller.read();
         controller
-            .update_heartbeat(
-                &session_id,
-                &req.agent_id,
-                &req.status,
-                req.summary.as_deref(),
-            )
+            .update_heartbeat(&session_id, &agent_id, &req.status, req.summary.as_deref())
             .map_err(|e| ApiError::internal(e))?;
     }
 
@@ -130,7 +143,7 @@ pub async fn post_heartbeat(
     // Queen) is simply a no-op here.
     state
         .queue_manager
-        .record_heartbeat(&session_id, &req.agent_id, &req.status)
+        .record_heartbeat(&session_id, &agent_id, &req.status)
         .await
         .map_err(|e| ApiError::internal(e.to_string()))?;
 

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -68,16 +68,53 @@ pub async fn post_heartbeat(
         ));
     }
 
+    // #175(f): reject heartbeats for agents that are not part of this session.
+    // A ghost id previously returned 200 and, worse, could finalize a durable
+    // queue row via `record_heartbeat` — which is how a `completed` beat for a
+    // nonexistent `worker-4` silently retired a real queue row.
+    //
+    // The gate is deliberately FAIL-OPEN across three signals (roster, live PTY,
+    // queue row). Every spawn path starts the PTY *before* pushing the roster
+    // entry, and several remove the old entry first, so a strict roster check
+    // would 404 during those windows — and the heartbeat snippet agents run uses
+    // `curl -fsS`, which turns a 404 into a hard non-zero exit that aborts the
+    // agent's shell block. Breaking heartbeating is worse than the bug.
+    //
+    // It still closes the hole: the harmful case is an id with no roster entry,
+    // no live PTY and no queue row, and this runs BEFORE `record_heartbeat`.
+    let known_locally = {
+        let controller = state.session_controller.read();
+        let session = controller.get_session(&session_id).ok_or_else(|| {
+            ApiError::not_found(format!("Session {} not found", session_id))
+        })?;
+        session.agents.iter().any(|a| a.id == req.agent_id)
+            || state.pty_manager.read().is_alive(&req.agent_id)
+    };
+
+    if !known_locally {
+        let has_queue_row = state
+            .queue_manager
+            .repo()
+            .rows_for_session(&session_id)
+            .map_err(|e| ApiError::internal(e.to_string()))?
+            .iter()
+            .any(|row| row.worker_id == req.agent_id);
+        if !has_queue_row {
+            tracing::warn!(
+                session_id = %session_id,
+                agent_id = %req.agent_id,
+                "rejecting heartbeat from an agent that is not a member of this session"
+            );
+            return Err(ApiError::not_found(format!(
+                "Agent {} is not a member of session {}",
+                req.agent_id, session_id
+            )));
+        }
+    }
+
     // Scope the (non-Send) parking_lot guard so it is dropped before the await below.
     {
         let controller = state.session_controller.read();
-        if controller.get_session(&session_id).is_none() {
-            return Err(ApiError::not_found(format!(
-                "Session {} not found",
-                session_id
-            )));
-        }
-
         controller
             .update_heartbeat(
                 &session_id,

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -65,6 +65,29 @@ pub fn validate_cell_id(cell_id: &str) -> Result<(), ApiError> {
     Ok(())
 }
 
+/// Resolve a possibly-bare agent alias to its session-qualified roster id.
+///
+/// The Queen's own wait loops post `{"agent_id":"queen"}` — a BARE alias, not
+/// `{session}-queen` — while its roster entry is `{session}-queen`. Any check
+/// that compares the posted id against the roster must canonicalize first, or it
+/// rejects the Queen; and because those loops use `curl -fsS`, a 4xx is a hard
+/// non-zero exit that aborts the Queen's shell block mid-wait.
+///
+/// Canonicalizing (rather than merely allowing the alias) also repairs a latent
+/// UI bug: heartbeats used to be stored under the raw `"queen"` key while
+/// `GET /api/sessions/active` looks the Queen up by `{session}-queen`, so its
+/// `last_activity` / `status` / `summary` were permanently `None`.
+///
+/// Ids that are already session-qualified are returned unchanged.
+pub fn canonical_agent_id(session_id: &str, agent_id: &str) -> String {
+    let prefix = format!("{}-", session_id);
+    if agent_id.starts_with(&prefix) {
+        agent_id.to_string()
+    } else {
+        format!("{}{}", prefix, agent_id)
+    }
+}
+
 /// Validate agent_id to prevent path traversal and malformed names.
 pub fn validate_agent_id(agent_id: &str) -> Result<(), ApiError> {
     if agent_id.is_empty() || agent_id.len() > 64 {

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -10,11 +10,36 @@ use std::sync::Arc;
 
 use super::{validate_cli, validate_session_id};
 use crate::cli::CliRegistry;
-use crate::coordination::{StateManager, WorkerStateInfo};
+use crate::coordination::{ReleaseAfterFailure, ReleaseOutcome, StateManager, WorkerStateInfo};
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use crate::pty::{AgentConfig, AgentRole, WorkerRole};
-use crate::session::SessionController;
+use crate::session::{AddWorkerError, AddWorkerRejectionReason, SessionController};
+
+/// Map a pre-spawn rejection to an accurate HTTP status (#175d).
+///
+/// A session that simply is not accepting workers right now is a conflict the
+/// caller can act on, not an internal error — the old blanket 500 gave the Queen
+/// nothing to work with.
+fn add_worker_error_to_api(err: AddWorkerError) -> ApiError {
+    match err {
+        AddWorkerError::SessionNotFound(id) => {
+            ApiError::not_found(format!("Session {} not found", id))
+        }
+        AddWorkerError::Rejected(rejection) => match rejection.reason {
+            AddWorkerRejectionReason::StateNotAcceptingWorkers => {
+                let mut details: HashMap<String, Value> = HashMap::new();
+                details.insert("reason".to_string(), json!("session_state"));
+                details.insert(
+                    "current_state".to_string(),
+                    json!(rejection.current_state.clone()),
+                );
+                ApiError::conflict_with_details(rejection.error, details)
+            }
+            _ => ApiError::bad_request(rejection.error),
+        },
+    }
+}
 
 fn deserialize_optional_trimmed_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
 where
@@ -142,25 +167,27 @@ pub async fn add_worker(
         initial_prompt: initial_task.clone(),
     };
 
+    // #175(d): VALIDATE BEFORE CLAIMING. The queue row used to be enqueued and
+    // claimed before the controller checked whether the session could accept a
+    // worker at all, and no failure path released it. A single rejected spawn
+    // therefore stranded the worker index permanently.
+    //
+    // The pre-check shares one implementation with the real check inside
+    // `add_worker`, so they cannot drift, and the common rejection now creates no
+    // queue row at all.
+    let reservation = {
+        let controller = state.session_controller.read();
+        controller.reserve_add_worker(&session_id, &role, parent_id.as_deref())
+    }
+    .map_err(add_worker_error_to_api)?;
+
     // #126: enqueue + atomically claim the worker BEFORE spawning. The queue table is the
     // source of truth, so we compute the deterministic worker_id the same way the controller
     // does (`{session}-worker-{index}`, index = existing worker count + 1), enqueue a
     // `queued` row, then try to claim it. A duplicate POST for the same worker hits an
     // already-`running` row, loses the claim, and is turned away with 409 — no double spawn.
-    let predicted_index = {
-        let controller = state.session_controller.read();
-        let existing = controller
-            .get_session(&session_id)
-            .map(|s| {
-                s.agents
-                    .iter()
-                    .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
-                    .count()
-            })
-            .unwrap_or(0);
-        (existing + 1) as u8
-    };
-    let predicted_worker_id = format!("{}-worker-{}", session_id, predicted_index);
+    let predicted_index = reservation.index;
+    let predicted_worker_id = reservation.worker_id.clone();
     let queue_id = predicted_worker_id.clone();
     let payload = json!({
         "role_type": role_type,
@@ -185,40 +212,101 @@ pub async fn add_worker(
         .await
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
-    let claimed = state
+    let epoch = match state
         .queue_manager
         .claim_and_spawn(&queue_id, &session_id, &predicted_worker_id)
         .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
-    if !claimed {
-        let mut details: HashMap<String, Value> = HashMap::new();
-        details.insert("worker_id".to_string(), json!(predicted_worker_id));
-        details.insert("session_id".to_string(), json!(session_id));
-        return Err(ApiError::conflict_with_details(
-            format!(
-                "Worker {} is already claimed and running",
-                predicted_worker_id
-            ),
-            details,
-        ));
-    }
+        .map_err(|e| ApiError::internal(e.to_string()))?
+    {
+        Some(epoch) => epoch,
+        None => {
+            let mut details: HashMap<String, Value> = HashMap::new();
+            details.insert("worker_id".to_string(), json!(predicted_worker_id));
+            details.insert("session_id".to_string(), json!(session_id));
+            details.insert("reason".to_string(), json!("already_claimed"));
+            return Err(ApiError::conflict_with_details(
+                format!(
+                    "Worker {} is already claimed and running",
+                    predicted_worker_id
+                ),
+                details,
+            ));
+        }
+    };
 
-    // Add worker through session controller
-    let (worker_id, worker_index) = {
+    // Add worker through session controller. The parking_lot guard is scoped out
+    // before the release await below — it is !Send and cannot cross an await.
+    let add_result = {
         let controller = state.session_controller.write();
+        controller.add_worker(
+            &session_id,
+            config,
+            role.clone(),
+            parent_id,
+            Some(reservation.index),
+        )
+    };
 
-        let agent_info = controller
-            .add_worker(&session_id, config, role.clone(), parent_id)
-            .map_err(|e| ApiError::internal(e.to_string()))?;
+    let agent_info = match add_result {
+        Ok(agent_info) => agent_info,
+        Err(err) => {
+            // #175(d): EVERY failure after a won claim must release it. Otherwise
+            // the index is stranded and no further worker can ever be spawned.
+            match state
+                .queue_manager
+                .release_after_failed_spawn(&session_id, &predicted_worker_id, &queue_id, epoch)
+                .await
+            {
+                Ok(ReleaseAfterFailure::Exhausted { attempts }) => {
+                    let mut details: HashMap<String, Value> = HashMap::new();
+                    details.insert("worker_id".to_string(), json!(predicted_worker_id));
+                    details.insert("session_id".to_string(), json!(session_id));
+                    details.insert("reason".to_string(), json!("spawn_failed"));
+                    details.insert("attempts".to_string(), json!(attempts));
+                    details.insert(
+                        "recovery".to_string(),
+                        json!(format!(
+                            "POST /api/sessions/{}/workers/{}/release",
+                            session_id, predicted_worker_id
+                        )),
+                    );
+                    return Err(ApiError::conflict_with_details(
+                        format!(
+                            "Worker {} failed to spawn {} times and has been retired: {}",
+                            predicted_worker_id, attempts, err
+                        ),
+                        details,
+                    ));
+                }
+                Ok(_) => {}
+                Err(e) => tracing::warn!(
+                    worker_id = %predicted_worker_id,
+                    error = %e,
+                    "failed to release the queue claim after a failed spawn"
+                ),
+            }
 
+            let mut details: HashMap<String, Value> = HashMap::new();
+            details.insert("worker_id".to_string(), json!(predicted_worker_id));
+            details.insert("session_id".to_string(), json!(session_id));
+            if err.starts_with("Worker index race") {
+                details.insert("reason".to_string(), json!("index_raced"));
+                return Err(ApiError::conflict_with_details(err, details));
+            }
+            return Err(ApiError::internal_with_details(err, details));
+        }
+    };
+
+    // From here to the response there must be NO fallible early return: the PTY
+    // is live, and releasing the claim past this point is a double-spawn vector.
+    let (worker_id, worker_index) = {
         // Extract worker index from ID (format: session-id-worker-N)
         let index = agent_info
             .id
             .rsplit('-')
             .next()
             .and_then(|s| s.parse::<u8>().ok())
-            .unwrap_or(1);
-
+            .unwrap_or(predicted_index);
         (agent_info.id, index)
     };
 
@@ -288,6 +376,101 @@ pub async fn add_worker(
             task_file,
         }),
     ))
+}
+
+/// POST /api/sessions/{id}/workers/{worker_id}/release
+///
+/// #175(e): recover a durable queue claim whose worker never made it onto the
+/// roster. Before this there was no API at all — a leaked claim capped the
+/// session permanently and only a backend restart cleared it.
+///
+/// Deliberately narrow: it releases the CLAIM, never the worker. It does not
+/// touch the roster (which keeps the worker-index allocator monotone), does not
+/// kill a PTY, and refuses outright if the worker is actually rostered — that
+/// case belongs to `DELETE /api/sessions/{id}/agents/{agent_id}`.
+pub async fn release_worker(
+    State(state): State<Arc<AppState>>,
+    Path((session_id, worker_id)): Path<(String, String)>,
+) -> Result<(StatusCode, Json<Value>), ApiError> {
+    validate_session_id(&session_id)?;
+    super::validate_agent_id(&worker_id)?;
+
+    // Scope every !Send guard before the await below.
+    let (rostered, live_pty) = {
+        let controller = state.session_controller.read();
+        let session = controller
+            .get_session(&session_id)
+            .ok_or_else(|| ApiError::not_found(format!("Session {} not found", session_id)))?;
+        let rostered = session.agents.iter().any(|a| a.id == worker_id);
+        let live_pty = state.pty_manager.read().is_alive(&worker_id);
+        (rostered, live_pty)
+    };
+
+    if rostered {
+        let mut details: HashMap<String, Value> = HashMap::new();
+        details.insert("reason".to_string(), json!("rostered"));
+        details.insert("worker_id".to_string(), json!(worker_id));
+        return Err(ApiError::conflict_with_details(
+            format!(
+                "Worker {} is a live member of this session. Releasing its claim would strand \
+                 the queue row. Use DELETE /api/sessions/{}/agents/{} to stop the agent instead.",
+                worker_id, session_id, worker_id
+            ),
+            details,
+        ));
+    }
+    if live_pty {
+        let mut details: HashMap<String, Value> = HashMap::new();
+        details.insert("reason".to_string(), json!("live_pty"));
+        details.insert("worker_id".to_string(), json!(worker_id));
+        return Err(ApiError::conflict_with_details(
+            format!("Worker {} still has a live PTY; refusing to release its claim", worker_id),
+            details,
+        ));
+    }
+
+    let outcome = state
+        .queue_manager
+        .release_claim(&session_id, &worker_id)
+        .await
+        .map_err(|e| ApiError::internal(e.to_string()))?;
+
+    match outcome {
+        ReleaseOutcome::Released { previous } => Ok((
+            StatusCode::OK,
+            Json(json!({
+                "session_id": session_id,
+                "worker_id": worker_id,
+                "released": true,
+                "previous_status": previous.as_tag(),
+                "new_status": "queued",
+            })),
+        )),
+        ReleaseOutcome::AlreadyQueued => Ok((
+            StatusCode::OK,
+            Json(json!({
+                "session_id": session_id,
+                "worker_id": worker_id,
+                "released": false,
+                "previous_status": "queued",
+                "new_status": "queued",
+            })),
+        )),
+        ReleaseOutcome::Terminal { status } => Ok((
+            StatusCode::OK,
+            Json(json!({
+                "session_id": session_id,
+                "worker_id": worker_id,
+                "released": false,
+                "previous_status": status.as_tag(),
+                "new_status": status.as_tag(),
+            })),
+        )),
+        ReleaseOutcome::NoRow => Err(ApiError::not_found(format!(
+            "No queue row for worker {} in session {}",
+            worker_id, session_id
+        ))),
+    }
 }
 
 /// GET /api/sessions/{id}/workers - List workers in a session

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -115,6 +115,13 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // Worker routes
         .route("/api/sessions/{id}/workers", get(workers::list_workers))
         .route("/api/sessions/{id}/workers", post(workers::add_worker))
+        // #175(e): recover a leaked durable claim. POST rather than DELETE — the
+        // object released is the queue CLAIM, not the worker; stopping an agent
+        // is already DELETE /api/sessions/{id}/agents/{agent_id}.
+        .route(
+            "/api/sessions/{id}/workers/{worker_id}/release",
+            post(workers::release_worker),
+        )
         // Read-only session artifact browser
         .route(
             "/api/sessions/{id}/files",

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -147,6 +147,14 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/qa/verdict",
             post(evaluator::post_verdict),
         )
+        // #175(a): explicit milestone handoff. This is what opens the QA review
+        // window and arms the QA clock. It is the only handoff path that survives
+        // a session launched without an app handle (where the peer file watcher
+        // never starts).
+        .route(
+            "/api/sessions/{id}/milestone-ready",
+            post(evaluator::post_milestone_ready),
+        )
         .route(
             "/api/sessions/{id}/qa/force-pass",
             post(evaluator::force_pass),

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -4777,6 +4777,370 @@ async fn test_launch_solo_with_evaluator_uses_solo_defaults() {
     }
 }
 
+/// #175(a) T14 — the headline fix. An evaluator-backed session must finish
+/// launching in `Running` with NO QA clock armed. Before this, launch went
+/// straight to `QaInProgress` and started a 300s timer, so any session whose
+/// first milestone took longer than the timeout was deterministically poisoned
+/// to `QaInconclusive` with a BLOCKED verdict for work never submitted.
+#[tokio::test]
+async fn launch_with_evaluator_stays_running_and_does_not_arm_the_qa_clock() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = TempDir::new().unwrap();
+    init_git_repo_for_launch_fixture(temp_dir.path());
+
+    let body = serde_json::json!({
+        "project_path": temp_dir.path().to_string_lossy(),
+        "task_description": "Ship a milestone",
+        "cli": "codex",
+        "evaluator_cli": "codex"
+    });
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/solo")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Unconditional: the older evaluator-launch tests guarded their assertions
+    // behind `if status == CREATED`, and without a git fixture the launch 500s,
+    // so those assertions never actually ran.
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let launch: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let session_id = launch["session_id"].as_str().unwrap();
+
+    let session = controller.read().get_session(session_id).unwrap();
+    assert!(
+        session
+            .agents
+            .iter()
+            .any(|a| matches!(a.role, AgentRole::Evaluator)),
+        "precondition: the session must actually be evaluator-backed"
+    );
+    assert_eq!(
+        session.state,
+        SessionState::Running,
+        "an evaluator-backed launch must not enter a QA state"
+    );
+    assert!(
+        !controller.read().qa_timeout_armed(session_id),
+        "the QA clock must not be armed before a milestone is submitted"
+    );
+
+    // NB: a verdict posted now WOULD be accepted, because `post_verdict`
+    // self-heals a Running evaluator-backed session into a QA window. That is
+    // deliberate — it rescues sessions whose peer watcher never started — so it
+    // is not asserted against here. `milestone_ready_opens_the_qa_window_...`
+    // covers the normal handoff path.
+
+    controller.write().close_session(session_id).unwrap();
+}
+
+/// #175(a) T17. The milestone handoff is what opens the QA window and starts the
+/// clock.
+#[tokio::test]
+async fn milestone_ready_opens_the_qa_window_and_arms_the_clock() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = TempDir::new().unwrap();
+    init_git_repo_for_launch_fixture(temp_dir.path());
+
+    let body = serde_json::json!({
+        "project_path": temp_dir.path().to_string_lossy(),
+        "task_description": "Ship a milestone",
+        "cli": "codex",
+        "evaluator_cli": "codex"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/solo")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let launch: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let session_id = launch["session_id"].as_str().unwrap().to_string();
+
+    assert!(!controller.read().qa_timeout_armed(&session_id));
+
+    let handoff = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/milestone-ready", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(handoff.status(), StatusCode::OK);
+
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaInProgress { iteration: None },
+        "the handoff must open the QA window"
+    );
+    assert!(
+        controller.read().qa_timeout_armed(&session_id),
+        "the handoff must arm the QA clock"
+    );
+
+    // Proof the window is genuinely open: a verdict is now accepted.
+    let verdict = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/verdict", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"verdict":"PASS"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(verdict.status(), StatusCode::OK);
+
+    controller.write().close_session(&session_id).unwrap();
+}
+
+/// #175(a) T18 — THE TRAP, plus the latent iteration-loss bug.
+///
+/// When the rostered Evaluator has no live PTY, `on_milestone_ready` takes the
+/// respawn branch and early-returns. That branch used to rely on
+/// `launch_evaluator`'s tail to transition and arm the clock; now that spawning
+/// an Evaluator no longer opens a QA window, the branch must do it itself.
+/// Without this the spurious-timeout bug is merely traded for a
+/// never-times-out bug.
+///
+/// The iteration assertion pins the second half: `launch_evaluator` writes
+/// `SpawningEvaluator` before its tail read the state back, so a respawn from
+/// `QaFailed { iteration: 2 }` used to reset the counter to `None` and defeat the
+/// max-retries ceiling.
+#[tokio::test]
+async fn milestone_ready_respawn_branch_arms_qa_and_preserves_iteration() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("respawn-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    init_git_repo_for_launch_fixture(temp_dir.path());
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaFailed { iteration: 2 };
+    // Rostered Evaluator with NO registered PTY -> is_alive() is false -> the
+    // dead-evaluator respawn branch.
+    session.agents.push(AgentInfo {
+        id: format!("{}-evaluator", session_id),
+        role: AgentRole::Evaluator,
+        status: AgentStatus::Running,
+        config: AgentConfig {
+            cli: "claude".to_string(),
+            ..AgentConfig::default()
+        },
+        parent_id: None,
+        commit_sha: None,
+        base_commit_sha: None,
+    });
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/milestone-ready", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaInProgress { iteration: Some(2) },
+        "the respawn branch must open a QA window AND carry the iteration forward"
+    );
+    assert!(
+        controller.read().qa_timeout_armed(&session_id),
+        "the respawn branch must arm the QA clock"
+    );
+}
+
+/// #175(c). `QaInconclusive` locked out worker spawning entirely, which is what
+/// made the field session permanently uncapped-at-3.
+#[tokio::test]
+async fn workers_can_be_added_while_qa_is_inconclusive() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("inconclusive-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    init_git_repo_for_launch_fixture(temp_dir.path());
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaInconclusive;
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"role_type":"backend","cli":"claude","initial_task":"fix it"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res.status(),
+        StatusCode::CREATED,
+        "QaInconclusive must not lock out worker spawning"
+    );
+}
+
+/// #175(a) + #176. With the launch state now `Running`, the operator override
+/// must still be reachable for an evaluator-backed session — otherwise the fix
+/// ships a session that can never complete (completion demands QaPassed).
+#[tokio::test]
+async fn force_pass_is_allowed_before_the_milestone_handoff() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("pre-handoff-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::Running;
+    session.agents.push(AgentInfo {
+        id: format!("{}-evaluator", session_id),
+        role: AgentRole::Evaluator,
+        status: AgentStatus::Running,
+        config: AgentConfig::default(),
+        parent_id: None,
+        commit_sha: None,
+        base_commit_sha: None,
+    });
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-pass", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::OK);
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaPassed
+    );
+}
+
+/// The widening above must stay conditioned on the session actually being
+/// evaluator-backed. A swarm forced into `QaPassed` permanently loses
+/// `add_planner`.
+#[tokio::test]
+async fn force_pass_still_rejected_for_a_running_session_without_an_evaluator() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("no-eval-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::Running;
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-pass", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::Running
+    );
+}
+
+/// #175(b). A milestone-ready arriving while QA is inconclusive is still
+/// dropped, but it must be recorded rather than silently discarded.
+#[tokio::test]
+async fn milestone_ready_on_an_inconclusive_session_is_logged_not_silent() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("drop-log-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaInconclusive;
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/milestone-ready", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // State is deliberately unchanged (re-entry is a separate follow-up)...
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaInconclusive
+    );
+    // ...but the drop must be visible to the operator.
+    let log = storage.read_coordination_log(&session_id, None).unwrap();
+    assert!(
+        log.iter().any(|m| m.content.contains("milestone-ready")
+            && m.content.contains("force-pass")),
+        "the dropped signal must be recorded with the recovery path, got {:?}",
+        log.iter().map(|m| &m.content).collect::<Vec<_>>()
+    );
+}
+
 #[tokio::test]
 async fn test_launch_solo_with_same_cli_evaluator_preserves_custom_session_model() {
     let (app, controller) = setup_test_app_with_controller().await;

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -5262,6 +5262,220 @@ impl Drop for TestPathCleanup {
     }
 }
 
+/// #176 T5. A bodyless POST to a destructive operator override must be refused.
+/// This is exactly how force-pass was tripped in the field, while an agent was
+/// enumerating the API surface.
+#[tokio::test]
+async fn force_pass_requires_explicit_confirmation() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("force-confirm-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaInProgress { iteration: Some(1) };
+    controller.write().insert_test_session(session);
+
+    let post = |body: Option<&'static str>| {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        async move {
+            let mut builder = Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-pass", session_id));
+            let request = match body {
+                Some(json) => builder
+                    .header("content-type", "application/json")
+                    .body(Body::from(json))
+                    .unwrap(),
+                None => {
+                    builder = builder.header("x-probe", "bodyless");
+                    builder.body(Body::empty()).unwrap()
+                }
+            };
+            app.oneshot(request).await.unwrap()
+        }
+    };
+
+    // (a) bodyless, no content-type — the shape a read-only API probe sends.
+    let res = post(None).await;
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "a bodyless force-pass must be refused"
+    );
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap(),
+    )
+    .unwrap();
+    assert!(
+        body["error"].as_str().unwrap().contains("confirm"),
+        "the 400 must tell the caller what is missing, got {body}"
+    );
+
+    // (b) empty object and (c) explicit false are equally refused.
+    assert_eq!(post(Some("{}")).await.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        post(Some(r#"{"confirm":false}"#)).await.status(),
+        StatusCode::BAD_REQUEST
+    );
+
+    // (d) none of the refusals may have changed state.
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaInProgress { iteration: Some(1) },
+        "a refused override must not mutate session state"
+    );
+
+    // (e) the confirmed call still works.
+    assert_eq!(
+        post(Some(r#"{"confirm":true}"#)).await.status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaPassed
+    );
+}
+
+/// #176 T6. force_pass / force_fail are copy-paste twins; guarding only one is a
+/// realistic half-done edit.
+#[tokio::test]
+async fn force_fail_requires_explicit_confirmation() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("force-fail-confirm-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaInProgress { iteration: Some(1) };
+    controller.write().insert_test_session(session);
+
+    let bodyless = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-fail", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(bodyless.status(), StatusCode::BAD_REQUEST);
+
+    let refused = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-fail", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":false}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(refused.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        controller.read().get_session(&session_id).unwrap().state,
+        SessionState::QaInProgress { iteration: Some(1) }
+    );
+
+    let confirmed = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-fail", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(confirmed.status(), StatusCode::OK);
+}
+
+/// #176 T7. Pins a deliberate precedence change: the confirmation guard runs
+/// before the session lookup, so a bodyless probe against a nonexistent session
+/// now answers 400 rather than 404.
+#[tokio::test]
+async fn force_override_confirmation_precedes_session_lookup() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, _controller, _storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/no-such-session/qa/force-pass")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        res.status(),
+        StatusCode::BAD_REQUEST,
+        "confirm is checked before the session exists"
+    );
+}
+
+/// #176 T8. The rationale must reach the durable operator audit log. Also pins
+/// the `create_dir_all` in `append_coordination_log`: without it the append
+/// silently no-ops because the caller discards the Result.
+#[tokio::test]
+async fn force_pass_rationale_is_recorded_in_the_operator_audit_log() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("force-rationale-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.state = SessionState::QaInProgress { iteration: Some(1) };
+    controller.write().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-pass", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"confirm":true,"rationale":"UI host unavailable, verified manually"}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // NB: `CoordinationMessage::system(to, content)` takes the recipient first,
+    // so operator audit entries are recorded as `SYSTEM -> OPERATOR`.
+    let log = storage.read_coordination_log(&session_id, None).unwrap();
+    let operator_line = log
+        .iter()
+        .find(|m| m.to == "OPERATOR")
+        .expect("an operator override must leave an audit entry");
+    assert!(
+        operator_line.content.contains("FORCE-PASS"),
+        "audit entry should name the action, got {}",
+        operator_line.content
+    );
+    assert!(
+        operator_line
+            .content
+            .contains("UI host unavailable, verified manually"),
+        "audit entry should carry the operator rationale, got {}",
+        operator_line.content
+    );
+}
+
 #[tokio::test]
 async fn test_force_pass_hot_reloads_clean_session_from_session_json() {
     let storage_dir = TempDir::new().unwrap();
@@ -5280,7 +5494,8 @@ async fn test_force_pass_hot_reloads_clean_session_from_session_json() {
             Request::builder()
                 .method("POST")
                 .uri(format!("/api/sessions/{}/qa/force-pass", session_id))
-                .body(Body::empty())
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":true}"#))
                 .unwrap(),
         )
         .await

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -8726,6 +8726,97 @@ async fn heartbeat_rejects_a_fully_unknown_agent() {
     assert_eq!(ok.status(), StatusCode::OK);
 }
 
+/// #175(f). The Queen's own wait loops post a BARE `queen` alias, not
+/// `{session}-queen`, and they use `curl -fsS` — so a 404 here is a hard
+/// non-zero exit that aborts the Queen's shell block while it waits for the
+/// Evaluator verdict or Prince remediation. The roster gate must canonicalize
+/// the alias before comparing.
+///
+/// The second half also pins a latent UI bug: heartbeats were stored under the
+/// raw `"queen"` key while `/api/sessions/active` looks the Queen up by
+/// `{session}-queen`, leaving its activity permanently null.
+#[tokio::test]
+async fn heartbeat_accepts_the_bare_queen_alias_and_canonicalizes_it() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = "queen-alias".to_string();
+    let temp_dir = TempDir::new().unwrap();
+
+    let queen_id = format!("{}-queen", session_id);
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.agents.push(AgentInfo {
+        id: queen_id.clone(),
+        role: AgentRole::Queen,
+        status: AgentStatus::Running,
+        config: AgentConfig::default(),
+        parent_id: None,
+        commit_sha: None,
+        base_commit_sha: None,
+    });
+    controller.read().insert_test_session(session);
+
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/heartbeat", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "agent_id": "queen",
+                        "status": "working",
+                        "summary": "Waiting for Evaluator verdict"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "the Queen's bare `queen` alias must be accepted"
+    );
+
+    // ...and it must be stored under the roster id, so the UI can find it.
+    let active = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(active.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    let queen = body["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["id"] == session_id.as_str())
+        .expect("session present")["agents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["id"] == queen_id.as_str())
+        .expect("queen present")
+        .clone();
+    assert_eq!(queen["status"], "working");
+    assert_eq!(queen["summary"], "Waiting for Evaluator verdict");
+    assert!(
+        !queen["last_activity"].is_null(),
+        "the heartbeat must be recorded against the roster id, not the bare alias"
+    );
+}
+
 /// #175(f) regression net. Breaking heartbeating is worse than the bug it fixes,
 /// so every legitimate managed-agent id shape must still be accepted. Guards
 /// against a later "tidy-up" narrowing the gate to a role allowlist.

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -162,6 +162,66 @@ async fn setup_test_app_with_controller_at(
     (create_router(state), session_controller, storage)
 }
 
+/// Like [`setup_test_app_with_controller_at`] but also hands back the `AppState`,
+/// so a test can reach the PTY manager and the durable queue directly (e.g. to
+/// register a live PTY, or to seed a leaked queue row).
+async fn setup_test_app_full(
+    base_dir: std::path::PathBuf,
+) -> (
+    axum::Router,
+    Arc<RwLock<SessionController>>,
+    Arc<SessionStorage>,
+    Arc<AppState>,
+) {
+    let storage = Arc::new(SessionStorage::new_with_base(base_dir.clone()).unwrap());
+    let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    session_controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new_with_base(base_dir).unwrap(),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    let app_state_db =
+        Arc::new(crate::storage::ApplicationStateDb::open(storage.base_dir()).unwrap());
+    let queue_repo = Arc::new(crate::storage::QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().unwrap();
+    let queue_manager = Arc::new(crate::coordination::QueueManager::new(
+        queue_repo,
+        event_bus.clone(),
+    ));
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller.clone(),
+        injection_manager,
+        storage.clone(),
+        event_bus,
+        app_state_db,
+        queue_manager,
+        None,
+    ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
+
+    (
+        create_router(state.clone()),
+        session_controller,
+        storage,
+        state,
+    )
+}
+
+/// Register a live stub PTY for `agent_id` so code gated on PTY liveness is
+/// reachable from tests.
+fn register_live_pty(state: &AppState, agent_id: &str, role: AgentRole) {
+    state
+        .pty_manager
+        .write()
+        .create_session(agent_id.to_string(), role, "cmd", &[], None, 80, 24)
+        .expect("stub PTY creation should succeed");
+}
+
 async fn setup_isolated_test_app_with_controller() -> (
     TempDir,
     axum::Router,
@@ -5473,6 +5533,142 @@ async fn force_pass_rationale_is_recorded_in_the_operator_audit_log() {
             .contains("UI host unavailable, verified manually"),
         "audit entry should carry the operator rationale, got {}",
         operator_line.content
+    );
+}
+
+/// #176 T9. The field report's second symptom: after force-pass, `GET /workers`
+/// reported ALL workers `Completed` while one was demonstrably still running.
+///
+/// The mechanism is in the READ path, not force-pass: reaching a state that
+/// triggers `should_reload_session_info_from_storage` makes the next
+/// `GET /api/sessions/{id}` reconstruct the roster from disk, and
+/// `session_from_persisted` hardcodes `Completed` because the persisted snapshot
+/// carries no runtime status.
+#[tokio::test]
+async fn force_pass_does_not_report_running_workers_as_completed() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("overlay-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let w1 = format!("{}-worker-1", session_id);
+    let w2 = format!("{}-worker-2", session_id);
+    let mut session = make_test_session_with_agents(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+        &[&w1, &w2],
+    );
+    session.state = SessionState::QaInProgress { iteration: Some(1) };
+    controller.write().insert_test_session(session.clone());
+    // Persist, so the reload has a snapshot to read back.
+    controller.read().persist_test_session(&session_id);
+
+    // Both workers are genuinely alive.
+    register_live_pty(&state, &w1, AgentRole::Worker { index: 1, parent: None });
+    register_live_pty(&state, &w2, AgentRole::Worker { index: 2, parent: None });
+
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/qa/force-pass", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"confirm":true}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+
+    // LOAD-BEARING: this GET is what triggers the disk reload. Omit it and the
+    // test passes even on broken code.
+    let info = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(info.status(), StatusCode::OK);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+
+    let workers = body["workers"].as_array().expect("workers array");
+    assert_eq!(workers.len(), 2);
+    for worker in workers {
+        assert_eq!(
+            worker["status"].as_str().unwrap(),
+            "Running",
+            "a live worker must not be reported Completed after a QA state change: {body}"
+        );
+    }
+    let _ = storage;
+}
+
+/// #176 T11. The overlay must stay conditioned on PTY liveness. An unconditional
+/// overlay would report a dead session's agents as `Running` forever, since
+/// nothing in the crate writes a non-Completed status after spawn.
+#[tokio::test]
+async fn reload_reports_dead_workers_as_completed() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("overlay-dead-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+
+    let w1 = format!("{}-worker-1", session_id);
+    let mut session =
+        make_test_session_with_agents(&session_id, temp_dir.path().to_str().unwrap(), &[&w1]);
+    // A terminal state that also triggers the reload, with NO live PTY.
+    session.state = SessionState::Completed;
+    controller.write().insert_test_session(session.clone());
+    controller.read().persist_test_session(&session_id);
+
+    let info = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(info.status(), StatusCode::OK);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let body: serde_json::Value =
+        serde_json::from_slice(&axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap())
+            .unwrap();
+    assert_eq!(
+        body["workers"][0]["status"].as_str().unwrap(),
+        "Completed",
+        "a dead worker must read Completed, not be pinned Running by the overlay"
     );
 }
 

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -8408,15 +8408,17 @@ async fn test_queue_endpoint_empty_snapshot() {
     let _ = std::fs::remove_dir_all(&temp_dir);
 }
 
+/// #175(d). A spawn that fails after winning the claim must RELEASE it.
+///
+/// This test replaces `test_add_worker_enqueues_and_claims`, whose assertions
+/// were the bug's specification: it asserted the row stayed `running` after a
+/// failed spawn and that the retry 409'd — i.e. exactly the permanent lockout
+/// reported from the field.
 #[tokio::test]
-async fn test_add_worker_enqueues_and_claims() {
-    // First POST /workers enqueues a queue row and atomically claims it (-> running). The
-    // downstream PTY/worktree spawn fails in the hermetic test env (temp dir is not a git
-    // repo), so no agent is added — but the queue row is the source of truth and is now
-    // `running`. A duplicate POST for the same worker re-enqueues (no-op), loses the claim
-    // on the already-running fresh row, and is turned away with 409.
+async fn add_worker_failure_releases_the_claimed_queue_row() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let temp_dir = std::env::temp_dir().join("hive-test-queue-claim");
+    // A NON-git temp dir, so the worktree step fails and the spawn errors out.
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-claim-release");
     let _ = std::fs::create_dir_all(&temp_dir);
     controller.read().insert_test_session(make_test_session(
         "session-queue-claim",
@@ -8424,51 +8426,342 @@ async fn test_add_worker_enqueues_and_claims() {
     ));
 
     let body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
+    let post = || {
+        let app = app.clone();
+        let body = body.clone();
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/sessions/session-queue-claim/workers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+    };
 
-    // First POST: enqueue + claim succeed; spawn may fail downstream (500), never 409.
-    let first = app
+    let first = post().await;
+    assert_ne!(first.status(), StatusCode::CONFLICT);
+
+    // The claim was released, so the row is claimable again rather than stranded.
+    let snap = fetch_queue_snapshot(&app, "session-queue-claim").await;
+    assert_eq!(
+        snap["running"], 0,
+        "a failed spawn must not leave the row claimed"
+    );
+    assert_eq!(snap["queued"], 1, "the row must be returned to queued");
+    assert_eq!(snap["rows"][0]["worker_id"], "session-queue-claim-worker-1");
+
+    // And the retry is NOT turned away with a 409 — the whole point of the fix.
+    let second = post().await;
+    assert_ne!(
+        second.status(),
+        StatusCode::CONFLICT,
+        "a retry after a released claim must not 409"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+/// #175(d). Releasing without a cap would turn a 90s-bounded oscillation into an
+/// unbounded retry loop, each iteration re-running worktree creation and branch
+/// deletion against the operator's real repository.
+#[tokio::test]
+async fn add_worker_spawn_attempts_are_capped() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-claim-cap");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    controller.read().insert_test_session(make_test_session(
+        "session-queue-cap",
+        temp_dir.to_str().unwrap(),
+    ));
+
+    let body = serde_json::json!({ "role_type": "backend", "cli": "claude" });
+    let post = || {
+        let app = app.clone();
+        let body = body.clone();
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/sessions/session-queue-cap/workers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&body).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+    };
+
+    post().await;
+    post().await;
+    let third = post().await;
+
+    assert_eq!(
+        third.status(),
+        StatusCode::CONFLICT,
+        "the third failed spawn must retire the row instead of looping forever"
+    );
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(third.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "spawn_failed");
+    assert_eq!(body["attempts"], 3);
+
+    let snap = fetch_queue_snapshot(&app, "session-queue-cap").await;
+    assert_eq!(snap["failed"], 1, "the retired row must be terminal");
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+/// #175(d). A session that cannot accept a worker must be refused BEFORE
+/// anything is written to the durable queue, with a 409 the caller can act on
+/// rather than an opaque 500.
+#[tokio::test]
+async fn add_worker_rejected_state_returns_409_and_creates_no_queue_row() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let temp_dir = std::env::temp_dir().join("hive-test-queue-reject");
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let mut session = make_test_session("session-queue-reject", temp_dir.to_str().unwrap());
+    session.state = SessionState::Completed;
+    controller.read().insert_test_session(session);
+
+    let res = app
         .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/sessions/session-queue-claim/workers")
+                .uri("/api/sessions/session-queue-reject/workers")
                 .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .body(Body::from(r#"{"role_type":"backend","cli":"claude"}"#))
                 .unwrap(),
         )
         .await
         .unwrap();
-    assert_ne!(
-        first.status(),
-        StatusCode::CONFLICT,
-        "first claim must not be a 409"
+
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "session_state");
+    assert!(body["current_state"].as_str().unwrap().contains("Completed"));
+
+    let snap = fetch_queue_snapshot(&app, "session-queue-reject").await;
+    assert_eq!(
+        snap["rows"].as_array().unwrap().len(),
+        0,
+        "a pre-validated rejection must not create a queue row at all"
     );
 
-    // The queue row exists and is running, even though the spawn failed.
-    let snap = fetch_queue_snapshot(&app, "session-queue-claim").await;
-    assert_eq!(snap["running"], 1, "first POST claims the row to running");
-    assert_eq!(snap["rows"][0]["worker_id"], "session-queue-claim-worker-1");
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
 
-    // Second POST for the same worker loses the claim → 409.
-    let second = app
+/// #175(e). The recovery route turns a leaked claim back into a claimable row.
+#[tokio::test]
+async fn release_recovers_a_leaked_claim() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("leak-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    controller
+        .read()
+        .insert_test_session(make_test_session(&session_id, temp_dir.path().to_str().unwrap()));
+
+    // Seed the leak directly, so this test does not depend on #175(d) being broken.
+    let leaked = format!("{}-worker-2", session_id);
+    state
+        .queue_manager
+        .enqueue_worker(&leaked, &session_id, &leaked, "backend", "claude", serde_json::json!({}), None)
+        .await
+        .unwrap();
+    assert!(state
+        .queue_manager
+        .claim_and_spawn(&leaked, &session_id, &leaked)
+        .await
+        .unwrap()
+        .is_some());
+    assert_eq!(state.queue_manager.queue_snapshot(&session_id).unwrap().running, 1);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/workers/{}/release",
+                    session_id, leaked
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["released"], true);
+    assert_eq!(body["previous_status"], "running");
+
+    let snap = state.queue_manager.queue_snapshot(&session_id).unwrap();
+    assert_eq!(snap.running, 0);
+    assert_eq!(snap.queued, 1, "the row must be claimable again");
+    assert_eq!(snap.rows[0].attempts, 0, "the spawn budget must be reset");
+}
+
+/// The release route must refuse a worker that is genuinely on the roster —
+/// releasing it would strand the row, since the index allocator targets N+1.
+#[tokio::test]
+async fn release_refuses_a_rostered_worker() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("rostered-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let worker = format!("{}-worker-1", session_id);
+    controller.read().insert_test_session(make_test_session_with_agents(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+        &[&worker],
+    ));
+
+    state
+        .queue_manager
+        .enqueue_worker(&worker, &session_id, &worker, "backend", "claude", serde_json::json!({}), None)
+        .await
+        .unwrap();
+    state
+        .queue_manager
+        .claim_and_spawn(&worker, &session_id, &worker)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/workers/{}/release",
+                    session_id, worker
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+
+    // And it must not have half-acted.
+    assert_eq!(
+        state.queue_manager.queue_snapshot(&session_id).unwrap().running,
+        1,
+        "a refused release must leave the row untouched"
+    );
+}
+
+/// #175(f). A heartbeat from an id with no roster entry, no PTY and no queue row
+/// must be refused BEFORE it can finalize anything.
+#[tokio::test]
+async fn heartbeat_rejects_a_fully_unknown_agent() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("ghost-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let real = format!("{}-worker-1", session_id);
+    controller.read().insert_test_session(make_test_session_with_agents(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+        &[&real],
+    ));
+
+    let ghost = format!("{}-worker-4", session_id);
+    let res = app
         .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri("/api/sessions/session-queue-claim/workers")
+                .uri(format!("/api/sessions/{}/heartbeat", session_id))
                 .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .body(Body::from(
+                    serde_json::json!({"agent_id": ghost, "status": "completed"}).to_string(),
+                ))
                 .unwrap(),
         )
         .await
         .unwrap();
     assert_eq!(
-        second.status(),
-        StatusCode::CONFLICT,
-        "duplicate worker POST must return 409 (lost claim)"
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "a heartbeat for a nonexistent agent must not be silently accepted"
     );
 
-    let _ = std::fs::remove_dir_all(&temp_dir);
+    // A rostered agent still works.
+    let ok = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/heartbeat", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"agent_id": real, "status": "working"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(ok.status(), StatusCode::OK);
+}
+
+/// Fail-open: every spawn path starts the PTY before pushing the roster entry,
+/// and the agents' heartbeat snippet uses `curl -fsS`, so a strict roster check
+/// would abort a healthy agent's shell block during that window.
+#[tokio::test]
+async fn heartbeat_accepts_an_agent_whose_roster_push_has_not_landed() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("prepush-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    // Roster deliberately does NOT contain the evaluator yet.
+    controller
+        .read()
+        .insert_test_session(make_test_session(&session_id, temp_dir.path().to_str().unwrap()));
+
+    let evaluator = format!("{}-evaluator", session_id);
+    register_live_pty(&state, &evaluator, AgentRole::Evaluator);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/heartbeat", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({"agent_id": evaluator, "status": "working"}).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::OK,
+        "a live PTY must be enough to accept a heartbeat during the roster-push window"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -8726,6 +8726,64 @@ async fn heartbeat_rejects_a_fully_unknown_agent() {
     assert_eq!(ok.status(), StatusCode::OK);
 }
 
+/// #175(f) regression net. Breaking heartbeating is worse than the bug it fixes,
+/// so every legitimate managed-agent id shape must still be accepted. Guards
+/// against a later "tidy-up" narrowing the gate to a role allowlist.
+#[tokio::test]
+async fn heartbeat_accepts_every_managed_agent_id_shape() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    // Short id so `{sid}-master-planner` stays under the 64-char agent-id cap.
+    let session_id = "hb-shapes".to_string();
+    let temp_dir = TempDir::new().unwrap();
+
+    let suffixes = [
+        "queen",
+        "worker-1",
+        "evaluator",
+        "prince",
+        "qa-worker-1",
+        "fusion-1",
+        "judge",
+        "debate-1-r1",
+        "master-planner",
+        "planner-1",
+    ];
+    let ids: Vec<String> = suffixes
+        .iter()
+        .map(|s| format!("{}-{}", session_id, s))
+        .collect();
+    let refs: Vec<&str> = ids.iter().map(|s| s.as_str()).collect();
+    controller.read().insert_test_session(make_test_session_with_agents(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+        &refs,
+    ));
+
+    for id in &ids {
+        let res = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/sessions/{}/heartbeat", session_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({"agent_id": id, "status": "working"}).to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            res.status(),
+            StatusCode::OK,
+            "heartbeat must be accepted for rostered agent {id}"
+        );
+    }
+}
+
 /// Fail-open: every spawn path starts the PTY before pushing the roster entry,
 /// and the agents' heartbeat snippet uses `curl -fsS`, so a strict roster check
 /// would abort a healthy agent's shell block during that window.

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -239,20 +239,33 @@ impl PtySession {
             cmd.cwd(dir);
         }
 
-        let child = pty_pair
+        let mut child = pty_pair
             .slave
             .spawn_command(cmd)
             .map_err(|e| PtyError::SpawnError(e.to_string()))?;
 
-        let writer = pty_pair
-            .master
-            .take_writer()
-            .map_err(into_io_error)?;
+        // #175(d): the child is ALREADY RUNNING at this point. Returning `Err`
+        // from either step below without killing it would leave a live process
+        // that no `PtySession` owns — and the caller, seeing `Err`, releases the
+        // worker's durable queue claim so a retry can spawn a second one. Any
+        // failure past the spawn must therefore reap the child first.
+        let writer = match pty_pair.master.take_writer() {
+            Ok(writer) => writer,
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(into_io_error(e));
+            }
+        };
 
-        let reader = pty_pair
-            .master
-            .try_clone_reader()
-            .map_err(into_io_error)?;
+        let reader = match pty_pair.master.try_clone_reader() {
+            Ok(reader) => reader,
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(into_io_error(e));
+            }
+        };
 
         // Keep the master alive - dropping it closes the PTY!
         let master = pty_pair.master;

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -212,9 +212,20 @@ impl PtySession {
         Ok(())
     }
 
-    #[allow(dead_code)]
+    /// Mirror the real session's liveness semantics instead of hardcoding
+    /// `false`.
+    ///
+    /// The real `PtySession::is_alive` reports whether the child process is
+    /// still running. A stub that always answers `false` makes every production
+    /// path gated on PTY liveness — the evaluator/prince respawn checks and the
+    /// live-status overlay — permanently untestable on the Windows CI runner,
+    /// which is where this crate's tests actually run. Track the stubbed status
+    /// instead so those branches are reachable from tests.
     pub fn is_alive(&self) -> bool {
-        false
+        !matches!(
+            *self.status.read(),
+            AgentStatus::Completed | AgentStatus::Error(_)
+        )
     }
 
     #[allow(dead_code)]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -8422,6 +8422,8 @@ phases and do EXACTLY this, then stop:
                     &base_branch,
                 ],
             )?;
+            // #177: halt ESLint's cascade before it escapes into the parent repo.
+            crate::workspace::git::ensure_worktree_config_boundary(&project_path, &worktree_path);
             self.emit_workspace_created(
                 &session_id,
                 &variant_to_cell_id(&variant.name),
@@ -8765,6 +8767,8 @@ phases and do EXACTLY this, then stop:
                     base_branch,
                 ],
             )?;
+            // #177: halt ESLint's cascade before it escapes into the parent repo.
+            crate::workspace::git::ensure_worktree_config_boundary(project_path, &worktree_path);
             controller.emit_workspace_created(
                 session_id,
                 &variant_to_cell_id(&debater.name),
@@ -9587,6 +9591,11 @@ phases and do EXACTLY this, then stop:
                     &base_branch,
                 ],
             )?;
+            // #177: halt ESLint's cascade before it escapes into the parent repo.
+            crate::workspace::git::ensure_worktree_config_boundary(
+                &session.project_path,
+                &worktree_path,
+            );
             self.emit_workspace_created(
                 session_id,
                 &variant_to_cell_id(&variant.name),

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -703,6 +703,22 @@ fn is_terminal_session_state(state: &SessionState) -> bool {
     )
 }
 
+/// States in which a QA review is open or already resolved. Used to stop
+/// unrelated worker progression from dragging a session back to `Running` and
+/// orphaning an in-flight review (#175a).
+fn is_qa_phase_state(state: &SessionState) -> bool {
+    matches!(
+        state,
+        SessionState::SpawningEvaluator
+            | SessionState::QaInProgress { .. }
+            | SessionState::QaPassed
+            | SessionState::QaFailed { .. }
+            | SessionState::QaInconclusive
+            | SessionState::QaMaxRetriesExceeded
+            | SessionState::PrinceRemediation
+    )
+}
+
 fn qa_in_progress_state(state: &SessionState) -> SessionState {
     match state {
         SessionState::QaFailed { iteration } => SessionState::QaInProgress {
@@ -1462,7 +1478,7 @@ impl SessionController {
             .collect()
     }
 
-    fn session_requires_internal_evaluator(session: &Session) -> bool {
+    pub(crate) fn session_requires_internal_evaluator(session: &Session) -> bool {
         session.agents.iter().any(|agent| {
             matches!(
                 agent.role,
@@ -4799,7 +4815,12 @@ When ALL {completion_scope} have completed, you MUST signal the existing Evaluat
    mv "$TMP_MILESTONE" "{milestone_ready_path}"
    ```
 
-3. You MUST NOT spawn an Evaluator here. The backend already launched it. After this handoff exists, continue with the Post-Workers Protocol and wait for `{qa_verdict_path}`."#,
+3. You MUST then signal the backend that the milestone is ready. This is what opens the QA review window and starts the QA clock — the clock does NOT run before this point, so there is no time pressure on the work above.
+   ```bash
+   curl -sS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/milestone-ready"
+   ```
+
+4. You MUST NOT spawn an Evaluator here. The backend already launched it. After this handoff exists, continue with the Post-Workers Protocol and wait for `{qa_verdict_path}`."#,
             completion_scope = completion_scope,
             peer_dir = peer_dir,
             milestone_ready_path = milestone_ready_path,
@@ -10103,9 +10124,18 @@ phases and do EXACTLY this, then stop:
             // All workers spawned - session complete
             let changes = {
                 let mut sessions = self.sessions.write();
-                sessions
-                    .get_mut(session_id)
-                    .map(|s| self.set_session_state_with_events(s, SessionState::Running))
+                sessions.get_mut(session_id).and_then(|s| {
+                    // #175(a): do not clobber an open QA window. Now that a
+                    // session sits in `Running` until the milestone handoff, a
+                    // worker completing AFTER the handoff would otherwise drag
+                    // the session back out of QaInProgress and orphan the
+                    // Evaluator's review.
+                    if is_qa_phase_state(&s.state) {
+                        None
+                    } else {
+                        Some(self.set_session_state_with_events(s, SessionState::Running))
+                    }
+                })
             };
             if let Some(changes) = changes {
                 self.persist_then_emit_session_update(session_id, changes)
@@ -10889,6 +10919,50 @@ phases and do EXACTLY this, then stop:
         Ok(())
     }
 
+    /// Surface a dropped milestone-ready signal to the UI. Reuses the existing
+    /// `qa-inconclusive` event rather than introducing a new one.
+    fn emit_qa_inconclusive_event(&self, session_id: &str) {
+        if let Some(ref app_handle) = self.app_handle {
+            let _ = app_handle.emit(
+                "qa-inconclusive",
+                serde_json::json!({
+                    "session_id": session_id,
+                    "action": "milestone-ready-dropped",
+                    "reason": "QA is inconclusive; resolve with qa/force-pass or qa/force-fail",
+                }),
+            );
+        }
+    }
+
+    /// Open the QA review window: move the session into `QaInProgress` and arm
+    /// the QA timeout.
+    ///
+    /// #175(a): this is the ONE place that starts the QA clock. Spawning an
+    /// Evaluator deliberately does not, because that happens at session launch,
+    /// long before there is anything to review.
+    pub(crate) fn begin_qa_window(&self, session_id: &str) -> Result<(), String> {
+        let (timeout_secs, changes) = {
+            let mut sessions = self.sessions.write();
+            let session = sessions
+                .get_mut(session_id)
+                .ok_or_else(|| format!("Session not found: {}", session_id))?;
+            let next_state = qa_in_progress_state(&session.state);
+            let changes = self.set_session_state_with_events(session, next_state);
+            (session.qa_timeout_secs, changes)
+        };
+        self.emit_session_update(session_id);
+        self.update_session_storage(session_id);
+        self.emit_cell_status_changes(session_id, changes);
+        self.start_qa_timeout(session_id, timeout_secs);
+        Ok(())
+    }
+
+    /// Whether a QA timeout is currently armed for this session.
+    #[cfg(test)]
+    pub fn qa_timeout_armed(&self, session_id: &str) -> bool {
+        self.qa_timeout_handles.lock().contains_key(session_id)
+    }
+
     #[allow(dead_code)]
     pub fn on_milestone_ready(&self, session_id: &str) -> Result<(), String> {
         let (maybe_evaluator, config) = {
@@ -10897,10 +10971,34 @@ phases and do EXACTLY this, then stop:
                 .get(session_id)
                 .ok_or_else(|| format!("Session not found: {}", session_id))?;
 
+            // #175(b): a milestone-ready signal arriving while the session is
+            // QaInconclusive is still dropped, but it must not be dropped
+            // SILENTLY -- that is how a Queen submitting the real milestone after
+            // a spurious timeout got no QA and no explanation. Recovery (re-entry
+            // into QaInProgress) is deliberately deferred; the operator path via
+            // force-pass / force-fail already accepts QaInconclusive.
+            if matches!(&session.state, SessionState::QaInconclusive) {
+                tracing::warn!(
+                    session_id = %session_id,
+                    "Dropping milestone-ready signal: QA is inconclusive for this session. \
+                     Operator must resolve it with qa/force-pass or qa/force-fail."
+                );
+                if let Some(storage) = self.storage.as_ref() {
+                    let msg = crate::coordination::CoordinationMessage::system(
+                        "OPERATOR",
+                        "milestone-ready was received but ignored: QA is inconclusive. \
+                         Resolve with POST /qa/force-pass or POST /qa/force-fail \
+                         (body: {\"confirm\":true}).",
+                    );
+                    let _ = storage.append_coordination_log(session_id, &msg);
+                }
+                self.emit_qa_inconclusive_event(session_id);
+                return Ok(());
+            }
+
             if matches!(
                 &session.state,
                 SessionState::PrinceRemediation
-                    | SessionState::QaInconclusive
                     | SessionState::QaPassed
                     | SessionState::QaMaxRetriesExceeded
             ) {
@@ -10957,24 +11055,17 @@ phases and do EXACTLY this, then stop:
             let result = self.launch_evaluator(session_id, config, false);
             self.finish_evaluator_respawn(session_id);
             result?;
+            // #175(a) THE TRAP: this branch used to rely on `launch_evaluator`'s
+            // tail to transition and arm the clock. Now that spawning an
+            // Evaluator no longer opens a QA window, this branch must open it
+            // itself -- otherwise the fix for a spurious-timeout bug becomes a
+            // never-times-out bug, and a real milestone would sit unreviewed
+            // forever.
+            self.begin_qa_window(session_id)?;
             return Ok(());
         }
 
-        let timeout_secs = {
-            let mut sessions = self.sessions.write();
-            let session = sessions
-                .get_mut(session_id)
-                .ok_or_else(|| format!("Session not found: {}", session_id))?;
-            let next_state = qa_in_progress_state(&session.state);
-            let changes = self.set_session_state_with_events(session, next_state);
-            (session.qa_timeout_secs, changes)
-        };
-        self.emit_session_update(session_id);
-        self.update_session_storage(session_id);
-        self.emit_cell_status_changes(session_id, timeout_secs.1);
-        self.start_qa_timeout(session_id, timeout_secs.0);
-
-        Ok(())
+        self.begin_qa_window(session_id)
     }
 
     #[allow(dead_code)]
@@ -12882,6 +12973,12 @@ phases and do EXACTLY this, then stop:
                 | SessionState::QaFailed { .. }
                 | SessionState::QaMaxRetriesExceeded
                 | SessionState::PrinceRemediation
+                // #175(c): QaInconclusive is strictly less terminal than
+                // QaMaxRetriesExceeded (which is allowed), is already accepted by
+                // is_monitorable and by the operator override gate, and excluding
+                // it stranded the Prince's fix team -- the parent-role check
+                // accepts Prince, but this state guard rejected first.
+                | SessionState::QaInconclusive
         );
         if !can_add_worker {
             return Err(format!(
@@ -13143,13 +13240,27 @@ phases and do EXACTLY this, then stop:
             config.label = Some("Evaluator".to_string());
         }
 
-        let spawning_changes = {
+        // #175(a): capture the state we are transitioning AWAY from, so the tail
+        // can restore it. Restoring the captured state rather than a hardcoded
+        // `Running` also fixes a latent iteration-loss bug: the tail used to read
+        // `qa_in_progress_state(&current.state)` AFTER this block had already
+        // written `SpawningEvaluator`, so a respawn from `QaFailed { iteration: 2 }`
+        // fell to the catch-all arm and reset the counter to `None`, defeating the
+        // max-retries ceiling.
+        let (previous_state, spawning_changes) = {
             let mut sessions = self.sessions.write();
             if let Some(current) = sessions.get_mut(session_id) {
+                let previous_state = current.state.clone();
                 current.agents.retain(|agent| agent.id != evaluator_id);
-                Some(self.set_session_state_with_events(current, SessionState::SpawningEvaluator))
+                (
+                    Some(previous_state),
+                    Some(self.set_session_state_with_events(
+                        current,
+                        SessionState::SpawningEvaluator,
+                    )),
+                )
             } else {
-                None
+                (None, None)
             }
         };
         self.emit_session_update(session_id);
@@ -13230,23 +13341,42 @@ phases and do EXACTLY this, then stop:
             base_commit_sha: None,
         };
 
-        let (timeout_secs, qa_changes) = {
+        // #175(a): spawning an Evaluator does NOT open a QA window. It used to
+        // transition straight to QaInProgress and arm the 300s QA timer, and
+        // because this runs at SESSION LAUNCH, every evaluator-backed session ran
+        // a live QA clock from the moment it started. Any session whose first
+        // milestone took longer than the timeout was deterministically poisoned
+        // to QaInconclusive with a spurious BLOCKED/timeout verdict for work that
+        // had never been submitted for review.
+        //
+        // The clock is now armed only by `begin_qa_window`, at milestone handoff.
+        let qa_changes = {
             let mut sessions = self.sessions.write();
             let current = sessions
                 .get_mut(session_id)
                 .ok_or_else(|| format!("Session not found: {}", session_id))?;
             current.agents.push(agent_info.clone());
             self.emit_agent_launched(current, &agent_info);
-            let next_state = qa_in_progress_state(&current.state);
-            let changes = self.set_session_state_with_events(current, next_state);
-            (current.qa_timeout_secs, changes)
+            // Restore the pre-spawn state, but only if we are still the ones
+            // holding SpawningEvaluator: the sessions lock is released across the
+            // PTY spawn and two file writes above, so an unguarded restore could
+            // silently revert a concurrent Failed/Closing/Closed transition.
+            match (&current.state, previous_state) {
+                (SessionState::SpawningEvaluator, Some(previous)) => {
+                    Some(self.set_session_state_with_events(current, previous))
+                }
+                _ => None,
+            }
         };
 
         self.emit_session_update(session_id);
         self.update_session_storage(session_id);
-        self.emit_cell_status_changes(session_id, qa_changes);
+        if let Some(changes) = qa_changes {
+            self.emit_cell_status_changes(session_id, changes);
+        }
+        // The peer watcher must still exist — without it the milestone handoff is
+        // never observed.
         self.ensure_task_watcher(session_id, &session.project_path);
-        self.start_qa_timeout(session_id, timeout_secs);
 
         // #125: evaluator spawned successfully — mark the write-step Completed.
         if let Some(step_id) = evaluator_journal_step.as_deref() {
@@ -13482,24 +13612,22 @@ phases and do EXACTLY this, then stop:
             base_commit_sha: None,
         };
 
-        let qa_changes = {
+        {
             let mut sessions = self.sessions.write();
             if let Some(current) = sessions.get_mut(session_id) {
                 current.agents.push(agent_info.clone());
                 self.emit_agent_launched(current, &agent_info);
-                let next_state = qa_in_progress_state(&current.state);
-                Some(self.set_session_state_with_events(current, next_state))
-            } else {
-                None
             }
-        };
+        }
 
         self.emit_session_update(session_id);
         self.update_session_storage(session_id);
-        if let Some(changes) = qa_changes {
-            self.emit_cell_status_changes(session_id, changes);
-        }
         self.ensure_task_watcher(session_id, &session.project_path);
+        // #175(a): route the QA transition through the single window-opener so
+        // this path gets a clock too. Otherwise it would be the only remaining
+        // way into QaInProgress with no timeout armed, and there is no UI
+        // escalation to compensate.
+        self.begin_qa_window(session_id)?;
 
         Ok(agent_info)
     }

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1317,6 +1317,58 @@ impl SessionController {
         Ok(updated)
     }
 
+    /// Overlay live in-memory agent statuses onto a session reconstructed from
+    /// disk, but only for agents whose PTY is still running.
+    ///
+    /// `session_from_persisted` hardcodes `AgentStatus::Completed` for every agent
+    /// because `PersistedAgentInfo` carries no runtime status. Any read path that
+    /// inserts its output raw therefore reports still-running workers as
+    /// `Completed` -- the misleading roster observed in the field, where all three
+    /// workers read `Completed` while one kept working for another ~30 minutes.
+    ///
+    /// The PTY-liveness condition is load-bearing, not decoration. The reload is
+    /// also reached for terminal states such as `Failed(_)` and
+    /// `QaMaxRetriesExceeded`, and nothing in the crate ever writes a non-Completed
+    /// status after spawn, so an unconditional overlay would replace a wrong
+    /// "Completed" with a wrong "Running" that never converges for a dead session.
+    fn overlay_live_agent_statuses(&self, refreshed: &mut Session) {
+        // Resolve PTY liveness BEFORE taking the sessions lock, so the two locks
+        // are never held together.
+        let alive: std::collections::HashSet<String> = {
+            let pty_manager = self.pty_manager.read();
+            refreshed
+                .agents
+                .iter()
+                .filter(|a| pty_manager.is_alive(&a.id))
+                .map(|a| a.id.clone())
+                .collect()
+        };
+        if alive.is_empty() {
+            return;
+        }
+
+        let current_statuses: std::collections::HashMap<String, AgentStatus> = {
+            let sessions = self.sessions.read();
+            match sessions.get(&refreshed.id) {
+                Some(current) => current
+                    .agents
+                    .iter()
+                    .map(|a| (a.id.clone(), a.status.clone()))
+                    .collect(),
+                None => return,
+            }
+        };
+
+        for agent in refreshed.agents.iter_mut() {
+            if !alive.contains(&agent.id) {
+                continue;
+            }
+            if let Some(status) = current_statuses.get(&agent.id) {
+                agent.status = status.clone();
+            }
+        }
+    }
+
     pub fn reload_session_from_storage(&self, session_id: &str) -> Result<Session, String> {
         let storage = self
             .storage
@@ -1328,7 +1380,12 @@ impl SessionController {
         storage
             .mark_session_synced(session_id, &persisted)
             .map_err(|e| format!("Failed to track session storage state: {}", e))?;
-        let session = self.session_from_persisted(&persisted)?;
+        let mut session = self.session_from_persisted(&persisted)?;
+        // #176: without this, a GET that triggers a reload reports every live
+        // worker as Completed. `WorkerStateInfo` is built from `a.status` too, so
+        // a poisoned status also becomes durable in the workers file the Queen
+        // polls.
+        self.overlay_live_agent_statuses(&mut session);
         {
             let mut sessions = self.sessions.write();
             sessions.insert(session.id.clone(), session.clone());
@@ -1983,6 +2040,13 @@ impl SessionController {
     pub fn insert_test_session(&self, session: Session) {
         let mut sessions = self.sessions.write();
         sessions.insert(session.id.clone(), session);
+    }
+
+    /// Persist an in-memory test session to storage, so read paths that
+    /// reconstruct from disk have a snapshot to load.
+    #[cfg(test)]
+    pub fn persist_test_session(&self, session_id: &str) {
+        self.update_session_storage(session_id);
     }
 
     #[cfg(test)]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -193,8 +193,13 @@ impl CompletionBlockedError {
             (
                 "Session completion blocked: evaluator-backed session must be in QaPassed state".to_string(),
                 vec![
-                    format!("POST /api/sessions/{{{{id}}}}/qa/verdict with {{\"verdict\":\"PASS\"}} (Evaluator submits PASS)"),
-                    format!("POST /api/sessions/{{{{id}}}}/qa/force-pass (Operator override)"),
+                    // NB: under `format!`, `{{` renders as a single `{`. These
+                    // strings ship inside a live 409 body, so the reader must
+                    // see `{id}` -- not a doubled `{{id}}`.
+                    format!("POST /api/sessions/{{id}}/qa/verdict with {{\"verdict\":\"PASS\"}} (Evaluator submits PASS)"),
+                    format!(
+                        "POST /api/sessions/{{id}}/qa/force-pass with {{\"confirm\":true}} (Operator override)"
+                    ),
                 ],
             )
         } else {

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -703,6 +703,49 @@ fn is_terminal_session_state(state: &SessionState) -> bool {
     )
 }
 
+/// Why a worker spawn was refused (#175d). Lets the HTTP layer answer with an
+/// accurate status and a machine-readable reason instead of a blanket 500.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AddWorkerRejectionReason {
+    SessionTypeUnsupported,
+    ResearchSessionReadOnly,
+    ParentNotInSession,
+    ParentCannotParent,
+    StateNotAcceptingWorkers,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AddWorkerRejection {
+    pub error: String,
+    pub reason: AddWorkerRejectionReason,
+    pub current_state: String,
+}
+
+#[derive(Debug)]
+pub enum AddWorkerError {
+    SessionNotFound(String),
+    Rejected(AddWorkerRejection),
+}
+
+impl std::fmt::Display for AddWorkerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Byte-identical to the historical string, so existing callers that
+            // classify on the message keep working.
+            AddWorkerError::SessionNotFound(id) => write!(f, "Session not found: {}", id),
+            AddWorkerError::Rejected(rejection) => write!(f, "{}", rejection.error),
+        }
+    }
+}
+
+/// An index reserved for a spawn that has not happened yet.
+#[derive(Debug, Clone)]
+pub struct AddWorkerReservation {
+    pub index: u8,
+    pub worker_id: String,
+}
+
 /// States in which a QA review is open or already resolved. Used to stop
 /// unrelated worker progression from dragging a session back to `Running` and
 /// orphaning an in-flight review (#175a).
@@ -6890,6 +6933,30 @@ curl -X POST "http://localhost:18800/api/sessions/{session_id}/workers" \
 }}
 ```
 
+## Error Responses
+
+A 4xx here is actionable — read `reason` before retrying.
+
+| Status | `reason` | What it means | What to do |
+|--------|----------|---------------|------------|
+| 409 | `already_claimed` | This worker index is already claimed and running | STOP. Do not retry — you would double-spawn. Check `GET /workers` |
+| 409 | `session_state` | The session cannot accept workers right now (see `current_state`) | Do not retry blindly. Resolve the state first (e.g. an unresolved QA verdict) |
+| 409 | `index_raced` | The roster moved between reservation and spawn | Re-read `GET /workers`, then retry ONCE |
+| 409 | `spawn_failed` | The spawn failed repeatedly and the queue row was retired (`attempts` included) | Call the release endpoint in `recovery`, then retry once |
+| 500 | — | Internal spawn failure; `worker_id` is included | If `GET /workers` shows no new worker, release the claim (below) and retry once |
+
+## Recovering a Stuck Worker Slot
+
+If a spawn failed and the slot appears stuck, release its durable claim:
+
+```bash
+curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/workers/{{worker_id}}/release"
+```
+
+Returns `{{"released": true|false, "previous_status": "...", "new_status": "queued"}}`. It only
+releases the queue claim — it never stops a live agent. If the worker is actually
+running, use `DELETE /api/sessions/{session_id}/agents/{{agent_id}}` instead.
+
 ## Notes
 
 - Workers spawn in a new Windows Terminal tab (visible window)
@@ -12916,49 +12983,56 @@ phases and do EXACTLY this, then stop:
         Ok(())
     }
 
-    /// Add a worker to an existing session
-    pub fn add_worker(
-        &self,
-        session_id: &str,
-        config: AgentConfig,
-        role: WorkerRole,
-        parent_id: Option<String>,
-    ) -> Result<AgentInfo, String> {
-        // Get session and validate
-        let session = {
-            let sessions = self.sessions.read();
-            sessions.get(session_id).cloned()
-        }
-        .ok_or_else(|| format!("Session not found: {}", session_id))?;
-
-        if !Self::session_allows_dynamic_principal(&session, &role, parent_id.as_deref()) {
-            return Err(format!(
-                "Cannot add a managed principal to {:?}; dynamic principals are supported only by Hive sessions",
-                session.session_type
-            ));
+    /// The single source of truth for "may a worker be added right now?".
+    ///
+    /// #175(d): the HTTP handler pre-checks this BEFORE writing anything to the
+    /// durable queue, and `add_worker` re-checks it under the write lock. Both go
+    /// through this one function so the pre-check can never drift from the real
+    /// check — a drift would either resurrect the leak or reject valid spawns.
+    pub(crate) fn check_add_worker_preconditions(
+        session: &Session,
+        role: &WorkerRole,
+        parent_id: Option<&str>,
+    ) -> Result<(), AddWorkerRejection> {
+        if !Self::session_allows_dynamic_principal(session, role, parent_id) {
+            return Err(AddWorkerRejection {
+                error: format!(
+                    "Cannot add a managed principal to {:?}; dynamic principals are supported only by Hive sessions",
+                    session.session_type
+                ),
+                reason: AddWorkerRejectionReason::SessionTypeUnsupported,
+                current_state: format!("{:?}", session.state),
+            });
         }
         if session.no_git && !role.role_type.eq_ignore_ascii_case("researcher") {
-            return Err("Research sessions accept only read-only researcher workers".to_string());
+            return Err(AddWorkerRejection {
+                error: "Research sessions accept only read-only researcher workers".to_string(),
+                reason: AddWorkerRejectionReason::ResearchSessionReadOnly,
+                current_state: format!("{:?}", session.state),
+            });
         }
-        if let Some(explicit_parent) = parent_id.as_deref() {
+        if let Some(explicit_parent) = parent_id {
             let parent = session
                 .agents
                 .iter()
                 .find(|agent| agent.id == explicit_parent)
-                .ok_or_else(|| {
-                    format!(
+                .ok_or_else(|| AddWorkerRejection {
+                    error: format!(
                         "Parent agent {} does not belong to session {}",
-                        explicit_parent, session_id
-                    )
+                        explicit_parent, session.id
+                    ),
+                    reason: AddWorkerRejectionReason::ParentNotInSession,
+                    current_state: format!("{:?}", session.state),
                 })?;
             if !matches!(
                 parent.role,
                 AgentRole::Queen | AgentRole::Planner { .. } | AgentRole::Prince
             ) {
-                return Err(format!(
-                    "Agent {} cannot parent a managed principal",
-                    explicit_parent
-                ));
+                return Err(AddWorkerRejection {
+                    error: format!("Agent {} cannot parent a managed principal", explicit_parent),
+                    reason: AddWorkerRejectionReason::ParentCannotParent,
+                    current_state: format!("{:?}", session.state),
+                });
             }
         }
 
@@ -12981,19 +13055,86 @@ phases and do EXACTLY this, then stop:
                 | SessionState::QaInconclusive
         );
         if !can_add_worker {
-            return Err(format!(
-                "Cannot add worker to session in state {:?}",
-                session.state
-            ));
+            return Err(AddWorkerRejection {
+                error: format!("Cannot add worker to session in state {:?}", session.state),
+                reason: AddWorkerRejectionReason::StateNotAcceptingWorkers,
+                current_state: format!("{:?}", session.state),
+            });
         }
 
-        // Determine worker index
-        let existing_workers = session
+        Ok(())
+    }
+
+    /// The worker index the next spawn will take. One definition, used by both
+    /// the handler's reservation and `add_worker` itself.
+    pub(crate) fn next_worker_index(session: &Session) -> u8 {
+        let existing = session
             .agents
             .iter()
             .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
             .count();
-        let worker_index = (existing_workers + 1) as u8;
+        (existing + 1) as u8
+    }
+
+    /// Read-only reservation used by the HTTP handler before it touches the
+    /// durable queue (#175d).
+    ///
+    /// Reads `self.sessions` directly rather than going through `get_session`,
+    /// which performs a mutating disk refresh.
+    pub fn reserve_add_worker(
+        &self,
+        session_id: &str,
+        role: &WorkerRole,
+        parent_id: Option<&str>,
+    ) -> Result<AddWorkerReservation, AddWorkerError> {
+        let sessions = self.sessions.read();
+        let session = sessions
+            .get(session_id)
+            .ok_or_else(|| AddWorkerError::SessionNotFound(session_id.to_string()))?;
+
+        Self::check_add_worker_preconditions(session, role, parent_id)
+            .map_err(AddWorkerError::Rejected)?;
+
+        let index = Self::next_worker_index(session);
+        Ok(AddWorkerReservation {
+            index,
+            worker_id: format!("{}-worker-{}", session_id, index),
+        })
+    }
+
+    /// Add a worker to an existing session
+    pub fn add_worker(
+        &self,
+        session_id: &str,
+        config: AgentConfig,
+        role: WorkerRole,
+        parent_id: Option<String>,
+        expected_index: Option<u8>,
+    ) -> Result<AgentInfo, String> {
+        // Get session and validate
+        let session = {
+            let sessions = self.sessions.read();
+            sessions.get(session_id).cloned()
+        }
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
+        Self::check_add_worker_preconditions(&session, &role, parent_id.as_deref())
+            .map_err(|rejection| rejection.error)?;
+
+        // Determine worker index
+        let worker_index = Self::next_worker_index(&session);
+        // #175(d): the handler reserved an index, then released the read lock
+        // across two awaits before this call. If the roster moved in between, the
+        // durable queue row protects a different id than the one we are about to
+        // spawn — fail cleanly so the handler can release its claim.
+        if let Some(expected) = expected_index {
+            if expected != worker_index {
+                return Err(format!(
+                    "Worker index race: reserved {} but session now needs {}",
+                    expected, worker_index
+                ));
+            }
+        }
 
         // Determine parent (default to Queen)
         let actual_parent_id = parent_id.unwrap_or_else(|| format!("{}-queen", session_id));

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -5,7 +5,8 @@ mod prompt_contract;
 
 #[allow(unused_imports)]
 pub use controller::{
-    AgentInfo, AuthStrategy, CompletionBlockedError, CompletionError, DebateDebaterConfig,
+    AddWorkerError, AddWorkerRejection, AddWorkerRejectionReason, AddWorkerReservation, AgentInfo,
+    AuthStrategy, CompletionBlockedError, CompletionError, DebateDebaterConfig,
     DebateDebaterStatus, DebateLaunchConfig, FusionLaunchConfig, FusionVariantConfig,
     FusionVariantStatus, HiveLaunchConfig, QaWorkerConfig, ResearchLaunchConfig, Session,
     SessionController, SessionState, SessionType, SwarmLaunchConfig, DEFAULT_MAX_QA_ITERATIONS,

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -767,10 +767,8 @@ impl SessionStorage {
         session_id: &str,
         message: &CoordinationMessage,
     ) -> Result<(), StorageError> {
-        let log_path = self
-            .session_dir(session_id)
-            .join("coordination")
-            .join("coordination.log");
+        let log_dir = self.session_dir(session_id).join("coordination");
+        let log_path = log_dir.join("coordination.log");
 
         let line = format!(
             "[{}] {} → {}: {}\n",
@@ -782,6 +780,12 @@ impl SessionStorage {
 
         use std::fs::OpenOptions;
         use std::io::Write;
+
+        // Without this the open fails whenever the directory has not been
+        // created yet, and because callers such as the operator-override audit
+        // path discard the Result, the append silently no-ops. An override that
+        // reports success while leaving no audit trail is worse than no log.
+        std::fs::create_dir_all(&log_dir)?;
 
         let mut file = OpenOptions::new()
             .create(true)
@@ -1490,6 +1494,30 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let storage = SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap();
         (storage, temp_dir)
+    }
+
+    /// #176. `append_coordination_log` must create its directory. Every caller in
+    /// the crate discards the returned Result -- notably the operator-override
+    /// audit path -- so without this the append silently no-ops for any session
+    /// whose directory has not been created yet, and a destructive override would
+    /// report success while leaving no audit trail.
+    #[test]
+    fn append_coordination_log_creates_its_directory() {
+        let (storage, _temp) = create_test_storage();
+        let session_id = "never-persisted-session";
+        assert!(
+            !storage.session_dir(session_id).join("coordination").exists(),
+            "precondition: the session directory must not exist yet"
+        );
+
+        let msg = CoordinationMessage::system("OPERATOR", "[FORCE-PASS] audit entry");
+        storage
+            .append_coordination_log(session_id, &msg)
+            .expect("append must succeed even when the session dir is absent");
+
+        let log = storage.read_coordination_log(session_id, None).unwrap();
+        assert_eq!(log.len(), 1, "the appended message must be readable back");
+        assert!(log[0].content.contains("[FORCE-PASS]"));
     }
 
     #[test]

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -202,12 +202,15 @@ impl QueueRepo {
     /// non-NULL, non-stale heartbeat and matches 0 rows. The worker's own heartbeats then
     /// keep the row fresh; if its first heartbeat never arrives within `stuck_cutoff_ms`,
     /// the row legitimately becomes reclaimable again (the stuck-detection path).
+    /// Returns the claimed row's `attempts` counter on a win — the fencing epoch
+    /// for [`Self::requeue_claimed`] / [`Self::fail_claimed`] — or `None` if the
+    /// claim was lost.
     pub fn try_claim(
         &self,
         id: &str,
         stuck_cutoff_ms: i64,
         now_ms: i64,
-    ) -> Result<bool, StorageError> {
+    ) -> Result<Option<i64>, StorageError> {
         self.db.with_conn(|conn| {
             conn.execute(
                 "UPDATE agent_run_queue
@@ -220,6 +223,74 @@ impl QueueRepo {
                         OR (status = 'running'
                             AND (heartbeat_at IS NULL OR heartbeat_at < ?3)))",
                 params![id, now_ms, stuck_cutoff_ms],
+            )?;
+            if conn.changes() != 1 {
+                return Ok(None);
+            }
+            let attempts: i64 = conn.query_row(
+                "SELECT attempts FROM agent_run_queue WHERE id = ?1",
+                params![id],
+                |row| row.get(0),
+            )?;
+            Ok(Some(attempts))
+        })
+    }
+
+    /// Fenced inverse of a claim: return a row we still own to `queued`.
+    ///
+    /// The `attempts = ?2` fence is required, not defensive. `status = 'running'`
+    /// alone is satisfied by ANY holder's claim and the schema has no owner
+    /// column, so this ABA is reachable: A wins (attempts=1) -> A's worktree
+    /// creation runs long -> the 30s maintenance pass reclaims the row past the
+    /// stuck cutoff -> a retry claims it (attempts=2) and spawns for real -> A
+    /// finally fails and releases, requeueing B's LIVE claim -> a third claimer
+    /// double-spawns. `attempts` is incremented exactly once per won claim, so it
+    /// is a free, already-persisted epoch.
+    pub fn requeue_claimed(
+        &self,
+        id: &str,
+        expected_attempts: i64,
+        now_ms: i64,
+    ) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET status = 'queued', updated_at = ?3
+                 WHERE id = ?1 AND status = 'running' AND attempts = ?2",
+                params![id, expected_attempts, now_ms],
+            )?;
+            Ok(conn.changes() == 1)
+        })
+    }
+
+    /// Fenced terminal failure, used once a run has burned its spawn budget.
+    pub fn fail_claimed(
+        &self,
+        id: &str,
+        expected_attempts: i64,
+        now_ms: i64,
+    ) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET status = 'failed', updated_at = ?3
+                 WHERE id = ?1 AND status = 'running' AND attempts = ?2",
+                params![id, expected_attempts, now_ms],
+            )?;
+            Ok(conn.changes() == 1)
+        })
+    }
+
+    /// Operator/agent recovery: force a stuck or failed row back to claimable and
+    /// reset its spawn budget. Unfenced by design — this is the documented exit
+    /// from a row that no automatic path can recover.
+    pub fn release_claim_manual(&self, id: &str, now_ms: i64) -> Result<bool, StorageError> {
+        self.db.with_conn(|conn| {
+            conn.execute(
+                "UPDATE agent_run_queue
+                 SET status = 'queued', attempts = 0, updated_at = ?2
+                 WHERE id = ?1 AND status IN ('running', 'failed')",
+                params![id, now_ms],
             )?;
             Ok(conn.changes() == 1)
         })
@@ -445,6 +516,77 @@ mod tests {
         repo
     }
 
+    /// #175(d). The release must be fenced on the claim epoch, not just on
+    /// `status = 'running'`.
+    ///
+    /// The ABA this prevents: A wins the claim (attempts=1) -> A's worktree
+    /// creation runs long -> the maintenance pass reclaims the row past the stuck
+    /// cutoff -> a retry claims it (attempts=2) and spawns a real worker -> A
+    /// finally fails and releases, requeueing B's LIVE claim -> a third claimer
+    /// double-spawns. Without the fence there is no way to tell A's release from
+    /// B's.
+    #[test]
+    fn requeue_claimed_is_fenced_against_a_stale_epoch() {
+        let repo = repo();
+        repo.enqueue(&sample_row("r1", "s1", "s1-worker-1")).unwrap();
+
+        // A claims (epoch 1).
+        let epoch_a = repo.try_claim("r1", 0, 1_000).unwrap().expect("A wins");
+        assert_eq!(epoch_a, 1);
+
+        // Maintenance reclaims it as stale, then B claims (epoch 2).
+        repo.reclaim_stuck(5_000, 6_000).unwrap();
+        let epoch_b = repo.try_claim("r1", 5_000, 7_000).unwrap().expect("B wins");
+        assert_eq!(epoch_b, 2);
+
+        // A now fails and tries to release. It must NOT touch B's live claim.
+        assert!(
+            !repo.requeue_claimed("r1", epoch_a, 8_000).unwrap(),
+            "a stale epoch must not release a newer claim"
+        );
+        assert_eq!(
+            repo.get_row("r1").unwrap().unwrap().status,
+            QueueStatus::Running,
+            "B's claim must survive A's late release"
+        );
+
+        // B's own release still works.
+        assert!(repo.requeue_claimed("r1", epoch_b, 9_000).unwrap());
+        assert_eq!(
+            repo.get_row("r1").unwrap().unwrap().status,
+            QueueStatus::Queued
+        );
+    }
+
+    /// The release must never drag a terminal row back to claimable.
+    #[test]
+    fn requeue_claimed_is_a_noop_on_finalized_and_queued_rows() {
+        let repo = repo();
+        repo.enqueue(&sample_row("r1", "s1", "s1-worker-1")).unwrap();
+        let epoch = repo.try_claim("r1", 0, 1_000).unwrap().unwrap();
+        repo.record_heartbeat("s1", "s1-worker-1", "completed", 2_000)
+            .unwrap();
+        assert_eq!(
+            repo.get_row("r1").unwrap().unwrap().status,
+            QueueStatus::Finalized
+        );
+
+        assert!(!repo.requeue_claimed("r1", epoch, 3_000).unwrap());
+        assert_eq!(
+            repo.get_row("r1").unwrap().unwrap().status,
+            QueueStatus::Finalized,
+            "verified work must not be dragged back to queued"
+        );
+
+        // A never-claimed queued row is likewise untouched.
+        repo.enqueue(&sample_row("r2", "s1", "s1-worker-2")).unwrap();
+        assert!(!repo.requeue_claimed("r2", 1, 4_000).unwrap());
+        assert_eq!(
+            repo.get_row("r2").unwrap().unwrap().status,
+            QueueStatus::Queued
+        );
+    }
+
     fn sample_row(id: &str, session_id: &str, worker_id: &str) -> QueueRow {
         QueueRow {
             id: id.to_string(),
@@ -520,7 +662,7 @@ mod tests {
         let rb = rb.unwrap();
 
         // Exactly one claimer wins.
-        assert!(ra ^ rb, "exactly one of two concurrent claimers must win");
+        assert!(ra.is_some() ^ rb.is_some(), "exactly one of two concurrent claimers must win");
 
         let row = repo.get_row("r1").unwrap().unwrap();
         assert_eq!(row.status, QueueStatus::Running);
@@ -550,7 +692,7 @@ mod tests {
         assert_eq!(repo.get_row("fresh").unwrap().unwrap().status, QueueStatus::Running);
 
         // The reclaimed row is now claimable again.
-        assert!(repo.try_claim("stale", 1000, 10000).unwrap());
+        assert!(repo.try_claim("stale", 1000, 10000).unwrap().is_some());
     }
 
     #[test]
@@ -570,7 +712,7 @@ mod tests {
         assert_eq!(completed.last_status.as_deref(), Some("completed"));
         assert_eq!(completed.heartbeat_at, Some(200));
         assert!(repo.reclaim_stuck(1_000, 2_000).unwrap().is_empty());
-        assert!(!repo.try_claim("r1", 1_000, 2_000).unwrap());
+        assert!(repo.try_claim("r1", 1_000, 2_000).unwrap().is_none());
 
         let mut failed = sample_row("failed", "s1", "s1-worker-2");
         failed.status = QueueStatus::Failed;
@@ -593,13 +735,13 @@ mod tests {
         repo.enqueue(&stale).unwrap();
 
         // Even without an explicit reclaim pass, try_claim recovers a stale-running row.
-        assert!(repo.try_claim("stale", 1000, 2000).unwrap());
+        assert!(repo.try_claim("stale", 1000, 2000).unwrap().is_some());
         // A fresh-running row is NOT claimable.
         let mut fresh = sample_row("fresh", "s1", "s1-worker-2");
         fresh.status = QueueStatus::Running;
         fresh.heartbeat_at = Some(5000);
         repo.enqueue(&fresh).unwrap();
-        assert!(!repo.try_claim("fresh", 1000, 2000).unwrap());
+        assert!(repo.try_claim("fresh", 1000, 2000).unwrap().is_none());
     }
 
     #[test]

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -600,8 +600,16 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/qa/verdict" \
 - `rationale`: Optional. Brief explanation for the verdict.
 
 ### Override Endpoints (Operator Use)
-- `POST /api/sessions/{{session_id}}/qa/force-pass` — Force QA to PASS state.
-- `POST /api/sessions/{{session_id}}/qa/force-fail` — Force QA to FAIL state.
+These are destructive overrides and require an explicit confirmation body.
+```bash
+curl -sS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/qa/force-pass" \
+  -H "Content-Type: application/json" \
+  -d '{"confirm":true,"rationale":"<why the override is warranted>"}'
+```
+- Force QA to PASS: `POST /api/sessions/{{session_id}}/qa/force-pass`
+- Force QA to FAIL: `POST /api/sessions/{{session_id}}/qa/force-fail`
+- `confirm`: Required, must be `true`. A bodyless POST is refused with 400.
+- `rationale`: Optional. Recorded in the operator audit log.
 
 ### Session Completion Preconditions
 - `POST /api/sessions/{{session_id}}/complete` returns 409 if blocked.
@@ -1404,7 +1412,9 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 - **Canonical**: `POST /api/sessions/{{session_id}}/qa/verdict` — Evaluator submits verdict
   - Body: `{"verdict":"PASS|FAIL","commit_sha":"<optional>","rationale":"<optional>"}`
 - **Force Pass**: `POST /api/sessions/{{session_id}}/qa/force-pass` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}` — a bodyless POST is refused with 400
 - **Force Fail**: `POST /api/sessions/{{session_id}}/qa/force-fail` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}`
 
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.
@@ -1649,7 +1659,9 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 - **Canonical**: `POST /api/sessions/{{session_id}}/qa/verdict` — Evaluator submits verdict
   - Body: `{"verdict":"PASS|FAIL","commit_sha":"<optional>","rationale":"<optional>"}`
 - **Force Pass**: `POST /api/sessions/{{session_id}}/qa/force-pass` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}` — a bodyless POST is refused with 400
 - **Force Fail**: `POST /api/sessions/{{session_id}}/qa/force-fail` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}`
 
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.
@@ -1755,7 +1767,9 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 - **Canonical**: `POST /api/sessions/{{session_id}}/qa/verdict` — Evaluator submits verdict
   - Body: `{"verdict":"PASS|FAIL","commit_sha":"<optional>","rationale":"<optional>"}`
 - **Force Pass**: `POST /api/sessions/{{session_id}}/qa/force-pass` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}` — a bodyless POST is refused with 400
 - **Force Fail**: `POST /api/sessions/{{session_id}}/qa/force-fail` — Operator override
+  - Body (required): `{"confirm":true,"rationale":"<why>"}`
 
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -178,6 +178,115 @@ fn detect_main_branch(project_path: &Path) -> String {
     "main".to_string()
 }
 
+/// Hive-owned directories that may sit directly under a project root and hold
+/// generated worktrees. Only these are eligible for a lint-config boundary — see
+/// [`worktree_config_boundary_root`] for why the whitelist is load-bearing.
+const HIVE_WORKTREE_ROOTS: &[&str] = &[".hive-manager", ".hive-fusion", ".hive-debate"];
+
+/// Legacy (`.eslintrc.*`) config filenames. Flat config (`eslint.config.js`) does
+/// not cascade and is deliberately absent — see the module note on #177.
+const ESLINTRC_NAMES: &[&str] = &[
+    ".eslintrc",
+    ".eslintrc.json",
+    ".eslintrc.js",
+    ".eslintrc.cjs",
+    ".eslintrc.yml",
+    ".eslintrc.yaml",
+];
+
+/// The hive-owned directory directly under `project_path` that contains
+/// `worktree_path`, or `None` when the worktree is not under one.
+///
+/// The [`HIVE_WORKTREE_ROOTS`] whitelist — rather than "just take the first
+/// component" — is load-bearing. `actions/git/mod.rs::git.worktree_add` accepts a
+/// caller-supplied worktree path with no containment check, so a generic
+/// derivation could write a `root: true` config into an arbitrary *tracked*
+/// source directory of the operator's repo and silently disable every lint rule
+/// beneath it.
+pub(crate) fn worktree_config_boundary_root(
+    project_path: &Path,
+    worktree_path: &Path,
+) -> Option<PathBuf> {
+    let relative = worktree_path.strip_prefix(project_path).ok()?;
+    let first = relative.components().next()?;
+    let name = first.as_os_str().to_str()?;
+    if HIVE_WORKTREE_ROOTS.contains(&name) {
+        Some(project_path.join(name))
+    } else {
+        None
+    }
+}
+
+/// True iff this worktree can lint itself — it carries an eslintrc-family file,
+/// or a `package.json` with an `eslintConfig` key.
+///
+/// Gating on this matters: writing a boundary above a worktree that has no config
+/// of its own would turn a loud `exit 2` into a silent **false green** (ESLint with
+/// an empty ruleset exits 0 with no output), which is strictly worse for a
+/// QA-gated pipeline.
+fn worktree_has_eslint_config(worktree_path: &Path) -> bool {
+    if ESLINTRC_NAMES
+        .iter()
+        .any(|name| worktree_path.join(name).exists())
+    {
+        return true;
+    }
+    std::fs::read_to_string(worktree_path.join("package.json"))
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .is_some_and(|pkg| pkg.get("eslintConfig").is_some())
+}
+
+/// Write an inert `{"root": true}` ESLint boundary into the hive-owned directory
+/// above a generated worktree (#177).
+///
+/// Worktrees live *inside* the parent repository, so ESLint 8's `.eslintrc`
+/// cascade walks up out of the worktree, finds the parent repo's config, and
+/// resolves the same plugin from two `node_modules` trees — failing with
+/// "couldn't determine the plugin ... uniquely" (exit 2) before linting a single
+/// file. A `root: true` config in an ancestor halts that upward walk.
+///
+/// Verified against ESLint 8.57.1: no boundary => exit 2; a `{}` boundary => still
+/// exit 2 (an empty object does **not** stop the cascade); `{"root": true}` => exit
+/// 0 with the worktree's own config and plugins still in force; and the parent
+/// repo's own files are unaffected (the cascade only ever walks upward).
+///
+/// Best effort by design: never returns an error and never fails a launch.
+pub(crate) fn ensure_worktree_config_boundary(project_path: &Path, worktree_path: &Path) {
+    let Some(root) = worktree_config_boundary_root(project_path, worktree_path) else {
+        // Fusion/debate paths round-trip through `to_string_lossy()` -> `PathBuf`,
+        // so a lost prefix match should be diagnosable rather than silent.
+        tracing::warn!(
+            project_path = %project_path.display(),
+            worktree_path = %worktree_path.display(),
+            "no hive-owned boundary root for worktree; skipping lint boundary"
+        );
+        return;
+    };
+
+    if !worktree_has_eslint_config(worktree_path) {
+        tracing::debug!(
+            worktree_path = %worktree_path.display(),
+            "worktree has no eslint config; not writing a lint boundary"
+        );
+        return;
+    }
+
+    let boundary = root.join(".eslintrc.json");
+    if boundary.exists() {
+        tracing::debug!(path = %boundary.display(), "lint boundary already present");
+        return;
+    }
+
+    if let Err(e) = std::fs::create_dir_all(&root) {
+        tracing::warn!(path = %root.display(), error = %e, "failed to create boundary dir");
+        return;
+    }
+    if let Err(e) = std::fs::write(&boundary, "{\"root\": true}\n") {
+        tracing::warn!(path = %boundary.display(), error = %e, "failed to write lint boundary");
+    }
+}
+
 pub fn create_session_worktree(
     session_id: &str,
     cell_id: &str,
@@ -210,6 +319,9 @@ pub fn create_session_worktree(
             &["worktree", "add", &worktree_str, "-b", branch, base_branch],
         )?;
     }
+
+    // #177: must run AFTER `worktree add` — the gate inspects the checked-out tree.
+    ensure_worktree_config_boundary(project_path, &worktree_path);
 
     let task_dir = worktree_path.join(".hive-manager").join("tasks");
     if let Err(e) = std::fs::create_dir_all(&task_dir) {
@@ -345,6 +457,150 @@ fn is_missing_worktree_error(message: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    /// #177 T1. The whitelist is what stops us writing a `root: true` config into
+    /// an operator's own source tree, so the `None` arms matter as much as the
+    /// `Some` ones.
+    #[test]
+    fn worktree_config_boundary_root_whitelists_hive_roots_only() {
+        let repo = Path::new("/repo");
+
+        assert_eq!(
+            worktree_config_boundary_root(repo, Path::new("/repo/.hive-manager/worktrees/sid/primary")),
+            Some(PathBuf::from("/repo/.hive-manager"))
+        );
+        // Isolated-cell layout nests one level deeper; still the same boundary.
+        assert_eq!(
+            worktree_config_boundary_root(
+                repo,
+                Path::new("/repo/.hive-manager/worktrees/isolated/sid/cell")
+            ),
+            Some(PathBuf::from("/repo/.hive-manager"))
+        );
+        assert_eq!(
+            worktree_config_boundary_root(repo, Path::new("/repo/.hive-fusion/sid/variant-a")),
+            Some(PathBuf::from("/repo/.hive-fusion"))
+        );
+        assert_eq!(
+            worktree_config_boundary_root(repo, Path::new("/repo/.hive-debate/sid/debater-a")),
+            Some(PathBuf::from("/repo/.hive-debate"))
+        );
+
+        // The worktree IS the repo root -> no component -> None. Without this the
+        // shim would land at `<repo>/.eslintrc.json` and disable the operator's
+        // own lint config.
+        assert_eq!(worktree_config_boundary_root(repo, repo), None);
+        // Outside the repo entirely.
+        assert_eq!(
+            worktree_config_boundary_root(repo, Path::new("/elsewhere/wt")),
+            None
+        );
+        // Inside the repo but NOT a hive-owned root: must be refused.
+        assert_eq!(
+            worktree_config_boundary_root(repo, Path::new("/repo/tmp/wt")),
+            None
+        );
+    }
+
+    /// #177 T2. Content equality is load-bearing: verified against ESLint 8.57.1,
+    /// a `{}` boundary does NOT stop the cascade, only `{"root": true}` does.
+    #[test]
+    fn ensure_worktree_config_boundary_writes_an_inert_root_marker() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path();
+        let worktree = repo.join(".hive-manager").join("worktrees").join("sid").join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+        // The worktree can lint itself.
+        std::fs::write(worktree.join(".eslintrc.json"), "{\"plugins\":[\"x\"]}").unwrap();
+
+        ensure_worktree_config_boundary(repo, &worktree);
+
+        let boundary = repo.join(".hive-manager").join(".eslintrc.json");
+        assert!(boundary.exists(), "boundary should be written");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&boundary).unwrap()).unwrap();
+        assert_eq!(parsed, serde_json::json!({ "root": true }));
+        // It must sit ABOVE the worktree, not inside it.
+        assert!(worktree.starts_with(boundary.parent().unwrap()));
+    }
+
+    /// #177 T3 — the highest-value test here. Writing a boundary above a worktree
+    /// that has no ESLint config of its own converts a loud `exit 2` into a silent
+    /// false green (empty ruleset exits 0), which is worse for a QA gate.
+    #[test]
+    fn boundary_is_not_written_when_the_worktree_has_no_eslint_config() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path();
+        let worktree = repo.join(".hive-manager").join("worktrees").join("sid").join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+
+        ensure_worktree_config_boundary(repo, &worktree);
+
+        assert!(!repo.join(".hive-manager").join(".eslintrc.json").exists());
+    }
+
+    /// A `package.json` carrying `eslintConfig` also counts as lintable.
+    #[test]
+    fn boundary_is_written_for_package_json_eslint_config() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path();
+        let worktree = repo.join(".hive-manager").join("worktrees").join("sid").join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(
+            worktree.join("package.json"),
+            "{\"name\":\"x\",\"eslintConfig\":{\"plugins\":[\"y\"]}}",
+        )
+        .unwrap();
+
+        ensure_worktree_config_boundary(repo, &worktree);
+
+        assert!(repo.join(".hive-manager").join(".eslintrc.json").exists());
+
+        // A package.json WITHOUT eslintConfig must not trigger it.
+        let temp2 = TempDir::new().unwrap();
+        let repo2 = temp2.path();
+        let wt2 = repo2.join(".hive-manager").join("worktrees").join("sid").join("primary");
+        std::fs::create_dir_all(&wt2).unwrap();
+        std::fs::write(wt2.join("package.json"), "{\"name\":\"x\"}").unwrap();
+        ensure_worktree_config_boundary(repo2, &wt2);
+        assert!(!repo2.join(".hive-manager").join(".eslintrc.json").exists());
+    }
+
+    /// #177 T4. Idempotent, and never clobbers a file the operator wrote.
+    #[test]
+    fn boundary_is_idempotent_and_never_clobbers_an_operator_file() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path();
+        let hive = repo.join(".hive-manager");
+        let worktree = hive.join("worktrees").join("sid").join("primary");
+        std::fs::create_dir_all(&worktree).unwrap();
+        std::fs::write(worktree.join(".eslintrc.json"), "{}").unwrap();
+
+        let operator = "{\"root\":true,\"rules\":{\"no-debugger\":\"error\"}}";
+        std::fs::create_dir_all(&hive).unwrap();
+        std::fs::write(hive.join(".eslintrc.json"), operator).unwrap();
+
+        ensure_worktree_config_boundary(repo, &worktree);
+        let wt_b = hive.join("worktrees").join("sid").join("second");
+        std::fs::create_dir_all(&wt_b).unwrap();
+        std::fs::write(wt_b.join(".eslintrc.json"), "{}").unwrap();
+        ensure_worktree_config_boundary(repo, &wt_b);
+
+        assert_eq!(
+            std::fs::read_to_string(hive.join(".eslintrc.json")).unwrap(),
+            operator,
+            "operator content must survive untouched"
+        );
+
+        // Deleted -> recreated (no process-wide latch).
+        std::fs::remove_file(hive.join(".eslintrc.json")).unwrap();
+        ensure_worktree_config_boundary(repo, &worktree);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(hive.join(".eslintrc.json")).unwrap())
+                .unwrap();
+        assert_eq!(parsed, serde_json::json!({ "root": true }));
+    }
 
     #[test]
     fn test_generate_branch_name_hive() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/StatusPanel.svelte
+++ b/src/lib/components/StatusPanel.svelte
@@ -21,6 +21,14 @@
   let closing = $state(false);
   let showForceFailConfirm = $state(false);
   let forceFailing = $state(false);
+  // #176: Force Pass / Skip QA are destructive one-click overrides. Server-side
+  // `confirm: true` protects nothing when the UI supplies it automatically, so
+  // the real guard for an operator misclick has to live here.
+  let showForcePassConfirm = $state(false);
+  let showSkipQaConfirm = $state(false);
+  // Operator-action failures were previously console-only: a 400 produced zero
+  // on-screen change. There is no toast system in this repo, so surface inline.
+  let opError = $state<string | null>(null);
   let cliHealthCollapsed = $state(false);
   let cliHealth = $state<CliHealthMap>({});
   let cliHealthLoading = $state(false);
@@ -166,35 +174,65 @@
   }
 
   // Operator controls — use HTTP API (Tauri commands not yet registered)
-  async function postSessionAction(path: string, errorMessage: string): Promise<boolean> {
+  // #176: force-pass / force-fail now require an explicit `{"confirm": true}`
+  // body. A bodyless POST is refused with a 400.
+  async function postSessionAction(
+    path: string,
+    errorMessage: string,
+    body?: unknown
+  ): Promise<boolean> {
     const sessionId = $activeSession?.id;
     if (!sessionId) return false;
     try {
-      const res = await fetch(apiUrl(`/api/sessions/${sessionId}${path}`), { method: 'POST' });
+      const res = await fetch(apiUrl(`/api/sessions/${sessionId}${path}`), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body ?? {})
+      });
       if (!res.ok) {
-        const body = await res.text();
-        console.error(errorMessage, body);
+        const raw = await res.text();
+        let detail = raw;
+        try {
+          detail = (JSON.parse(raw) as { error?: string }).error ?? raw;
+        } catch {
+          // non-JSON body — surface it verbatim
+        }
+        console.error(errorMessage, raw);
+        opError = `${errorMessage} ${detail}`;
         return false;
       }
+      opError = null;
       return true;
     } catch (err) {
       console.error(errorMessage, err);
+      opError = `${errorMessage} ${err instanceof Error ? err.message : String(err)}`;
       return false;
     }
   }
 
   async function handleSkipQa() {
-    await postSessionAction('/qa/force-pass', 'Failed to skip QA:');
+    const ok = await postSessionAction('/qa/force-pass', 'Failed to skip QA:', {
+      confirm: true,
+      rationale: 'Skip QA from the Status panel'
+    });
+    if (ok) showSkipQaConfirm = false;
   }
 
   async function handleForcePass() {
-    await postSessionAction('/qa/force-pass', 'Failed to force pass milestone:');
+    const ok = await postSessionAction('/qa/force-pass', 'Failed to force pass milestone:', {
+      confirm: true,
+      rationale: 'Force pass from the Status panel'
+    });
+    if (ok) showForcePassConfirm = false;
   }
 
   async function handleForceFail() {
     forceFailing = true;
     try {
-      const ok = await postSessionAction('/qa/force-fail', 'Failed to force fail milestone:');
+      const ok = await postSessionAction('/qa/force-fail', 'Failed to force fail milestone:', {
+        confirm: true,
+        rationale: 'Force fail from the Status panel'
+      });
       if (ok) {
         showForceFailConfirm = false;
       }
@@ -365,16 +403,20 @@
           <section class="section actions-section">
             <div class="operator-controls">
               {#if serdeEnumVariantName($activeSession.state) === 'QaInProgress'}
-                <button class="op-button skip" onclick={handleSkipQa}>Skip QA</button>
+                <button class="op-button skip" onclick={() => showSkipQaConfirm = true}>Skip QA</button>
               {/if}
 
               {#if isQaPhase($activeSession.state)}
                 <div class="op-group">
-                  <button class="op-button pass" onclick={handleForcePass}>Force Pass</button>
+                  <button class="op-button pass" onclick={() => showForcePassConfirm = true}>Force Pass</button>
                   <button class="op-button fail" onclick={() => showForceFailConfirm = true}>Force Fail</button>
                 </div>
               {/if}
             </div>
+
+            {#if opError}
+              <p class="op-error" role="alert">{opError}</p>
+            {/if}
 
             <button
               class="close-button"
@@ -440,6 +482,58 @@
               <button class="confirm-btn" onclick={handleForceFail} disabled={forceFailing}>
                 {forceFailing ? 'Failing...' : 'Force Fail'}
               </button>
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      <!-- #176: Force Pass confirmation dialog. Previously a single unguarded click. -->
+      {#if showForcePassConfirm}
+        <div
+          class="confirm-overlay"
+          onclick={() => (showForcePassConfirm = false)}
+          onkeydown={(event) => event.key === 'Escape' && (showForcePassConfirm = false)}
+          role="presentation"
+        >
+          <div
+            class="confirm-dialog"
+            onclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => { e.stopPropagation(); if (e.key === 'Escape') showForcePassConfirm = false; }}
+            role="dialog"
+            aria-modal="true"
+            tabindex="-1"
+          >
+            <h3>Force Pass Milestone?</h3>
+            <p>This bypasses the Evaluator and marks QA as passed without review. Are you sure?</p>
+            <div class="confirm-actions">
+              <button class="cancel-btn" onclick={() => (showForcePassConfirm = false)}>Cancel</button>
+              <button class="confirm-btn" onclick={handleForcePass}>Force Pass</button>
+            </div>
+          </div>
+        </div>
+      {/if}
+
+      <!-- #176: Skip QA confirmation dialog (same destructive force-pass endpoint). -->
+      {#if showSkipQaConfirm}
+        <div
+          class="confirm-overlay"
+          onclick={() => (showSkipQaConfirm = false)}
+          onkeydown={(event) => event.key === 'Escape' && (showSkipQaConfirm = false)}
+          role="presentation"
+        >
+          <div
+            class="confirm-dialog"
+            onclick={(e) => e.stopPropagation()}
+            onkeydown={(e) => { e.stopPropagation(); if (e.key === 'Escape') showSkipQaConfirm = false; }}
+            role="dialog"
+            aria-modal="true"
+            tabindex="-1"
+          >
+            <h3>Skip QA?</h3>
+            <p>This force-passes the current milestone without an Evaluator review. Are you sure?</p>
+            <div class="confirm-actions">
+              <button class="cancel-btn" onclick={() => (showSkipQaConfirm = false)}>Cancel</button>
+              <button class="confirm-btn" onclick={handleSkipQa}>Skip QA</button>
             </div>
           </div>
         </div>
@@ -615,6 +709,14 @@
   .cli-health-badge.pending,
   .cli-health-detail.pending {
     color: var(--text-disabled);
+  }
+
+  /* #176: operator-action failures were console-only before this. */
+  .op-error {
+    margin: 0.5rem 0 0;
+    color: var(--status-error);
+    font-size: 0.8rem;
+    word-break: break-word;
   }
 
   .cli-health-detail,

--- a/src/lib/components/StatusPanel.svelte
+++ b/src/lib/components/StatusPanel.svelte
@@ -241,6 +241,8 @@
     }
   }
 
+  // Unchanged — still gates the QA Feedback panel. Deliberately NOT widened:
+  // that section should only appear once QA has actually started.
   function isQaPhase(state: Session['state']): boolean {
     const v = serdeEnumVariantName(state);
     return (
@@ -252,6 +254,21 @@
       v === 'QaMaxRetriesExceeded' ||
       (typeof state === 'object' && state !== null && 'QaFailed' in state)
     );
+  }
+
+  // #175: evaluator-backed sessions now stay in Running until the milestone
+  // handoff, but still cannot complete without reaching QaPassed — so the
+  // operator needs the override controls before QA has ever started. Mirrors the
+  // backend gate, which widens to Running/SpawningEvaluator only when the session
+  // actually has an Evaluator or QA worker.
+  function canOverrideQa(state: Session['state'], agents: Session['agents']): boolean {
+    if (isQaPhase(state)) return true;
+    const v = serdeEnumVariantName(state);
+    if (v !== 'Running' && v !== 'SpawningEvaluator') return false;
+    return (agents ?? []).some((a) => {
+      const role = serdeEnumVariantName(a.role);
+      return role === 'Evaluator' || role === 'QaWorker';
+    });
   }
 </script>
 
@@ -406,7 +423,7 @@
                 <button class="op-button skip" onclick={() => showSkipQaConfirm = true}>Skip QA</button>
               {/if}
 
-              {#if isQaPhase($activeSession.state)}
+              {#if canOverrideQa($activeSession.state, $activeSession.agents)}
                 <div class="op-group">
                   <button class="op-button pass" onclick={() => showForcePassConfirm = true}>Force Pass</button>
                   <button class="op-button fail" onclick={() => showForceFailConfirm = true}>Force Fail</button>


### PR DESCRIPTION
Resolves #175
Resolves #176
Resolves #177

All three issues came from one operator field report (client-repo hive session `d957c438`). They are bundled because #175 and #176 both touch the QA state machine and the same handlers; #177 is disjoint but came from the same report.

## What was actually wrong

**#175 was worse than filed.** The QA timer wasn't racing — it was *deterministic*. `launch_evaluator`'s tail transitioned to `QaInProgress` and armed the 300s clock, and it runs at **session launch**. Nothing afterwards reset the state, so every evaluator-backed session ran a live QA clock from the moment it started. Any session whose first milestone took longer than the timeout was poisoned to `QaInconclusive` with a spurious `BLOCKED/timeout` verdict for work never submitted — which for real work is essentially every session, since the Queen only signals QA after all principals complete. Then `QaInconclusive` locked out worker spawning, and the claim leak pinned the worker index permanently.

**#176's second symptom is real, but not caused by force-pass.** The report said all three workers showed `Completed` while one kept working for ~30 minutes. The mechanism is in the **read** path: reaching `QaPassed` (one of five trigger states) makes the next `GET /api/sessions/{id}` reconstruct the roster from disk, and `session_from_persisted` hardcodes `AgentStatus::Completed` because `PersistedAgentInfo` carries no runtime status. The sibling refresh path already had a status overlay; `reload_session_from_storage` did not. Reverting the fix reproduces the field report exactly — both live workers report `"status":"Completed"`.

## Beyond the filed scope (each required for correctness)

- **`PtySession::new` leaked a live child.** If `take_writer`/`try_clone_reader` failed after the spawn, the child kept running with no owner. Until that held, "`add_worker` returned `Err`" did not imply "nothing is running" — which would make releasing the claim a **double-spawn vector**. Fixed as a prerequisite.
- **ABA race in claim release.** `status = 'running'` alone is satisfied by *any* holder's claim and the schema has no owner column. A slow first claimer could requeue a live second claim. Release is now fenced on `attempts` (incremented exactly once per won claim — a free, already-persisted epoch).
- **Latent iteration-loss bug.** `launch_evaluator`'s tail read `qa_in_progress_state(&current.state)` *after* `SpawningEvaluator` was written, so a respawn from `QaFailed{2}` fell to the catch-all arm and reset the counter to `None`, defeating the max-retries ceiling. Restoring the *captured* state fixes it.
- **The Windows test stub's `is_alive()` returned `false` unconditionally**, making every production path gated on PTY liveness unreachable from tests on the CI runner (same class as the `#[cfg(unix)]`-tests-never-run lesson). It now mirrors the real session's semantics.

## #177 verified empirically

hive-manager has no ESLint of its own, so this was proven in a purpose-built ESLint **8.57.1** fixture with two `node_modules` trees:

| Case | Result |
|---|---|
| No boundary | `ESLint couldn't determine the plugin "dup" uniquely.` **exit 2** — field report reproduced |
| Boundary = `{}` | **exit 2** — an empty object does *not* stop the cascade |
| Boundary = `{"root": true}` | **exit 0** — worktree's own config and plugins still in force |
| Parent repo's own files | **exit 0** — unaffected (the cascade only walks upward) |

The exact-content assertion in the test is load-bearing because of row 2. Guards: a `HIVE_WORKTREE_ROOTS` whitelist (not a generic first-component derivation, which could drop a `root: true` config into an operator's tracked source tree and silently disable every rule beneath it); only written when the worktree can actually lint itself (otherwise an empty ruleset exits 0 — a silent false green, strictly worse than exit 2 for a QA gate); idempotent; never clobbers an operator file; never fails a launch.

## Testing

**586 tests pass** (baseline 559, +27). `svelte-check`: 0 errors, 0 warnings.

Every fix is **mutation-proven** — the fix was reverted and the test watched go red, then restored:

| Mutation | Caught by |
|---|---|
| Restore launch-time `QaInProgress` | state assert fails |
| Re-arm timer at launch only | clock assert fails (independently) |
| Drop `begin_qa_window` from the respawn branch | state stays `QaFailed{2}` |
| Remove the confirm guard | 3 tests |
| Remove the status overlay | both live workers report `Completed` |
| Make the overlay unconditional | dead worker pinned `Running` forever |
| Remove the claim release | row stays `running: 1`, retry 409s |
| Drop the `attempts` epoch fence | a stale epoch releases a live claim |
| Drop the ESLint whitelist | `Some("/repo/tmp")` vs `None` |
| Drop the lint-config gate | boundary written for an unlintable worktree |
| Disable `create_dir_all` in the audit log | append fails `NotFound` |

The respawn-branch test initially did **not** catch its mutation — the live-evaluator branch was being taken — so it was rewritten to force the dead-evaluator path. That gap is exactly the trap this PR fixes.

## Deliberate scope decisions

- **`QaInconclusive` re-entry is deferred**, shipping only the visibility half (warn + coordination-log entry + UI event instead of a silent drop). The obvious freshness guard is broken as specified: `PeerMessageRecord::timestamp` has no `#[serde(default)]` and the Queen's handoff emits no `timestamp`, so parsing fails on every production file. #175's acceptance criteria explicitly allowed "at minimum log + surface the dropped signal". Needs its own follow-up.
- **Worktree relocation (#177 Option A) is deferred** — 23+ hardcoded path literals across four files, and it changes the meaning of the *persisted* `session.worktree_path`, so in-flight sessions would resume into dangling paths on upgrade. Not appropriate to bundle with a critical bugfix. This also means the ESLint 9 flat-config **inward** descent is *not* fixed; only the worktree-outward eslintrc cascade is.
- **Breaking API change**: `force-pass`/`force-fail` now require `{"confirm": true}`. All callers updated (frontend, prompt templates, generated tool docs). A bodyless POST to a nonexistent session now returns 400 rather than 404 — the guard precedes the session lookup, pinned by a test.

## Not verifiable locally

- `cargo clippy` / `cargo fmt --check` run in CI on `windows-latest`.
- The `PtySession::new` child-kill cannot be tested here by construction — the Windows test stub replaces that path. Argued in code, not asserted in CI.
- The live ABA interleaving is constructed synthetically at the repo layer; the real timing race isn't reproducible in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
