### PR TITLE
fix(#194): scroll-chain repairs (Atlas + right-panel tabs), Windows console-window flash, and a task-file channel fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.40.0"
+version = "0.40.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/actions/git/mod.rs
+++ b/src-tauri/src/actions/git/mod.rs
@@ -1,9 +1,9 @@
 //! Git actions: wrap the existing git free functions behind the unified
 //! [`Action`] contract.
 //!
-//! The [`run_git_in_dir`] helper (and its load-bearing `#[cfg(windows)]`
-//! `CREATE_NO_WINDOW` creation flag, which prevents a console window from
-//! flashing on Windows) lives here as the single source of truth.
+//! The [`run_git_in_dir`] helper lives here as the single source of truth for
+//! git execution. Its shared process configuration prevents a console window
+//! from flashing on Windows.
 //! `commands/git_commands.rs` re-exports the types and helper from this module.
 
 use std::path::Path;
@@ -18,12 +18,6 @@ use serde_json::Value;
 use super::error::ActionError;
 use super::registry::{Action, ActionRegistry};
 use super::ActionContext;
-
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BranchInfo {
@@ -43,8 +37,8 @@ pub struct WorktreeInfo {
 /// Run a git command in `project_path`, returning stdout on success or a
 /// human-readable error string on failure.
 ///
-/// IMPORTANT (load-bearing): the `#[cfg(windows)]` `CREATE_NO_WINDOW` creation
-/// flag must remain — without it git spawns a flashing console window on Windows.
+/// IMPORTANT (load-bearing): the shared no-window configuration must remain —
+/// without it git spawns a flashing console window on Windows.
 pub fn run_git_in_dir(args: &[&str], project_path: &str) -> Result<String, String> {
     let path = Path::new(project_path);
     if !path.exists() {
@@ -54,9 +48,7 @@ pub fn run_git_in_dir(args: &[&str], project_path: &str) -> Result<String, Strin
     let mut cmd = Command::new("git");
     cmd.args(args).current_dir(path);
 
-    // Prevent console window from flashing on Windows
-    #[cfg(windows)]
-    cmd.creation_flags(CREATE_NO_WINDOW);
+    crate::process::hide_std_console_window(&mut cmd);
 
     let output = cmd
         .output()

--- a/src-tauri/src/artifacts/collector.rs
+++ b/src-tauri/src/artifacts/collector.rs
@@ -1,18 +1,12 @@
 use std::path::Path;
 use std::process::Command;
 
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
-
 use serde_json::json;
 
 use crate::{
     domain::ArtifactBundle,
     storage::{SessionStorage, StorageError},
 };
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
 
 pub struct ArtifactCollector {
     storage: SessionStorage,
@@ -80,8 +74,7 @@ fn run_git(worktree_path: &Path, args: &[&str]) -> Result<Option<String>, Storag
     let mut cmd = Command::new("git");
     cmd.args(args).current_dir(worktree_path);
 
-    #[cfg(windows)]
-    cmd.creation_flags(CREATE_NO_WINDOW);
+    crate::process::hide_std_console_window(&mut cmd);
 
     let output = cmd
         .output()?;

--- a/src-tauri/src/cli/health.rs
+++ b/src-tauri/src/cli/health.rs
@@ -414,6 +414,7 @@ fn build_probe_command(
     if !is_batch {
         let mut command = Command::new(program);
         command.args(args);
+        crate::process::hide_tokio_console_window(&mut command);
         return Ok((command, None));
     }
 
@@ -435,6 +436,7 @@ fn build_probe_command(
 
     let mut command = Command::new("cmd.exe");
     command.arg("/d").arg("/c").arg(script_path);
+    crate::process::hide_tokio_console_window(&mut command);
     Ok((command, Some(temp_path)))
 }
 
@@ -595,6 +597,7 @@ async fn refreshed_windows_path() -> Option<OsString> {
         |key| {
             let mut command = Command::new("reg.exe");
             command.args(["query", key, "/v", "Path"]);
+            crate::process::hide_tokio_console_window(&mut command);
             command
         },
         REGISTRY_QUERY_TIMEOUT,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ pub mod events;
 mod http;
 pub mod orchestrator;
 mod preview;
+mod process;
 mod pty;
 pub mod runtime;
 mod session;

--- a/src-tauri/src/process/mod.rs
+++ b/src-tauri/src/process/mod.rs
@@ -1,0 +1,24 @@
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
+/// Prevent a standard-library child process from opening a console window on Windows.
+pub(crate) fn hide_std_console_window(command: &mut std::process::Command) {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+
+        command.creation_flags(CREATE_NO_WINDOW);
+    }
+
+    #[cfg(not(windows))]
+    let _ = command;
+}
+
+/// Prevent a Tokio child process from opening a console window on Windows.
+pub(crate) fn hide_tokio_console_window(command: &mut tokio::process::Command) {
+    #[cfg(windows)]
+    command.creation_flags(CREATE_NO_WINDOW);
+
+    #[cfg(not(windows))]
+    let _ = command;
+}

--- a/src-tauri/src/runtime/local_process.rs
+++ b/src-tauri/src/runtime/local_process.rs
@@ -70,6 +70,7 @@ impl RuntimeAdapter for LocalProcessRuntime {
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped());
+        crate::process::hide_std_console_window(&mut cmd);
 
         for (key, value) in &spec.env {
             cmd.env(key, value);

--- a/src-tauri/src/runtime/worktree.rs
+++ b/src-tauri/src/runtime/worktree.rs
@@ -9,12 +9,6 @@ use std::process::Command;
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
-
 /// Error type for worktree operations.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorktreeError {
@@ -145,9 +139,7 @@ impl WorktreeManager {
         let mut cmd = Command::new("git");
         cmd.args(args).current_dir(&self.project_path);
 
-        // Prevent console window on Windows
-        #[cfg(windows)]
-        cmd.creation_flags(CREATE_NO_WINDOW);
+        crate::process::hide_std_console_window(&mut cmd);
 
         let output = cmd
             .output()

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -2514,12 +2514,7 @@ impl SessionController {
             .arg("-D")
             .arg(&branch_name);
 
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            cmd.creation_flags(CREATE_NO_WINDOW);
-        }
+        crate::process::hide_std_console_window(&mut cmd);
 
         match cmd.output() {
             Ok(output) if output.status.success() => {}
@@ -3011,12 +3006,7 @@ cat "{prince_verdict}"
         let mut cmd = Command::new("git");
         cmd.args(args).current_dir(project_path);
 
-        #[cfg(windows)]
-        {
-            use std::os::windows::process::CommandExt;
-            const CREATE_NO_WINDOW: u32 = 0x08000000;
-            cmd.creation_flags(CREATE_NO_WINDOW);
-        }
+        crate::process::hide_std_console_window(&mut cmd);
 
         let output = cmd
             .output()

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -842,7 +842,7 @@ fn get_polling_instructions(
         None => String::new(),
     };
 
-    match CliRegistry::get_behavior_for_role(cli, role_type) {
+    let activation_block = match CliRegistry::get_behavior_for_role(cli, role_type) {
         CliBehavior::ExplicitPolling => {
             format!(
                 r#"
@@ -913,7 +913,44 @@ last heartbeat is over {cutoff_secs}s old is treated as stuck and its run is req
                 heartbeat_block = heartbeat_block("Heartbeat command:"),
             )
         }
-    }
+    };
+
+    format!(
+        "{activation_block}{standing_channel}",
+        activation_block = activation_block,
+        standing_channel = task_file_standing_channel(task_file),
+    )
+}
+
+/// The task file is the orchestrator's only write channel to a running agent, and it stays open
+/// for the whole run — activation is just its first message.
+///
+/// IMPORTANT (load-bearing): every `get_polling_instructions` behavior arm models the file as a
+/// one-shot gate — the poll loop breaks on ACTIVE and never runs again. Without this block an
+/// agent that reports COMPLETED or BLOCKED stops reading, so a Queen answering a blocker writes
+/// into a file nobody will open and the run is stranded. BLOCKED especially is a question, not an
+/// exit; the answer arrives as an edit to this same file.
+fn task_file_standing_channel(task_file: &str) -> String {
+    format!(
+        r#"
+## The Task File Is A Standing Channel (MANDATORY)
+
+Activation is not the only thing {task_file} carries. The orchestrator writes direction to it at
+any point during your run, INCLUDING AFTER you report COMPLETED or BLOCKED. You MUST re-read it:
+
+- after each meaningful unit of work,
+- immediately after you set Status to COMPLETED or BLOCKED, and
+- every time you heartbeat, for as long as your run is alive.
+
+BLOCKED is a question to the orchestrator, not an exit. After reporting it you MUST keep polling
+and keep heartbeating. The answer arrives as an edit to this file — typically a new directive
+section plus Status set back to ACTIVE. Read it, act on it, and continue. An agent that stops
+reading after reporting a terminal status cannot be unblocked or corrected, and its run is wasted.
+
+Stop only when the orchestrator accepts your work or the session ends.
+"#,
+        task_file = task_file,
+    )
 }
 
 impl SessionController {
@@ -3417,7 +3454,7 @@ Read {task_file}. Begin work only when Status is ACTIVE.{polling_instructions}
    ```bash
    {completed_heartbeat}
    ```
-5. Report the commit SHA and validation evidence, then stop. Do not replace the completed status with an idle or working heartbeat unless a new ACTIVE assignment is issued."#,
+5. Report the commit SHA and validation evidence, then RESUME POLLING {task_file} on your heartbeat cadence — reporting COMPLETED does not end your run, and the Queen may reply there. Do not replace the completed status with an idle or working heartbeat unless a new ACTIVE assignment is issued."#,
             variant_name = variant_name,
             worktree_path = worktree_path,
             branch = branch,
@@ -6267,7 +6304,7 @@ When the objective and every configured gate are complete, send an idle heartbea
    ```bash
    {completed_heartbeat}
    ```
-4. Send the Queen a concise findings summary with citations, then stop. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
+4. Send the Queen a concise findings summary with citations, then RESUME POLLING {task_file} on your heartbeat cadence — reporting COMPLETED does not end your run, and the Queen may reply there. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
 "#,
                 validation_and_handoff_rule = validation_and_handoff_rule,
                 task_file = task_file,
@@ -6284,7 +6321,7 @@ When the objective and every configured gate are complete, send an idle heartbea
    ```bash
    {completed_heartbeat}
    ```
-5. Send the Queen the commit SHA when applicable plus focused validation evidence, then stop. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
+5. Send the Queen the commit SHA when applicable plus focused validation evidence, then RESUME POLLING {task_file} on your heartbeat cadence — reporting COMPLETED does not end your run, and the Queen may reply there. Do not replace the completed status with an idle or working heartbeat unless the Queen issues a new ACTIVE assignment.
 "#,
                 validation_and_handoff_rule = validation_and_handoff_rule,
                 task_file = task_file,

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -761,7 +761,7 @@ You MUST use your native browser tools directly. Do NOT search the codebase for 
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -833,7 +833,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -905,7 +905,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -983,7 +983,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then stop. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
 
 ## Report Format
 

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -634,7 +634,7 @@ curl -sS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/qa/force-pass" \
    done
    ```
 4. If the peer file is still missing, you MUST retry the same POST exactly once and poll again for up to 30 seconds.
-5. If `.hive-manager/{{session_id}}/peer/qa-verdict.json` is still missing after the retry window, you MUST report `BLOCKED` and stop.
+5. If `.hive-manager/{{session_id}}/peer/qa-verdict.json` is still missing after the retry window, you MUST report `BLOCKED`, then keep polling your task file and heartbeating. BLOCKED is a question to the Queen, not an exit — the answer arrives as an edit to your task file.
 6. You MUST rely on that POST to write `.hive-manager/{{session_id}}/peer/qa-verdict.json`.
 7. You MUST NOT write `.hive-manager/{{session_id}}/peer/qa-verdict.md` or any other shadow verdict file.
 
@@ -761,7 +761,7 @@ You MUST use your native browser tools directly. Do NOT search the codebase for 
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED or BLOCKED does not end your run, and the Evaluator or Queen may reply there. BLOCKED is a question to them, not an exit. Do not replace either terminal status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -833,7 +833,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED or BLOCKED does not end your run, and the Evaluator or Queen may reply there. BLOCKED is a question to them, not an exit. Do not replace either terminal status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -905,7 +905,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED or BLOCKED does not end your run, and the Evaluator or Queen may reply there. BLOCKED is a question to them, not an exit. Do not replace either terminal status with an idle or working heartbeat.
 
 ## Report Format
 
@@ -983,7 +983,7 @@ curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/heartbeat" \
    ```bash
    {{qa_worker_completed_heartbeat}}
    ```
-4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED does not end your run, and the Evaluator or Queen may reply there. Do not replace the completed status with an idle or working heartbeat.
+4. Return the criterion-numbered result to the Evaluator, then RESUME POLLING your task file on your heartbeat cadence — reporting COMPLETED or BLOCKED does not end your run, and the Evaluator or Queen may reply there. BLOCKED is a question to them, not an exit. Do not replace either terminal status with an idle or working heartbeat.
 
 ## Report Format
 

--- a/src-tauri/src/workspace/git.rs
+++ b/src-tauri/src/workspace/git.rs
@@ -6,12 +6,6 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-#[cfg(windows)]
-use std::os::windows::process::CommandExt;
-
-#[cfg(windows)]
-const CREATE_NO_WINDOW: u32 = 0x08000000;
-
 use crate::domain::{CellType, SessionMode};
 use crate::runtime::WorktreeManager;
 use crate::session::{Session, SessionType};
@@ -421,8 +415,7 @@ fn run_git(cwd: &Path, args: &[&str]) -> Result<String, String> {
     let mut cmd = Command::new("git");
     cmd.args(args).current_dir(cwd);
 
-    #[cfg(windows)]
-    cmd.creation_flags(CREATE_NO_WINDOW);
+    crate::process::hide_std_console_window(&mut cmd);
 
     let output = cmd
         .output()

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.40.0",
+  "version": "0.40.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -188,6 +188,7 @@
 
   .tab-content {
     flex: 1;
+    min-height: 0;
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/src/lib/components/SessionFilesView.svelte
+++ b/src/lib/components/SessionFilesView.svelte
@@ -410,10 +410,22 @@
     padding: 4px 0;
   }
 
-  .file-browser :global(.file-tree-skeleton),
-  .content-body :global(.file-content-skeleton) {
+  .file-browser :global(.file-tree-skeleton) {
     width: 100%;
     min-height: 100%;
+  }
+
+  .content-body :global(.file-content-skeleton) {
+    width: 100%;
+    height: 100%;
+    min-height: 0;
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .content-body :global(.file-content-skeleton > .lattice-skeleton-placeholder),
+  .content-body :global(.file-content-skeleton > .lattice-skeleton-content) {
+    min-height: 0;
+    overflow: hidden;
   }
 
   .file-tree-skeleton-shape,

--- a/src/lib/components/knowledge/KnowledgeTable.svelte
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte
@@ -88,7 +88,8 @@
 
 <style>
   .table-scroll {
-    height: 100%;
+    min-height: 0;
+    flex: 1;
     overflow: auto;
     background: var(--bg-void);
   }

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -477,6 +477,7 @@
     flex: 1;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
     min-height: 0;
     overflow: hidden;
   }
@@ -493,6 +494,17 @@
   .atlas-panel :global(.lattice-skeleton-content) {
     width: 100%;
     height: 100%;
+  }
+
+  .atlas-panel :global(.atlas-skeleton) {
+    min-height: 0;
+    grid-template-rows: minmax(0, 1fr);
+  }
+
+  .atlas-panel :global(.atlas-skeleton > .lattice-skeleton-placeholder),
+  .atlas-panel :global(.atlas-skeleton > .lattice-skeleton-content) {
+    min-height: 0;
+    overflow: hidden;
   }
 
   .atlas-loading-shape {
@@ -527,7 +539,12 @@
     letter-spacing: 0.05em;
   }
 
-  .view-body { flex: 1; min-height: 0; }
+  .view-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
 
   .legend {
     display: flex;


### PR DESCRIPTION
Three user-visible defects plus one orchestration fix. Five commits, each readable on its own.

| | Defect | Commit |
|---|---|---|
| **WS-A** | Console windows flash over the app when opening routine UI | `ede895f` |
| **WS-C** | Right-panel tabs don't scroll (reported against Files; affects all six) | `e4cd059` |
| **WS-B** | Knowledge Atlas Table view doesn't scroll — **#194** | `8c4a11c` |
| — | Task file goes silent after COMPLETED/BLOCKED | `77f2501` |
| — | Version bump | `7591bb3` |

## WS-A — console flash

Mounting `AgentConfigEditor` fires `CliHealthRegistry::check_all()`, which awaits `refreshed_windows_path()` (one `reg.exe`) then `join_all`s one probe per `VALID_CLIS` entry — ~7 concurrent spawns, none carrying `CREATE_NO_WINDOW`.

The flag was already correct in six files, but as a copy-pasted local `const` in each, so the two newest spawn paths never got it. Four production sites were unguarded: the probe binary, the `cmd.exe` batch-wrapper path, the `reg.exe` PATH query, and the agent CLI itself in `local_process.rs`.

Now a single `src-tauri/src/process/` module declares `0x08000000` once and exposes one helper per command type (`std` and `tokio` are different types reaching `creation_flags` by different routes), with non-Windows no-ops so call sites stay unconditional. All six duplicate consts collapsed onto it.

`portable-pty 0.8.1` was audited read-only: it drives ConPTY via `NativePtySystem` with no winpty fallback, so the PTY path was not a second source.

## WS-C — right-panel tabs

`.tab-content` is a column flex item with no `min-height: 0`, so `flex: 1` could never cap it — it inflated to content and `overflow: hidden` clipped the rest. `PlanView` is the proof: it declares `overflow-y: auto` at its own root and still couldn't scroll.

One line at the host fixed four of six tabs outright. Measured at window heights 1000/777/555, `.tab-content` goes from following a >15,900px content chain to **958/958, 736/736, 514/514** — and holds after a `ResizeHandle` drag from 320px to 453px.

| Tab | After host fix | Extra edit |
|---|---|---|
| Plan | `scrollHeight` 8,660, scrolls internally | none |
| Status | 514/547, own auto overflow | none |
| Logs | 455/42,271, own auto overflow | none |
| Timeline | 145/2,158, own auto overflow | none |
| Files | needed one follow-up (below) | yes |
| Chat | **not measurable — see #195** | — |

Files needed one measurement-justified follow-up: its file-content Skeleton still resolved its implicit grid row to the 15,379px `<pre>`. Fixed with a definite `minmax(0, 1fr)` row scoped to `SessionFilesView` — the shared skeleton primitive is untouched. Both panes now scroll independently (tree held `scrollTop=160` while the `<pre>` stayed at 0, then the `<pre>` reached 900 while the tree held).

> **Expected visible change:** `.file-browser`'s `max-height: 42%` now resolves to a real px value instead of `none`, so the Files split changes proportion. That is what the code always asked for, not a regression.

## WS-B — Knowledge Atlas (#194)

Below `.knowledge-page` there was no content-independent height anywhere. `.workspace` and the Atlas Skeleton are both grid containers with **implicit auto rows**, and an auto row cannot shrink below its items' max-content contribution. So the table's height propagated *upward* instead of the viewport's propagating *down*.

**#194's guess was close but not right.** It blamed the wrapper between `.atlas-panel` and `.table-scroll`. Measurement showed `.workspace` was already capping correctly (876/654/432) — the first link to inflate was a `Skeleton` component the issue doesn't mention, whose row stayed at 9,019px.

| | 1000px | 777px | 555px |
|---|---|---|---|
| `.table-scroll` **before** | 8,963/8,963 | 8,963/8,963 | 8,963/8,963 |
| `.table-scroll` **after** | 820/8,963 | 598/8,963 | 375/8,963 |
| **after**, w/ 37.552px notice | 782/8,963 | 560/8,963 | 338/8,963 |

`clientHeight` tracks the viewport while `scrollHeight` stays at content — and the conditional notice strip is absorbed rather than hard-coded, which is why no `calc(100vh - Npx)` appears anywhere. At the bottom, the final row sits 520.99px inside the 521.55px container and the sticky `th` holds.

**The scoped anchor was sufficient — `src/lib/styles/globals/skeleton.css` and its other 12 consumers are untouched.** That was the biggest risk in this change and it did not materialize.

Graph view unregressed: 820/820, 598/598, 375/375, staying above `.graph-host`'s 320px floor.

## Task-file channel fix

`get_polling_instructions` modelled the task file as a one-shot activation gate — the poll loop breaks on ACTIVE and never runs again — and all seven Completion Protocols ended with *"then stop"*. An agent reporting COMPLETED or BLOCKED therefore stopped reading, so an orchestrator answering a blocker wrote into a file nobody would reopen. That stranded this very session twice.

All four `CliBehavior` arms now get a standing-channel block from one place, and all seven protocols say resume polling. The "don't downgrade a completed heartbeat" rule is preserved.

## Validation

| Gate | Result |
|---|---|
| `cargo check --tests` | PASS (re-run independently) |
| `npm run check` | PASS — 0 errors, 0 warnings |
| `npm run test` | PASS — 25 files, 117 tests |

**No tests added, deliberately.** The frontend stack is jsdom-only and jsdom computes no layout: `scrollHeight`/`clientHeight` are identically `0` before and after. A test asserting "the table scrolls" would pass against the broken code. Every number above comes from live Chromium measurement instead.

## Outstanding — operator verification

Browser measurement does not close these. They need the packaged WebView2 build:

- [ ] **G5** — no console window on `AgentConfigEditor` mount; CLI health still correct across `VALID_CLIS`, including a `.bat`/`.cmd`-wrapped CLI
- [ ] **G6** — worker stdout/stderr still streams to the UI (`CREATE_NO_WINDOW` on the piped `local_process` spawn)
- [ ] **G11 / B4** — repeat the Atlas and tab measurements in the packaged app; #194's own acceptance bar requires this

## Filed separately

**#195** — the conversation tab is inert: `conversationStore.selectAgent()` is never called anywhere, so `selectedAgent` stays `null`, every fetched conversation is discarded, the 5s poll never fires, and the operator cannot send. Pre-existing, unrelated to these fixes, and the reason the Chat tab is the one gap in the six-tab sweep.

Fixes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unwanted console windows from appearing when running commands on Windows.
  * Improved workspace, knowledge table, and session file layouts to prevent content overflow.
  * Updated loading placeholders to fill available space more reliably.
  * Improved worker polling so completed or blocked tasks can receive later instructions.

* **Chores**
  * Updated the application version to 0.40.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->