### PR TITLE
feat(lattice): borderless separation wave — #198 #199 #200 #201

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.40.2",
+  "version": "0.41.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.40.2"
+version = "0.41.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.40.2",
+  "version": "0.41.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -148,7 +148,8 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
+    if (open && event.key === 'Escape') {
+      event.preventDefault();
       close();
     }
   }

--- a/src/lib/components/ContractViewer.svelte
+++ b/src/lib/components/ContractViewer.svelte
@@ -46,7 +46,7 @@
 </script>
 
 {#if contract}
-  <div class="contract-viewer lattice-panel">
+  <div class="contract-viewer">
     <div class="contract-header">
       <div class="header-info">
         <h3>Sprint Contract</h3>
@@ -99,6 +99,9 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
+    background: var(--bg-chrome);
+    border-radius: var(--radius-shell);
+    box-shadow: var(--edge-lip);
   }
 
   .contract-header {

--- a/src/lib/components/ContractViewer.svelte
+++ b/src/lib/components/ContractViewer.svelte
@@ -46,7 +46,7 @@
 </script>
 
 {#if contract}
-  <div class="contract-viewer">
+  <div class="contract-viewer lattice-forced-colors-boundary">
     <div class="contract-header">
       <div class="header-info">
         <h3>Sprint Contract</h3>

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -480,14 +480,11 @@
 
   .debater-status-card {
     overflow: hidden;
-    transition:
-      background-color var(--motion-duration-standard) var(--motion-ease-standard),
-      border-color var(--motion-duration-standard) var(--motion-ease-standard);
+    transition: background-color var(--motion-duration-standard) var(--motion-ease-standard);
   }
 
   .debater-status-card.completed {
     /* Completed-card tint is semantic state layered over the structural panel. */
-    border-color: color-mix(in srgb, var(--status-success) 20%, transparent);
     background: color-mix(in srgb, var(--status-success) 2%, var(--bg-surface));
   }
 

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -485,7 +485,7 @@
 
   .debater-status-card.completed {
     /* Completed-card tint is semantic state layered over the structural panel. */
-    background: color-mix(in srgb, var(--status-success) 2%, var(--bg-surface));
+    background: color-mix(in srgb, var(--status-success) 2%, var(--bg-panel));
   }
 
   .debater-card-header {

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -22,9 +22,12 @@
   import { templates, selectedTemplate } from '$lib/stores/templates';
   import { defaultRoles } from '$lib/config/clis';
 
+  type SessionMode = 'templates' | 'hive' | 'fusion' | 'solo' | 'research' | 'debate';
+
   export let show: boolean = false;
   export let launching: boolean = false;
   export let launchError: string = '';
+  export let initialMode: SessionMode | undefined = undefined;
 
   const dispatch = createEventDispatcher<{
     close: void;
@@ -35,7 +38,6 @@
     launchDebate: DebateLaunchConfig;
   }>();
 
-  type SessionMode = 'templates' | 'hive' | 'fusion' | 'solo' | 'research' | 'debate';
   type LaunchWorkerConfig = CodingPrincipalFormConfig;
   let cliHealth: CliHealthMap = {};
   let cliHealthLoading = false;
@@ -601,6 +603,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   $: if (!show) healthLoadedForOpen = false;
   $: if (show && !healthLoadedForOpen) {
     healthLoadedForOpen = true;
+    if (initialMode !== undefined) mode = initialMode;
     void loadCliHealth();
   }
   $: if (!show) {
@@ -1752,8 +1755,10 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   }
 
   .node {
+    --node-role: transparent;
     padding: 8px 12px;
     border-radius: var(--radius-sm);
+    box-shadow: inset 0 0 0 1px var(--node-role), var(--elev-1), var(--edge-lip);
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -1762,7 +1767,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
   .node.queen {
     /* Topology role tones are semantic node states, not structural surfaces. */
-    border-color: var(--accent-amber);
+    --node-role: var(--accent-amber);
     background: color-mix(in srgb, var(--accent-amber) 10%, transparent);
   }
 
@@ -1797,12 +1802,21 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   }
 
   .node.worker {
-    border-color: var(--accent-cyan);
+    --node-role: var(--accent-cyan);
     background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
   }
-  .node.fusion { border-color: var(--status-success); }
-  .node.debate { border-color: var(--accent-purple, #bb9af7); }
-  .node.solo { border-color: var(--status-warning); }
+  .node.fusion {
+    --node-role: var(--status-success);
+    background: color-mix(in srgb, var(--status-success) 10%, transparent);
+  }
+  .node.debate {
+    --node-role: var(--accent-purple, #bb9af7);
+    background: color-mix(in srgb, var(--accent-purple, #bb9af7) 10%, transparent);
+  }
+  .node.solo {
+    --node-role: var(--status-warning);
+    background: color-mix(in srgb, var(--status-warning) 10%, transparent);
+  }
 
   .topology-contract {
     width: 100%;

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -62,7 +62,7 @@
   </div>
 
   <div
-    class="panel-drawer"
+    class="panel-drawer lattice-forced-colors-boundary"
     class:collapsed
     style:width={`${drawerWidth}px`}
     inert={collapsed}

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -20,7 +20,7 @@
 
   let collapsed = $derived($layout.rightCollapsed);
   let activeTab = $derived($layout.rightTab);
-  let panelWidth = $derived(collapsed ? RAIL_WIDTH : $layout.rightWidth);
+  let drawerWidth = $derived($layout.rightWidth - RAIL_WIDTH);
 
   function handleResize(clientX: number) {
     layout.setRightWidth(window.innerWidth - clientX);
@@ -29,59 +29,47 @@
 
 <aside
   class="right-panel"
-  class:collapsed
-  style:width={`${panelWidth}px`}
-  style:min-width={`${panelWidth}px`}
+  style:width={`${RAIL_WIDTH}px`}
+  style:min-width={`${RAIL_WIDTH}px`}
+  style:flex-basis={`${RAIL_WIDTH}px`}
 >
-  {#if collapsed}
-    <div class="rail">
-      <button
-        type="button"
-        class="rail-control expand lattice-btn lattice-btn--ghost lattice-btn--icon"
-        onclick={() => layout.toggleRight()}
-        title="Expand panel (Ctrl+J)"
-        aria-label="Expand panel"
-      >
+  <div class="rail">
+    <button
+      type="button"
+      class="rail-control expand lattice-btn lattice-btn--ghost lattice-btn--icon"
+      onclick={() => layout.toggleRight()}
+      title={collapsed ? "Expand panel (Ctrl+J)" : "Collapse panel (Ctrl+J)"}
+      aria-label={collapsed ? "Expand panel" : "Collapse panel"}
+    >
+      {#if collapsed}
         <CaretLeft size={14} weight="light" />
-      </button>
-      {#each TABS as tab (tab.id)}
-        {@const Icon = tab.icon}
-        <button
-          type="button"
-          class={`rail-control lattice-btn lattice-btn--icon ${activeTab === tab.id ? 'lattice-btn--primary' : 'lattice-btn--ghost'}`}
-          onclick={() => layout.setRightTab(tab.id)}
-          title={tab.label}
-          aria-label={tab.label}
-        >
-          <Icon size={18} weight="light" />
-        </button>
-      {/each}
-    </div>
-  {:else}
-    <div class="panel-header">
-      <nav class="tab-bar" aria-label="Panel tabs">
-        {#each TABS as tab (tab.id)}
-          {@const Icon = tab.icon}
-          <button
-            type="button"
-            class={`panel-tab lattice-tab${activeTab === tab.id ? ' lattice-tab--active' : ''}`}
-            onclick={() => layout.setRightTab(tab.id)}
-            title={tab.label}
-          >
-            <Icon size={15} weight="light" />
-            <span class="tab-label">{tab.label}</span>
-          </button>
-        {/each}
-      </nav>
+      {:else}
+        <CaretRight size={14} weight="light" />
+      {/if}
+    </button>
+    {#each TABS as tab (tab.id)}
+      {@const Icon = tab.icon}
       <button
         type="button"
-        class="panel-collapse lattice-btn lattice-btn--ghost lattice-btn--icon"
-        onclick={() => layout.toggleRight()}
-        title="Collapse panel (Ctrl+J)"
-        aria-label="Collapse panel"
+        class={`rail-control lattice-btn lattice-btn--icon ${activeTab === tab.id ? 'lattice-btn--primary' : 'lattice-btn--ghost'}`}
+        onclick={() => layout.setRightTab(tab.id)}
+        title={tab.label}
+        aria-label={tab.label}
       >
-        <CaretRight size={14} weight="light" />
+        <Icon size={18} weight="light" />
       </button>
+    {/each}
+  </div>
+
+  <div
+    class="panel-drawer"
+    class:collapsed
+    style:width={`${drawerWidth}px`}
+    inert={collapsed}
+    aria-hidden={collapsed}
+  >
+    <div class="panel-header">
+      <h2 class="panel-title">{TABS.find((tab) => tab.id === activeTab)?.label}</h2>
     </div>
 
     <div class="tab-content">
@@ -104,7 +92,7 @@
       label="Resize panel"
       onResize={handleResize}
     />
-  {/if}
+  </div>
 </aside>
 
 <style>
@@ -113,21 +101,28 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
+    overflow: visible;
     /* Shell chrome intentionally remains outside the content-card surface primitive. */
     background: var(--bg-void);
-    border-left: 1px solid var(--border-structural);
+    box-shadow: inset 1px 0 0 rgba(0, 0, 0, 0.45);
+    z-index: 20;
   }
 
-  .right-panel :global(.resize-handle) {
+  .panel-drawer :global(.resize-handle) {
     left: -3px;
   }
 
   .rail {
+    position: relative;
+    z-index: 2;
     display: flex;
+    flex: 1;
     flex-direction: column;
     align-items: center;
     gap: 6px;
     padding: 8px 0;
+    background: var(--bg-void);
   }
 
   .rail-control {
@@ -141,49 +136,47 @@
 
   .rail-control.expand {
     margin-bottom: 6px;
-    border-bottom: 1px solid var(--border-structural);
     border-radius: var(--radius-none);
     width: 100%;
     padding-bottom: 12px;
+    box-shadow: var(--edge-seam);
+  }
+
+  .panel-drawer {
+    position: absolute;
+    top: 11px;
+    right: 100%;
+    bottom: 11px;
+    z-index: 1;
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+    background: var(--bg-panel);
+    box-shadow: var(--elev-3), var(--edge-lip);
+    transform: translateX(0);
+    transition: transform var(--motion-duration-standard) var(--motion-ease-standard);
+  }
+
+  .panel-drawer.collapsed {
+    pointer-events: none;
+    transform: translateX(104%);
   }
 
   .panel-header {
     display: flex;
     align-items: center;
-    gap: 4px;
-    padding: 4px 6px;
-    border-bottom: 1px solid var(--border-structural);
+    min-height: 40px;
+    padding: 4px 10px;
+    box-shadow: var(--edge-seam);
   }
 
-  .tab-bar {
-    display: flex;
-    flex: 1;
-    min-width: 0;
-    overflow-x: auto;
-    /* Deliberately chromeless horizontal tab strip; ruling R9 excludes lattice scrollbars. */
-    scrollbar-width: none;
-  }
-
-  .panel-tab {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-
-  .tab-label {
-    display: inline;
-  }
-
-  .panel-collapse {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    padding: 0;
-    flex-shrink: 0;
+  .panel-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: var(--text-h3);
+    font-weight: 600;
   }
 
   .tab-content {

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -428,7 +428,7 @@
   </div>
 
   <div
-    class="sidebar-drawer"
+    class="sidebar-drawer lattice-forced-colors-boundary"
     class:collapsed
     style:width={`${drawerWidth}px`}
     inert={collapsed}

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -5,7 +5,7 @@
   import { layout, RAIL_WIDTH } from '$lib/stores/layout';
   import { ui } from '$lib/stores/ui';
   import { invoke } from '@tauri-apps/api/core';
-  import { onMount } from 'svelte';
+  import { onMount, tick } from 'svelte';
   import LaunchDialog from './LaunchDialog.svelte';
   import AgentTree from './AgentTree.svelte';
   import QueenControls from './QueenControls.svelte';
@@ -55,6 +55,7 @@
     onLaunchSolo?: (config: SoloLaunchConfig) => Promise<void>;
     onLaunchDebate?: (config: DebateLaunchConfig) => Promise<void>;
     onOpenAddWorker?: () => void;
+    startAction?: { id: number; action: 'hive' | 'fusion' | 'debate' | 'recent' } | null;
   }
 
   interface SessionSummary {
@@ -67,11 +68,12 @@
     state: string;
   }
 
-  let { onLaunchHiveV2, onLaunchResearch, onLaunchFusion, onLaunchSolo, onLaunchDebate, onOpenAddWorker }: Props = $props();
+  let { onLaunchHiveV2, onLaunchResearch, onLaunchFusion, onLaunchSolo, onLaunchDebate, onOpenAddWorker, startAction = null }: Props = $props();
 
   let showLaunchDialog = $state(false);
   let launching = $state(false);
   let launchError = $state('');
+  let launchInitialMode = $state<'hive' | 'fusion' | 'debate' | undefined>(undefined);
   let persistedSessions = $state<SessionSummary[]>([]);
   let loadingPersisted = $state(false);
   let currentDirectory = $state<string | null>(null);
@@ -83,14 +85,33 @@
   let resuming = $state(false);
   let resumeError = $state<string | null>(null);
   let resumeReportRequestId = 0;
+  let handledStartActionId = 0;
+  let recentDisclosure: HTMLButtonElement;
 
   let collapsed = $derived($layout.leftCollapsed);
-  let sidebarWidth = $derived(collapsed ? RAIL_WIDTH : $layout.leftWidth);
+  let drawerWidth = $derived($layout.leftWidth - RAIL_WIDTH);
   let knowledgeHref = $derived(
     $activeSession
       ? `/knowledge?session_id=${encodeURIComponent($activeSession.id)}`
       : '/knowledge',
   );
+
+  $effect(() => {
+    const request = startAction;
+    if (!request || request.id === handledStartActionId) return;
+
+    handledStartActionId = request.id;
+    if (request.action === 'recent') {
+      if ($layout.leftCollapsed) layout.toggleLeft();
+      if ($layout.recentCollapsed) layout.toggleSection('recentCollapsed');
+      void tick().then(() => recentDisclosure?.focus());
+      return;
+    }
+
+    launchInitialMode = request.action;
+    launchError = '';
+    showLaunchDialog = true;
+  });
 
   onMount(async () => {
     // Get current working directory first
@@ -365,19 +386,16 @@
   }
 </script>
 
-<!-- The sidebar is chrome, not a panel: it must stay --bg-void so the content card
-     reads as a lit surface against the void (#183). Adopting .lattice-panel here
-     paints it --bg-surface, i.e. the same tone as .main-content, which collapses
-     that contrast entirely. -->
+<!-- The permanent rail is shell chrome; the adjacent drawer is a floating panel. -->
 <aside
   class="sidebar"
-  class:collapsed
   class:resizing
-  style:width={`${sidebarWidth}px`}
-  style:min-width={`${sidebarWidth}px`}
+  style:width={`${RAIL_WIDTH}px`}
+  style:min-width={`${RAIL_WIDTH}px`}
+  style:flex-basis={`${RAIL_WIDTH}px`}
 >
-  <div class="sidebar-header" class:collapsed>
-    <nav class="view-toggle" class:collapsed aria-label="View switcher">
+  <div class="sidebar-rail">
+    <nav class="view-toggle" aria-label="View switcher">
       {#each [
         { path: '/', href: '/', icon: House, label: 'Sessions' },
         { path: '/dashboard', href: '/dashboard', icon: Kanban, label: 'Dashboard' },
@@ -409,8 +427,14 @@
     </button>
   </div>
 
-  {#if !collapsed}
-  <div class="sidebar-content lattice-scroll-chrome">
+  <div
+    class="sidebar-drawer"
+    class:collapsed
+    style:width={`${drawerWidth}px`}
+    inert={collapsed}
+    aria-hidden={collapsed}
+  >
+    <div class="sidebar-content lattice-scroll-chrome">
     <section class="section">
       <button type="button" class="lattice-btn lattice-btn--link lattice-btn--row" aria-expanded={!$layout.sessionsCollapsed} onclick={() => layout.toggleSection('sessionsCollapsed')}>
         <span class="chevron" class:collapsed={$layout.sessionsCollapsed}>
@@ -536,7 +560,7 @@
     </section>
 
     <section class="section">
-      <button type="button" class="lattice-btn lattice-btn--link lattice-btn--row" aria-expanded={!$layout.recentCollapsed} onclick={() => layout.toggleSection('recentCollapsed')}>
+      <button bind:this={recentDisclosure} type="button" class="lattice-btn lattice-btn--link lattice-btn--row" aria-expanded={!$layout.recentCollapsed} onclick={() => layout.toggleSection('recentCollapsed')}>
         <span class="chevron" class:collapsed={$layout.recentCollapsed}>
           {#if $layout.recentCollapsed}
             <CaretRight size={12} weight="light" />
@@ -613,31 +637,28 @@
         {/if}
       </section>
     {/if}
-  </div>
-  {/if}
+    </div>
 
-  <div class="sidebar-footer">
-    <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled lattice-btn--row" onclick={() => { launchError = ''; showLaunchDialog = true; }} title="New Session">
-      <span class="icon">+</span>
-      {#if !collapsed}
+    <div class="sidebar-footer">
+      <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled lattice-btn--row" onclick={() => { launchInitialMode = undefined; launchError = ''; showLaunchDialog = true; }} title="New Session">
+        <span class="icon">+</span>
         New Session
-      {/if}
-    </button>
-  </div>
+      </button>
+    </div>
 
-  {#if !collapsed}
     <ResizeHandle
       label="Resize sidebar"
       onResize={(clientX) => layout.setLeftWidth(clientX)}
       onDragChange={(d) => resizing = d}
     />
-  {/if}
+  </div>
 </aside>
 
 <LaunchDialog
   show={showLaunchDialog}
   {launching}
   {launchError}
+  initialMode={launchInitialMode}
   on:close={() => { showLaunchDialog = false; launchError = ''; }}
   on:launchHive={handleLaunchHive}
   on:launchResearch={handleLaunchResearch}
@@ -691,40 +712,60 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    flex-shrink: 0;
+    overflow: visible;
+    background: var(--bg-void);
+    box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.45);
+    z-index: 20;
   }
 
-  .sidebar.resizing {
+  .sidebar.resizing .sidebar-drawer {
     transition: none;
   }
 
-  .sidebar :global(.resize-handle) {
+  .sidebar-drawer :global(.resize-handle) {
     right: -3px;
   }
 
-  .sidebar-header {
+  .sidebar-rail {
+    position: relative;
+    z-index: 2;
     display: flex;
+    flex: 1;
+    flex-direction: column;
     align-items: center;
-    gap: 8px;
-    padding: 8px;
-    border-bottom: 1px solid var(--border-structural);
+    gap: 6px;
+    padding: 8px 0;
     width: 100%;
+    background: var(--bg-void);
   }
 
-  .sidebar-header.collapsed {
+  .sidebar-drawer {
+    position: absolute;
+    top: 11px;
+    bottom: 11px;
+    left: 100%;
+    z-index: 1;
+    display: flex;
+    min-width: 0;
     flex-direction: column;
-    gap: 6px;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+    background: var(--bg-panel);
+    box-shadow: var(--elev-3), var(--edge-lip);
+    transform: translateX(0);
+    transition: transform var(--motion-duration-standard) var(--motion-ease-standard);
+  }
+
+  .sidebar-drawer.collapsed {
+    pointer-events: none;
+    transform: translateX(-104%);
   }
 
   .view-toggle {
     display: flex;
-    flex-direction: row;
-    gap: 4px;
-    flex: 1;
-    min-width: 0;
-  }
-
-  .view-toggle.collapsed {
     flex-direction: column;
+    gap: 4px;
     flex: none;
   }
 
@@ -790,8 +831,8 @@
 
   .session-item {
     margin-bottom: 4px;
-    border-left: 3px solid var(--session-color);
     border-radius: var(--radius-md);
+    box-shadow: inset 3px 0 0 var(--session-color);
   }
 
   .session-copy {
@@ -829,7 +870,7 @@
     grid-template-columns: repeat(4, 1fr);
     gap: 4px;
     z-index: 20;
-    box-shadow: 0 4px 12px color-mix(in srgb, var(--bg-void) 30%, transparent);
+    box-shadow: var(--elev-3), var(--edge-lip);
   }
 
   .session-row {
@@ -860,24 +901,24 @@
     text-transform: uppercase;
     background: var(--bg-void);
     color: var(--text-secondary);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
   }
 
   .type-tag.solo {
     background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
     color: var(--accent-cyan);
-    border-color: color-mix(in srgb, var(--accent-cyan) 30%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cyan) 30%, transparent);
   }
 
   .queen-controls-section {
     margin-top: 8px;
-    border-top: 1px solid var(--border-structural);
     padding-top: 8px;
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
   }
 
   .sidebar-footer {
     padding: 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
   }
 
   .sidebar-footer .icon {
@@ -891,7 +932,6 @@
     align-items: center;
     gap: 8px;
     padding: 8px 10px;
-    border: 1px solid transparent;
     border-radius: var(--radius-md);
     transition: background-color var(--motion-duration-fast) var(--motion-ease-standard);
   }

--- a/src/lib/components/StatusPanel.svelte
+++ b/src/lib/components/StatusPanel.svelte
@@ -663,7 +663,7 @@
     gap: 5px;
     flex: 0 0 auto;
     padding: 2px 6px;
-    border: 1px solid currentColor;
+    box-shadow: inset 0 0 0 1px currentColor;
     border-radius: var(--radius-full);
     font-size: 9px;
     font-weight: 600;
@@ -826,7 +826,7 @@
   .actions-section {
     margin-top: auto;
     padding-top: 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
   }
 
   .close-session-action {

--- a/src/lib/components/Terminal.svelte
+++ b/src/lib/components/Terminal.svelte
@@ -936,7 +936,7 @@
     padding: var(--space-4) var(--space-5);
     min-width: 240px;
     border-radius: var(--radius-lg);
-    box-shadow: 0 14px 30px rgba(0, 0, 0, 0.28);
+    box-shadow: var(--elev-2), var(--edge-lip);
     text-align: center;
   }
 
@@ -964,7 +964,7 @@
     gap: 4px;
     padding: 4px 6px;
     border-radius: var(--radius-lg);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--elev-2), var(--edge-lip);
   }
 
   .search-icon {
@@ -1000,7 +1000,7 @@
     /* Anchored warning strip: translucency preserves terminal context underneath. */
     background: color-mix(in srgb, var(--bg-surface) 85%, transparent);
     backdrop-filter: blur(4px);
-    border-top: 1px solid var(--status-warning);
+    box-shadow: inset 0 1px 0 var(--status-warning);
     z-index: 10;
     display: flex;
     justify-content: center;
@@ -1026,7 +1026,7 @@
     border-radius: var(--radius-lg);
     padding: 4px;
     min-width: 180px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    box-shadow: var(--elev-3), var(--edge-lip);
     z-index: 1000;
   }
 

--- a/src/lib/components/TerminalGrid.svelte
+++ b/src/lib/components/TerminalGrid.svelte
@@ -338,8 +338,7 @@
       >
         <div
           class="terminal-header"
-          style:border-top-color={$activeSession?.color || 'transparent'}
-          style:border-top-width={$activeSession?.color ? '3px' : '0'}
+          style:--session-color={$activeSession?.color || 'transparent'}
         >
           <button
             type="button"
@@ -503,9 +502,7 @@
     display: flex;
     flex-direction: column;
     overflow: hidden;
-    transition:
-      border-color var(--motion-duration-standard) var(--motion-ease-standard),
-      box-shadow var(--motion-duration-standard) var(--motion-ease-standard);
+    transition: box-shadow var(--motion-duration-standard) var(--motion-ease-standard);
     min-height: 0;
   }
 
@@ -528,7 +525,9 @@
     justify-content: space-between;
     gap: 8px;
     padding: 6px 10px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow:
+      inset 0 3px 0 var(--session-color),
+      var(--edge-seam);
     user-select: none;
   }
 
@@ -621,6 +620,5 @@
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
-    border: 0;
   }
 </style>

--- a/src/lib/components/TerminalGrid.svelte
+++ b/src/lib/components/TerminalGrid.svelte
@@ -169,9 +169,15 @@
   }
 
   function handleWindowKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape' && maximizedTerminalId) {
-      layout.setMaximizedTerminalId(null);
-    }
+    if (
+      event.key !== 'Escape' ||
+      !maximizedTerminalId ||
+      event.defaultPrevented ||
+      document.querySelector('[aria-modal="true"]') !== null
+    ) return;
+
+    event.preventDefault();
+    layout.setMaximizedTerminalId(null);
   }
 
   function markTerminalReady(id: string) {

--- a/src/lib/components/UpdateChecker.svelte
+++ b/src/lib/components/UpdateChecker.svelte
@@ -100,7 +100,7 @@
     flex-direction: column;
     gap: 8px;
     z-index: 1000;
-    box-shadow: 0 4px 12px color-mix(in srgb, var(--bg-void) 70%, transparent);
+    box-shadow: var(--elev-3), var(--edge-lip);
     max-width: 300px;
   }
 

--- a/src/lib/components/composer/MentionMenu.svelte
+++ b/src/lib/components/composer/MentionMenu.svelte
@@ -46,7 +46,7 @@
     max-width: 320px;
     max-height: 240px;
     overflow-y: auto;
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--elev-3), var(--edge-lip);
     padding: 4px;
     display: flex;
     flex-direction: column;

--- a/src/lib/components/composer/SlashMenu.svelte
+++ b/src/lib/components/composer/SlashMenu.svelte
@@ -37,7 +37,7 @@
     max-width: 340px;
     max-height: 240px;
     overflow-y: auto;
-    box-shadow: var(--shadow-lg);
+    box-shadow: var(--elev-3), var(--edge-lip);
     padding: 4px;
     display: flex;
     flex-direction: column;

--- a/src/lib/components/dashboard/KanbanBoard.svelte
+++ b/src/lib/components/dashboard/KanbanBoard.svelte
@@ -47,6 +47,7 @@
     gap: var(--space-4);
     height: 100%;
     min-height: 0;
+    background: var(--bg-void);
   }
   .columns {
     display: flex;

--- a/src/lib/components/dashboard/KanbanCard.svelte
+++ b/src/lib/components/dashboard/KanbanCard.svelte
@@ -39,7 +39,7 @@
   }
 </script>
 
-<article class="card lattice-panel" aria-label={title} style:--session-color={session.color || 'var(--color-border)'}>
+<article class="card lattice-panel" aria-label={title} style:--session-color={session.color || 'var(--text-disabled)'}>
   <header class="card-head">
     <div class="title-wrap">
       <div class="status-icon" title={status} aria-hidden="true">
@@ -64,17 +64,22 @@
 
 <style>
   .card {
-    border-left: 3px solid var(--session-color);
+    background-color: var(--bg-panel);
+    border-radius: var(--radius-lg);
+    box-shadow: inset 3px 0 0 var(--session-color), var(--elev-1), var(--edge-lip);
     padding: var(--space-3);
     display: flex;
     flex-direction: column;
     gap: var(--space-2);
-    transition: border-color var(--motion-duration-fast);
+    transition:
+      background-color var(--motion-duration-fast) var(--motion-ease-standard),
+      box-shadow var(--motion-duration-fast) var(--motion-ease-standard),
+      transform var(--motion-duration-fast) var(--motion-ease-standard);
   }
   .card:hover {
-    border-top-color: var(--accent-cyan);
-    border-right-color: var(--accent-cyan);
-    border-bottom-color: var(--accent-cyan);
+    background-color: var(--bg-raised);
+    box-shadow: inset 3px 0 0 var(--session-color), var(--elev-2), var(--edge-lip);
+    transform: translateY(-1px);
   }
   .card-head {
     display: flex;

--- a/src/lib/components/dashboard/KanbanColumn.svelte
+++ b/src/lib/components/dashboard/KanbanColumn.svelte
@@ -12,7 +12,7 @@
   let { label, sessions: items, status = 'queued', accent = 'var(--text-secondary)' }: Props = $props();
 </script>
 
-<section class="column lattice-panel" style="--col-accent: {accent};" aria-label={label}>
+<section class="column" style="--col-accent: {accent};" aria-label={label}>
   <header class="col-head">
     <span class="dot" aria-hidden="true"></span>
     <span class="label">{label}</span>
@@ -35,13 +35,17 @@
     min-width: 220px;
     width: 220px;
     max-height: 100%;
+    overflow: hidden;
+    background: var(--bg-chrome);
+    border-radius: var(--radius-shell);
+    box-shadow: var(--edge-lip);
   }
   .col-head {
     display: flex;
     align-items: center;
     gap: var(--space-2);
     padding: var(--space-3);
-    border-bottom: 1px solid var(--color-border);
+    box-shadow: var(--edge-seam);
     font-family: var(--font-display);
     font-size: var(--text-small);
     text-transform: uppercase;

--- a/src/lib/components/dashboard/KanbanColumn.svelte
+++ b/src/lib/components/dashboard/KanbanColumn.svelte
@@ -12,7 +12,7 @@
   let { label, sessions: items, status = 'queued', accent = 'var(--text-secondary)' }: Props = $props();
 </script>
 
-<section class="column" style="--col-accent: {accent};" aria-label={label}>
+<section class="column lattice-forced-colors-boundary" style="--col-accent: {accent};" aria-label={label}>
   <header class="col-head">
     <span class="dot" aria-hidden="true"></span>
     <span class="label">{label}</span>

--- a/src/lib/components/fusion/FusionComparisonView.svelte
+++ b/src/lib/components/fusion/FusionComparisonView.svelte
@@ -40,7 +40,7 @@
     </div>
 {/snippet}
 
-<div class="fusion-comparison-view lattice-panel lattice-scroll-content">
+<div class="fusion-comparison-view lattice-scroll-content">
     <div class="grid" style="grid-template-columns: repeat({Math.max(1, candidates.length)}, 1fr);">
         {#each candidates as cell (cell.id)}
             <div class="candidate-card lattice-panel" class:completed={cell.status === 'completed'} class:failed={cell.status === 'failed'}>
@@ -90,7 +90,9 @@
         height: 100%;
         overflow-x: auto;
         padding: 16px;
-        background: var(--bg-sunken);
+        background: var(--bg-chrome);
+        border-radius: var(--radius-shell);
+        box-shadow: var(--edge-lip);
     }
 
     .grid {
@@ -104,20 +106,16 @@
         flex-direction: column;
         min-width: 320px;
         max-width: 500px;
-        transition:
-            background-color var(--motion-duration-standard) var(--motion-ease-standard),
-            border-color var(--motion-duration-standard) var(--motion-ease-standard);
+        transition: background-color var(--motion-duration-standard) var(--motion-ease-standard);
     }
 
     .candidate-card.completed {
         /* Candidate outcome tint is semantic state, layered over the structural panel. */
-        border-color: color-mix(in srgb, var(--status-success) 20%, transparent);
         background: color-mix(in srgb, var(--status-success) 4%, var(--bg-surface));
     }
 
     .candidate-card.failed {
         /* Candidate outcome tint is semantic state, layered over the structural panel. */
-        border-color: color-mix(in srgb, var(--status-error) 20%, transparent);
         background: color-mix(in srgb, var(--status-error) 4%, var(--bg-surface));
     }
 

--- a/src/lib/components/fusion/FusionComparisonView.svelte
+++ b/src/lib/components/fusion/FusionComparisonView.svelte
@@ -40,7 +40,7 @@
     </div>
 {/snippet}
 
-<div class="fusion-comparison-view lattice-scroll-content">
+<div class="fusion-comparison-view lattice-scroll-content lattice-forced-colors-boundary">
     <div class="grid" style="grid-template-columns: repeat({Math.max(1, candidates.length)}, 1fr);">
         {#each candidates as cell (cell.id)}
             <div class="candidate-card lattice-panel" class:completed={cell.status === 'completed'} class:failed={cell.status === 'failed'}>
@@ -111,12 +111,12 @@
 
     .candidate-card.completed {
         /* Candidate outcome tint is semantic state, layered over the structural panel. */
-        background: color-mix(in srgb, var(--status-success) 4%, var(--bg-surface));
+        background: color-mix(in srgb, var(--status-success) 4%, var(--bg-panel));
     }
 
     .candidate-card.failed {
         /* Candidate outcome tint is semantic state, layered over the structural panel. */
-        background: color-mix(in srgb, var(--status-error) 4%, var(--bg-surface));
+        background: color-mix(in srgb, var(--status-error) 4%, var(--bg-panel));
     }
 
     .card-header {

--- a/src/lib/components/fusion/ResolverPanel.svelte
+++ b/src/lib/components/fusion/ResolverPanel.svelte
@@ -29,7 +29,7 @@
 <div class="resolver-panel lattice-scroll-content">
     <Skeleton loading={loading} skeleton={resolverSkeleton} class="resolver-loading">
         {#if output}
-            <div class="output-card lattice-panel">
+            <div class="output-card">
                 <div class="card-header">
                     <span class="label">Resolver Decision</span>
                     <div class="selected-badge">
@@ -92,6 +92,9 @@
         display: flex;
         flex-direction: column;
         gap: 20px;
+        background: var(--bg-chrome);
+        border-radius: var(--radius-shell);
+        box-shadow: var(--edge-lip);
     }
 
     .resolver-skeleton {

--- a/src/lib/components/fusion/ResolverPanel.svelte
+++ b/src/lib/components/fusion/ResolverPanel.svelte
@@ -29,7 +29,7 @@
 <div class="resolver-panel lattice-scroll-content">
     <Skeleton loading={loading} skeleton={resolverSkeleton} class="resolver-loading">
         {#if output}
-            <div class="output-card">
+            <div class="output-card lattice-forced-colors-boundary">
                 <div class="card-header">
                     <span class="label">Resolver Decision</span>
                     <div class="selected-badge">

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte
@@ -1,3 +1,225 @@
+<script module lang="ts">
+  import { resolveTokens, type CssTokenName } from '$lib/theme/resolveTokens';
+
+  export interface SvgShadowLayer {
+    dx: number;
+    dy: number;
+    stdDeviation: number;
+    floodColor: string;
+    floodOpacity: number;
+  }
+
+  export interface NodeGlowParameters {
+    stdDeviation: number;
+    opacity: number;
+  }
+
+  export const HALO_SCALE = 1.625;
+  export const DEFAULT_NODE_GLOW: NodeGlowParameters = {
+    stdDeviation: 2,
+    opacity: 0.28,
+  };
+
+  const NODE_GLOW_TOKENS = {
+    interactive: '--elev-2',
+  } as const satisfies Record<string, CssTokenName>;
+  const RGB_FUNCTION = /^rgba?\((.*)\)$/i;
+  const PIXEL_LENGTH = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+))px$/i;
+  const UNITLESS_ZERO = /^[+-]?(?:0+(?:\.0*)?|\.0+)$/;
+
+  export function haloRadius(radius: number): number {
+    return radius * HALO_SCALE;
+  }
+
+  function splitAtTopLevel(value: string, separator: string): string[] {
+    const parts: string[] = [];
+    let depth = 0;
+    let start = 0;
+
+    for (let index = 0; index < value.length; index += 1) {
+      const character = value[index];
+      if (character === '(') depth += 1;
+      else if (character === ')') {
+        depth -= 1;
+        if (depth < 0) throw new Error(`Unbalanced CSS shadow value: ${value}`);
+      } else if (character === separator && depth === 0) {
+        const part = value.slice(start, index).trim();
+        if (!part) throw new Error(`Empty CSS shadow segment: ${value}`);
+        parts.push(part);
+        start = index + 1;
+      }
+    }
+
+    if (depth !== 0) throw new Error(`Unbalanced CSS shadow value: ${value}`);
+    const tail = value.slice(start).trim();
+    if (!tail) throw new Error(`Empty CSS shadow segment: ${value}`);
+    parts.push(tail);
+    return parts;
+  }
+
+  function tokenizeShadowLayer(value: string): string[] {
+    const tokens: string[] = [];
+    let depth = 0;
+    let start = -1;
+
+    for (let index = 0; index <= value.length; index += 1) {
+      const character = value[index] ?? ' ';
+      if (character === '(') depth += 1;
+      else if (character === ')') {
+        depth -= 1;
+        if (depth < 0) throw new Error(`Unbalanced CSS shadow layer: ${value}`);
+      }
+
+      const separator = /\s/.test(character) && depth === 0;
+      if (separator) {
+        if (start !== -1) {
+          tokens.push(value.slice(start, index));
+          start = -1;
+        }
+      } else if (start === -1) {
+        start = index;
+      }
+    }
+
+    if (depth !== 0) throw new Error(`Unbalanced CSS shadow layer: ${value}`);
+    return tokens;
+  }
+
+  function parsePixelLength(token: string): number | null {
+    if (UNITLESS_ZERO.test(token)) return 0;
+    const match = PIXEL_LENGTH.exec(token);
+    return match ? Number(match[1]) : null;
+  }
+
+  function parseRgbChannel(token: string): number {
+    const trimmed = token.trim();
+    const value = trimmed.endsWith('%')
+      ? Number(trimmed.slice(0, -1)) * 2.55
+      : Number(trimmed);
+    if (!Number.isFinite(value) || value < 0 || value > 255) {
+      throw new Error(`Invalid RGB channel in elevation token: ${token}`);
+    }
+    return value;
+  }
+
+  function parseAlpha(token: string | undefined): number {
+    if (token === undefined) return 1;
+    const trimmed = token.trim();
+    const value = trimmed.endsWith('%')
+      ? Number(trimmed.slice(0, -1)) / 100
+      : Number(trimmed);
+    if (!Number.isFinite(value) || value < 0 || value > 1) {
+      throw new Error(`Invalid alpha channel in elevation token: ${token}`);
+    }
+    return value;
+  }
+
+  function parseRgbColor(token: string): { floodColor: string; floodOpacity: number } {
+    const match = RGB_FUNCTION.exec(token);
+    if (!match) throw new Error(`Unsupported elevation shadow color: ${token}`);
+
+    const body = match[1].trim();
+    let channels: string[];
+    let alpha: string | undefined;
+    if (body.includes(',')) {
+      const parts = body.split(',').map((part) => part.trim());
+      if (parts.length !== 3 && parts.length !== 4) {
+        throw new Error(`Unsupported elevation shadow color: ${token}`);
+      }
+      channels = parts.slice(0, 3);
+      alpha = parts[3];
+    } else {
+      const slashParts = body.split('/').map((part) => part.trim());
+      if (slashParts.length > 2) throw new Error(`Unsupported elevation shadow color: ${token}`);
+      channels = slashParts[0].split(/\s+/);
+      alpha = slashParts[1];
+    }
+
+    if (channels.length !== 3) throw new Error(`Unsupported elevation shadow color: ${token}`);
+    const [red, green, blue] = channels.map(parseRgbChannel);
+    return {
+      floodColor: `rgb(${red}, ${green}, ${blue})`,
+      floodOpacity: parseAlpha(alpha),
+    };
+  }
+
+  /** Parse a browser-computed box-shadow list into concrete SVG filter values. */
+  export function parseComputedBoxShadows(value: string): SvgShadowLayer[] {
+    if (!value.trim() || value.trim().toLowerCase() === 'none') {
+      throw new Error('Elevation tokens must contain at least one outer shadow');
+    }
+
+    return splitAtTopLevel(value, ',').map((shadow) => {
+      const lengths: number[] = [];
+      let color: { floodColor: string; floodOpacity: number } | null = null;
+
+      for (const token of tokenizeShadowLayer(shadow)) {
+        if (token.toLowerCase() === 'inset') {
+          throw new Error(`Inset shadows cannot drive the node glow: ${shadow}`);
+        }
+        if (RGB_FUNCTION.test(token)) {
+          if (color) throw new Error(`Multiple colors in elevation shadow: ${shadow}`);
+          color = parseRgbColor(token);
+          continue;
+        }
+        const length = parsePixelLength(token);
+        if (length === null) throw new Error(`Unsupported elevation shadow token: ${token}`);
+        lengths.push(length);
+      }
+
+      if (!color) throw new Error(`Elevation shadow has no computed RGB color: ${shadow}`);
+      if (lengths.length < 2 || lengths.length > 4) {
+        throw new Error(`Elevation shadow must contain two to four lengths: ${shadow}`);
+      }
+      const [dx, dy, blur = 0, spread = 0] = lengths;
+      if (blur < 0) throw new Error(`Elevation shadow blur cannot be negative: ${shadow}`);
+      if (spread !== 0) {
+        throw new Error(`Non-zero spread cannot drive the node glow: ${shadow}`);
+      }
+
+      return {
+        dx,
+        dy,
+        stdDeviation: blur / 2,
+        floodColor: color.floodColor,
+        floodOpacity: color.floodOpacity,
+      };
+    });
+  }
+
+  function canonicalizeBoxShadow(value: string): string {
+    const probe = document.createElement('span');
+    probe.style.position = 'fixed';
+    probe.style.visibility = 'hidden';
+    probe.style.pointerEvents = 'none';
+    probe.style.boxShadow = value;
+    if (!probe.style.boxShadow) throw new Error(`Invalid elevation token value: ${value}`);
+
+    document.documentElement.append(probe);
+    try {
+      const computed = getComputedStyle(probe).boxShadow;
+      if (!computed || computed === 'none') throw new Error(`Invalid elevation token value: ${value}`);
+      return computed;
+    } finally {
+      probe.remove();
+    }
+  }
+
+  /**
+   * Preserve the proven single-blur filter shape while sourcing its depth from
+   * the first `--elev-2` layer (sigma 2 and opacity .55 in the current ramp).
+   */
+  export function resolveNodeGlowParameters(): NodeGlowParameters {
+    const resolved = resolveTokens(NODE_GLOW_TOKENS);
+    const [layer] = parseComputedBoxShadows(canonicalizeBoxShadow(resolved.interactive));
+    if (!layer) throw new Error('The interactive elevation token has no shadow layer');
+    return {
+      stdDeviation: layer.stdDeviation,
+      opacity: layer.floodOpacity,
+    };
+  }
+</script>
+
 <script lang="ts">
   import { onMount, untrack } from 'svelte';
   import { ArrowClockwise } from 'phosphor-svelte';
@@ -53,6 +275,7 @@
   let dragSnapshot: DragSnapshot | null = null;
   let reducedMotionQuery = getReducedMotionQuery();
   let reducedMotion = $state(reducedMotionQuery?.matches ?? false);
+  let nodeGlow = $state<NodeGlowParameters>(DEFAULT_NODE_GLOW);
 
   let positionById = $derived.by(() => new Map(positions.map((node) => [node.id, node])));
   let pinnedCount = $derived(positions.filter((node) => node.fx !== null).length);
@@ -122,6 +345,13 @@
   });
 
   onMount(() => {
+    try {
+      nodeGlow = resolveNodeGlowParameters();
+    } catch {
+      // Component tests and defensive embeds may mount without the global token sheet.
+      nodeGlow = DEFAULT_NODE_GLOW;
+    }
+
     const updateSize = () => {
       const rect = host.getBoundingClientRect();
       const nextWidth = Math.max(Math.round(rect.width), 320);
@@ -255,6 +485,10 @@
     return Math.min(11, 5 + Math.sqrt(nodeDegree(node)) * 1.25);
   }
 
+  function nodeHaloRadius(node: KnowledgeNode): number {
+    return haloRadius(radius(node));
+  }
+
   /**
    * Side of a 45deg-rotated square whose half-diagonal equals `r`, so a diamond
    * occupies exactly the circle's horizontal/vertical extent. Layout, label
@@ -301,6 +535,8 @@
     </button>
   </div>
 
+  <!-- Keep normal nodes filterless. The proven interactive glow retains one
+       Gaussian primitive while taking blur/halo opacity from --elev-2. -->
   <svg
     bind:this={svg}
     viewBox={`0 0 ${width} ${height}`}
@@ -309,13 +545,14 @@
     onpointermove={handlePointerMove}
     onpointerup={finishPointer}
     onpointercancel={cancelPointer}
+    style={`--node-glow-opacity: ${nodeGlow.opacity};`}
   >
     <defs>
       <pattern id="knowledge-grid" width="28" height="28" patternUnits="userSpaceOnUse">
         <path d="M 28 0 L 0 0 0 28" fill="none" stroke="var(--border-structural)" stroke-width="0.45" />
       </pattern>
       <filter id="node-glow" x="-100%" y="-100%" width="300%" height="300%">
-        <feGaussianBlur stdDeviation="2" result="glow" />
+        <feGaussianBlur stdDeviation={nodeGlow.stdDeviation} result="glow" />
         <feMerge><feMergeNode in="glow" /><feMergeNode in="SourceGraphic" /></feMerge>
       </filter>
     </defs>
@@ -369,7 +606,7 @@
           }}
         >
           {#if isRelationship}
-            {@const haloSide = diamondSide(radius(node) + 5)}
+            {@const haloSide = diamondSide(nodeHaloRadius(node))}
             {@const coreSide = diamondSide(radius(node))}
             <rect
               class="node-halo"
@@ -390,7 +627,7 @@
               fill={folderColor(node.folder)}
             />
           {:else}
-            <circle class="node-halo" r={radius(node) + 5} fill={folderColor(node.folder)} />
+            <circle class="node-halo" r={nodeHaloRadius(node)} fill={folderColor(node.folder)} />
             <circle class="node-core" r={radius(node)} fill={folderColor(node.folder)} />
           {/if}
           {#if node.fx !== null}
@@ -470,7 +707,7 @@
   .node:hover .node-halo,
   .node:focus-visible .node-halo,
   .node.selected .node-halo {
-    opacity: 0.28;
+    opacity: var(--node-glow-opacity, 0.28);
   }
 
   .node:hover .node-core,
@@ -511,9 +748,10 @@
     align-items: center;
     gap: var(--space-1);
     padding: var(--space-1);
-    border: 1px solid var(--border-structural);
     /* Floating graph-control scrim, not a structural panel surface. */
-    background: color-mix(in srgb, var(--bg-surface) 91%, transparent);
+    background: color-mix(in srgb, var(--bg-panel) 91%, transparent);
+    border-radius: var(--radius-md);
+    box-shadow: var(--elev-2), var(--edge-lip);
     backdrop-filter: blur(8px);
   }
 

--- a/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeGraph.svelte.test.ts
@@ -39,7 +39,12 @@ vi.mock('$lib/knowledge/forceSim', () => ({
   createForceSimulation: forceMocks.createForceSimulation,
 }));
 
-import KnowledgeGraph from './KnowledgeGraph.svelte';
+import KnowledgeGraph, {
+  DEFAULT_NODE_GLOW,
+  HALO_SCALE,
+  haloRadius,
+  parseComputedBoxShadows,
+} from './KnowledgeGraph.svelte';
 
 let resizeCallback: ResizeObserverCallback;
 let hostSize = { width: 760, height: 520 };
@@ -47,6 +52,12 @@ let reducedMotionMatches = false;
 let motionChangeListener: (() => void) | null = null;
 let requestAnimationFrameMock: ReturnType<typeof vi.fn>;
 let cancelAnimationFrameMock: ReturnType<typeof vi.fn>;
+
+const ELEVATION_TOKEN_FIXTURE = {
+  '--elev-1': '0 1px 2px rgba(0, 0, 0, 0.55), 0 2px 6px rgba(0, 0, 0, 0.35)',
+  '--elev-2': '0 2px 4px rgba(0, 0, 0, 0.55), 0 6px 16px rgba(0, 0, 0, 0.42)',
+  '--elev-3': '0 4px 8px rgba(0, 0, 0, 0.60), 0 16px 40px rgba(0, 0, 0, 0.55)',
+} as const;
 
 beforeEach(() => {
   forceMocks.createForceSimulation.mockClear();
@@ -126,15 +137,102 @@ beforeEach(() => {
     unobserve() {}
     disconnect() {}
   });
+  for (const [token, value] of Object.entries(ELEVATION_TOKEN_FIXTURE)) {
+    document.documentElement.style.setProperty(token, value);
+  }
 });
 
 afterEach(() => {
   cleanup();
+  for (const token of Object.keys(ELEVATION_TOKEN_FIXTURE)) {
+    document.documentElement.style.removeProperty(token);
+  }
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
 });
 
 describe('KnowledgeGraph', () => {
+  it('parses token-derived multi-layer shadows into concrete SVG values', () => {
+    expect(parseComputedBoxShadows(
+      'rgba(0, 0, 0, 0.55) 0px 1px 2px 0px, rgb(0 0 0 / 35%) 0px 2px 6px',
+    )).toEqual([
+      {
+        dx: 0,
+        dy: 1,
+        stdDeviation: 1,
+        floodColor: 'rgb(0, 0, 0)',
+        floodOpacity: 0.55,
+      },
+      {
+        dx: 0,
+        dy: 2,
+        stdDeviation: 3,
+        floodColor: 'rgb(0, 0, 0)',
+        floodOpacity: 0.35,
+      },
+    ]);
+
+    expect(() => parseComputedBoxShadows('rgba(0, 0, 0, 0.5) 0 2px 4px 1px'))
+      .toThrow(/Non-zero spread/);
+    expect(() => parseComputedBoxShadows('inset rgba(0, 0, 0, 0.5) 0 2px 4px'))
+      .toThrow(/Inset shadows/);
+  });
+
+  it('keeps halo geometry proportional to the node radius', () => {
+    expect(haloRadius(5)).toBe(5 * HALO_SCALE);
+    expect(haloRadius(8)).toBe(13);
+    expect(haloRadius(11)).toBe(11 * HALO_SCALE);
+  });
+
+  it('drives the proven single-blur node glow from the interactive elevation token', async () => {
+    const { container } = render(KnowledgeGraph, {
+      props: {
+        nodes: [forceMocks.pinnedNode],
+        edges: [],
+        selectedId: forceMocks.pinnedNode.id,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    const svg = container.querySelector<SVGSVGElement>('svg[role="group"]');
+    expect(svg).not.toBeNull();
+    expect(svg!.style.getPropertyValue('--node-glow-opacity')).toBe('0.55');
+
+    const filter = container.querySelector('#node-glow');
+    expect(filter).not.toBeNull();
+    expect({
+      x: filter!.getAttribute('x'),
+      y: filter!.getAttribute('y'),
+      width: filter!.getAttribute('width'),
+      height: filter!.getAttribute('height'),
+    }).toEqual({ x: '-100%', y: '-100%', width: '300%', height: '300%' });
+    expect(filter!.firstElementChild!.tagName.toLowerCase()).toBe('fegaussianblur');
+    expect(filter!.firstElementChild!.getAttribute('stdDeviation')).toBe('2');
+    expect(container.querySelectorAll('filter')).toHaveLength(1);
+    expect(container.querySelectorAll('[result^="shadow-with-source-"]')).toHaveLength(0);
+  });
+
+  it('uses the baseline node glow when the global elevation token sheet is absent', async () => {
+    for (const token of Object.keys(ELEVATION_TOKEN_FIXTURE)) {
+      document.documentElement.style.removeProperty(token);
+    }
+    const { container } = render(KnowledgeGraph, {
+      props: {
+        nodes: [forceMocks.pinnedNode],
+        edges: [],
+        selectedId: null,
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    const svg = container.querySelector<SVGSVGElement>('svg[role="group"]');
+    const blur = container.querySelector('#node-glow')!.firstElementChild!;
+    expect(svg!.style.getPropertyValue('--node-glow-opacity')).toBe(String(DEFAULT_NODE_GLOW.opacity));
+    expect(blur.getAttribute('stdDeviation')).toBe(String(DEFAULT_NODE_GLOW.stdDeviation));
+  });
+
   it('updates simulation bounds without recreating the pinned layout on resize', async () => {
     const { getByText } = render(KnowledgeGraph, {
       props: {
@@ -232,6 +330,12 @@ describe('KnowledgeGraph', () => {
     expect(patternMark.querySelector('.node-core')?.tagName.toLowerCase()).toBe('circle');
     expect(clientMark.querySelector('.node-halo')?.tagName.toLowerCase()).toBe('rect');
     expect(patternMark.querySelector('.node-halo')?.tagName.toLowerCase()).toBe('circle');
+    const clientHaloWidth = Number(clientMark.querySelector('.node-halo')?.getAttribute('width'));
+    const clientCoreWidth = Number(clientMark.querySelector('.node-core')?.getAttribute('width'));
+    const patternHaloRadius = Number(patternMark.querySelector('.node-halo')?.getAttribute('r'));
+    const patternCoreRadius = Number(patternMark.querySelector('.node-core')?.getAttribute('r'));
+    expect(clientHaloWidth / clientCoreWidth).toBeCloseTo(HALO_SCALE, 10);
+    expect(patternHaloRadius / patternCoreRadius).toBeCloseTo(HALO_SCALE, 10);
 
     // ...and it is never the only signal: the accessible name says it too.
     expect(clientMark.getAttribute('aria-label')).toContain('clients relationship entity');

--- a/src/lib/components/knowledge/KnowledgePagePreview.svelte
+++ b/src/lib/components/knowledge/KnowledgePagePreview.svelte
@@ -320,7 +320,7 @@
     margin: 1em 0;
     padding: 1px;
     background: var(--bg-void);
-    box-shadow: var(--edge-lip), var(--edge-seam);
+    box-shadow: var(--edge-seam), var(--edge-lip);
   }
 
   .code-block > span {

--- a/src/lib/components/knowledge/KnowledgePagePreview.svelte
+++ b/src/lib/components/knowledge/KnowledgePagePreview.svelte
@@ -162,7 +162,7 @@
     justify-content: space-between;
     min-height: 44px;
     padding: 0 var(--space-3) 0 var(--space-4);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .preview-kicker,
@@ -175,8 +175,8 @@
 
   .page-head {
     padding: var(--space-5) var(--space-5) var(--space-4);
-    border-bottom: 1px solid var(--border-structural);
     background: linear-gradient(150deg, color-mix(in srgb, var(--accent-cyan) 4%, transparent), transparent 52%);
+    box-shadow: var(--edge-seam);
   }
 
   .folder-label {
@@ -311,14 +311,16 @@
   .markdown hr {
     margin: var(--space-5) 0;
     border: 0;
-    border-top: 1px solid var(--border-structural);
+    height: 1px;
+    box-shadow: var(--edge-seam), var(--edge-lip);
   }
 
   .code-block {
     position: relative;
     margin: 1em 0;
-    border: 1px solid var(--border-structural);
+    padding: 1px;
     background: var(--bg-void);
+    box-shadow: var(--edge-lip), var(--edge-seam);
   }
 
   .code-block > span {

--- a/src/lib/components/knowledge/KnowledgeTable.svelte
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte
@@ -116,17 +116,17 @@
   .knowledge-table tbody tr.selected td {
     background: color-mix(in srgb, var(--accent-cyan) 4%, var(--bg-panel));
     box-shadow:
+      var(--edge-seam),
       var(--elev-1),
-      var(--edge-lip),
-      var(--edge-seam);
+      var(--edge-lip);
   }
 
   .knowledge-table tbody tr.selected td:first-child {
     box-shadow:
       inset 2px 0 var(--accent-cyan),
+      var(--edge-seam),
       var(--elev-1),
-      var(--edge-lip),
-      var(--edge-seam);
+      var(--edge-lip);
   }
 
   td:first-child {

--- a/src/lib/components/knowledge/KnowledgeTable.svelte
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte
@@ -112,13 +112,21 @@
     color: var(--accent-cyan);
   }
 
-  /* Selected-record tint, not a structural panel surface. */
-  tbody tr.selected td {
-    background: color-mix(in srgb, var(--accent-cyan) 7%, var(--bg-surface));
+  /* Dense rows use a quieter wash than the 5% active-panel convention. */
+  .knowledge-table tbody tr.selected td {
+    background: color-mix(in srgb, var(--accent-cyan) 4%, var(--bg-panel));
+    box-shadow:
+      var(--elev-1),
+      var(--edge-lip),
+      var(--edge-seam);
   }
 
-  tbody tr.selected td:first-child {
-    box-shadow: inset 2px 0 var(--accent-cyan);
+  .knowledge-table tbody tr.selected td:first-child {
+    box-shadow:
+      inset 2px 0 var(--accent-cyan),
+      var(--elev-1),
+      var(--edge-lip),
+      var(--edge-seam);
   }
 
   td:first-child {

--- a/src/lib/components/knowledge/KnowledgeTable.svelte.test.ts
+++ b/src/lib/components/knowledge/KnowledgeTable.svelte.test.ts
@@ -33,6 +33,18 @@ function rowTitles(container: HTMLElement): string[] {
 afterEach(cleanup);
 
 describe('KnowledgeTable', () => {
+  it('marks only the selected record without replacing native row semantics', () => {
+    const { container, getByRole } = render(KnowledgeTable, {
+      props: { nodes, selectedId: 'beta', onSelect: vi.fn() },
+    });
+
+    const betaRow = getByRole('button', { name: 'Open Beta' }).closest('tr');
+    expect(betaRow?.classList.contains('selected')).toBe(true);
+    expect(betaRow?.getAttribute('role')).toBeNull();
+    expect(betaRow?.hasAttribute('tabindex')).toBe(false);
+    expect(container.querySelectorAll('tbody tr.selected')).toHaveLength(1);
+  });
+
   it('sorts every row and exposes a native action without replacing table semantics', async () => {
     const onSelect = vi.fn();
     const { container, getByRole } = render(KnowledgeTable, {

--- a/src/lib/components/knowledge/MarkdownInline.svelte
+++ b/src/lib/components/knowledge/MarkdownInline.svelte
@@ -28,9 +28,9 @@
   .inline-markdown :global(strong) { color: var(--text-primary); font-weight: 600; }
   .inline-markdown :global(em) { color: var(--accent-chrome); }
   .inline-markdown :global(code) {
-    padding: 1px 4px;
-    border: 1px solid var(--border-structural);
-    background: var(--bg-void);
+    padding: 2px 5px;
+    background: var(--bg-panel);
+    box-shadow: var(--edge-lip), var(--edge-seam);
     color: var(--accent-chrome);
     font: 0.9em var(--font-mono);
   }

--- a/src/lib/components/knowledge/MarkdownInline.svelte
+++ b/src/lib/components/knowledge/MarkdownInline.svelte
@@ -30,7 +30,7 @@
   .inline-markdown :global(code) {
     padding: 2px 5px;
     background: var(--bg-panel);
-    box-shadow: var(--edge-lip), var(--edge-seam);
+    box-shadow: var(--edge-seam), var(--edge-lip);
     color: var(--accent-chrome);
     font: 0.9em var(--font-mono);
   }

--- a/src/lib/components/timeline/EventDetailsModal.svelte
+++ b/src/lib/components/timeline/EventDetailsModal.svelte
@@ -27,6 +27,7 @@
 
     function handleWindowKeydown(event: KeyboardEvent) {
         if (event.key === 'Escape') {
+            event.preventDefault();
             closeModal();
         }
     }

--- a/src/lib/styles/globals/controls.css
+++ b/src/lib/styles/globals/controls.css
@@ -5,6 +5,7 @@
 .lattice-btn {
   --lattice-btn-tone: var(--accent-cyan);
   --lattice-btn-tone-rgb: var(--rgb-running);
+  --lattice-btn-ring: transparent;
 
   display: inline-flex;
   align-items: center;
@@ -17,45 +18,50 @@
   line-height: 1.2;
   text-decoration: none;
   white-space: nowrap;
-  padding: var(--space-2) var(--space-4);
-  border: 1px solid transparent;
+  /* The former 1px border contributed to the border box. The extra padding
+     preserves existing button geometry while the inset ring stays layout-free. */
+  padding: calc(var(--space-2) + 1px) calc(var(--space-4) + 1px);
+  border: 0;
   border-radius: var(--radius-md);
   cursor: pointer;
   transition:
     color var(--motion-duration-standard) var(--motion-ease-standard),
     background-color var(--motion-duration-standard) var(--motion-ease-standard),
-    border-color var(--motion-duration-standard) var(--motion-ease-standard),
     box-shadow var(--motion-duration-standard) var(--motion-ease-standard),
     text-shadow var(--motion-duration-standard) var(--motion-ease-standard),
     opacity var(--motion-duration-standard) var(--motion-ease-standard);
   background: transparent;
+  box-shadow: inset 0 0 0 1px var(--lattice-btn-ring);
 }
 
 .lattice-btn--primary {
   --lattice-btn-tone: var(--accent-cyan);
   --lattice-btn-tone-rgb: var(--rgb-running);
-  border: 1px solid var(--accent-cyan);
+  --lattice-btn-ring: var(--accent-cyan);
   color: var(--accent-cyan);
   background-color: rgba(var(--rgb-running), 0.1);
 }
 
 .lattice-btn--primary:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
   background-color: rgba(var(--rgb-running), 0.2);
-  box-shadow: 0 0 8px rgba(var(--rgb-running), 0.3), inset 0 0 4px rgba(var(--rgb-running), 0.2);
+  box-shadow:
+    inset 0 0 0 1px var(--lattice-btn-ring),
+    0 0 8px rgba(var(--rgb-running), 0.3),
+    inset 0 0 4px rgba(var(--rgb-running), 0.2);
   text-shadow: 0 0 4px var(--accent-cyan);
 }
 
 .lattice-btn--secondary {
-  border: 1px solid var(--border-structural);
+  --lattice-btn-ring: var(--border-structural);
   color: var(--text-primary);
 }
 
 .lattice-btn--secondary:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
-  border-color: var(--accent-chrome);
+  --lattice-btn-ring: var(--accent-chrome);
+  background-color: var(--bg-elevated);
 }
 
 .lattice-btn--ghost {
-  border: 1px solid transparent;
   color: var(--text-secondary);
 }
 
@@ -67,17 +73,20 @@
 .lattice-btn--danger {
   --lattice-btn-tone: var(--status-error);
   --lattice-btn-tone-rgb: var(--rgb-error);
-  border: 1px solid var(--status-error);
+  --lattice-btn-ring: var(--status-error);
   color: var(--status-error);
+  background-color: rgba(var(--rgb-error), 0.08);
 }
 
 .lattice-btn--danger:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
-  background-color: rgba(var(--rgb-error), 0.1);
-  box-shadow: 0 0 8px rgba(var(--rgb-error), 0.2);
+  background-color: rgba(var(--rgb-error), 0.16);
+  box-shadow:
+    inset 0 0 0 1px var(--lattice-btn-ring),
+    0 0 8px rgba(var(--rgb-error), 0.2);
 }
 
 .lattice-btn--ghost.lattice-btn--danger {
-  border-color: transparent;
+  --lattice-btn-ring: transparent;
   background-color: transparent;
 }
 
@@ -90,32 +99,36 @@
 .lattice-btn--success {
   --lattice-btn-tone: var(--status-success);
   --lattice-btn-tone-rgb: var(--rgb-success);
-  border: 1px solid var(--status-success);
+  --lattice-btn-ring: var(--status-success);
   color: var(--status-success);
   background-color: rgba(var(--rgb-success), 0.1);
 }
 
 .lattice-btn--success:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
   background-color: rgba(var(--rgb-success), 0.2);
-  box-shadow: 0 0 8px rgba(var(--rgb-success), 0.2);
+  box-shadow:
+    inset 0 0 0 1px var(--lattice-btn-ring),
+    0 0 8px rgba(var(--rgb-success), 0.2);
 }
 
 .lattice-btn--warning {
   --lattice-btn-tone: var(--status-warning);
   --lattice-btn-tone-rgb: var(--rgb-warning);
-  border: 1px solid var(--status-warning);
+  --lattice-btn-ring: var(--status-warning);
   color: var(--status-warning);
   background-color: rgba(var(--rgb-warning), 0.1);
 }
 
 .lattice-btn--warning:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
   background-color: rgba(var(--rgb-warning), 0.2);
-  box-shadow: 0 0 8px rgba(var(--rgb-warning), 0.2);
+  box-shadow:
+    inset 0 0 0 1px var(--lattice-btn-ring),
+    0 0 8px rgba(var(--rgb-warning), 0.2);
 }
 
 .lattice-btn--filled {
+  --lattice-btn-ring: color-mix(in srgb, var(--bg-void) 35%, transparent);
   color: var(--bg-void);
-  border-color: var(--lattice-btn-tone);
   background-color: var(--lattice-btn-tone);
 }
 
@@ -126,14 +139,16 @@
 
 /* ── Composable affordance and size modifiers ───────────────────── */
 
-.lattice-btn--dashed {
-  border-style: dashed;
+.lattice-btn.lattice-btn--dashed {
+  --lattice-btn-ring: transparent;
+  outline: 1px dashed currentColor;
+  outline-offset: -1px;
   background-color: transparent;
 }
 
 .lattice-btn--compact {
   gap: var(--space-1);
-  padding: var(--space-1) var(--space-2);
+  padding: calc(var(--space-1) + 1px) calc(var(--space-2) + 1px);
   font-size: var(--text-micro);
 }
 
@@ -176,8 +191,7 @@
 }
 
 .lattice-btn--menu-item {
-  padding: var(--space-2) var(--space-3);
-  border-color: transparent;
+  padding: calc(var(--space-2) + 1px) calc(var(--space-3) + 1px);
   background-color: transparent;
 }
 
@@ -186,8 +200,7 @@
 }
 
 .lattice-btn--row {
-  padding: var(--space-1) var(--space-2);
-  border-color: transparent;
+  padding: calc(var(--space-1) + 1px) calc(var(--space-2) + 1px);
   background-color: transparent;
 }
 
@@ -198,19 +211,19 @@
 
 .lattice-btn--card {
   align-items: flex-start;
-  padding: var(--space-3);
-  border-color: var(--border-structural);
+  --lattice-btn-ring: var(--border-structural);
+  padding: calc(var(--space-3) + 1px);
   background-color: var(--bg-surface);
 }
 
 .lattice-btn--card:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
-  border-color: var(--accent-chrome);
+  --lattice-btn-ring: var(--accent-chrome);
   background-color: var(--bg-elevated);
 }
 
 .lattice-btn--chip {
-  padding: 2px var(--space-2);
-  border-color: var(--border-structural);
+  --lattice-btn-ring: var(--border-structural);
+  padding: calc(2px + 1px) calc(var(--space-2) + 1px);
   border-radius: var(--radius-sm);
   color: var(--text-secondary);
   text-transform: none;
@@ -219,16 +232,16 @@
 
 .lattice-btn--chip:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
   color: var(--text-primary);
-  border-color: var(--accent-chrome);
+  --lattice-btn-ring: var(--accent-chrome);
 }
 
 .lattice-btn--menu-item.lattice-btn--compact,
 .lattice-btn--row.lattice-btn--compact {
-  padding: var(--space-1) var(--space-2);
+  padding: calc(var(--space-1) + 1px) calc(var(--space-2) + 1px);
 }
 
 .lattice-btn--card.lattice-btn--compact {
-  padding: var(--space-2);
+  padding: calc(var(--space-2) + 1px);
 }
 
 /* Flush row: full-width, left-aligned, zero-padding. --link supplies the zero
@@ -239,7 +252,6 @@
 .lattice-btn--row.lattice-btn--link,
 .lattice-btn--menu-item.lattice-btn--link {
   padding: 0;
-  border-color: transparent;
   background-color: transparent;
 }
 
@@ -251,9 +263,8 @@
 .lattice-btn[aria-current="true"],
 .lattice-btn[aria-current="page"] {
   color: var(--lattice-btn-tone);
-  border-color: var(--lattice-btn-tone);
   background-color: rgba(var(--lattice-btn-tone-rgb), 0.1);
-  box-shadow: inset 0 0 0 1px rgba(var(--lattice-btn-tone-rgb), 0.25);
+  box-shadow: inset 0 0 0 1px rgba(var(--lattice-btn-tone-rgb), 0.65);
 }
 
 .lattice-btn.lattice-btn--selected:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)),
@@ -262,9 +273,8 @@
 .lattice-btn[aria-current="true"]:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)),
 .lattice-btn[aria-current="page"]:hover:where(:not(:disabled):not([aria-disabled="true"]):not([aria-busy="true"]):not(.lattice-btn--waiting)) {
   color: var(--lattice-btn-tone);
-  border-color: var(--lattice-btn-tone);
   background-color: rgba(var(--lattice-btn-tone-rgb), 0.16);
-  box-shadow: inset 0 0 0 1px rgba(var(--lattice-btn-tone-rgb), 0.25);
+  box-shadow: inset 0 0 0 1px rgba(var(--lattice-btn-tone-rgb), 0.75);
 }
 
 /* Labels and role-controls can share selection/focus without button layout. */
@@ -356,6 +366,11 @@
   cursor: default;
   box-shadow: none;
   text-shadow: none;
+}
+
+.lattice-btn:disabled,
+.lattice-btn[aria-disabled="true"] {
+  box-shadow: inset 0 0 0 1px var(--lattice-btn-ring);
 }
 
 .lattice-btn.lattice-btn--waiting,

--- a/src/lib/styles/globals/shell.css
+++ b/src/lib/styles/globals/shell.css
@@ -73,7 +73,6 @@ button:disabled,
   margin: 1px var(--space-2) var(--space-2) 1px;
   overflow: hidden;
   border-radius: var(--radius-shell);
-  background: var(--bg-surface);
-  box-shadow: -1px -1px 0 0
-    color-mix(in srgb, var(--border-structural) 45%, transparent);
+  background: var(--bg-panel);
+  box-shadow: var(--edge-lip);
 }

--- a/src/lib/styles/globals/surfaces.css
+++ b/src/lib/styles/globals/surfaces.css
@@ -33,6 +33,15 @@
 }
 
 @media (forced-colors: active) {
+  .lattice-forced-colors-boundary {
+    border: 1px solid CanvasText !important;
+  }
+
+  .lattice-forced-colors-boundary--active,
+  .lattice-forced-colors-boundary--focus-within:focus-within {
+    border-color: Highlight !important;
+  }
+
   .lattice-panel,
   .lattice-modal {
     border: 1px solid CanvasText !important;

--- a/src/lib/styles/globals/surfaces.css
+++ b/src/lib/styles/globals/surfaces.css
@@ -3,13 +3,20 @@
    ═══════════════════════════════════════════════════════════════════ */
 
 .lattice-panel {
-  background-color: var(--bg-surface);
-  border: 1px solid var(--border-structural);
+  background-color: var(--bg-panel);
   border-radius: var(--radius-lg);
+  box-shadow: var(--elev-1), var(--edge-lip);
 }
 
+/* Canonical shadow order: state/identity inset, elevation, edge lip. Consumers
+   adding an identity inset must restate the full stack in this order; a
+   box-shadow stack cannot be appended to the component recipe. */
 .lattice-panel--active {
-  border-color: var(--border-active);
+  background-color: color-mix(in srgb, var(--accent-cyan) 5%, var(--bg-panel));
+  box-shadow:
+    inset 0 0 0 1px var(--accent-cyan),
+    var(--elev-1),
+    var(--edge-lip);
 }
 
 .lattice-modal {
@@ -23,4 +30,19 @@
 .lattice-modal-backdrop {
   backdrop-filter: blur(4px);
   background-color: rgba(6, 7, 9, 0.7);
+}
+
+@media (forced-colors: active) {
+  .lattice-panel,
+  .lattice-modal {
+    border: 1px solid CanvasText !important;
+  }
+
+  .lattice-panel--active {
+    border-color: Highlight !important;
+  }
+
+  .lattice-btn {
+    border: 1px solid ButtonBorder !important;
+  }
 }

--- a/src/lib/styles/globals/table.css
+++ b/src/lib/styles/globals/table.css
@@ -9,7 +9,16 @@
   font-size: var(--text-small);
 }
 
-.lattice-table th {
+/* Include the table element so these shared surface semantics outrank a
+   consumer's scoped cell rules without resorting to !important. */
+table.lattice-table th,
+table.lattice-table td {
+  background-color: var(--bg-panel);
+  border-bottom: 0;
+  box-shadow: var(--edge-seam);
+}
+
+table.lattice-table th {
   text-align: left;
   font-weight: 500;
   color: var(--text-secondary);
@@ -17,16 +26,22 @@
   letter-spacing: 0.06em;
   font-size: var(--text-micro);
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--border-structural);
 }
 
-.lattice-table td {
+table.lattice-table td {
   padding: var(--space-2) var(--space-3);
-  border-bottom: 1px solid var(--border-structural);
   height: 32px;
   vertical-align: middle;
 }
 
-.lattice-table tr:hover td {
-  background-color: var(--bg-surface);
+table.lattice-table tbody tr:hover td {
+  background-color: var(--bg-raised);
+}
+
+@media (forced-colors: active) {
+  table.lattice-table th,
+  table.lattice-table td {
+    border-bottom: 1px solid CanvasText;
+    box-shadow: none;
+  }
 }

--- a/src/lib/styles/lattice-tokens.css
+++ b/src/lib/styles/lattice-tokens.css
@@ -1,12 +1,19 @@
 :root {
   /* ── Core Surfaces ─────────────────────────────────────────────── */
   --bg-void: #060709;
-  --bg-surface: #0D0F14;
+
+  /* ── Surface ladder (#198) — tonal steps, not hairlines ───────── */
+  --bg-chrome: #0D0F14;   /* app chrome: rails, toolbars, headers, tab strips */
+  --bg-panel:  #131720;   /* panels, cards, modals — the .lattice-panel tone   */
+  --bg-raised: #181D27;   /* hover / raised card state                          */
+
+  /* D3: --bg-surface stays a value-preserving chrome alias. The large lit
+     .main-content card deliberately consumes --bg-panel in shell.css. */
+  --bg-surface: var(--bg-chrome);
   --bg-elevated: #151820;
   --bg-sunken: color-mix(in srgb, var(--bg-void) 45%, var(--bg-surface));
 
   --border-structural: #222631;
-  --border-active: #00E5FF;
 
   /* ── Text ──────────────────────────────────────────────────────── */
   --text-primary: #E4E7EB;
@@ -87,9 +94,15 @@
   --color-running: var(--status-running);
 
   /* ── Shadows ───────────────────────────────────────────────────── */
-  --shadow-sm: 0 2px 4px rgba(0, 0, 0, 0.15);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.2);
-  --shadow-lg: 0 10px 30px rgba(0, 0, 0, 0.5);
+  /* ── Edges — a lit top lip and an inset seam replace the 1px rule ── */
+  --edge-lip:  inset 0 1px 0 rgba(255, 255, 255, 0.055);
+  --edge-seam: inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+
+  /* ── Elevation — occlusion shadow; must read on --bg-void ──────── */
+  --elev-1: 0 1px 2px rgba(0, 0, 0, 0.55), 0 2px 6px  rgba(0, 0, 0, 0.35);
+  --elev-2: 0 2px 4px rgba(0, 0, 0, 0.55), 0 6px 16px rgba(0, 0, 0, 0.42);
+  --elev-3: 0 4px 8px rgba(0, 0, 0, 0.60), 0 16px 40px rgba(0, 0, 0, 0.55);
+
   --shadow-glow-sm: 0 0 4px;
   --shadow-glow-md: 0 0 8px;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -162,18 +162,27 @@
     }
     if (event.key === 'Escape') {
       if (showShortcuts) {
+        event.preventDefault();
         showShortcuts = false;
         return;
       }
 
-      if (!event.defaultPrevented) {
+      const modalWasOpen = document.querySelector('[aria-modal="true"]') !== null;
+      queueMicrotask(() => {
+        if (event.defaultPrevented || modalWasOpen) return;
+
+        let collapsedPanel = false;
         if (!$layout.leftCollapsed) {
           layout.toggleLeft();
+          collapsedPanel = true;
         }
         if ($activeSession && !$layout.rightCollapsed) {
           layout.toggleRight();
+          collapsedPanel = true;
         }
-      }
+
+        if (collapsedPanel) event.preventDefault();
+      });
     }
     // Ctrl+I: capture the terminal/window text selection as one-shot operator context for the
     // next composer submit. Skip when focus is inside the composer (don't hijack its own
@@ -188,7 +197,7 @@
     }
     // Navigate agents with arrow keys — skip when user is typing in inputs, textareas,
     // contenteditable regions, or terminal panes so we don't hijack their keystrokes.
-    const target = event.target as HTMLElement | null;
+    const target = event.target instanceof HTMLElement ? event.target : null;
     const inTypingContext = !!target && (
       target.tagName === 'INPUT' ||
       target.tagName === 'TEXTAREA' ||

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount, untrack, tick } from 'svelte';
-  import { ChartBar, ChatCenteredText, Crown, GearSix } from 'phosphor-svelte';
+  import { ArrowsSplit, ClockCounterClockwise, Crown, Scales } from 'phosphor-svelte';
   import SessionSidebar from '$lib/components/SessionSidebar.svelte';
   import RightPanel from '$lib/components/RightPanel.svelte';
   import AddWorkerDialog from '$lib/components/AddWorkerDialog.svelte';
@@ -18,6 +18,8 @@
 
   let showAddWorkerDialog = $state(false);
   let showShortcuts = $state(false);
+  let startAction = $state<{ id: number; action: 'hive' | 'fusion' | 'debate' | 'recent' } | null>(null);
+  let startActionId = 0;
 
   // Use UI store as single source of truth for focused agent
   let focusedAgentId = $derived($ui.focusedAgentId);
@@ -113,6 +115,10 @@
     showAddWorkerDialog = false;
   }
 
+  function requestStartAction(action: 'hive' | 'fusion' | 'debate' | 'recent') {
+    startAction = { id: ++startActionId, action };
+  }
+
   // Read an xterm terminal selection if the focused/under-cursor element is inside one.
   function readXtermSelection(): string | null {
     return readTerminalSelection($ui.focusedAgentId);
@@ -154,8 +160,20 @@
       event.preventDefault();
       showShortcuts = !showShortcuts;
     }
-    if (event.key === 'Escape' && showShortcuts) {
-      showShortcuts = false;
+    if (event.key === 'Escape') {
+      if (showShortcuts) {
+        showShortcuts = false;
+        return;
+      }
+
+      if (!event.defaultPrevented) {
+        if (!$layout.leftCollapsed) {
+          layout.toggleLeft();
+        }
+        if ($activeSession && !$layout.rightCollapsed) {
+          layout.toggleRight();
+        }
+      }
     }
     // Ctrl+I: capture the terminal/window text selection as one-shot operator context for the
     // next composer submit. Skip when focus is inside the composer (don't hijack its own
@@ -200,49 +218,65 @@
     onLaunchFusion={handleLaunchFusion}
     onLaunchDebate={handleLaunchDebate}
     onOpenAddWorker={openAddWorkerDialog}
+    {startAction}
   />
 
   <main class="main-content">
     {#if !$activeSession}
       <div class="welcome lattice-scroll-content">
-        <div class="welcome-content">
-          <h1>Hive Manager</h1>
-          <p>Orchestrate and monitor Claude Code multi-agent workflows</p>
-          <div class="features">
-            <div class="feature lattice-panel">
-              <span class="feature-icon">
+        <section class="welcome-content" aria-labelledby="welcome-title">
+          <h1 id="welcome-title">Hive Manager</h1>
+          <p class="welcome-intro">Choose how you want to start.</p>
+          <div class="features" role="group" aria-label="Start a session">
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('hive')}>
+              <span class="feature-icon" aria-hidden="true">
                 <Crown size={24} weight="light" />
               </span>
-              <span class="feature-text">Launch principal-led Hive or comparative Fusion sessions</span>
-            </div>
-            <div class="feature lattice-panel">
-              <span class="feature-icon">
-                <GearSix size={24} weight="light" />
+              <span class="feature-copy">
+                <span class="feature-title">Hive</span>
+                <span class="feature-text">Coordinate implementation with a principal-led team.</span>
               </span>
-              <span class="feature-text">Configure each agent with different commands</span>
-            </div>
-            <div class="feature lattice-panel">
-              <span class="feature-icon">
-                <ChartBar size={24} weight="light" />
+            </button>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('fusion')}>
+              <span class="feature-icon" aria-hidden="true">
+                <ArrowsSplit size={24} weight="light" />
               </span>
-              <span class="feature-text">Monitor agent status in real-time</span>
-            </div>
-            <div class="feature lattice-panel">
-              <span class="feature-icon">
-                <ChatCenteredText size={24} weight="light" />
+              <span class="feature-copy">
+                <span class="feature-title">Fusion</span>
+                <span class="feature-text">Compare independent approaches and synthesize the best.</span>
               </span>
-              <span class="feature-text">Interact with agents directly</span>
-            </div>
+            </button>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('debate')}>
+              <span class="feature-icon" aria-hidden="true">
+                <Scales size={24} weight="light" />
+              </span>
+              <span class="feature-copy">
+                <span class="feature-title">Debate</span>
+                <span class="feature-text">Test a decision through structured opposing arguments.</span>
+              </span>
+            </button>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('recent')}>
+              <span class="feature-icon" aria-hidden="true">
+                <ClockCounterClockwise size={24} weight="light" />
+              </span>
+              <span class="feature-copy">
+                <span class="feature-title">Open recent</span>
+                <span class="feature-text">Resume a stored session from this project.</span>
+              </span>
+            </button>
           </div>
-          <p class="cta">Click <strong>New Session</strong> in the sidebar to get started</p>
           <p class="cta hint">Press <strong>Ctrl+/</strong> for keyboard shortcuts</p>
-        </div>
+        </section>
       </div>
     {:else}
       <div class="terminal-area">
         {#if $activeAgents.length === 0}
           <div class="no-agents">
-            <p>No agents in this session</p>
+            <section class="no-agents-content lattice-panel" aria-labelledby="no-agents-title">
+              <h2 id="no-agents-title">No principals yet</h2>
+              <p>Add a principal to begin working in this session.</p>
+              <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled" onclick={openAddWorkerDialog}>Add Principal</button>
+            </section>
           </div>
         {:else if $activeSession?.session_type && 'Fusion' in $activeSession.session_type && activeSessionState !== 'Planning' && activeSessionState !== 'PlanReady'}
           <FusionPanel />
@@ -271,41 +305,52 @@
     align-items: safe center;
     justify-content: center;
     min-height: 0;
-    padding: 40px;
+    padding: calc(var(--space-6) + var(--space-2));
     overflow-y: auto;
   }
 
   .welcome-content {
-    max-width: 500px;
+    width: min(100%, calc(var(--space-7) * 10));
     text-align: center;
   }
 
   .welcome h1 {
-    margin: 0 0 12px 0;
-    font-size: 32px;
+    margin: 0 0 var(--space-3);
+    font-family: var(--font-display);
+    font-size: var(--text-h1);
     font-weight: 700;
-    color: var(--color-text);
+    color: var(--text-primary);
   }
 
-  .welcome p {
-    margin: 0 0 32px 0;
-    font-size: 16px;
-    color: var(--color-text-muted);
+  .welcome-intro {
+    margin: 0 0 var(--space-6);
+    font-size: var(--text-h3);
+    color: var(--text-secondary);
   }
 
   .features {
     display: flex;
     flex-direction: column;
-    gap: 16px;
-    margin-bottom: 32px;
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
   }
 
   .feature {
     display: flex;
     align-items: center;
-    gap: 12px;
-    padding: 16px 20px;
+    gap: var(--space-3);
+    padding: var(--space-4) calc(var(--space-4) + var(--space-1));
+    background: var(--bg-panel);
+    box-shadow: var(--elev-1), var(--edge-lip);
     text-align: left;
+    transition:
+      background-color var(--motion-duration-fast) var(--motion-ease-standard),
+      box-shadow var(--motion-duration-fast) var(--motion-ease-standard);
+  }
+
+  .feature:hover:where(:not(:disabled):not([aria-disabled="true"])) {
+    background: var(--bg-raised);
+    box-shadow: var(--elev-2), var(--edge-lip);
   }
 
   .feature-icon {
@@ -313,32 +358,48 @@
     align-items: center;
     justify-content: center;
     flex-shrink: 0;
+    color: var(--accent-cyan);
+  }
+
+  .feature-copy {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  .feature-title {
+    font-family: var(--font-display);
+    font-size: var(--text-h3);
+    font-weight: 600;
+    color: var(--text-primary);
   }
 
   .feature-text {
-    font-size: 14px;
-    color: var(--color-text);
+    font-size: var(--text-base);
+    color: var(--text-secondary);
   }
 
   .cta {
-    font-size: 14px;
-    color: var(--color-text-muted);
+    margin: 0;
+    font-size: var(--text-base);
+    color: var(--text-secondary);
   }
 
   .cta strong {
-    color: var(--color-accent);
+    color: var(--accent-cyan);
   }
 
   .cta.hint {
-    margin-top: 8px;
-    font-size: 12px;
-    opacity: 0.8;
+    margin-top: var(--space-2);
+    font-size: var(--text-small);
+    color: var(--text-disabled);
   }
 
   .terminal-area {
     flex: 1;
     position: relative;
-    padding: 16px;
+    padding: var(--space-4);
     overflow: hidden;
   }
 
@@ -347,6 +408,26 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: var(--color-text-muted);
+    min-height: 100%;
+    padding: var(--space-6);
+    color: var(--text-secondary);
+  }
+
+  .no-agents-content {
+    width: min(100%, calc(var(--space-7) * 8));
+    padding: var(--space-6);
+    text-align: center;
+  }
+
+  .no-agents-content h2 {
+    margin: 0 0 var(--space-3);
+    font-family: var(--font-display);
+    font-size: var(--text-h2);
+    color: var(--text-primary);
+  }
+
+  .no-agents-content p {
+    margin: 0 0 var(--space-5);
+    font-size: var(--text-base);
   }
 </style>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -58,7 +58,7 @@
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
-    border-bottom: 1px solid var(--color-border);
+    box-shadow: var(--edge-seam);
     padding-bottom: var(--space-3);
   }
   h1 {

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -87,16 +87,16 @@
 <svelte:head><title>Knowledge · Hive Manager</title></svelte:head>
 
 <div class="knowledge-page">
-  <header class="page-header">
+  <header class="page-header atlas-surface atlas-surface--strip">
     <div class="identity">
-      <div class="identity-mark" aria-hidden="true"><Brain size={20} weight="light" /></div>
+      <div class="identity-mark atlas-surface atlas-surface--active" aria-hidden="true"><Brain size={20} weight="light" /></div>
       <div>
         <div class="eyebrow">Institutional memory</div>
         <h1>Knowledge Atlas</h1>
       </div>
     </div>
 
-    <div class="corpus-stats" aria-label="Knowledge corpus totals">
+    <div class="corpus-stats atlas-surface" aria-label="Knowledge corpus totals">
       <div><strong>{$knowledgeStore.graph.nodes.length}</strong><span>Pages</span></div>
       <div><strong>{$knowledgeStore.graph.edges.length}</strong><span>Links</span></div>
       <div><strong>{folders.length}</strong><span>Folders</span></div>
@@ -108,8 +108,8 @@
     </nav>
   </header>
 
-  <section class="toolbar" aria-label="Knowledge controls">
-    <label class="search-field">
+  <section class="toolbar atlas-surface atlas-surface--strip" aria-label="Knowledge controls">
+    <label class="search-field atlas-surface">
       <MagnifyingGlass size={15} weight="light" aria-hidden="true" />
       <span class="sr-only">Search knowledge</span>
       <input bind:value={query} type="search" placeholder="Search title, path, or folder…" />
@@ -126,7 +126,7 @@
       </select>
     </label>
 
-    <div class="view-switch" aria-label="Knowledge view">
+    <div class="view-switch atlas-surface" aria-label="Knowledge view">
       <button
         type="button"
         class={`lattice-tab${view === 'graph' ? ' lattice-tab--active' : ''}`}
@@ -160,12 +160,12 @@
   </section>
 
   {#if $knowledgeStore.error && $knowledgeStore.graph.nodes.length > 0}
-    <div class="notice error-notice" role="alert">
+    <div class="notice error-notice atlas-surface atlas-surface--strip atlas-surface--raised" role="alert">
       Refresh failed: {$knowledgeStore.error}. Showing the last loaded graph.
     </div>
   {/if}
   {#if omissions.length > 0}
-    <div class="notice cap-notice">
+    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised">
       <strong>Not everything is shown.</strong>
       <ul>
         {#each omissions as omission (omission.reason)}
@@ -175,7 +175,7 @@
     </div>
   {:else if $knowledgeStore.graph.truncated}
     <!-- Older backend: the boolean without the report behind it. -->
-    <div class="notice cap-notice">
+    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised">
       This atlas reached a scan limit, but this backend does not report which one.
     </div>
   {/if}
@@ -222,7 +222,7 @@
           </div>
         {:else}
           <div class="view-frame">
-            <div class="result-strip">
+            <div class="result-strip atlas-surface atlas-surface--strip atlas-surface--sunken">
               <span>{filteredGraph.nodes.length} of {$knowledgeStore.graph.nodes.length} pages</span>
               <span>{filteredGraph.edges.length} visible relationships</span>
             </div>
@@ -242,7 +242,7 @@
                 />
               {/if}
             </div>
-            <footer class="legend lattice-scroll-chrome">
+            <footer class="legend lattice-scroll-chrome atlas-surface atlas-surface--strip">
               <div class="legend-group" aria-label="Folder colors and shapes">
                 {#each folders as name (name)}
                   <span>
@@ -297,16 +297,47 @@
     font-family: var(--font-body);
   }
 
+  /* One recipe for Atlas chrome and controls. Variants only select tokens; the
+     surface declarations stay centralized so graph/table lenses cannot drift. */
+  .atlas-surface {
+    --atlas-surface-background: var(--bg-panel);
+    --atlas-surface-elevation: var(--elev-1);
+    --atlas-surface-edge: var(--edge-lip);
+    --atlas-surface-radius: var(--radius-md);
+
+    border-radius: var(--atlas-surface-radius);
+    background: var(--atlas-surface-background);
+    box-shadow: var(--atlas-surface-elevation), var(--atlas-surface-edge);
+  }
+
+  .atlas-surface--strip {
+    --atlas-surface-background: var(--bg-chrome);
+    --atlas-surface-elevation: var(--edge-seam);
+    --atlas-surface-radius: var(--radius-none);
+  }
+
+  .atlas-surface--raised {
+    --atlas-surface-background: var(--bg-raised);
+  }
+
+  .atlas-surface--sunken {
+    --atlas-surface-background: var(--bg-void);
+  }
+
+  .atlas-surface--active {
+    --atlas-surface-background: color-mix(in srgb, var(--accent-cyan) 5%, var(--bg-panel));
+    --atlas-surface-elevation: inset 0 0 0 1px var(--accent-cyan), var(--elev-1);
+  }
+
   .page-header {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
     align-items: center;
     min-height: 72px;
     padding: 0 var(--space-5);
-    border-bottom: 1px solid var(--border-structural);
-    background:
+    --atlas-surface-background:
       linear-gradient(90deg, color-mix(in srgb, var(--accent-cyan) 4%, transparent), transparent 34%),
-      var(--bg-surface);
+      var(--bg-chrome);
   }
 
   /* Full-bleed route chrome and its hover tones cannot adopt bordered panel primitives. */
@@ -322,10 +353,7 @@
     place-items: center;
     width: 38px;
     height: 38px;
-    border: 1px solid var(--accent-cyan);
     color: var(--accent-cyan);
-    background: color-mix(in srgb, var(--accent-cyan) 7%, transparent);
-    box-shadow: inset 0 0 12px color-mix(in srgb, var(--accent-cyan) 5%, transparent);
   }
 
   .eyebrow {
@@ -348,8 +376,8 @@
   .corpus-stats {
     display: flex;
     align-items: stretch;
-    border: 1px solid var(--border-structural);
-    background: var(--bg-void);
+    gap: 1px;
+    padding: 1px;
   }
 
   .corpus-stats div {
@@ -357,10 +385,9 @@
     align-items: baseline;
     gap: 5px;
     padding: 6px 11px;
-    border-right: 1px solid var(--border-structural);
+    background: var(--bg-chrome);
   }
 
-  .corpus-stats div:last-child { border-right: 0; }
   .corpus-stats strong { color: var(--accent-cyan); font: 14px var(--font-mono); }
   .corpus-stats span { color: var(--text-disabled); font: 9px var(--font-mono); text-transform: uppercase; }
 
@@ -381,9 +408,6 @@
     gap: var(--space-2);
     min-height: 52px;
     padding: var(--space-2) var(--space-4);
-    border-bottom: 1px solid var(--border-structural);
-    /* Fixed workspace controls form a toolbar strip, not a standalone panel. */
-    background: var(--bg-surface);
   }
 
   .search-field {
@@ -393,13 +417,12 @@
     width: min(430px, 42vw);
     height: 34px;
     padding: 0 var(--space-3);
-    border: 1px solid var(--border-structural);
-    background: var(--bg-void);
     color: var(--text-disabled);
   }
 
   .search-field:focus-within {
-    border-color: var(--accent-cyan);
+    --atlas-surface-background: color-mix(in srgb, var(--accent-cyan) 5%, var(--bg-panel));
+    --atlas-surface-elevation: inset 0 0 0 1px var(--accent-cyan), var(--elev-1);
     color: var(--accent-cyan);
   }
 
@@ -426,16 +449,10 @@
 
   .view-switch {
     display: flex;
+    gap: var(--space-1);
     margin-left: auto;
-    border: 1px solid var(--border-structural);
+    padding: 1px;
   }
-
-  .view-switch :global(.lattice-tab) {
-    height: 32px;
-    border-right: 1px solid var(--border-structural);
-  }
-
-  .view-switch :global(.lattice-tab:last-child) { border-right: 0; }
 
   .refresh {
     display: inline-flex;
@@ -452,10 +469,7 @@
 
   .notice {
     padding: 5px var(--space-4);
-    border-bottom: 1px solid var(--border-structural);
     color: var(--text-secondary);
-    /* Full-width query/cap feedback is a semantic notice strip, not a modal or panel. */
-    background: var(--bg-elevated);
     font: var(--text-micro) var(--font-mono);
   }
 
@@ -531,9 +545,7 @@
     display: flex;
     justify-content: space-between;
     padding: 5px var(--space-3);
-    border-bottom: 1px solid var(--border-structural);
     color: var(--text-disabled);
-    background: var(--bg-void);
     font: 9px var(--font-mono);
     text-transform: uppercase;
     letter-spacing: 0.05em;
@@ -553,9 +565,6 @@
     gap: var(--space-3);
     min-height: 34px;
     padding: 0 var(--space-3);
-    border-top: 1px solid var(--border-structural);
-    /* Persistent graph keys form a footer legend strip, not a standalone panel. */
-    background: var(--bg-surface);
     overflow-x: auto;
   }
 

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -87,16 +87,16 @@
 <svelte:head><title>Knowledge · Hive Manager</title></svelte:head>
 
 <div class="knowledge-page">
-  <header class="page-header atlas-surface atlas-surface--strip">
+  <header class="page-header atlas-surface atlas-surface--strip lattice-forced-colors-boundary">
     <div class="identity">
-      <div class="identity-mark atlas-surface atlas-surface--active" aria-hidden="true"><Brain size={20} weight="light" /></div>
+      <div class="identity-mark atlas-surface atlas-surface--active lattice-forced-colors-boundary lattice-forced-colors-boundary--active" aria-hidden="true"><Brain size={20} weight="light" /></div>
       <div>
         <div class="eyebrow">Institutional memory</div>
         <h1>Knowledge Atlas</h1>
       </div>
     </div>
 
-    <div class="corpus-stats atlas-surface" aria-label="Knowledge corpus totals">
+    <div class="corpus-stats atlas-surface lattice-forced-colors-boundary" aria-label="Knowledge corpus totals">
       <div><strong>{$knowledgeStore.graph.nodes.length}</strong><span>Pages</span></div>
       <div><strong>{$knowledgeStore.graph.edges.length}</strong><span>Links</span></div>
       <div><strong>{folders.length}</strong><span>Folders</span></div>
@@ -108,8 +108,8 @@
     </nav>
   </header>
 
-  <section class="toolbar atlas-surface atlas-surface--strip" aria-label="Knowledge controls">
-    <label class="search-field atlas-surface">
+  <section class="toolbar atlas-surface atlas-surface--strip lattice-forced-colors-boundary" aria-label="Knowledge controls">
+    <label class="search-field atlas-surface lattice-forced-colors-boundary lattice-forced-colors-boundary--focus-within">
       <MagnifyingGlass size={15} weight="light" aria-hidden="true" />
       <span class="sr-only">Search knowledge</span>
       <input bind:value={query} type="search" placeholder="Search title, path, or folder…" />
@@ -126,7 +126,7 @@
       </select>
     </label>
 
-    <div class="view-switch atlas-surface" aria-label="Knowledge view">
+    <div class="view-switch atlas-surface lattice-forced-colors-boundary lattice-forced-colors-boundary--focus-within" aria-label="Knowledge view">
       <button
         type="button"
         class={`lattice-tab${view === 'graph' ? ' lattice-tab--active' : ''}`}
@@ -160,12 +160,12 @@
   </section>
 
   {#if $knowledgeStore.error && $knowledgeStore.graph.nodes.length > 0}
-    <div class="notice error-notice atlas-surface atlas-surface--strip atlas-surface--raised" role="alert">
+    <div class="notice error-notice atlas-surface atlas-surface--strip atlas-surface--raised lattice-forced-colors-boundary" role="alert">
       Refresh failed: {$knowledgeStore.error}. Showing the last loaded graph.
     </div>
   {/if}
   {#if omissions.length > 0}
-    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised">
+    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised lattice-forced-colors-boundary">
       <strong>Not everything is shown.</strong>
       <ul>
         {#each omissions as omission (omission.reason)}
@@ -175,7 +175,7 @@
     </div>
   {:else if $knowledgeStore.graph.truncated}
     <!-- Older backend: the boolean without the report behind it. -->
-    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised">
+    <div class="notice cap-notice atlas-surface atlas-surface--strip atlas-surface--raised lattice-forced-colors-boundary">
       This atlas reached a scan limit, but this backend does not report which one.
     </div>
   {/if}
@@ -222,7 +222,7 @@
           </div>
         {:else}
           <div class="view-frame">
-            <div class="result-strip atlas-surface atlas-surface--strip atlas-surface--sunken">
+            <div class="result-strip atlas-surface atlas-surface--strip atlas-surface--sunken lattice-forced-colors-boundary">
               <span>{filteredGraph.nodes.length} of {$knowledgeStore.graph.nodes.length} pages</span>
               <span>{filteredGraph.edges.length} visible relationships</span>
             </div>
@@ -242,7 +242,7 @@
                 />
               {/if}
             </div>
-            <footer class="legend lattice-scroll-chrome atlas-surface atlas-surface--strip">
+            <footer class="legend lattice-scroll-chrome atlas-surface atlas-surface--strip lattice-forced-colors-boundary">
               <div class="legend-group" aria-label="Folder colors and shapes">
                 {#each folders as name (name)}
                   <span>

--- a/src/routes/knowledge/knowledge-page.svelte.test.ts
+++ b/src/routes/knowledge/knowledge-page.svelte.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, waitFor } from '@testing-library/svelte';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
 
 const pageStore = vi.hoisted(() => {
   type PageValue = { url: URL };
@@ -192,5 +192,45 @@ describe('Knowledge route scope', () => {
     expect(container.querySelector('.cap-notice')?.textContent).toContain(
       'does not report which one',
     );
+  });
+
+  it('keeps one toolbar DOM and chrome surface across the graph/table lens switch', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        nodes: [graphNode('patterns/known', 'patterns')],
+        edges: [],
+        omissions: [],
+      }),
+    );
+
+    const { container, getByRole } = render(KnowledgePage);
+    await waitFor(() => expect(container.querySelector('.graph-host')).not.toBeNull());
+
+    const toolbar = container.querySelector('.toolbar');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar?.classList.contains('atlas-surface')).toBe(true);
+    expect(toolbar?.classList.contains('atlas-surface--strip')).toBe(true);
+    const controls = [...toolbar!.children];
+    const toolbarClass = toolbar!.className;
+    const graphButton = getByRole('button', { name: 'Graph' });
+    const tableButton = getByRole('button', { name: 'Table' });
+
+    await fireEvent.click(tableButton);
+    await waitFor(() => expect(container.querySelector('.knowledge-table')).not.toBeNull());
+
+    expect(container.querySelector('.toolbar')).toBe(toolbar);
+    expect(toolbar!.className).toBe(toolbarClass);
+    expect(toolbar!.children).toHaveLength(controls.length);
+    controls.forEach((control, index) => expect(toolbar!.children[index]).toBe(control));
+    expect(graphButton.getAttribute('aria-pressed')).toBe('false');
+    expect(tableButton.getAttribute('aria-pressed')).toBe('true');
+
+    await fireEvent.click(graphButton);
+    await waitFor(() => expect(container.querySelector('.graph-host')).not.toBeNull());
+
+    expect(container.querySelector('.toolbar')).toBe(toolbar);
+    controls.forEach((control, index) => expect(toolbar!.children[index]).toBe(control));
+    expect(graphButton.getAttribute('aria-pressed')).toBe('true');
+    expect(tableButton.getAttribute('aria-pressed')).toBe('false');
   });
 });

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -1,0 +1,280 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { tick } from 'svelte';
+import type { AgentInfo } from '$lib/stores/sessions';
+
+interface TestLayoutState {
+  leftCollapsed: boolean;
+  leftWidth: number;
+  rightCollapsed: boolean;
+  rightWidth: number;
+  rightTab: 'status';
+  sessionsCollapsed: boolean;
+  recentCollapsed: boolean;
+  agentsCollapsed: boolean;
+  maximizedTerminalId: string | null;
+}
+
+const testMocks = vi.hoisted(() => ({
+  setLayoutState: undefined as ((state: TestLayoutState) => void) | undefined,
+  toggleLeft: vi.fn(),
+  toggleRight: vi.fn(),
+  setMaximizedTerminalId: vi.fn(),
+  toggleMaximizedTerminal: vi.fn(),
+  setSessionId: vi.fn(),
+  loadSessions: vi.fn().mockResolvedValue(undefined),
+  fetchCliHealth: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('phosphor-svelte', () => ({
+  ArrowsIn: () => {},
+  ArrowsOut: () => {},
+  ArrowsSplit: () => {},
+  Check: () => {},
+  Circle: () => {},
+  ClockCounterClockwise: () => {},
+  Crown: () => {},
+  Hourglass: () => {},
+  Plus: () => {},
+  Scales: () => {},
+  X: () => {},
+}));
+
+vi.mock('$lib/stores/sessions', async () => {
+  const { writable } = await import('svelte/store');
+  const activeSession = writable({
+    id: 'session-a',
+    state: 'Running',
+    session_type: { Hive: {} },
+    project_path: 'D:/project',
+    worktree_path: 'D:/project',
+    default_cli: 'codex',
+    default_model: 'gpt-5.6-sol',
+    default_principal_cli: 'codex',
+    default_principal_model: 'gpt-5.6-sol',
+    default_principal_flags: [],
+  });
+  const activeAgents = writable<AgentInfo[]>([]);
+
+  return {
+    sessions: {
+      loadSessions: testMocks.loadSessions,
+      launchHiveV2: vi.fn(),
+      launchFusion: vi.fn(),
+      launchDebate: vi.fn(),
+    },
+    activeSession,
+    activeAgents,
+    serdeEnumVariantName: (value: unknown) => {
+      if (typeof value === 'string') return value;
+      if (value && typeof value === 'object') return Object.keys(value)[0];
+      return undefined;
+    },
+  };
+});
+
+vi.mock('$lib/stores/layout', async () => {
+  const { writable } = await import('svelte/store');
+  const state = writable<TestLayoutState>({
+    leftCollapsed: false,
+    leftWidth: 250,
+    rightCollapsed: false,
+    rightWidth: 320,
+    rightTab: 'status',
+    sessionsCollapsed: false,
+    recentCollapsed: true,
+    agentsCollapsed: false,
+    maximizedTerminalId: null,
+  });
+  testMocks.setLayoutState = state.set;
+  testMocks.toggleLeft.mockImplementation(() => {
+    state.update((current) => ({ ...current, leftCollapsed: !current.leftCollapsed }));
+  });
+  testMocks.toggleRight.mockImplementation(() => {
+    state.update((current) => ({ ...current, rightCollapsed: !current.rightCollapsed }));
+  });
+  testMocks.setMaximizedTerminalId.mockImplementation((id: string | null) => {
+    state.update((current) => ({ ...current, maximizedTerminalId: id }));
+  });
+  testMocks.toggleMaximizedTerminal.mockImplementation((id: string) => {
+    state.update((current) => ({
+      ...current,
+      maximizedTerminalId: current.maximizedTerminalId === id ? null : id,
+    }));
+  });
+
+  return {
+    layout: {
+      subscribe: state.subscribe,
+      toggleLeft: testMocks.toggleLeft,
+      toggleRight: testMocks.toggleRight,
+      setMaximizedTerminalId: testMocks.setMaximizedTerminalId,
+      toggleMaximizedTerminal: testMocks.toggleMaximizedTerminal,
+    },
+  };
+});
+
+vi.mock('$lib/stores/coordination', () => ({
+  coordination: {
+    setSessionId: testMocks.setSessionId,
+    addWorker: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/stores/ui', async () => {
+  const { writable } = await import('svelte/store');
+  const state = writable({ focusedAgentId: null as string | null });
+  return {
+    ui: {
+      subscribe: state.subscribe,
+      setFocusedAgent: vi.fn((id: string | null) => {
+        state.update((current) => ({ ...current, focusedAgentId: id }));
+      }),
+      setSelectedAgent: vi.fn(),
+    },
+  };
+});
+
+vi.mock('$lib/stores/pendingContext', () => ({
+  pendingContext: { capture: vi.fn() },
+}));
+
+vi.mock('$lib/stores/scratchTerminals', async () => {
+  const { writable } = await import('svelte/store');
+  const state = writable({ panesBySession: {}, focusedBySession: {} });
+  return {
+    scratchTerminals: {
+      subscribe: state.subscribe,
+      add: vi.fn(),
+      remove: vi.fn(),
+      focus: vi.fn(),
+      clearSession: vi.fn(),
+    },
+    shellCommand: vi.fn(() => ({ command: 'powershell', args: [] })),
+  };
+});
+
+vi.mock('$lib/components/SessionSidebar.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/RightPanel.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/ShortcutsOverlay.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/UpdateChecker.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/FusionPanel.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/DebatePanel.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/session/SessionOverview.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/AgentConfigEditor.svelte', () => ({
+  default: () => {},
+  fetchCliHealth: testMocks.fetchCliHealth,
+}));
+vi.mock('$lib/components/composer/Composer.svelte', () => ({ default: () => {} }));
+vi.mock('$lib/components/Terminal.svelte', () => ({
+  default: () => {},
+  readTerminalSelection: vi.fn(() => null),
+}));
+
+import Page from './+page.svelte';
+import TerminalGrid from '$lib/components/TerminalGrid.svelte';
+
+const expandedLayout: TestLayoutState = {
+  leftCollapsed: false,
+  leftWidth: 250,
+  rightCollapsed: false,
+  rightWidth: 320,
+  rightTab: 'status',
+  sessionsCollapsed: false,
+  recentCollapsed: true,
+  agentsCollapsed: false,
+  maximizedTerminalId: null,
+};
+
+function setLayoutState(state: TestLayoutState): void {
+  if (!testMocks.setLayoutState) throw new Error('Layout mock was not initialized');
+  testMocks.setLayoutState(state);
+}
+
+async function pressEscape(): Promise<KeyboardEvent> {
+  const event = new KeyboardEvent('keydown', {
+    key: 'Escape',
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(event);
+  await Promise.resolve();
+  await tick();
+  return event;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setLayoutState(expandedLayout);
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = '';
+});
+
+describe('page Escape priority', () => {
+  it('closes Add Worker without collapsing either expanded panel', async () => {
+    const view = render(Page);
+    await fireEvent.click(view.getByRole('button', { name: 'Add Principal' }));
+    expect(view.getByRole('dialog')).toBeTruthy();
+
+    const event = await pressEscape();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(view.queryByRole('dialog')).toBeNull();
+    expect(testMocks.toggleLeft).not.toHaveBeenCalled();
+    expect(testMocks.toggleRight).not.toHaveBeenCalled();
+  });
+
+  it('collapses expanded panels when Add Worker is closed and no modal is open', async () => {
+    render(Page);
+
+    const event = await pressEscape();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(testMocks.toggleLeft).toHaveBeenCalledTimes(1);
+    expect(testMocks.toggleRight).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves panels and a maximized terminal unchanged behind an open modal', async () => {
+    setLayoutState({ ...expandedLayout, maximizedTerminalId: 'agent-1' });
+    const page = render(Page);
+    render(TerminalGrid, {
+      props: {
+        agents: [{
+          id: 'agent-1',
+          role: { Worker: { index: 1, parent: null } },
+          status: 'Running',
+          config: { cli: 'codex', flags: [] },
+          parent_id: null,
+        }],
+        focusedAgentId: 'agent-1',
+        onSelect: vi.fn(),
+      },
+    });
+    await tick();
+
+    const modal = document.createElement('div');
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    document.body.append(modal);
+    const opener = page.getByRole('button', { name: 'Add Principal' });
+    opener.focus();
+    testMocks.toggleLeft.mockClear();
+    testMocks.toggleRight.mockClear();
+    testMocks.setMaximizedTerminalId.mockClear();
+
+    const event = await pressEscape();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(opener);
+    expect(testMocks.toggleLeft).not.toHaveBeenCalled();
+    expect(testMocks.toggleRight).not.toHaveBeenCalled();
+    expect(testMocks.setMaximizedTerminalId).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Lands the four open `scope:lattice-design` issues as one coherent wave. The unifying change: **stop using the 1px hairline as the primary boundary device.** Separation moves to tonal steps, lit edges, occlusion shadow, and negative space.

Sequenced as four waves across three principals in a shared worktree, with file-level ownership and no two writers on any file.

## What changed

| Workstream | Issue | Result |
|---|---|---|
| A1/A2 — style layer | #198 A | `.lattice-panel` + button layer borderless; ramp widened; one elevation vocabulary; `forced-colors` fallback added |
| B — shell float | #198 B | Permanent 52px rails, floating drawers, **workspace geometry invariant across toggle** |
| C — Kanban | #200 | Concentric depth; identity off `border-left`; 6 → 0 border declarations |
| D — Knowledge Atlas | #201 | Toolbar surfaces unified; 22 → 4 borders (all knockouts); graph repaint **33% faster** |
| F — start screen | #199 | Zero literal `px`; four feature cards become real launch buttons |

## The performance story

#198 Workstream B is a performance change wearing a design hat. `Terminal.svelte` runs a `ResizeObserver` → `fitAddon.fit()` → `invoke('resize_pty')` chain, so **every panel toggle used to reflow the workspace by up to 368px and re-fit every visible terminal**, forcing each CLI to rewrap its scrollback mid-session.

Proven fixed by geometry rather than by counting: `.main-content`'s rect is byte-identical across open → closed → open on both sides (`{x:53, width:1339, height:891}` and `{x:53, width:1287, height:891}`). A `ResizeObserver` cannot fire if the box never changes, which covers terminals that weren't even open during the test.

## A measured rejection worth reading

#201 asked for a `feDropShadow` set derived from the elevation tokens. We built it and measured it on a signature-pinned 167-node corpus:

| Configuration | Paint / 30 cycles | RasterTask |
|---|---|---|
| Baseline | 71.4 ms | 15.1 ms |
| `feDropShadow` + documented fallback | **114.4 ms** | 43.3 ms |
| Shipped (single Gaussian, token-derived sigma) | **47.8 ms** | 21.9 ms |

The multi-layer filter is not viable at this corpus size — and the corpus has already grown from #171's 167 nodes to 189 live. The shipped solution keeps #201's real intent (SVG depth driven by the token source, not magic numbers) and comes in **33% faster than the pre-existing baseline**. Details are going back to #201.

## Corrections to the issue text

- **#198's "1720+ refs"** to the surface tokens is really **125** (74/37/14). Aliasing was cheap and auditable.
- **`--shadow-sm`/`--shadow-md` were dead** — 0 refs each. Retired outright.
- **#198's repo-wide `1px solid` < 45 is arithmetically unreachable as scoped** — perfect execution of all four issues touches at most 43 of 135. Resolved as **D1-b**: retargeted to in-scope files and carrying the remainder to a follow-up issue.
- **#198's `2 × RAIL_WIDTH` inset is wrong where there is no right panel** — `RightPanel` is conditionally mounted, so cold launch has no right rail. Implemented as **D2**: the right inset is conditional on mount; the invariant that matters (and that the perf gate depends on) is across *toggle*, not *mount*.
- **#201's sixth cited anchor** is `.notice`, not the legend. Both are swept.

## Gates

- `svelte-check` **0 errors / 0 warnings**
- `vitest` **27 files / 138 tests** (up from 132 — new coverage for the Atlas toolbar DOM invariance)
- `stores/layout.test.ts` passes **unmodified** — the layout state model was not touched
- Shell border declarations **16 → 1** (target < 5); the survivor is a functional dashed drop target
- Greyscale depth verified against live computed tokens, not hand-copied hex
- Dense-cluster graph legibility checked at a 49-node cluster; **every knockout stroke and `paint-order: stroke` preserved** — this was the wave's highest-severity risk
- Real-app smoke across Hive, Fusion, Debate, Dashboard, Knowledge, cold launch, and empty session

## Not in this PR

Under D1-b, ~92 pre-existing `1px solid` occurrences in files no issue scoped are left alone; a follow-up issue will carry them. A blast-radius cross-review of the shared style layer found and fixed 6 regressions this wave introduced in files outside the original scope (nested panels collapsing to one depth, clobbered shadow stacks, dead `border-color` state) — those *are* included, since we caused them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-click actions for starting Hive, Fusion, and Debate sessions, plus quick access to recent sessions.
  * Added improved sidebar and right-panel expand/collapse behavior.
  * Added token-based knowledge graph glow effects and refined graph/table controls.

* **Improvements**
  * Introduced layered surfaces, elevation, seams, and consistent shadows across the app.
  * Updated buttons, cards, tables, terminals, dialogs, and panels for a cohesive interface.
  * Improved Escape-key behavior and forced-colors accessibility support.

* **Release**
  * Updated the application version to 0.41.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->