### PR TITLE
feat(shell): rail-driven panel toggles and a persistent left rail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hive-manager",
-  "version": "0.35.1",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hive-manager",
-      "version": "0.35.1",
+      "version": "0.42.0",
       "license": "MIT",
       "dependencies": {
         "@tauri-apps/api": "^2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.41.0"
+version = "0.42.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CaretLeft, CaretRight, ChartBar, ChatCenteredText, ClockCounterClockwise, FileText, ListBullets, NotePencil } from 'phosphor-svelte';
+  import { ChartBar, ChatCenteredText, ClockCounterClockwise, FileText, ListBullets, NotePencil } from 'phosphor-svelte';
   import { layout, RAIL_WIDTH, type RightPanelTab } from '$lib/stores/layout';
   import StatusPanel from './StatusPanel.svelte';
   import PlanView from './PlanView.svelte';
@@ -34,31 +34,25 @@
   style:flex-basis={`${RAIL_WIDTH}px`}
 >
   <div class="rail">
-    <button
-      type="button"
-      class="rail-control expand lattice-btn lattice-btn--ghost lattice-btn--icon"
-      onclick={() => layout.toggleRight()}
-      title={collapsed ? "Expand panel (Ctrl+J)" : "Collapse panel (Ctrl+J)"}
-      aria-label={collapsed ? "Expand panel" : "Collapse panel"}
-    >
-      {#if collapsed}
-        <CaretLeft size={14} weight="light" />
-      {:else}
-        <CaretRight size={14} weight="light" />
-      {/if}
-    </button>
     {#each TABS as tab (tab.id)}
       {@const Icon = tab.icon}
       <button
         type="button"
         class={`rail-control lattice-btn lattice-btn--icon ${activeTab === tab.id ? 'lattice-btn--primary' : 'lattice-btn--ghost'}`}
-        onclick={() => layout.setRightTab(tab.id)}
+        onclick={() => layout.activateRightTab(tab.id)}
         title={tab.label}
         aria-label={tab.label}
       >
         <Icon size={18} weight="light" />
       </button>
     {/each}
+    <button
+      type="button"
+      class="rail-filler"
+      onclick={() => layout.toggleRight()}
+      title={collapsed ? "Expand panel (Ctrl+J)" : "Collapse panel (Ctrl+J)"}
+      aria-label={collapsed ? "Expand panel (Ctrl+J)" : "Collapse panel (Ctrl+J)"}
+    ></button>
   </div>
 
   <div
@@ -134,12 +128,19 @@
     padding: 0;
   }
 
-  .rail-control.expand {
-    margin-bottom: 6px;
-    border-radius: var(--radius-none);
-    width: 100%;
-    padding-bottom: 12px;
-    box-shadow: var(--edge-seam);
+  .rail-filler {
+    align-self: stretch;
+    flex: 1;
+    min-height: 24px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    transition: background-color var(--motion-duration-standard) var(--motion-ease-standard);
+  }
+
+  .rail-filler:hover {
+    background: var(--color-surface-hover);
   }
 
   .panel-drawer {

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Brain, CaretDown, CaretLeft, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
+  import { Brain, CaretDown, CaretRight, Check, House, Kanban, PencilSimple } from 'phosphor-svelte';
   import { page } from '$app/stores';
   import { sessions, activeSession, activeAgents, serdeEnumVariantName, type Session, type ResumeReport, type HiveLaunchConfig, type ResearchLaunchConfig, type FusionLaunchConfig, type SoloLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
   import { layout, RAIL_WIDTH } from '$lib/stores/layout';
@@ -384,6 +384,19 @@
     node.focus();
     node.select();
   }
+
+  function handleViewClick(event: MouseEvent, path: string) {
+    if (event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    if ($page.url.pathname === path) {
+      event.preventDefault();
+      layout.toggleLeft();
+    } else if (path === '/') {
+      layout.setLeftCollapsed(false);
+    }
+  }
 </script>
 
 <!-- The permanent rail is shell chrome; the adjacent drawer is a floating panel. -->
@@ -407,6 +420,7 @@
           aria-label={label}
           aria-current={$page.url.pathname === path ? 'page' : undefined}
           title={label}
+          onclick={(event) => handleViewClick(event, path)}
         >
           <Icon size={18} weight="light" />
         </a>
@@ -414,17 +428,11 @@
     </nav>
     <button
       type="button"
-      class="lattice-btn lattice-btn--ghost lattice-btn--icon"
+      class="rail-filler"
       onclick={() => layout.toggleLeft()}
       title={collapsed ? "Expand sidebar (Ctrl+B)" : "Collapse sidebar (Ctrl+B)"}
-      aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
-    >
-      {#if collapsed}
-        <CaretRight size={14} weight="light" />
-      {:else}
-        <CaretLeft size={14} weight="light" />
-      {/if}
-    </button>
+      aria-label={collapsed ? "Expand sidebar (Ctrl+B)" : "Collapse sidebar (Ctrl+B)"}
+    ></button>
   </div>
 
   <div
@@ -767,6 +775,21 @@
     flex-direction: column;
     gap: 4px;
     flex: none;
+  }
+
+  .rail-filler {
+    align-self: stretch;
+    flex: 1;
+    min-height: 24px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    transition: background-color var(--motion-duration-standard) var(--motion-ease-standard);
+  }
+
+  .rail-filler:hover {
+    background: var(--color-surface-hover);
   }
 
   .sidebar-content {

--- a/src/lib/stores/layout.test.ts
+++ b/src/lib/stores/layout.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createLayoutStore, type LayoutState } from './layout';
 
 function createStorage(initial: Record<string, string> = {}): Storage {
   const values = new Map(Object.entries(initial));
@@ -25,35 +26,111 @@ function createStorage(initial: Record<string, string> = {}): Storage {
   };
 }
 
-async function loadStore(storage: Storage) {
+function loadStore(storage: Storage) {
   vi.stubGlobal('localStorage', storage);
-  vi.resetModules();
-  return import('./layout');
+  return createLayoutStore();
 }
 
 afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+function readPersistedLayout(storage: Storage): Partial<LayoutState> {
+  return JSON.parse(storage.getItem('hive-manager-layout') ?? '{}');
+}
+
+function readStore(layout: ReturnType<typeof createLayoutStore>): LayoutState {
+  let current: LayoutState | undefined;
+  const unsubscribe = layout.subscribe((state) => {
+    current = state;
+  });
+  unsubscribe();
+  if (!current) throw new Error('Layout store did not emit its current state');
+  return current;
+}
+
+describe('layout panel state', () => {
+  it('collapses the open active right tab without changing the tab', () => {
+    const storage = createStorage();
+    const layout = loadStore(storage);
+
+    layout.activateRightTab('status');
+
+    expect(readStore(layout)).toMatchObject({ rightTab: 'status', rightCollapsed: true });
+    expect(readPersistedLayout(storage)).toMatchObject({
+      rightTab: 'status',
+      rightCollapsed: true,
+    });
+  });
+
+  it('expands the active right tab when it is collapsed', () => {
+    const storage = createStorage({
+      'hive-manager-layout': JSON.stringify({ rightTab: 'logs', rightCollapsed: true }),
+    });
+    const layout = loadStore(storage);
+
+    layout.activateRightTab('logs');
+
+    expect(readStore(layout)).toMatchObject({ rightTab: 'logs', rightCollapsed: false });
+  });
+
+  it.each([false, true])(
+    'switches to and expands a different right tab when collapsed is %s',
+    (rightCollapsed) => {
+      const storage = createStorage({
+        'hive-manager-layout': JSON.stringify({ rightTab: 'status', rightCollapsed }),
+      });
+      const layout = loadStore(storage);
+
+      layout.activateRightTab('chat');
+
+      expect(readStore(layout)).toMatchObject({ rightTab: 'chat', rightCollapsed: false });
+      expect(readPersistedLayout(storage)).toMatchObject({
+        rightTab: 'chat',
+        rightCollapsed: false,
+      });
+    },
+  );
+
+  it('persists an absolute left-panel expansion even when already expanded', () => {
+    const storage = createStorage();
+    const persist = vi.spyOn(storage, 'setItem');
+    const layout = loadStore(storage);
+
+    layout.setLeftCollapsed(false);
+
+    expect(persist).toHaveBeenCalledOnce();
+    expect(readStore(layout).leftCollapsed).toBe(false);
+  });
+
+  it('round-trips collapsed panel state through localStorage', () => {
+    const storage = createStorage();
+    const layout = loadStore(storage);
+    layout.setLeftCollapsed(true);
+    layout.toggleRight();
+
+    const restoredLayout = createLayoutStore();
+
+    expect(readStore(restoredLayout)).toMatchObject({
+      leftCollapsed: true,
+      rightCollapsed: true,
+    });
+  });
+});
+
 describe('layout terminal maximize state', () => {
-  it('resets a persisted maximized terminal when the store loads', async () => {
+  it('resets a persisted maximized terminal when the store loads', () => {
     const storage = createStorage({
       'hive-manager-layout': JSON.stringify({ maximizedTerminalId: 'agent-1' }),
     });
-    const { layout } = await loadStore(storage);
+    const layout = loadStore(storage);
 
-    let current: { maximizedTerminalId: string | null } | undefined;
-    const unsubscribe = layout.subscribe((state) => {
-      current = state;
-    });
-
-    expect(current?.maximizedTerminalId).toBeNull();
-    unsubscribe();
+    expect(readStore(layout).maximizedTerminalId).toBeNull();
   });
 
-  it('toggles and persists maximize state during the current app run', async () => {
+  it('toggles and persists maximize state during the current app run', () => {
     const storage = createStorage();
-    const { layout } = await loadStore(storage);
+    const layout = loadStore(storage);
 
     layout.toggleMaximizedTerminal('agent-2');
     expect(JSON.parse(storage.getItem('hive-manager-layout') ?? '{}').maximizedTerminalId).toBe(

--- a/src/lib/stores/layout.ts
+++ b/src/lib/stores/layout.ts
@@ -57,7 +57,7 @@ function loadInitial(): LayoutState {
   }
 }
 
-function createLayoutStore() {
+export function createLayoutStore() {
   const { subscribe, update } = writable<LayoutState>(loadInitial());
 
   function updateAndPersist(mutate: (state: LayoutState) => LayoutState) {
@@ -79,11 +79,21 @@ function createLayoutStore() {
     toggleLeft() {
       updateAndPersist((s) => ({ ...s, leftCollapsed: !s.leftCollapsed }));
     },
+    setLeftCollapsed(collapsed: boolean) {
+      updateAndPersist((s) => ({ ...s, leftCollapsed: collapsed }));
+    },
     toggleRight() {
       updateAndPersist((s) => ({ ...s, rightCollapsed: !s.rightCollapsed }));
     },
     setRightTab(tab: RightPanelTab) {
       updateAndPersist((s) => ({ ...s, rightTab: tab, rightCollapsed: false }));
+    },
+    activateRightTab(tab: RightPanelTab) {
+      updateAndPersist((s) =>
+        tab === s.rightTab && !s.rightCollapsed
+          ? { ...s, rightCollapsed: true }
+          : { ...s, rightTab: tab, rightCollapsed: false },
+      );
     },
     setLeftWidth(width: number) {
       updateAndPersist((s) => ({ ...s, leftWidth: clamp(width, LEFT_WIDTH_MIN, LEFT_WIDTH_MAX) }));

--- a/src/lib/stores/shell.test.ts
+++ b/src/lib/stores/shell.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { createShellStore } from './shell';
+
+describe('shell store', () => {
+  it('issues strictly increasing ids for repeated start actions', () => {
+    const shell = createShellStore();
+
+    shell.requestStartAction('hive');
+    const first = get(shell).startAction;
+    shell.requestStartAction('hive');
+    const second = get(shell).startAction;
+
+    expect(first).toMatchObject({ action: 'hive' });
+    expect(second).toMatchObject({ action: 'hive' });
+    expect(second?.id).toBeGreaterThan(first?.id ?? Number.NEGATIVE_INFINITY);
+  });
+
+  it('opens and closes the Add Worker dialog', () => {
+    const shell = createShellStore();
+
+    shell.openAddWorker();
+    expect(get(shell).addWorkerOpen).toBe(true);
+
+    shell.closeAddWorker();
+    expect(get(shell).addWorkerOpen).toBe(false);
+  });
+});

--- a/src/lib/stores/shell.ts
+++ b/src/lib/stores/shell.ts
@@ -1,0 +1,39 @@
+import { writable } from 'svelte/store';
+
+export type ShellStartActionName = 'hive' | 'fusion' | 'debate' | 'recent';
+
+export interface ShellStartAction {
+  id: number;
+  action: ShellStartActionName;
+}
+
+export interface ShellState {
+  addWorkerOpen: boolean;
+  startAction: ShellStartAction | null;
+}
+
+export function createShellStore() {
+  const { subscribe, update } = writable<ShellState>({
+    addWorkerOpen: false,
+    startAction: null,
+  });
+  let startActionId = 0;
+
+  return {
+    subscribe,
+    openAddWorker() {
+      update((state) => ({ ...state, addWorkerOpen: true }));
+    },
+    closeAddWorker() {
+      update((state) => ({ ...state, addWorkerOpen: false }));
+    },
+    requestStartAction(action: ShellStartActionName) {
+      update((state) => ({
+        ...state,
+        startAction: { id: ++startActionId, action },
+      }));
+    },
+  };
+}
+
+export const shell = createShellStore();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -33,7 +33,7 @@
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+    if (!event.repeat && (event.ctrlKey || event.metaKey) && event.key === 'b') {
       event.preventDefault();
       layout.toggleLeft();
     }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,6 +1,56 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import '../lib/styles/lattice-tokens.css';
   import '../lib/styles/lattice.css';
+  import SessionSidebar from '$lib/components/SessionSidebar.svelte';
+  import AddWorkerDialog from '$lib/components/AddWorkerDialog.svelte';
+  import {
+    sessions,
+    type DebateLaunchConfig,
+    type FusionLaunchConfig,
+    type HiveLaunchConfig,
+  } from '$lib/stores/sessions';
+  import { layout } from '$lib/stores/layout';
+  import { shell } from '$lib/stores/shell';
+
+  let { children }: { children?: Snippet } = $props();
+  let showAddWorkerDialog = $state(false);
+
+  $effect(() => {
+    showAddWorkerDialog = $shell.addWorkerOpen;
+  });
+
+  async function handleLaunchHiveV2(config: HiveLaunchConfig): Promise<void> {
+    await sessions.launchHiveV2(config);
+  }
+
+  async function handleLaunchFusion(config: FusionLaunchConfig): Promise<void> {
+    await sessions.launchFusion(config);
+  }
+
+  async function handleLaunchDebate(config: DebateLaunchConfig): Promise<void> {
+    await sessions.launchDebate(config);
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+      event.preventDefault();
+      layout.toggleLeft();
+    }
+  }
 </script>
 
-<slot />
+<svelte:window onkeydown={handleKeydown} />
+
+<div class="app">
+  <SessionSidebar
+    onLaunchHiveV2={handleLaunchHiveV2}
+    onLaunchFusion={handleLaunchFusion}
+    onLaunchDebate={handleLaunchDebate}
+    onOpenAddWorker={() => shell.openAddWorker()}
+    startAction={$shell.startAction}
+  />
+  {@render children?.()}
+</div>
+
+<AddWorkerDialog bind:open={showAddWorkerDialog} on:close={() => shell.closeAddWorker()} />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,25 +1,21 @@
 <script lang="ts">
   import { onMount, untrack, tick } from 'svelte';
   import { ArrowsSplit, ClockCounterClockwise, Crown, Scales } from 'phosphor-svelte';
-  import SessionSidebar from '$lib/components/SessionSidebar.svelte';
   import RightPanel from '$lib/components/RightPanel.svelte';
-  import AddWorkerDialog from '$lib/components/AddWorkerDialog.svelte';
   import ShortcutsOverlay from '$lib/components/ShortcutsOverlay.svelte';
   import UpdateChecker from '$lib/components/UpdateChecker.svelte';
   import FusionPanel from '$lib/components/FusionPanel.svelte';
   import DebatePanel from '$lib/components/DebatePanel.svelte';
   import SessionOverview from '$lib/components/session/SessionOverview.svelte';
   import { readTerminalSelection } from '$lib/components/Terminal.svelte';
-  import { sessions, activeSession, activeAgents, serdeEnumVariantName, type HiveLaunchConfig, type FusionLaunchConfig, type DebateLaunchConfig } from '$lib/stores/sessions';
+  import { sessions, activeSession, activeAgents, serdeEnumVariantName } from '$lib/stores/sessions';
   import { coordination } from '$lib/stores/coordination';
   import { ui } from '$lib/stores/ui';
   import { layout } from '$lib/stores/layout';
   import { pendingContext } from '$lib/stores/pendingContext';
+  import { shell } from '$lib/stores/shell';
 
-  let showAddWorkerDialog = $state(false);
   let showShortcuts = $state(false);
-  let startAction = $state<{ id: number; action: 'hive' | 'fusion' | 'debate' | 'recent' } | null>(null);
-  let startActionId = 0;
 
   // Use UI store as single source of truth for focused agent
   let focusedAgentId = $derived($ui.focusedAgentId);
@@ -95,30 +91,6 @@
     }
   });
 
-  async function handleLaunchHiveV2(config: HiveLaunchConfig): Promise<void> {
-    await sessions.launchHiveV2(config);
-  }
-
-  async function handleLaunchFusion(config: FusionLaunchConfig): Promise<void> {
-    await sessions.launchFusion(config);
-  }
-
-  async function handleLaunchDebate(config: DebateLaunchConfig): Promise<void> {
-    await sessions.launchDebate(config);
-  }
-
-  function openAddWorkerDialog() {
-    showAddWorkerDialog = true;
-  }
-
-  function closeAddWorkerDialog() {
-    showAddWorkerDialog = false;
-  }
-
-  function requestStartAction(action: 'hive' | 'fusion' | 'debate' | 'recent') {
-    startAction = { id: ++startActionId, action };
-  }
-
   // Read an xterm terminal selection if the focused/under-cursor element is inside one.
   function readXtermSelection(): string | null {
     return readTerminalSelection($ui.focusedAgentId);
@@ -145,11 +117,6 @@
   // Keyboard shortcuts (Ctrl on Windows/Linux, Cmd on macOS)
   function handleKeydown(event: KeyboardEvent) {
     const mod = event.ctrlKey || event.metaKey;
-    // Ctrl+B to toggle the left sidebar
-    if (mod && event.key === 'b') {
-      event.preventDefault();
-      layout.toggleLeft();
-    }
     // Ctrl+J to toggle the right panel
     if (mod && event.key === 'j') {
       event.preventDefault();
@@ -221,23 +188,14 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="app">
-  <SessionSidebar
-    onLaunchHiveV2={handleLaunchHiveV2}
-    onLaunchFusion={handleLaunchFusion}
-    onLaunchDebate={handleLaunchDebate}
-    onOpenAddWorker={openAddWorkerDialog}
-    {startAction}
-  />
-
-  <main class="main-content">
+<main class="main-content">
     {#if !$activeSession}
       <div class="welcome lattice-scroll-content">
         <section class="welcome-content" aria-labelledby="welcome-title">
           <h1 id="welcome-title">Hive Manager</h1>
           <p class="welcome-intro">Choose how you want to start.</p>
           <div class="features" role="group" aria-label="Start a session">
-            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('hive')}>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => shell.requestStartAction('hive')}>
               <span class="feature-icon" aria-hidden="true">
                 <Crown size={24} weight="light" />
               </span>
@@ -246,7 +204,7 @@
                 <span class="feature-text">Coordinate implementation with a principal-led team.</span>
               </span>
             </button>
-            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('fusion')}>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => shell.requestStartAction('fusion')}>
               <span class="feature-icon" aria-hidden="true">
                 <ArrowsSplit size={24} weight="light" />
               </span>
@@ -255,7 +213,7 @@
                 <span class="feature-text">Compare independent approaches and synthesize the best.</span>
               </span>
             </button>
-            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('debate')}>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => shell.requestStartAction('debate')}>
               <span class="feature-icon" aria-hidden="true">
                 <Scales size={24} weight="light" />
               </span>
@@ -264,7 +222,7 @@
                 <span class="feature-text">Test a decision through structured opposing arguments.</span>
               </span>
             </button>
-            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => requestStartAction('recent')}>
+            <button type="button" class="feature lattice-btn lattice-btn--card lattice-panel" onclick={() => shell.requestStartAction('recent')}>
               <span class="feature-icon" aria-hidden="true">
                 <ClockCounterClockwise size={24} weight="light" />
               </span>
@@ -284,7 +242,7 @@
             <section class="no-agents-content lattice-panel" aria-labelledby="no-agents-title">
               <h2 id="no-agents-title">No principals yet</h2>
               <p>Add a principal to begin working in this session.</p>
-              <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled" onclick={openAddWorkerDialog}>Add Principal</button>
+              <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled" onclick={() => shell.openAddWorker()}>Add Principal</button>
             </section>
           </div>
         {:else if $activeSession?.session_type && 'Fusion' in $activeSession.session_type && activeSessionState !== 'Planning' && activeSessionState !== 'PlanReady'}
@@ -296,14 +254,12 @@
         {/if}
       </div>
     {/if}
-  </main>
+</main>
 
-  {#if $activeSession}
-    <RightPanel />
-  {/if}
-</div>
+{#if $activeSession}
+  <RightPanel />
+{/if}
 
-<AddWorkerDialog bind:open={showAddWorkerDialog} on:close={closeAddWorkerDialog} />
 <ShortcutsOverlay open={showShortcuts} onClose={() => showShortcuts = false} />
 <UpdateChecker />
 

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { House } from 'phosphor-svelte';
   import KanbanBoard from '$lib/components/dashboard/KanbanBoard.svelte';
   import { sessions } from '$lib/stores/sessions';
 
@@ -31,10 +30,6 @@
       <h1>Dashboard</h1>
       <p class="subtitle">All sessions grouped by status</p>
     </div>
-    <a href="/" class="home-link lattice-btn lattice-btn--secondary lattice-btn--compact" title="Back to session view">
-      <House size={16} weight="light" />
-      Session View
-    </a>
   </header>
   <div class="board-wrap">
     <KanbanBoard />
@@ -45,8 +40,9 @@
   .dashboard {
     display: flex;
     flex-direction: column;
-    width: 100vw;
-    height: 100vh;
+    flex: 1;
+    min-width: 0;
+    height: 100%;
     background: var(--color-bg);
     color: var(--color-text);
     padding: var(--space-5);
@@ -72,12 +68,6 @@
     margin: var(--space-1) 0 0 0;
     color: var(--text-secondary);
     font-size: var(--text-small);
-  }
-  .home-link {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    text-decoration: none;
   }
   .board-wrap {
     flex: 1;

--- a/src/routes/knowledge/+page.svelte
+++ b/src/routes/knowledge/+page.svelte
@@ -4,8 +4,6 @@
     ArrowClockwise,
     Brain,
     GitBranch,
-    House,
-    Kanban,
     ListBullets,
     MagnifyingGlass,
   } from 'phosphor-svelte';
@@ -102,10 +100,6 @@
       <div><strong>{folders.length}</strong><span>Folders</span></div>
     </div>
 
-    <nav class="page-nav" aria-label="Main views">
-      <a href="/" class="lattice-btn lattice-btn--ghost lattice-btn--compact" title="Session view"><House size={16} weight="light" /><span>Sessions</span></a>
-      <a href="/dashboard" class="lattice-btn lattice-btn--ghost lattice-btn--compact" title="Dashboard"><Kanban size={16} weight="light" /><span>Dashboard</span></a>
-    </nav>
   </header>
 
   <section class="toolbar atlas-surface atlas-surface--strip lattice-forced-colors-boundary" aria-label="Knowledge controls">
@@ -289,9 +283,12 @@
   .knowledge-page {
     display: flex;
     flex-direction: column;
-    width: 100vw;
-    height: 100vh;
+    flex: 1;
+    min-width: 0;
+    min-height: 0;
+    height: 100%;
     overflow: hidden;
+    container: knowledge / inline-size;
     background: var(--bg-void);
     color: var(--text-primary);
     font-family: var(--font-body);
@@ -390,17 +387,6 @@
 
   .corpus-stats strong { color: var(--accent-cyan); font: 14px var(--font-mono); }
   .corpus-stats span { color: var(--text-disabled); font: 9px var(--font-mono); text-transform: uppercase; }
-
-  .page-nav {
-    display: flex;
-    justify-content: flex-end;
-    gap: var(--space-2);
-  }
-
-  .page-nav :global(.lattice-btn) {
-    gap: 6px;
-    text-decoration: none;
-  }
 
   .toolbar {
     display: flex;
@@ -628,16 +614,15 @@
     border: 0;
   }
 
-  @media (max-width: 920px) {
+  @container knowledge (max-width: 920px) {
     .page-header { grid-template-columns: 1fr auto; }
     .corpus-stats { display: none; }
     .workspace.preview-open { grid-template-columns: minmax(0, 1fr) minmax(300px, 42vw); }
     .edge-legend { display: none; }
   }
 
-  @media (max-width: 700px) {
+  @container knowledge (max-width: 700px) {
     .page-header { min-height: 62px; padding: 0 var(--space-3); }
-    .page-nav span { display: none; }
     .identity-mark { display: none; }
     .toolbar { flex-wrap: wrap; min-height: auto; padding: var(--space-2); }
     .search-field { width: 100%; }

--- a/src/routes/layout.svelte.test.ts
+++ b/src/routes/layout.svelte.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/svelte';
+import { get } from 'svelte/store';
+import { tick } from 'svelte';
+
+const testMocks = vi.hoisted(() => ({
+  toggleLeft: vi.fn(),
+  launchHiveV2: vi.fn().mockResolvedValue(undefined),
+  launchFusion: vi.fn().mockResolvedValue(undefined),
+  launchDebate: vi.fn().mockResolvedValue(undefined),
+  fetchCliHealth: vi.fn().mockResolvedValue({}),
+  sessionSidebar: vi.fn(),
+}));
+
+vi.mock('$lib/stores/layout', () => ({
+  layout: {
+    toggleLeft: testMocks.toggleLeft,
+  },
+}));
+
+vi.mock('$lib/stores/sessions', async () => {
+  const { writable } = await import('svelte/store');
+  return {
+    sessions: {
+      launchHiveV2: testMocks.launchHiveV2,
+      launchFusion: testMocks.launchFusion,
+      launchDebate: testMocks.launchDebate,
+    },
+    activeSession: writable({
+      id: 'session-a',
+      state: 'Running',
+      session_type: { Hive: {} },
+      project_path: 'D:/project',
+      worktree_path: 'D:/project',
+      default_cli: 'codex',
+      default_model: 'gpt-5.6-sol',
+      default_principal_cli: 'codex',
+      default_principal_model: 'gpt-5.6-sol',
+      default_principal_flags: [],
+    }),
+    activeAgents: writable([]),
+    serdeEnumVariantName: (value: unknown) => {
+      if (typeof value === 'string') return value;
+      if (value && typeof value === 'object') return Object.keys(value)[0];
+      return undefined;
+    },
+  };
+});
+
+vi.mock('$lib/stores/coordination', () => ({
+  coordination: {
+    addWorker: vi.fn(),
+  },
+}));
+
+vi.mock('$lib/components/SessionSidebar.svelte', () => ({
+  default: (anchor: unknown, props: unknown) => testMocks.sessionSidebar(anchor, props),
+}));
+vi.mock('$lib/components/AgentConfigEditor.svelte', () => ({
+  default: () => {},
+  fetchCliHealth: testMocks.fetchCliHealth,
+}));
+vi.mock('$lib/components/composer/Composer.svelte', () => ({ default: () => {} }));
+
+import Layout from './+layout.svelte';
+import { shell } from '$lib/stores/shell';
+
+interface SidebarProps {
+  onOpenAddWorker: () => void;
+  startAction: { id: number; action: string } | null;
+}
+
+function getSidebarProps(): SidebarProps {
+  const call = testMocks.sessionSidebar.mock.calls.at(-1);
+  if (!call) throw new Error('SessionSidebar mock was not rendered');
+  return call[1] as SidebarProps;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  shell.closeAddWorker();
+});
+
+afterEach(() => {
+  cleanup();
+  shell.closeAddWorker();
+  document.body.innerHTML = '';
+});
+
+describe('persistent app layout', () => {
+  it('owns the real Add Worker dialog open and close path', async () => {
+    const view = render(Layout);
+
+    getSidebarProps().onOpenAddWorker();
+    await tick();
+    expect(view.getByRole('dialog')).toBeTruthy();
+
+    await fireEvent.click(view.getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(view.queryByRole('dialog')).toBeNull());
+    expect(get(shell).addWorkerOpen).toBe(false);
+  });
+
+  it('passes repeat start actions to the persistent sidebar with increasing ids', async () => {
+    render(Layout);
+    const sidebar = getSidebarProps();
+
+    shell.requestStartAction('recent');
+    await tick();
+    const first = sidebar.startAction;
+    shell.requestStartAction('recent');
+    await tick();
+    const second = sidebar.startAction;
+
+    expect(first).toMatchObject({ action: 'recent' });
+    expect(second).toMatchObject({ action: 'recent' });
+    expect(second?.id).toBeGreaterThan(first?.id ?? Number.NEGATIVE_INFINITY);
+  });
+
+  it('toggles the left sidebar exactly once for Ctrl+B', async () => {
+    render(Layout);
+    const event = new KeyboardEvent('keydown', {
+      key: 'b',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+    await tick();
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(testMocks.toggleLeft).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/routes/layout.svelte.test.ts
+++ b/src/routes/layout.svelte.test.ts
@@ -132,4 +132,21 @@ describe('persistent app layout', () => {
     expect(event.defaultPrevented).toBe(true);
     expect(testMocks.toggleLeft).toHaveBeenCalledTimes(1);
   });
+
+  it('ignores repeated Ctrl+B keydown events', async () => {
+    render(Layout);
+    const event = new KeyboardEvent('keydown', {
+      key: 'b',
+      ctrlKey: true,
+      repeat: true,
+      bubbles: true,
+      cancelable: true,
+    });
+
+    window.dispatchEvent(event);
+    await tick();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(testMocks.toggleLeft).not.toHaveBeenCalled();
+  });
 });

--- a/src/routes/page.svelte.test.ts
+++ b/src/routes/page.svelte.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render } from '@testing-library/svelte';
+import { cleanup, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import type { AgentInfo } from '$lib/stores/sessions';
 
@@ -143,6 +143,13 @@ vi.mock('$lib/stores/pendingContext', () => ({
   pendingContext: { capture: vi.fn() },
 }));
 
+vi.mock('$lib/stores/shell', () => ({
+  shell: {
+    openAddWorker: vi.fn(),
+    requestStartAction: vi.fn(),
+  },
+}));
+
 vi.mock('$lib/stores/scratchTerminals', async () => {
   const { writable } = await import('svelte/store');
   const state = writable({ panesBySession: {}, focusedBySession: {} });
@@ -218,15 +225,14 @@ afterEach(() => {
 });
 
 describe('page Escape priority', () => {
-  it('closes Add Worker without collapsing either expanded panel', async () => {
-    const view = render(Page);
-    await fireEvent.click(view.getByRole('button', { name: 'Add Principal' }));
-    expect(view.getByRole('dialog')).toBeTruthy();
+  it('leaves panels alone while a modal is open', async () => {
+    render(Page);
+    const modal = document.createElement('div');
+    modal.setAttribute('aria-modal', 'true');
+    document.body.append(modal);
 
-    const event = await pressEscape();
+    await pressEscape();
 
-    expect(event.defaultPrevented).toBe(true);
-    expect(view.queryByRole('dialog')).toBeNull();
     expect(testMocks.toggleLeft).not.toHaveBeenCalled();
     expect(testMocks.toggleRight).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Removes the caret collapse arrows from both side panels, makes the icon rails themselves the open/close affordance, and puts the left rail on every primary route instead of only the session view.

Rebased onto `f5119aa` after #202 merged mid-flight — #202 restructured both panels into an always-mounted rail + floating drawer, which this builds directly on.

## Interaction model

**Left rail**

| State | Click target | Result |
|---|---|---|
| Any | icon of the **current** route | toggle |
| Any | **Sessions** from another route | navigate to `/` **and** expand |
| Any | **Dashboard**/**Knowledge** from another route | navigate only, preserve collapsed state |
| Any | empty strip below the icons | toggle |

**Right rail**

| State | Click target | Result |
|---|---|---|
| Collapsed | any tab icon | expand + select |
| Expanded | the **active** tab | collapse |
| Expanded | a **different** tab | switch, stay open |
| Any | empty strip below the icons | toggle |

The left/right asymmetry is deliberate: the left drawer's body *is* the session list, so navigating to Dashboard/Knowledge must not override a deliberate collapse, while navigating to Sessions should reveal what you came for.

Collapsing the right panel deliberately leaves `rightTab` untouched, so re-expanding restores the same tab.

Modifier and non-primary clicks fall through untouched — Ctrl+click and middle-click still open links normally, and `href`/`aria-current` are preserved.

## Shell

- `+layout.svelte` becomes the app shell and owns `SessionSidebar`, the Add Worker dialog, and `Ctrl+B`. `Ctrl+B` is **removed** from `+page.svelte` so exactly one listener owns it — two would toggle twice per press and look dead.
- `Ctrl+J`, `Ctrl+/`, `Ctrl+I` and #202's Escape-priority handler stay page-scoped and unchanged. Escape-collapse remains `/`-only as #202 shipped it; globalizing it was out of scope.
- New `src/lib/stores/shell.ts` carries the two signals that now cross the layout/page boundary: Add Worker dialog state and the `startAction` handoff. Deliberately **not** added to `ui.ts`, which carries debounced `application-state` persistence — both of these are ephemeral and must never persist.
- `/dashboard` and `/knowledge` are de-viewported (`100vw/100vh` → `flex: 1; height: 100%`) to sit beside the rail. Knowledge's breakpoints become **container queries**, since its width no longer tracks the viewport once the rail is always present.

## Note for review — operator-visible removal

Per the plan's stated assumption, this removes the now-redundant in-page navigation: the "Session View" link on `/dashboard` and the `.page-nav` on `/knowledge`. The always-present rail supersedes them, and leaving them yields two competing navigations side by side. Trivially reversible if you'd rather keep them.

## Validation

- `npm run check` — 0 errors, 0 warnings
- `npm run test` — 30 files / 152 tests green (baseline on `f5119aa` was 28 files / 141)
- Caret grep — `RightPanel.svelte` returns nothing; `SessionSidebar.svelte` retains only the section-disclosure carets, which are out of scope
- Scope — only the 12 intended paths plus the version bump; no `src/lib/styles/**`, no `src-tauri/**` beyond the version

**Mutation-proven.** Every new behavior was reverted one at a time and confirmed to fail a *named* test. Two were re-verified independently at integration:

| Mutation | Named test that failed |
|---|---|
| `activateRightTab` always expands | `collapses the open active right tab without changing the tab` |
| `startAction` reuses its id | `issues strictly increasing ids for repeated start actions` **and** `passes repeat start actions to the persistent sidebar with increasing ids` |

That second one guards a genuine silent regression: `SessionSidebar` dedupes on `startAction.id`, so a reset id would make the second click of the same welcome card do nothing at all — no error, just dead UI.

`page.svelte.test.ts` test 1 was rewritten to use a synthetic `[aria-modal="true"]` element instead of the real dialog (the pattern test 3 in that file already uses), since the dialog moved to the layout. The assertions it gave up — that the dialog handles Escape and closes — moved into the new `layout.svelte.test.ts` rather than being dropped.

Visual/Tauri walkthrough and the in-app keypress pass are being run separately; these routes render blank outside Tauri, so no browser-based visual claim is made here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a persistent application layout with integrated session navigation and Add Worker dialog.
  * Improved worker launch actions and dialog state handling.
  * Added intuitive panel behavior: select an active right-panel tab to collapse it, and use Ctrl/Cmd+B to toggle the left sidebar.
* **Improvements**
  * Updated dashboard and knowledge views for more flexible, responsive sizing.
  * Released version 0.42.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->