### PR TITLE
fix: revive the conversation tab (#195) and fit the Launch mode strip

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.40.1"
+version = "0.40.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.40.1"
+version = "0.40.2"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.40.1",
+  "version": "0.40.2",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -51,6 +51,7 @@
   // Load conversation when agent tab is selected
   function selectTab(agentId: string) {
     if (!sessionId) return;
+    conversationStore.selectAgent(agentId);
     conversationStore.loadConversation(sessionId, agentId);
   }
 
@@ -69,7 +70,7 @@
   onMount(() => {
     pollInterval = setInterval(() => {
       if (sessionId && selectedAgent) {
-        conversationStore.loadConversation(sessionId, selectedAgent);
+        conversationStore.loadConversation(sessionId, selectedAgent, undefined, { silent: true });
       }
     }, 5000);
   });

--- a/src/lib/components/ConversationViewer.svelte.test.ts
+++ b/src/lib/components/ConversationViewer.svelte.test.ts
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+interface TestConversationState {
+  messages: Array<{ timestamp: string; from: string; content: string }>;
+  loading: boolean;
+  error: string | null;
+  selectedAgent: string | null;
+  sessionId: string | null;
+}
+
+const storeMocks = vi.hoisted(() => ({
+  setConversationState: undefined as
+    | ((state: TestConversationState) => void)
+    | undefined,
+  selectAgent: vi.fn(),
+  setSessionId: vi.fn(),
+  loadConversation: vi.fn().mockResolvedValue(undefined),
+  sendMessage: vi.fn().mockResolvedValue(undefined),
+  clearError: vi.fn(),
+  loadHeartbeats: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+vi.mock('$lib/stores/sessions', async () => {
+  const { derived, writable } = await import('svelte/store');
+  const activeSession = writable({
+    id: 'session-a',
+    agents: [
+      {
+        id: 'worker-1',
+        role: { Worker: { index: 1 } },
+        status: 'Running',
+        config: { label: 'Worker One' },
+      },
+    ],
+  });
+  return {
+    activeSession,
+    activeAgents: derived(activeSession, (session) => session?.agents ?? []),
+    sessions: { subscribe: writable([]).subscribe },
+  };
+});
+
+vi.mock('$lib/stores/conversations', async () => {
+  const { writable } = await import('svelte/store');
+  const initialState: TestConversationState = {
+    messages: [],
+    loading: false,
+    error: null,
+    selectedAgent: null,
+    sessionId: 'session-a',
+  };
+  const conversationState = writable(initialState);
+  let currentState = initialState;
+  conversationState.subscribe((state) => {
+    currentState = state;
+  });
+  storeMocks.setConversationState = conversationState.set;
+  storeMocks.setSessionId.mockImplementation((sessionId: string | null) => {
+    if (currentState.sessionId === sessionId) return;
+    conversationState.set({ ...initialState, sessionId });
+  });
+  storeMocks.selectAgent.mockImplementation((agentId: string | null) => {
+    conversationState.update((state) => ({
+      ...state,
+      selectedAgent: agentId,
+      messages: [],
+      loading: false,
+      error: null,
+    }));
+  });
+  storeMocks.loadConversation.mockImplementation(async (sessionId: string, agentId: string) => {
+    if (currentState.sessionId !== sessionId || currentState.selectedAgent !== agentId) return;
+    conversationState.update((state) => ({
+      ...state,
+      messages: [{
+        timestamp: '2026-08-01T20:00:00Z',
+        from: 'worker-1',
+        content: 'Loaded conversation',
+      }],
+      loading: false,
+    }));
+  });
+  const heartbeatState = writable({
+    agents: {},
+    stalledAgents: new Set<string>(),
+    staleAgents: new Set<string>(),
+  });
+
+  return {
+    conversationStore: {
+      subscribe: conversationState.subscribe,
+      selectAgent: storeMocks.selectAgent,
+      setSessionId: storeMocks.setSessionId,
+      loadConversation: storeMocks.loadConversation,
+      sendMessage: storeMocks.sendMessage,
+      clearError: storeMocks.clearError,
+    },
+    heartbeatStore: {
+      subscribe: heartbeatState.subscribe,
+      loadHeartbeats: storeMocks.loadHeartbeats,
+    },
+  };
+});
+
+import ConversationViewer from './ConversationViewer.svelte';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  storeMocks.setConversationState?.({
+    messages: [],
+    loading: false,
+    error: null,
+    selectedAgent: null,
+    sessionId: 'session-a',
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllTimers();
+  vi.useRealTimers();
+});
+
+describe('ConversationViewer tab selection', () => {
+  it('selects the clicked agent in the conversation store', async () => {
+    const { getByRole } = render(ConversationViewer);
+    await tick();
+
+    await fireEvent.click(getByRole('tab', { name: 'Worker One' }));
+
+    expect(storeMocks.selectAgent).toHaveBeenCalledWith('worker-1');
+    expect(getByRole('textbox', { name: /Send message as operator/ })).toBeTruthy();
+    expect(getByRole('tab', { name: 'Worker One' }).getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('selects the agent strictly before loading its conversation', async () => {
+    const { getByRole } = render(ConversationViewer);
+    await tick();
+
+    await fireEvent.click(getByRole('tab', { name: 'Worker One' }));
+
+    expect(storeMocks.loadConversation).toHaveBeenCalledWith('session-a', 'worker-1');
+    expect(storeMocks.selectAgent.mock.invocationCallOrder[0]).toBeLessThan(
+      storeMocks.loadConversation.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('renders the selected conversation only after the store selection gate is established', async () => {
+    const { getByRole, getByText, queryByText } = render(ConversationViewer);
+    await tick();
+
+    await fireEvent.click(getByRole('tab', { name: 'Worker One' }));
+    await tick();
+
+    expect(getByText('Loaded conversation')).toBeTruthy();
+    expect(queryByText('Select an agent tab to view conversation.')).toBeNull();
+  });
+
+  it('polls an already-selected conversation without raising the loading skeleton', async () => {
+    vi.useFakeTimers();
+    storeMocks.setConversationState?.({
+      messages: [],
+      loading: false,
+      error: null,
+      selectedAgent: 'worker-1',
+      sessionId: 'session-a',
+    });
+    render(ConversationViewer);
+    await tick();
+    storeMocks.loadConversation.mockClear();
+
+    vi.advanceTimersByTime(5000);
+    await tick();
+
+    expect(storeMocks.loadConversation).toHaveBeenCalledWith(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+  });
+});

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -1323,7 +1323,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   .dialog {
     border-radius: var(--radius-lg);
     padding: 24px;
-    width: 520px;
+    width: 600px;
     max-width: 90vw;
     max-height: 85vh;
     overflow-y: auto;
@@ -1337,6 +1337,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
   .mode-tabs {
     display: flex;
+    flex-wrap: wrap;
     gap: 4px;
     margin-bottom: 20px;
     background: var(--bg-void);

--- a/src/lib/stores/conversations.test.ts
+++ b/src/lib/stores/conversations.test.ts
@@ -1,0 +1,180 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn().mockResolvedValue(() => {}),
+}));
+
+import { conversationStore, type ConversationMessage } from './conversations';
+
+const fetchMock = vi.fn();
+
+function responseWith(messages: ConversationMessage[]): Response {
+  return {
+    ok: true,
+    status: 200,
+    json: vi.fn().mockResolvedValue({ messages }),
+  } as unknown as Response;
+}
+
+function deferredResponse(): {
+  promise: Promise<Response>;
+  resolve: (response: Response) => void;
+} {
+  let resolve!: (response: Response) => void;
+  const promise = new Promise<Response>((fulfill) => {
+    resolve = fulfill;
+  });
+  return { promise, resolve };
+}
+
+function message(content = 'hello'): ConversationMessage {
+  return {
+    id: `message-${content}`,
+    timestamp: '2026-08-01T20:00:00Z',
+    from: 'worker-1',
+    content,
+  };
+}
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+  conversationStore.setSessionId(`reset-${Math.random()}`);
+});
+
+describe('conversationStore conversation selection', () => {
+  it('stores messages after selecting the matching agent before loading', async () => {
+    fetchMock.mockResolvedValue(responseWith([message()]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+
+    await conversationStore.loadConversation('session-a', 'worker-1');
+
+    expect(get(conversationStore).messages).toEqual([message()]);
+  });
+
+  it('discards a response for an agent that is not selected', async () => {
+    fetchMock.mockResolvedValue(responseWith([message('wrong agent')]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+
+    await conversationStore.loadConversation('session-a', 'worker-2');
+
+    expect(get(conversationStore)).toMatchObject({
+      selectedAgent: 'worker-1',
+      messages: [],
+      loading: false,
+    });
+  });
+
+  it('preserves the selected agent and messages for an unchanged session id', async () => {
+    fetchMock.mockResolvedValueOnce(responseWith([message()]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+
+    const pendingResponse = deferredResponse();
+    fetchMock.mockReturnValueOnce(pendingResponse.promise);
+    const load = conversationStore.loadConversation('session-a', 'worker-1');
+    conversationStore.setSessionId('session-a');
+
+    expect(get(conversationStore)).toMatchObject({
+      sessionId: 'session-a',
+      selectedAgent: 'worker-1',
+      messages: [message()],
+    });
+
+    pendingResponse.resolve(responseWith([message('updated')]));
+    await load;
+    expect(get(conversationStore).messages).toEqual([message('updated')]);
+  });
+
+  it('resets the selected agent and messages when the session id changes', async () => {
+    fetchMock.mockResolvedValue(responseWith([message()]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+
+    conversationStore.setSessionId('session-b');
+
+    expect(get(conversationStore)).toMatchObject({
+      sessionId: 'session-b',
+      selectedAgent: null,
+      messages: [],
+      loading: false,
+    });
+  });
+});
+
+describe('conversationStore loading intent', () => {
+  it('does not raise loading during a silent refresh with existing messages', async () => {
+    fetchMock.mockResolvedValueOnce(responseWith([message()]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+
+    const pendingResponse = deferredResponse();
+    fetchMock.mockReturnValueOnce(pendingResponse.promise);
+    const load = conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+
+    expect(get(conversationStore).loading).toBe(false);
+    pendingResponse.resolve(responseWith([message()]));
+    await load;
+  });
+
+  it('does not raise loading during a silent refresh of an empty conversation', async () => {
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    const pendingResponse = deferredResponse();
+    fetchMock.mockReturnValueOnce(pendingResponse.promise);
+
+    const load = conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+
+    expect(get(conversationStore)).toMatchObject({ messages: [], loading: false });
+    pendingResponse.resolve(responseWith([]));
+    await load;
+  });
+
+  it('raises loading for an operator-initiated, non-silent load', async () => {
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    const pendingResponse = deferredResponse();
+    fetchMock.mockReturnValueOnce(pendingResponse.promise);
+
+    const load = conversationStore.loadConversation('session-a', 'worker-1');
+
+    expect(get(conversationStore).loading).toBe(true);
+    pendingResponse.resolve(responseWith([]));
+    await load;
+    expect(get(conversationStore).loading).toBe(false);
+  });
+
+  it('polls the selected conversation silently from its last timestamp', async () => {
+    fetchMock.mockResolvedValueOnce(responseWith([message()]));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+    const loadSpy = vi.spyOn(conversationStore, 'loadConversation').mockResolvedValue(undefined);
+
+    await conversationStore.pollMessages();
+
+    expect(loadSpy).toHaveBeenCalledWith(
+      'session-a',
+      'worker-1',
+      message().timestamp,
+      { silent: true },
+    );
+    loadSpy.mockRestore();
+  });
+});

--- a/src/lib/stores/conversations.test.ts
+++ b/src/lib/stores/conversations.test.ts
@@ -160,6 +160,68 @@ describe('conversationStore loading intent', () => {
     expect(get(conversationStore).loading).toBe(false);
   });
 
+  it('preserves an existing error while a silent refresh is pending and clears it on success', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('existing failure'));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+
+    const pendingResponse = deferredResponse();
+    fetchMock.mockReturnValueOnce(pendingResponse.promise);
+    const load = conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+
+    expect(get(conversationStore).error).toBe('Error: existing failure');
+    pendingResponse.resolve(responseWith([]));
+    await load;
+    expect(get(conversationStore).error).toBeNull();
+  });
+
+  it('clears an existing error after a successful silent refresh', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('transient failure'));
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    await conversationStore.loadConversation('session-a', 'worker-1');
+    fetchMock.mockResolvedValueOnce(responseWith([]));
+
+    await conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+
+    expect(get(conversationStore).error).toBeNull();
+  });
+
+  it('surfaces a silent refresh failure and clears it after recovery', async () => {
+    conversationStore.setSessionId('session-a');
+    conversationStore.selectAgent('worker-1');
+    fetchMock.mockRejectedValueOnce(new Error('silent failure'));
+
+    await conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+
+    expect(get(conversationStore).error).toBe('Error: silent failure');
+
+    fetchMock.mockResolvedValueOnce(responseWith([]));
+    await conversationStore.loadConversation(
+      'session-a',
+      'worker-1',
+      undefined,
+      { silent: true },
+    );
+    expect(get(conversationStore).error).toBeNull();
+  });
+
   it('polls the selected conversation silently from its last timestamp', async () => {
     fetchMock.mockResolvedValueOnce(responseWith([message()]));
     conversationStore.setSessionId('session-a');

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -161,7 +161,7 @@ function createConversationStore() {
       update((state) => ({
         ...state,
         loading: options?.silent ? state.loading : true,
-        error: null,
+        error: options?.silent ? state.error : null,
       }));
       try {
         let url = apiUrl(`/api/sessions/${sessionId}/conversations/${agentId}`);
@@ -188,6 +188,7 @@ function createConversationStore() {
             ...state,
             messages: newMessages,
             loading: false,
+            error: null,
             sessionId,
             selectedAgent: agentId,
           };

--- a/src/lib/stores/conversations.ts
+++ b/src/lib/stores/conversations.ts
@@ -139,6 +139,7 @@ function createConversationStore() {
     },
 
     setSessionId(sessionId: string | null) {
+      if (getState().sessionId === sessionId) return;
       activeConversationRequest += 1;
       update((state) => ({
         ...state,
@@ -150,9 +151,18 @@ function createConversationStore() {
       }));
     },
 
-    async loadConversation(sessionId: string, agentId: string, since?: string) {
+    async loadConversation(
+      sessionId: string,
+      agentId: string,
+      since?: string,
+      options?: { silent?: boolean },
+    ) {
       const requestToken = ++activeConversationRequest;
-      update((state) => ({ ...state, loading: true, error: null }));
+      update((state) => ({
+        ...state,
+        loading: options?.silent ? state.loading : true,
+        error: null,
+      }));
       try {
         let url = apiUrl(`/api/sessions/${sessionId}/conversations/${agentId}`);
         if (since) url += `?since=${encodeURIComponent(since)}`;
@@ -218,7 +228,7 @@ function createConversationStore() {
       const lastMsg = state.messages[state.messages.length - 1];
       const since = lastMsg?.timestamp;
       
-      await this.loadConversation(state.sessionId, state.selectedAgent, since);
+      await this.loadConversation(state.sessionId, state.selectedAgent, since, { silent: true });
     },
 
     clearError() {


### PR DESCRIPTION
Fixes #195.

Two operator-reported frontend defects. Frontend only — no Rust source, HTTP handler, or prompt-template changes.

## Defect A — the conversation tab was inert (#195)

`conversationStore.selectAgent()` had **no caller anywhere in the codebase**, so `state.selectedAgent` was permanently `null` and every fetched conversation was discarded at the `state.selectedAgent !== agentId` guard.

The issue names one dead consumer. There were five:

| Site | Symptom |
|---|---|
| `ConversationViewer.svelte:71` | 5s refresh poll never fired |
| `ConversationViewer.svelte:99` | operator composer early-returned |
| `ConversationViewer.svelte:110` | approval-injection fallback unreachable |
| `conversations.ts:108` | realtime `conversation-message` listener early-returned — **push was dead too** |
| `SessionOverview.svelte:61` | its 10s `pollMessages()` returned at `conversations.ts:216` |

**The fix, as written in the issue, would have shipped a new defect.** `loadConversation` set `loading: true` unconditionally, and `Skeleton` marks real content `aria-hidden` **and `inert`** while loading. The 5s poll calls `loadConversation` with no `since`, so the one-line fix makes the message list flip to a skeleton and go non-interactive every 5 seconds. That regression is fixed in the same change.

Three changes:

1. `selectTab` calls `selectAgent(agentId)` **strictly before** `loadConversation`. Ordering is load-bearing — `selectAgent` bumps `activeConversationRequest`, so calling it afterwards would invalidate the very request it enables.
2. `setSessionId` early-returns on an unchanged id, without bumping the request token on the no-op. Mirrors `sessionFiles.ts:176-182`.
3. `loadConversation(sessionId, agentId, since?, options?: { silent?: boolean })`, with both poll sites passing `{ silent: true }` and the tab click path left non-silent.

A `messages.length === 0` heuristic was **deliberately rejected**: a conversation with zero messages is a legitimate settled state, so that shape would flash forever on empty conversations.

## Defect B — Launch dialog mode strip clipped SOLO

The six tabs needed ~504px against the 472px available inside the 520px `.dialog`. `.mode-tabs` sets no `overflow`, but `.dialog` has `overflow-y: auto`, which per CSS forces the other axis to `auto` too — so the clip landed at the dialog boundary.

`.dialog` 520px → 600px, plus `flex-wrap: wrap` on `.mode-tabs`. The width fixes the reported defect; the wrap guarantees that below ~600px viewport, where `max-width: 90vw` binds, tabs move to a second row instead of being cut.

`flex-wrap` is an addition beyond the literal request ("make it wider"). It is invisible at the new width and is the only thing keeping the narrow case non-clipping.

**Rejected alternatives**, recorded so they are not re-litigated: shrinking `--space-4` on `.lattice-tab` (shared primitive — affects every tab strip in the app); abbreviating the labels (the ask was fit, not truncation); `min-width: 0` on the tabs (permits the mid-word clipping that *is* the defect); horizontal scrolling on the strip.

## Evidence

Every claim below is tagged with its tier. **No Tier-1 evidence has been promoted to a Tier-2 claim.**

- **G1 `npm run check` — PASS (static).** `svelte-check found 0 errors and 0 warnings`. Re-run after the version bump.
- **G2 `npm test` — PASS (static).** 27 files / 129 tests. Re-run after the version bump.
- **G3 mutation proof — PASS (static).** Four mutations, each run independently and each file restored byte-identical afterwards:

| Mutation | Result |
|---|---|
| Remove `selectAgent(agentId)` from `selectTab` | **3 fail** — `selects the clicked agent…`, `selects the agent strictly before loading…`, `renders the selected conversation only after the store selection gate…` |
| Reverse the order (`selectAgent` **after** `loadConversation`) | **2 fail** — proves AC-A2 is order-sensitive, not merely presence-sensitive |
| Drop `{ silent: true }` from the 5s poll site | **1 fail** — `polls an already-selected conversation without raising the loading skeleton` |
| Drop `{ silent: true }` from `pollMessages` | **1 fail** — `polls the selected conversation silently from its last timestamp` |

- **G4 pixels at default width — PASS (Tier-1, browser via `npm run dev`).** `{ scrollW: 540, clientW: 540, lastRight: 1328, stripRight: 1332, rows: 1, dialogScrollW: 588, dialogClientW: 588 }`. All six labels render complete; screenshot confirms SOLO clear of the modal edge.
- **G4-narrow — PASS (Tier-1).** Measured with the resolved `90vw` constraint supplied directly to the layout engine at simulated viewports 700/600/560/480/400: strip always fits (`scrollWidth <= clientWidth`), no tab ever exceeds the strip's right edge, dialog never scrolls horizontally, and the strip wraps to 2 rows at and below the 600px equivalent. Real-viewport measurements across the 560px media boundary (561/560/559) were also taken during the build and showed the expanded grids reflowing to one column without overflow.
- **G5 — UNVERIFIED (Tier-2).** Not run and **not inferred from the gates above.** A second app instance cannot attach to the live session owned by the running app, so click-a-tab / no-flash-over-15s / send-from-a-non-`shared`-tab were not observed on the installed app. Static plus mutation evidence stands on its own here.
- **`cargo check --tests` — PASS (static).** Run once to confirm the `Cargo.lock` bump is consistent. No Rust source changed, so `clippy`/`cargo test` were deliberately not run.

**Coverage this PR does not claim:** Defect B has no automated gate. jsdom performs no layout, so no unit test can assert the strip fits — the Tier-1 measurements are the only real evidence. A test asserting the stylesheet contains `600px` was deliberately not added; it would prove nothing and would read as coverage that does not exist.

## Known issue, recorded not fixed

`ConversationViewer` polls every 5s with **no** `since` (full replace) while `SessionOverview` polls every 10s **with** `since` (merge). Both bump the same `activeConversationRequest`, so they mutually invalidate and roughly half the fetches are wasted now that the tab works. No data is lost — the no-`since` path refetches everything. Left as-is deliberately; consolidating the two pollers is a larger change than this fix warrants.

## Release

`0.40.1` → `0.40.2` (fix-only, patch). `Cargo.lock` edited in place at the `hive-manager` package rather than regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation updates when switching between agent tabs.
  * Background message polling now updates conversations without disrupting loading indicators.
  * Preserved conversation state more reliably during session changes and refreshes.
* **UI Improvements**
  * Expanded the launch dialog for improved readability.
  * Mode tabs now wrap across multiple lines when needed.
* **Release**
  * Updated the application version to 0.40.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Update — reconciliation round (`c51ed5e`)

CodeRabbit's review surfaced a **real** defect this PR had introduced: the silent-refresh path guarded `loading` but not `error`, so the newly-live 5s poll cleared the operator's error banner at request start and raised one on any transient failure.

Fixed in `c51ed5e` by adopting the lifecycle `sessionFiles.ts` already uses — preserve on silent start (`:191`), clear on accepted success (`:222`), surface on accepted failure (`:233`).

CodeRabbit's proposed patch was applied only in part. Its second hunk would have suppressed silent failures entirely; because both poll sites are silent and `RightPanel.svelte:87-100` renders the panels as mutually exclusive tabs, that would leave a persistent backend outage with no operator-visible indication anywhere. Its patch also omitted the success-path reset, which is load-bearing: with only the request-start guard applied, a transient error would stick forever instead of self-healing.

On re-review of `c51ed5e`, CodeRabbit reported **no new findings** and endorsed the amended lifecycle, including that an accepted failed request should expose the error.

Two further comments were not actioned, with rationale posted on the PR: the `pollMessages` mock request (conditioned on a refactor that has not happened) and the 0% docstring-coverage check (not a repo convention — `sessionFiles.ts`, `agents.ts`, and `knowledge.ts` carry no JSDoc).

**Final gate state:** `npm run check` 0 errors / 0 warnings; `npm test` **27 files / 132 tests** (three new revert-sensitive error-lifecycle tests). Each of the three production edits was mutation-proven independently — reverting them fails 1, 3, and 1 tests respectively, the last being direct evidence for rejecting the second hunk.

Four commits, each independently revertible: `385f572` (WS-A), `f56315a` (WS-B), `bbde37d` (release), `c51ed5e` (review fix).
