### PR TITLE
fix: quiescence reflects work not liveness (#205) + lattice 1px solid sweep (#203)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.42.0"
+version = "0.42.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -382,6 +382,27 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
     }
 }
 
+fn make_test_agent(id: &str, role: AgentRole) -> AgentInfo {
+    AgentInfo {
+        id: id.to_string(),
+        role,
+        status: AgentStatus::Running,
+        config: AgentConfig::default(),
+        parent_id: None,
+        commit_sha: None,
+        base_commit_sha: None,
+    }
+}
+
+fn make_quiet_test_session(id: &str, project_path: &str, agents: Vec<AgentInfo>) -> Session {
+    let quiet_since = chrono::Utc::now() - chrono::Duration::minutes(11);
+    let mut session = make_test_session(id, project_path);
+    session.created_at = quiet_since - chrono::Duration::minutes(1);
+    session.last_activity_at = quiet_since;
+    session.agents = agents;
+    session
+}
+
 fn make_test_session_for_completion(
     id: &str,
     project_path: &str,
@@ -409,6 +430,48 @@ fn make_test_session_for_completion(
         };
     }
     session
+}
+
+async fn post_test_heartbeat(
+    app: &axum::Router,
+    session_id: &str,
+    agent_id: &str,
+    status: &str,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{session_id}/heartbeat"))
+                .header("Content-Type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({
+                        "agent_id": agent_id,
+                        "status": status,
+                        "summary": format!("test {status} heartbeat")
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn post_test_completion(
+    app: &axum::Router,
+    session_id: &str,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{session_id}/complete"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap()
 }
 
 #[tokio::test]
@@ -7406,6 +7469,379 @@ async fn test_complete_session_returns_conflict_when_not_quiescent() {
         .and_then(|value| value.as_str())
         .unwrap();
     assert!(error.contains("QaPassed"));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_completed_heartbeat_does_not_extend_quiescence() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-completed-quiet-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let worker_1 = format!("{session_id}-worker-1");
+    let worker_2 = format!("{session_id}-worker-2");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![
+                make_test_agent(
+                    &worker_1,
+                    AgentRole::Worker {
+                        index: 1,
+                        parent: None,
+                    },
+                ),
+                make_test_agent(
+                    &worker_2,
+                    AgentRole::Worker {
+                        index: 2,
+                        parent: None,
+                    },
+                ),
+            ],
+        ));
+    let quiet_since = controller
+        .read()
+        .get_session(&session_id)
+        .expect("session inserted")
+        .last_activity_at;
+
+    for _ in 0..3 {
+        for worker_id in [&worker_1, &worker_2] {
+            let heartbeat =
+                post_test_heartbeat(&app, &session_id, worker_id, "completed").await;
+            assert_eq!(heartbeat.status(), StatusCode::OK);
+        }
+        assert!(
+            controller.read().can_complete_session(&session_id).is_ok(),
+            "repeated completed heartbeats must not restore remaining quiescence time"
+        );
+        assert_eq!(
+            controller
+                .read()
+                .get_session(&session_id)
+                .expect("session remains loaded")
+                .last_activity_at,
+            quiet_since
+        );
+    }
+
+    let response = post_test_completion(&app, &session_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_working_heartbeat_still_extends_quiescence() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-working-active-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let worker_id = format!("{session_id}-worker-1");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![make_test_agent(
+                &worker_id,
+                AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
+            )],
+        ));
+
+    let heartbeat = post_test_heartbeat(&app, &session_id, &worker_id, "working").await;
+    assert_eq!(heartbeat.status(), StatusCode::OK);
+
+    let response = post_test_completion(&app, &session_id).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response_json["current_state"], "quiescence_required");
+    assert!(
+        response_json["remaining_quiescence_seconds"]
+            .as_i64()
+            .is_some_and(|remaining| (590..=600).contains(&remaining)),
+        "working heartbeat should restore a fresh quiescence wait: {response_json}"
+    );
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_completed_heartbeat_still_refreshes_agent_liveness() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-completed-live-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let worker_id = format!("{session_id}-worker-1");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![make_test_agent(
+                &worker_id,
+                AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
+            )],
+        ));
+    assert!(controller
+        .read()
+        .get_heartbeat_info(&session_id)
+        .is_empty());
+
+    let heartbeat_started = chrono::Utc::now();
+    let heartbeat = post_test_heartbeat(&app, &session_id, &worker_id, "completed").await;
+    assert_eq!(heartbeat.status(), StatusCode::OK);
+
+    let heartbeat_info = controller.read().get_heartbeat_info(&session_id);
+    let worker_info = heartbeat_info
+        .get(&worker_id)
+        .expect("completed heartbeat should remain visible as agent liveness");
+    assert_eq!(worker_info.status, "completed");
+    assert!(worker_info.last_activity >= heartbeat_started);
+    assert!(controller
+        .read()
+        .get_stalled_agents(&session_id, std::time::Duration::ZERO)
+        .is_empty());
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions/active")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let listed_agent = response_json["sessions"]
+        .as_array()
+        .and_then(|sessions| {
+            sessions
+                .iter()
+                .find(|session| session["id"].as_str() == Some(session_id.as_str()))
+        })
+        .and_then(|session| session["agents"].as_array())
+        .and_then(|agents| {
+            agents
+                .iter()
+                .find(|agent| agent["id"].as_str() == Some(worker_id.as_str()))
+        })
+        .expect("active sessions should expose the completed agent heartbeat");
+    assert_eq!(listed_agent["status"], "completed");
+    assert!(listed_agent["last_activity"].as_str().is_some());
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_list_sessions_ignores_completed_heartbeats_for_activity() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-list-completed-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let worker_id = format!("{session_id}-worker-1");
+    let session = make_quiet_test_session(
+        &session_id,
+        temp_dir.to_str().unwrap(),
+        vec![make_test_agent(
+            &worker_id,
+            AgentRole::Worker {
+                index: 1,
+                parent: None,
+            },
+        )],
+    );
+    let quiet_since = session.last_activity_at;
+    controller.read().insert_test_session(session);
+
+    let heartbeat = post_test_heartbeat(&app, &session_id, &worker_id, "completed").await;
+    assert_eq!(heartbeat.status(), StatusCode::OK);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/sessions")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let listed = response_json["sessions"]
+        .as_array()
+        .and_then(|sessions| {
+            sessions
+                .iter()
+                .find(|session| session["id"].as_str() == Some(session_id.as_str()))
+        })
+        .expect("session should be listed");
+    let listed_last_activity = chrono::DateTime::parse_from_rfc3339(
+        listed["last_activity_at"]
+            .as_str()
+            .expect("listed last_activity_at"),
+    )
+    .unwrap()
+    .with_timezone(&chrono::Utc);
+    assert_eq!(listed_last_activity, quiet_since);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_queen_working_heartbeat_holds_session_open_while_workers_idle() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-queen-working-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let queen_id = format!("{session_id}-queen");
+    let worker_1 = format!("{session_id}-worker-1");
+    let worker_2 = format!("{session_id}-worker-2");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![
+                make_test_agent(&queen_id, AgentRole::Queen),
+                make_test_agent(
+                    &worker_1,
+                    AgentRole::Worker {
+                        index: 1,
+                        parent: None,
+                    },
+                ),
+                make_test_agent(
+                    &worker_2,
+                    AgentRole::Worker {
+                        index: 2,
+                        parent: None,
+                    },
+                ),
+            ],
+        ));
+
+    for worker_id in [&worker_1, &worker_2] {
+        let heartbeat = post_test_heartbeat(&app, &session_id, worker_id, "completed").await;
+        assert_eq!(heartbeat.status(), StatusCode::OK);
+    }
+    let queen_heartbeat = post_test_heartbeat(&app, &session_id, &queen_id, "working").await;
+    assert_eq!(queen_heartbeat.status(), StatusCode::OK);
+
+    let response = post_test_completion(&app, &session_id).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response_json["current_state"], "quiescence_required");
+    assert!(response_json["remaining_quiescence_seconds"]
+        .as_i64()
+        .is_some_and(|remaining| (590..=600).contains(&remaining)));
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_queen_completed_heartbeat_releases_session() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-queen-completed-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let queen_id = format!("{session_id}-queen");
+    let worker_1 = format!("{session_id}-worker-1");
+    let worker_2 = format!("{session_id}-worker-2");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![
+                make_test_agent(&queen_id, AgentRole::Queen),
+                make_test_agent(
+                    &worker_1,
+                    AgentRole::Worker {
+                        index: 1,
+                        parent: None,
+                    },
+                ),
+                make_test_agent(
+                    &worker_2,
+                    AgentRole::Worker {
+                        index: 2,
+                        parent: None,
+                    },
+                ),
+            ],
+        ));
+
+    for agent_id in [&worker_1, &worker_2, &queen_id] {
+        let heartbeat = post_test_heartbeat(&app, &session_id, agent_id, "completed").await;
+        assert_eq!(heartbeat.status(), StatusCode::OK);
+    }
+
+    let response = post_test_completion(&app, &session_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_prince_idle_heartbeat_still_extends_quiescence() {
+    let (app, controller) = setup_test_app_with_controller().await;
+    let session_id = format!("session-prince-idle-{}", uuid::Uuid::new_v4());
+    let temp_dir = std::env::temp_dir().join(&session_id);
+    let _ = std::fs::create_dir_all(&temp_dir);
+    let prince_id = format!("{session_id}-prince");
+
+    controller
+        .read()
+        .insert_test_session(make_quiet_test_session(
+            &session_id,
+            temp_dir.to_str().unwrap(),
+            vec![make_test_agent(&prince_id, AgentRole::Prince)],
+        ));
+
+    let heartbeat = post_test_heartbeat(&app, &session_id, &prince_id, "idle").await;
+    assert_eq!(heartbeat.status(), StatusCode::OK);
+
+    let response = post_test_completion(&app, &session_id).await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let response_json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(response_json["current_state"], "quiescence_required");
+    assert!(response_json["remaining_quiescence_seconds"]
+        .as_i64()
+        .is_some_and(|remaining| (590..=600).contains(&remaining)));
 
     let _ = std::fs::remove_dir_all(&temp_dir);
 }

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -7476,7 +7476,7 @@ async fn test_complete_session_returns_conflict_when_not_quiescent() {
 #[tokio::test]
 async fn test_completed_heartbeat_does_not_extend_quiescence() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-completed-quiet-{}", uuid::Uuid::new_v4());
+    let session_id = format!("completed-quiet-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let worker_1 = format!("{session_id}-worker-1");
@@ -7539,7 +7539,7 @@ async fn test_completed_heartbeat_does_not_extend_quiescence() {
 #[tokio::test]
 async fn test_working_heartbeat_still_extends_quiescence() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-working-active-{}", uuid::Uuid::new_v4());
+    let session_id = format!("working-active-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let worker_id = format!("{session_id}-worker-1");
@@ -7581,7 +7581,7 @@ async fn test_working_heartbeat_still_extends_quiescence() {
 #[tokio::test]
 async fn test_completed_heartbeat_still_refreshes_agent_liveness() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-completed-live-{}", uuid::Uuid::new_v4());
+    let session_id = format!("completed-live-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let worker_id = format!("{session_id}-worker-1");
@@ -7657,7 +7657,7 @@ async fn test_completed_heartbeat_still_refreshes_agent_liveness() {
 #[tokio::test]
 async fn test_list_sessions_ignores_completed_heartbeats_for_activity() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-list-completed-{}", uuid::Uuid::new_v4());
+    let session_id = format!("list-completed-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let worker_id = format!("{session_id}-worker-1");
@@ -7714,9 +7714,9 @@ async fn test_list_sessions_ignores_completed_heartbeats_for_activity() {
 }
 
 #[tokio::test]
-async fn test_queen_working_heartbeat_holds_session_open_while_workers_idle() {
+async fn test_queen_working_heartbeat_holds_session_open_while_workers_completed() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-queen-working-{}", uuid::Uuid::new_v4());
+    let session_id = format!("queen-working-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let queen_id = format!("{session_id}-queen");
@@ -7771,7 +7771,7 @@ async fn test_queen_working_heartbeat_holds_session_open_while_workers_idle() {
 #[tokio::test]
 async fn test_queen_completed_heartbeat_releases_session() {
     let (app, controller) = setup_test_app_with_controller().await;
-    let session_id = format!("session-queen-completed-{}", uuid::Uuid::new_v4());
+    let session_id = format!("queen-completed-{}", uuid::Uuid::new_v4());
     let temp_dir = std::env::temp_dir().join(&session_id);
     let _ = std::fs::create_dir_all(&temp_dir);
     let queen_id = format!("{session_id}-queen");

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1539,6 +1539,12 @@ impl SessionController {
         })
     }
 
+    /// A heartbeat represents session work unless the reporting actor has finished.
+    /// Completed heartbeats still refresh per-agent liveness for stall detection.
+    fn status_counts_as_session_activity(status: &str) -> bool {
+        status != "completed"
+    }
+
     pub fn list_sessions(&self) -> Vec<Session> {
         let sessions = self.sessions.read();
         let heartbeats = self.agent_heartbeats.read();
@@ -1547,7 +1553,14 @@ impl SessionController {
             .cloned()
             .map(|mut session| {
                 if let Some(map) = heartbeats.get(&session.id) {
-                    if let Some(max_hb) = map.values().map(|h| h.last_activity).max() {
+                    if let Some(max_hb) = map
+                        .values()
+                        .filter(|heartbeat| {
+                            Self::status_counts_as_session_activity(&heartbeat.status)
+                        })
+                        .map(|heartbeat| heartbeat.last_activity)
+                        .max()
+                    {
                         if max_hb > session.last_activity_at {
                             session.last_activity_at = max_hb;
                         }
@@ -1647,7 +1660,9 @@ impl SessionController {
         let session_snapshot = {
             let mut sessions = self.sessions.write();
             sessions.get_mut(session_id).map(|session| {
-                if now > session.last_activity_at {
+                if Self::status_counts_as_session_activity(status)
+                    && now > session.last_activity_at
+                {
                     session.last_activity_at = now;
                 }
                 session.clone()
@@ -6004,6 +6019,13 @@ This tests that:
             "working",
             "Coordinating managed principals",
         );
+        let queen_completed_heartbeat = heartbeat_snippet(
+            "http://localhost:18800",
+            session_id,
+            "queen",
+            "completed",
+            "Objective and every configured gate complete",
+        );
 
         format!(
             r#"# Queen - Hive Meta-Harness
@@ -6070,7 +6092,12 @@ Log every quality-reconciliation iteration to {coordination_log_path}:
 
 {objective}
 
-When the objective and every configured gate are complete, send an idle heartbeat and continue monitoring the Queen conversation."#,
+While you intend further waves, keep heartbeating `working` to hold the session open — including across wave boundaries while you deliberate and no principal is active.
+
+When the objective and every configured gate are complete, send this `completed` heartbeat and continue monitoring the Queen conversation:
+```bash
+{queen_completed_heartbeat}
+```"#,
             role_kernel = role_kernel,
             capability_card = capability_card,
             delegation = delegation,
@@ -6092,6 +6119,7 @@ When the objective and every configured gate are complete, send an idle heartbea
             post_workers_protocol = post_workers_protocol,
             coordination_log_path = coordination_log_path,
             queen_quality_log = Self::queen_quality_reconciliation_log_lines(has_evaluator),
+            queen_completed_heartbeat = queen_completed_heartbeat,
             objective = objective,
         )
     }
@@ -7149,7 +7177,7 @@ Content-Type: application/json
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | agent_id | string | Yes | Exact full agent ID from the roster or worker API, such as `{session_id}-worker-2` or `{session_id}-fusion-1` |
-| status | string | Yes | `working`, `idle`, or `completed` |
+| status | string | Yes | `working` = doing work or holding the session open; `idle` = alive and blocked on another actor; `completed` = this actor is finished |
 | summary | string | No | Concise evidence-backed status summary |
 
 ## Mark a Verified Completion
@@ -7166,6 +7194,7 @@ For a Fusion variant or another agent type, keep the request identical and use t
 
 - Verify the deliverable and required gates before sending `completed`; a task-file claim alone is not sufficient.
 - Use the exact full agent ID. A shortened ID such as `worker-N` will not drive that agent's UI status, and the `<exact-agent-id>` placeholder fails validation if left unchanged.
+- A `completed` heartbeat keeps agent liveness fresh for stall detection but does not extend the session's 10-minute quiescence window; `working` and `idle` heartbeats do extend it.
 - Send `completed` immediately after verification. A later `working` or `idle` heartbeat replaces it, so do not downgrade a completed agent unless it has received a new ACTIVE assignment.
 "#,
             session_id = session_id,
@@ -14525,6 +14554,17 @@ mod tests {
     }
 
     #[test]
+    fn heartbeat_activity_semantics_only_exempt_completed_status() {
+        assert!(SessionController::status_counts_as_session_activity(
+            "working"
+        ));
+        assert!(SessionController::status_counts_as_session_activity("idle"));
+        assert!(!SessionController::status_counts_as_session_activity(
+            "completed"
+        ));
+    }
+
+    #[test]
     fn stall_sweep_excludes_completed_heartbeats() {
         let controller = test_controller();
         controller
@@ -15309,6 +15349,12 @@ mod tests {
         assert!(status_content.contains(r#""status":"completed""#));
         assert!(status_content.contains("shortened ID such as `worker-N`"));
         assert!(status_content.contains("placeholder fails validation"));
+        assert!(status_content.contains("`working` = doing work or holding the session open"));
+        assert!(status_content.contains("`idle` = alive and blocked on another actor"));
+        assert!(status_content.contains("`completed` = this actor is finished"));
+        assert!(status_content.contains(
+            "keeps agent liveness fresh for stall detection but does not extend the session's 10-minute quiescence window"
+        ));
     }
 
     fn shared_meta_harness_policy() -> HiveExecutionPolicy {
@@ -15411,6 +15457,13 @@ mod tests {
         assert!(prompt.contains("Managed principals are visible Hive agents"));
         assert!(prompt.contains("mark-worker-status.md"));
         assert!(prompt.contains("UI completion checkoff and stall monitor depend on it"));
+        let objective_tail = extract_markdown_section(&prompt, "## Operator Objective");
+        assert!(objective_tail.contains("across wave boundaries"));
+        assert!(objective_tail.contains("keep heartbeating `working` to hold the session open"));
+        assert!(objective_tail.contains("send this `completed` heartbeat"));
+        assert!(objective_tail.contains(r#""agent_id":"queen""#));
+        assert!(objective_tail.contains(r#""status":"completed""#));
+        assert!(!objective_tail.contains("send an idle heartbeat"));
         assert!(!prompt.contains("full Claude Code capabilities"));
         assert!(!prompt.contains("Claude Code Tools"));
         assert!(!prompt.contains("git checkout -b"));

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -1419,7 +1419,7 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.
 - Returns 409 if blocked with structured body: `{"error":"...","current_state":"<state>","unblock_paths":[...],"remaining_quiescence_seconds":<num|null>}`
-- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence.
+- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence. A `completed` heartbeat keeps the agent live for stall detection but does not extend session quiescence; `working` and `idle` heartbeats do.
 
 ## Communication Format
 
@@ -1666,7 +1666,7 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.
 - Returns 409 if blocked with structured body: `{"error":"...","current_state":"<state>","unblock_paths":[...],"remaining_quiescence_seconds":<num|null>}`
-- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence.
+- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence. A `completed` heartbeat keeps the agent live for stall detection but does not extend session quiescence; `working` and `idle` heartbeats do.
 
 ## Communication Format
 
@@ -1774,7 +1774,7 @@ The QA state machine exposes HTTP endpoints for verdict submission and session c
 ### Session Completion
 - `POST /api/sessions/{{session_id}}/complete` marks the session completed.
 - Returns 409 if blocked with structured body: `{"error":"...","current_state":"<state>","unblock_paths":[...],"remaining_quiescence_seconds":<num|null>}`
-- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence.
+- **Preconditions**: Evaluator-backed sessions require `QaPassed`; non-evaluator sessions require `Running` or `QaPassed`; all sessions require 10-minute quiescence. A `completed` heartbeat keeps the agent live for stall detection but does not extend session quiescence; `working` and `idle` heartbeats do.
 
 ## Communication Format
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -278,7 +278,7 @@
         </div>
 
         {#if error}
-          <div class="error-message">{error}</div>
+          <div class="error-message lattice-forced-colors-boundary">{error}</div>
         {/if}
 
         <div class="dialog-actions">
@@ -319,7 +319,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 16px 20px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .dialog-header h2 {
@@ -404,7 +404,7 @@
     /* Semantic validation alert, not a reusable structural surface. */
     padding: 10px 12px;
     background: rgba(var(--rgb-error), 0.1);
-    border: 1px solid rgba(var(--rgb-error), 0.4);
+    box-shadow: inset 0 0 0 1px rgba(var(--rgb-error), 0.4);
     color: var(--status-error);
     border-radius: var(--radius-sm);
     font-size: 13px;

--- a/src/lib/components/AddWorkerDialog.svelte
+++ b/src/lib/components/AddWorkerDialog.svelte
@@ -162,7 +162,7 @@
   <div class="dialog-overlay lattice-modal-backdrop" on:click={close} role="presentation">
     <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
     <div class="dialog lattice-modal lattice-scroll-chrome" on:click|stopPropagation role="dialog" aria-modal="true" tabindex="-1">
-      <div class="dialog-header">
+      <div class="dialog-header lattice-forced-colors-boundary">
         <h2>Add Managed Principal</h2>
         <button type="button" class="lattice-btn lattice-btn--ghost lattice-btn--icon" on:click={close} aria-label="Close add principal dialog">&times;</button>
       </div>

--- a/src/lib/components/AgentConfigEditor.svelte
+++ b/src/lib/components/AgentConfigEditor.svelte
@@ -612,7 +612,7 @@
       <label for={`${idPrefix}-cli`}>CLI</label>
       <!-- Indeterminate CLI health-check action affordance, not content loading. -->
       <span
-        class="cli-health-badge {cliHealthTone(selectedCliHealth, cliHealthError)}"
+        class="cli-health-badge lattice-forced-colors-boundary {cliHealthTone(selectedCliHealth, cliHealthError)}"
         title={cliHealthTitle(selectedCliHealth, cliHealthLoading, cliHealthError)}
         aria-label={`CLI health: ${cliHealthLabel(selectedCliHealth, cliHealthLoading, cliHealthError)}`}
         aria-busy={cliHealthLoading}
@@ -694,7 +694,7 @@
     gap: 5px;
     max-width: 70%;
     padding: 2px 7px;
-    border: 1px solid currentColor;
+    box-shadow: inset 0 0 0 1px currentColor;
     border-radius: var(--radius-full);
     font-size: 10px;
     font-weight: 600;

--- a/src/lib/components/AgentStatusBar.svelte
+++ b/src/lib/components/AgentStatusBar.svelte
@@ -63,7 +63,7 @@
     {#each agents as agent (agent.id)}
       {@const statusStr = typeof agent.status === 'string' ? agent.status : 'Unknown'}
       {@const hb = getHeartbeat(agent.id)}
-      <div class="agent-chip" title={hb?.summary || statusStr}>
+      <div class="agent-chip lattice-forced-colors-boundary" title={hb?.summary || statusStr}>
         <span
           class="status-dot"
           class:pulse-error={$heartbeatStore.stalledAgents.has(agent.id)}
@@ -95,7 +95,7 @@
     gap: 5px;
     padding: 4px 10px;
     background: var(--bg-void);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-sm);
     font-size: 11px;
     cursor: default;

--- a/src/lib/components/ContractViewer.svelte
+++ b/src/lib/components/ContractViewer.svelte
@@ -110,7 +110,7 @@
     align-items: center;
     padding: 12px 16px;
     background: var(--bg-void);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .header-info h3 {
@@ -205,7 +205,7 @@
   .weights-section {
     padding: 12px 16px;
     background: var(--bg-void);
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
   }
 
   h4 {

--- a/src/lib/components/ContractViewer.svelte
+++ b/src/lib/components/ContractViewer.svelte
@@ -47,7 +47,7 @@
 
 {#if contract}
   <div class="contract-viewer lattice-forced-colors-boundary">
-    <div class="contract-header">
+    <div class="contract-header lattice-forced-colors-boundary">
       <div class="header-info">
         <h3>Sprint Contract</h3>
         <span class="milestone-id">Milestone: {contract.milestone_id}</span>
@@ -79,7 +79,7 @@
     </div>
 
     {#if Object.keys(contract.grading_weights).length > 0}
-      <div class="weights-section">
+      <div class="weights-section lattice-forced-colors-boundary">
         <h4>Grading Weights</h4>
         <div class="weights-grid">
           {#each Object.entries(contract.grading_weights) as [key, weight]}

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -186,7 +186,7 @@
   <AgentStatusBar />
 
   <!-- Agent tabs -->
-  <div class="agent-tabs lattice-scroll-chrome" role="tablist">
+  <div class="agent-tabs lattice-scroll-chrome lattice-forced-colors-boundary" role="tablist">
     {#each agentTabs as tab (tab.id)}
       <button
         class="lattice-tab"
@@ -231,7 +231,7 @@
           </div>
         {:else}
           {#each filteredMessages as msg, i (i)}
-            <div class="message">
+            <div class="message lattice-forced-colors-boundary">
               <span class="msg-time">{formatTimestamp(msg.timestamp)}</span>
               <span class="msg-sender" style="color: {getSenderColor(msg.from)}">{msg.from}</span>
               {#if msg.renderer || msg.data}
@@ -254,7 +254,7 @@
 
   <!-- Input -->
   {#if selectedAgent && selectedAgent !== 'shared'}
-    <div class="input-bar">
+    <div class="input-bar lattice-forced-colors-boundary">
       <Composer
         sessionId={sessionId}
         agentId={selectedAgent}

--- a/src/lib/components/ConversationViewer.svelte
+++ b/src/lib/components/ConversationViewer.svelte
@@ -266,14 +266,14 @@
   {/if}
 
   {#if $conversationStore.error}
-    <div class="error">
+    <div class="error lattice-forced-colors-boundary">
       {$conversationStore.error}
       <button class="lattice-btn lattice-btn--ghost lattice-btn--danger lattice-btn--icon" onclick={() => conversationStore.clearError()} aria-label="Dismiss conversation error">&#10005;</button>
     </div>
   {/if}
 
   {#if approvalError}
-    <div class="error">
+    <div class="error lattice-forced-colors-boundary">
       {approvalError}
       <button class="lattice-btn lattice-btn--ghost lattice-btn--danger lattice-btn--icon" onclick={() => approvalError = ''} aria-label="Dismiss approval error">&#10005;</button>
     </div>
@@ -292,7 +292,7 @@
     display: flex;
     flex-wrap: wrap;
     gap: 0;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
     padding: 0 4px;
     overflow-x: auto;
   }
@@ -342,11 +342,11 @@
     display: flex;
     gap: 6px;
     padding: 3px 0;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .message:last-child {
-    border-bottom: none;
+    box-shadow: none;
   }
 
   .msg-time {
@@ -374,7 +374,7 @@
     display: flex;
     gap: 8px;
     padding: 8px 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
     /* Composer dock remains a distinct full-width input surface. */
     background: var(--bg-surface);
   }
@@ -388,7 +388,7 @@
     background: var(--bg-surface);
     color: var(--status-error);
     font-size: 12px;
-    border: 1px solid var(--status-error);
+    box-shadow: inset 0 0 0 1px var(--status-error);
   }
 
 </style>

--- a/src/lib/components/CoordinationPanel.svelte
+++ b/src/lib/components/CoordinationPanel.svelte
@@ -98,7 +98,7 @@
 {/snippet}
 
 <div class="coordination-panel">
-  <div class="panel-header">
+  <div class="panel-header lattice-forced-colors-boundary">
     <h3>Coordination Log</h3>
     <div class="header-actions">
       <input
@@ -127,7 +127,7 @@
         </div>
       {:else}
         {#each displayMessages as message (message.id)}
-          <div class="message">
+          <div class="message lattice-forced-colors-boundary">
             <span class="timestamp">{formatTimestamp(message.timestamp)}</span>
             <span class="sender {getSenderColor(message.from)}">
               <span class="sender-icon">{getSenderIcon(message.from)}</span>

--- a/src/lib/components/CoordinationPanel.svelte
+++ b/src/lib/components/CoordinationPanel.svelte
@@ -168,7 +168,7 @@
     padding: 12px 16px;
     /* The fixed log header remains visually distinct from scrolling content. */
     background: var(--bg-surface);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .panel-header h3 {
@@ -223,11 +223,11 @@
     flex-wrap: wrap;
     gap: 4px;
     padding: 4px 0;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .message:last-child {
-    border-bottom: none;
+    box-shadow: none;
   }
 
   .timestamp {

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -163,7 +163,7 @@
     </div>
     
     <div class="panel-controls">
-      <div class="view-tabs">
+      <div class="view-tabs lattice-forced-colors-boundary">
         <button class="lattice-tab" class:lattice-tab--active={viewMode === 'terminals'} aria-pressed={viewMode === 'terminals'} onclick={() => viewMode = 'terminals'}>
           <Keyboard size={18} weight="light" /> Terminals
         </button>
@@ -178,7 +178,7 @@
   </div>
 
   {#if error}
-    <div class="error-banner">
+    <div class="error-banner lattice-forced-colors-boundary">
       <Warning size={16} />
       <span>{error}</span>
     </div>
@@ -273,7 +273,7 @@
     <!-- JUDGE VERDICT VIEW -->
     <div class="verdict-layout">
       {#if prUrl}
-        <div class="pr-banner">
+        <div class="pr-banner lattice-forced-colors-boundary">
           <div class="pr-icon-wrapper">
             <GitPullRequest size={24} />
           </div>
@@ -329,7 +329,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
     padding-bottom: 12px;
   }
 
@@ -366,7 +366,7 @@
     background: color-mix(in srgb, var(--text-primary) 3%, var(--bg-surface));
     padding: 4px;
     border-radius: var(--radius-md);
-    border: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam), var(--edge-lip);
     gap: 4px;
   }
 
@@ -377,7 +377,7 @@
     padding: 12px;
     background: color-mix(in srgb, var(--status-error) 12%, transparent);
     color: var(--status-error);
-    border: 1px solid color-mix(in srgb, var(--status-error) 25%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 25%, transparent);
     border-radius: var(--radius-sm);
     font-size: 13px;
   }
@@ -400,7 +400,7 @@
     padding: 10px 14px;
     /* Fixed terminal header keeps a subtle chrome tint above terminal content. */
     background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .section-header h3 {
@@ -442,7 +442,7 @@
     padding: 10px 14px;
     /* Fixed terminal header keeps a subtle chrome tint above terminal content. */
     background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .variant-name {
@@ -495,7 +495,7 @@
     padding: 12px 16px;
     /* Fixed comparison header keeps a subtle chrome tint above card content. */
     background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .status-indicator {
@@ -590,7 +590,7 @@
     align-items: center;
     /* Captured-PR banner intentionally uses a success-state surface. */
     background: color-mix(in srgb, var(--status-success) 10%, var(--bg-surface));
-    border: 1px solid color-mix(in srgb, var(--status-success) 20%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-success) 20%, transparent);
     border-radius: var(--radius-md);
     padding: 16px;
     gap: 16px;
@@ -631,7 +631,7 @@
     padding: 12px 16px;
     /* Fixed verdict header keeps a subtle chrome tint above report content. */
     background: color-mix(in srgb, var(--text-primary) 2%, var(--bg-surface));
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .verdict-header h3 {

--- a/src/lib/components/DebatePanel.svelte
+++ b/src/lib/components/DebatePanel.svelte
@@ -148,7 +148,7 @@
 
 <div class="debate-panel lattice-scroll-content">
   <!-- Debate Header Bar -->
-  <div class="debate-header-bar">
+  <div class="debate-header-bar lattice-forced-colors-boundary">
     <div class="info-group">
       <div class="state-tag" class:eval-ready={evaluationReady}>
         {#if evaluationReady}
@@ -189,7 +189,7 @@
     <div class="terminals-layout">
       {#if queenAgent}
         <div class="orchestrator-section lattice-panel">
-          <div class="section-header">
+          <div class="section-header lattice-forced-colors-boundary">
             <Crown size={20} weight="light" class="icon-queen" />
             <h3>Orchestrator Queen</h3>
             <span class="cli-badge">{queenAgent.config?.cli || 'unknown'}</span>
@@ -203,7 +203,7 @@
       <div class="debaters-terminals-grid">
         {#each debaterAgents as agent (agent.id)}
           <div class="variant-card lattice-panel">
-            <div class="variant-header">
+            <div class="variant-header lattice-forced-colors-boundary">
               <span class="variant-name">{agent.config?.label || 'Debater'}</span>
               <span class="cli-badge">{agent.config?.cli || 'unknown'}</span>
             </div>
@@ -216,7 +216,7 @@
 
       {#if judgeAgent}
         <div class="orchestrator-section lattice-panel">
-          <div class="section-header">
+          <div class="section-header lattice-forced-colors-boundary">
             <Scales size={20} weight="light" class="icon-judge" />
             <h3>Debate Judge</h3>
             <span class="cli-badge">{judgeAgent.config?.cli || 'unknown'}</span>
@@ -234,7 +234,7 @@
       <div class="debaters-grid">
         {#each debaters as debater (debater.index)}
           <div class="debater-status-card lattice-panel" class:completed={debater.status === 'Completed'}>
-            <div class="debater-card-header">
+            <div class="debater-card-header lattice-forced-colors-boundary">
               <div class="status-indicator">
                 <span class="status-dot {getDebaterStatusClass(debater.status)}"></span>
                 <span class="debater-name">{debater.name}</span>
@@ -288,7 +288,7 @@
       {/if}
 
       <div class="verdict-card lattice-panel">
-        <div class="verdict-header">
+        <div class="verdict-header lattice-forced-colors-boundary">
           <Scales size={22} weight="light" />
           <h3>Structured Verdict</h3>
           {#if debateEvaluation?.report_path}

--- a/src/lib/components/FusionPanel.svelte
+++ b/src/lib/components/FusionPanel.svelte
@@ -57,7 +57,7 @@
 
 <div class="fusion-panel lattice-scroll-content">
   <div class="panel-controls">
-    <div class="view-tabs">
+    <div class="view-tabs lattice-forced-colors-boundary">
       <button class="lattice-tab" class:lattice-tab--active={viewMode === 'terminals'} aria-pressed={viewMode === 'terminals'} onclick={() => viewMode = 'terminals'}>
         <Keyboard size={20} weight="light" /> Terminals
       </button>
@@ -155,7 +155,7 @@
   {/if}
 
   {#if error}
-    <div class="error-banner">{error}</div>
+    <div class="error-banner lattice-forced-colors-boundary">{error}</div>
   {/if}
 
   {#if showCleanupConfirm}
@@ -193,7 +193,7 @@
     background: var(--bg-void);
     padding: 4px;
     border-radius: var(--radius-md);
-    border: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam), var(--edge-lip);
     gap: 4px;
   }
 
@@ -216,7 +216,7 @@
     gap: 10px;
     padding: 10px 14px;
     background: var(--bg-void);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .orchestrator-header h3 {
@@ -263,7 +263,7 @@
     align-items: center;
     padding: 10px 14px;
     background: var(--bg-void);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .variant-name {
@@ -281,7 +281,7 @@
   .variant-actions {
     padding: 12px;
     background: var(--bg-void);
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
     display: flex;
     justify-content: center;
   }
@@ -296,7 +296,7 @@
     gap: 10px;
     padding: 12px 16px;
     background: var(--bg-void);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .section-header h3 {
@@ -325,7 +325,7 @@
     /* Full-width semantic error banner intentionally remains state-tinted. */
     background: color-mix(in srgb, var(--status-error) 15%, transparent);
     color: var(--status-error);
-    border: 1px solid var(--status-error);
+    box-shadow: inset 0 0 0 1px var(--status-error);
     border-radius: var(--radius-sm);
     font-size: 13px;
   }

--- a/src/lib/components/FusionPanel.svelte
+++ b/src/lib/components/FusionPanel.svelte
@@ -70,7 +70,7 @@
   {#if viewMode === 'terminals'}
     {#if queenAgent}
       <div class="orchestrator-section lattice-panel">
-        <div class="orchestrator-header">
+        <div class="orchestrator-header lattice-forced-colors-boundary">
           <Crown size={24} weight="light" />
           <h3>Fusion Queen</h3>
           <span class="cli-badge">{queenAgent.config?.cli || 'unknown'}</span>
@@ -86,7 +86,7 @@
         {@const variantName = typeof agent.role === 'object' && 'Fusion' in agent.role ? agent.role.Fusion.variant : ''}
         {@const status = getVariantStatus(variantName)}
         <div class="variant-card lattice-panel">
-          <div class="variant-header">
+          <div class="variant-header lattice-forced-colors-boundary">
             <span class="variant-name">{variantName}</span>
             <span class="status-badge" class:status-running={status === 'Running'} class:status-success={status === 'Completed'} class:status-error={status === 'Failed'}>
               {status}
@@ -96,7 +96,7 @@
             <Terminal agentId={agent.id} isFocused={true} />
           </div>
           {#if evaluationReady}
-            <div class="variant-actions">
+            <div class="variant-actions lattice-forced-colors-boundary">
               <button 
                 class="lattice-btn lattice-btn--primary"
                 onclick={() => handleApplyWinner(variantName)}
@@ -112,7 +112,7 @@
 
     {#if judgeAgent}
       <div class="orchestrator-section lattice-panel">
-        <div class="orchestrator-header">
+        <div class="orchestrator-header lattice-forced-colors-boundary">
           <Scales size={24} weight="light" />
           <h3>Judge</h3>
           <span class="cli-badge">{judgeAgent.config?.cli || 'unknown'}</span>
@@ -132,7 +132,7 @@
 
   {#if isResolvingOrCompleted}
     <div class="resolver-section lattice-panel lattice-panel--active">
-      <div class="section-header">
+      <div class="section-header lattice-forced-colors-boundary">
         <MagnifyingGlass size={24} weight="light" />
         <h3>Resolver Analysis</h3>
       </div>
@@ -144,7 +144,7 @@
 
   {#if evaluationReady && judgeReport}
     <div class="judge-section lattice-panel">
-      <div class="section-header">
+      <div class="section-header lattice-forced-colors-boundary">
         <Scales size={24} weight="light" />
         <h3>Judge Evaluation Report</h3>
       </div>

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -877,7 +877,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               {showHiveAdvanced ? 'Hide' : 'Show'} delegation guidance
             </button>
             {#if showHiveAdvanced}
-              <div class="advanced-grid" id="hive-delegation-limits">
+              <div class="advanced-grid lattice-forced-colors-boundary" id="hive-delegation-limits">
                 <label>Queen target max children <input class="lattice-input" type="number" min="1" max="8" bind:value={queenMaxChildren} /></label>
                 <label>Queen target max depth <input class="lattice-input" type="number" min="1" max="4" bind:value={queenMaxDepth} /></label>
                 <label>Principal target max children <input class="lattice-input" type="number" min="1" max="8" bind:value={principalMaxChildren} /></label>
@@ -920,7 +920,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
                 </label>
               </div>
               {#if (mode === 'hive' && withEvaluator) || (mode === 'solo' && withSoloEvaluator)}
-                <div class="evaluator-config subsection">
+                <div class="evaluator-config subsection lattice-forced-colors-boundary">
                   <h4>Evaluator Configuration</h4>
                   <AgentConfigEditor
                     bind:config={evaluatorConfig}
@@ -932,7 +932,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
                   />
                 </div>
 
-                <div class="qa-workers-config subsection">
+                <div class="qa-workers-config subsection lattice-forced-colors-boundary">
                   <div class="section-header">
                     <h4>QA Workers ({qaWorkers.length})</h4>
                     <button type="button" class="lattice-btn lattice-btn--secondary lattice-btn--compact lattice-btn--dashed" on:click={addQaWorker} disabled={qaWorkers.length >= 6}>+ Add</button>
@@ -1024,7 +1024,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               </select>
             </div>
 
-            <div class="subsection">
+            <div class="subsection lattice-forced-colors-boundary">
               <h4>Variant Configurations</h4>
               <div class="workers-list">
                 {#each activeFusionVariants as variant, i (i)}
@@ -1051,7 +1051,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               </div>
             </div>
 
-            <div class="subsection">
+            <div class="subsection lattice-forced-colors-boundary">
               <h4>Judge Configuration</h4>
               <p class="section-description">Evaluates variant outputs and recommends a winner.</p>
               <div class="worker-card lattice-panel">
@@ -1094,7 +1094,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               </div>
             </div>
 
-            <div class="subsection">
+            <div class="subsection lattice-forced-colors-boundary">
               <h4>Debater Configurations</h4>
               <div class="workers-list">
                 {#each activeDebaters as debater, i (i)}
@@ -1129,7 +1129,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
               </div>
             </div>
 
-            <div class="subsection">
+            <div class="subsection lattice-forced-colors-boundary">
               <h4>Judge Configuration</h4>
               <p class="section-description">Evaluates the debate and renders the verdict.</p>
               <div class="worker-card lattice-panel">
@@ -1191,7 +1191,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
         {/if}
 
         {#if mode !== 'templates'}
-        <div class="launch-preview-section">
+        <div class="launch-preview-section lattice-forced-colors-boundary">
           <button
             type="button"
             class="lattice-btn lattice-btn--ghost lattice-btn--link"
@@ -1262,7 +1262,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
                 {/if}
 
                 {#if mode === 'hive'}
-                  <div class="topology-contract">
+                  <div class="topology-contract lattice-forced-colors-boundary">
                     <div class="topology-layer lattice-forced-colors-boundary">
                       <span class="topology-layer-title">Managed principals</span>
                       <span>1 Queen + {codingPrincipals.length} manager-launched coding principal{codingPrincipals.length === 1 ? '' : 's'}</span>

--- a/src/lib/components/LaunchDialog.svelte
+++ b/src/lib/components/LaunchDialog.svelte
@@ -706,7 +706,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
           </div>
           <div class="form-group flex-1">
             <span class="group-label">Session Color</span>
-            <div class="color-picker-inline">
+            <div class="color-picker-inline lattice-forced-colors-boundary">
               {#each COLORS as color}
                 <button
                   type="button"
@@ -765,7 +765,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
         {/if}
 
         {#if mode === 'hive'}
-          <div class="form-section hive-policy-section">
+          <div class="form-section hive-policy-section lattice-forced-colors-boundary">
             <div class="section-heading-copy">
               <h3>Hive Topology</h3>
               <p>Keep the team legible: a Queen, a small set of coding principals, and bounded native delegation.</p>
@@ -1187,7 +1187,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
         {/if}
 
         {#if error || launchError}
-          <div class="error-message" role="alert">{error || launchError}</div>
+          <div class="error-message lattice-forced-colors-boundary" role="alert">{error || launchError}</div>
         {/if}
 
         {#if mode !== 'templates'}
@@ -1263,18 +1263,18 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
                 {#if mode === 'hive'}
                   <div class="topology-contract">
-                    <div class="topology-layer">
+                    <div class="topology-layer lattice-forced-colors-boundary">
                       <span class="topology-layer-title">Managed principals</span>
                       <span>1 Queen + {codingPrincipals.length} manager-launched coding principal{codingPrincipals.length === 1 ? '' : 's'}</span>
                       <span>Workspace: {workspaceStrategy === 'shared_cell' ? 'one shared cell' : 'one Queen worktree plus one per principal'}</span>
                     </div>
                     {#if withEvaluator}
-                      <div class="topology-layer">
+                      <div class="topology-layer lattice-forced-colors-boundary">
                         <span class="topology-layer-title">Verification control plane</span>
                         <span>Evaluator + Prince peers; {qaWorkers.length} configured QA role{qaWorkers.length === 1 ? '' : 's'}, plus {automaticAdversarialLanes} missing adversarial lane{automaticAdversarialLanes === 1 ? '' : 's'} added automatically to reach the {adversarialLaneTarget}-lane target.</span>
                       </div>
                     {/if}
-                    <div class="topology-layer">
+                    <div class="topology-layer lattice-forced-colors-boundary">
                       <span class="topology-layer-title">Potential native children</span>
                       <span>Queen: {delegationModeLabel(queenDelegationMode)} · Principals: {delegationModeLabel(principalDelegationMode)}</span>
                       <span>Harness-native children stay inside their parent’s assignment; they are not additional managed principals.</span>
@@ -1385,7 +1385,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
     gap: 6px;
     padding: 6px;
     background: var(--bg-void);
-    border: 1px solid var(--border-structural);
+    box-shadow: var(--edge-lip);
     border-radius: var(--radius-md);
   }
 
@@ -1471,7 +1471,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
   .hive-policy-section {
     /* Semantic policy emphasis, not a reusable structural surface. */
-    border: 1px solid color-mix(in srgb, var(--accent-cyan) 26%, var(--border-structural));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cyan) 26%, var(--border-structural));
     background: color-mix(in srgb, var(--accent-cyan) 4%, var(--bg-void));
   }
 
@@ -1547,7 +1547,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   .advanced-grid {
     margin-top: 12px;
     padding-top: 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
   }
 
   .advanced-grid label {
@@ -1576,7 +1576,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
   .subsection {
     margin-top: 16px;
     padding-top: 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
   }
 
   .subsection h4 {
@@ -1655,7 +1655,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
     padding: 12px;
     margin-bottom: 16px;
     background: color-mix(in srgb, var(--status-error) 15%, transparent);
-    border: 1px solid var(--status-error);
+    box-shadow: inset 0 0 0 1px var(--status-error);
     border-radius: var(--radius-sm);
     color: var(--status-error);
     font-size: 13px;
@@ -1735,7 +1735,7 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
 
   .launch-preview-section {
     margin-top: 20px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
     padding-top: 16px;
   }
 
@@ -1824,14 +1824,14 @@ Use /resolveprcomments style workflow to systematically address quality issues.`
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 10px;
     padding-top: 12px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
   }
 
   .topology-layer {
     display: grid;
     gap: 4px;
     padding: 10px;
-    border: 1px solid var(--border-structural);
+    box-shadow: var(--edge-lip);
     border-radius: var(--radius-sm);
     color: var(--text-secondary);
     font-size: 10px;

--- a/src/lib/components/PlanView.svelte
+++ b/src/lib/components/PlanView.svelte
@@ -412,7 +412,7 @@
   </Skeleton>
 
   {#if error}
-    <div class="error">{error}</div>
+    <div class="error lattice-forced-colors-boundary">{error}</div>
   {/if}
 </div>
 
@@ -483,7 +483,7 @@
   .plan-header {
     margin-bottom: 20px;
     padding-bottom: 16px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .plan-header h3 {
@@ -591,7 +591,7 @@
     border-radius: var(--radius-sm);
     font-size: 12px;
     margin-top: 12px;
-    border: 1px solid var(--status-error);
+    box-shadow: inset 0 0 0 1px var(--status-error);
   }
 
   /* Raw content display (for plans in progress) */
@@ -605,7 +605,7 @@
     gap: 8px;
     margin-bottom: 12px;
     padding-bottom: 8px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .raw-icon {
@@ -701,7 +701,7 @@
   .plan-actions {
     margin-top: 24px;
     padding-top: 20px;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
     display: flex;
     flex-direction: column;
     gap: 20px;

--- a/src/lib/components/PlanView.svelte
+++ b/src/lib/components/PlanView.svelte
@@ -287,7 +287,7 @@
       <span class="hint">The Master Planner will create a plan when the session starts.</span>
     </div>
   {:else}
-    <div class="plan-header">
+    <div class="plan-header lattice-forced-colors-boundary">
       <h3>{plan.title}</h3>
       {#if plan.summary}
         <p class="summary">{plan.summary}</p>
@@ -334,7 +334,7 @@
     {:else}
       <!-- Show raw markdown when no tasks parsed yet (plan in progress) -->
       <div class="raw-content">
-        <div class="raw-header">
+        <div class="raw-header lattice-forced-colors-boundary">
           <span class="raw-icon">
             <FileText size={16} weight="light" />
           </span>
@@ -351,7 +351,7 @@
     {/if}
 
     {#if isPlanning() || isPlanReady()}
-      <div class="plan-actions">
+      <div class="plan-actions lattice-forced-colors-boundary">
         {#if canRefine()}
           <div class="refinement-section">
             <p class="refinement-hint">

--- a/src/lib/components/QaFeedbackPanel.svelte
+++ b/src/lib/components/QaFeedbackPanel.svelte
@@ -102,7 +102,7 @@
 
         <div class="criteria-list">
           {#each verdict.criteria as criterion}
-            <div class="criterion-item" class:passed={criterion.passed}>
+            <div class="criterion-item lattice-forced-colors-boundary" class:passed={criterion.passed}>
               <div class="criterion-header">
                 <span class="criterion-icon">
                   {#if criterion.passed}
@@ -191,7 +191,7 @@
     line-height: 1.5;
     color: var(--text-primary);
     padding-bottom: 12px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .summary p {
@@ -208,12 +208,12 @@
     padding: 10px;
     border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--status-error) 5%, transparent);
-    border: 1px solid color-mix(in srgb, var(--status-error) 10%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 10%, transparent);
   }
 
   .criterion-item.passed {
     background: color-mix(in srgb, var(--status-success) 5%, transparent);
-    border-color: color-mix(in srgb, var(--status-success) 10%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-success) 10%, transparent);
   }
 
   .criterion-header {

--- a/src/lib/components/QaFeedbackPanel.svelte
+++ b/src/lib/components/QaFeedbackPanel.svelte
@@ -96,7 +96,7 @@
 
     {#if !collapsed}
       <div class="panel-content">
-        <div class="summary">
+        <div class="summary lattice-forced-colors-boundary">
           <p>{verdict.summary}</p>
         </div>
 

--- a/src/lib/components/ResumeConfirmModal.svelte
+++ b/src/lib/components/ResumeConfirmModal.svelte
@@ -164,7 +164,7 @@
 
   .modal-header {
     padding: 1rem 1.25rem;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .modal-header h2 {
@@ -227,7 +227,7 @@
 
   .modal-footer {
     padding: 0.85rem 1.25rem;
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;

--- a/src/lib/components/ResumeConfirmModal.svelte
+++ b/src/lib/components/ResumeConfirmModal.svelte
@@ -65,7 +65,7 @@
       on:click|stopPropagation
       on:keydown|stopPropagation={(e) => e.key === 'Escape' && cancel()}
     >
-      <header class="modal-header">
+      <header class="modal-header lattice-forced-colors-boundary">
         <h2>Resume {sessionName ?? 'session'}</h2>
       </header>
 
@@ -130,7 +130,7 @@
         </label>
       </div>
 
-      <footer class="modal-footer">
+      <footer class="modal-footer lattice-forced-colors-boundary">
         <button type="button" class="lattice-btn lattice-btn--secondary" on:click={cancel} disabled={confirming}>
           Cancel
         </button>

--- a/src/lib/components/SessionFilesView.svelte
+++ b/src/lib/components/SessionFilesView.svelte
@@ -145,7 +145,7 @@
       <span>Select a session to browse its files.</span>
     </div>
   {:else}
-    <header class="files-header">
+    <header class="files-header lattice-forced-colors-boundary">
       <div class="heading">
         <span class="title">Session Files</span>
         <span class="read-only-badge lattice-forced-colors-boundary">Read only</span>
@@ -169,7 +169,7 @@
     </header>
 
     {#if $sessionFilesStore.error && $sessionFilesStore.entries.length > 0}
-      <div class="inline-error" role="alert">
+      <div class="inline-error lattice-forced-colors-boundary" role="alert">
         <span>{$sessionFilesStore.error}</span>
         <button
           class="lattice-btn lattice-btn--secondary lattice-btn--compact"
@@ -181,7 +181,7 @@
       </div>
     {/if}
 
-    <section class="file-browser lattice-scroll-content" aria-label="Session file browser">
+    <section class="file-browser lattice-scroll-content lattice-forced-colors-boundary" aria-label="Session file browser">
       {#snippet fileTreeSkeleton()}
         <div class="file-tree-skeleton-shape">
           {#each FILE_TREE_SKELETON_ROWS as row}
@@ -256,7 +256,7 @@
             {/each}
           </div>
           {#if visibleEntries.length > FILE_WINDOW_SIZE}
-            <div class="file-window-controls" role="group" aria-label="File list navigation">
+            <div class="file-window-controls lattice-forced-colors-boundary" role="group" aria-label="File list navigation">
               <button
                 class="lattice-btn lattice-btn--secondary lattice-btn--compact"
                 type="button"
@@ -286,7 +286,7 @@
 
     <section class="content-viewer" aria-label="File content">
       {#if selectedEntry}
-        <header class="content-header">
+        <header class="content-header lattice-forced-colors-boundary">
           <div class="content-heading">
             <FileText size={14} weight="light" />
             <span title={normalizePath(selectedEntry.path)}>{normalizePath(selectedEntry.path)}</span>

--- a/src/lib/components/SessionFilesView.svelte
+++ b/src/lib/components/SessionFilesView.svelte
@@ -148,7 +148,7 @@
     <header class="files-header">
       <div class="heading">
         <span class="title">Session Files</span>
-        <span class="read-only-badge">Read only</span>
+        <span class="read-only-badge lattice-forced-colors-boundary">Read only</span>
       </div>
       <button
         type="button"
@@ -350,7 +350,7 @@
     padding: 9px 10px;
     /* Dense section header, not a standalone panel surface. */
     background: var(--bg-surface);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .heading,
@@ -368,7 +368,7 @@
 
   .read-only-badge {
     padding: 2px 5px;
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-sm);
     color: var(--text-muted);
     font-size: 9px;
@@ -386,7 +386,7 @@
     color: var(--status-error);
     /* Semantic inline error strip, not a structural panel. */
     background: var(--bg-surface);
-    border-bottom: 1px solid var(--status-error);
+    box-shadow: inset 0 -1px 0 var(--status-error);
     font-size: 11px;
   }
 
@@ -402,7 +402,7 @@
     max-height: 42%;
     flex: 0 1 42%;
     overflow: auto;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .file-list {
@@ -464,7 +464,7 @@
     gap: 8px;
     /* Sticky pagination controls remain a control strip, not a panel. */
     background: var(--bg-surface);
-    border-top: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam-top);
   }
 
   .file-window-status {
@@ -520,7 +520,7 @@
     padding: 8px 10px;
     /* File metadata header, not a standalone panel surface. */
     background: var(--bg-surface);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
     font-family: var(--font-mono);
     font-size: 10px;
   }

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -639,7 +639,7 @@
             selectedId={$ui.focusedAgentId}
             on:select={handleAgentSelect}
           />
-          <div class="queen-controls-section">
+          <div class="queen-controls-section lattice-forced-colors-boundary">
             <QueenControls on:openAddWorker={() => onOpenAddWorker?.()} />
           </div>
         {/if}
@@ -647,7 +647,7 @@
     {/if}
     </div>
 
-    <div class="sidebar-footer">
+    <div class="sidebar-footer lattice-forced-colors-boundary">
       <button type="button" class="lattice-btn lattice-btn--primary lattice-btn--filled lattice-btn--row" onclick={() => { launchInitialMode = undefined; launchError = ''; showLaunchDialog = true; }} title="New Session">
         <span class="icon">+</span>
         New Session

--- a/src/lib/components/SessionSidebar.svelte
+++ b/src/lib/components/SessionSidebar.svelte
@@ -936,12 +936,12 @@
   .queen-controls-section {
     margin-top: 8px;
     padding-top: 8px;
-    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
+    box-shadow: var(--edge-seam-top);
   }
 
   .sidebar-footer {
     padding: 12px;
-    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
+    box-shadow: var(--edge-seam-top);
   }
 
   .sidebar-footer .icon {

--- a/src/lib/components/ShortcutsOverlay.svelte
+++ b/src/lib/components/ShortcutsOverlay.svelte
@@ -83,7 +83,7 @@
                   <span class="keys">
                     {#each shortcut.keys as key, i (key)}
                       {#if i > 0}<span class="plus">+</span>{/if}
-                      <kbd>{key}</kbd>
+                      <kbd class="lattice-forced-colors-boundary">{key}</kbd>
                     {/each}
                   </span>
                   <span class="action">{shortcut.action}</span>
@@ -121,7 +121,7 @@
     align-items: center;
     gap: 10px;
     padding: 14px 16px;
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .dialog-icon {
@@ -179,8 +179,9 @@
   kbd {
     padding: 2px 6px;
     background: var(--bg-void);
-    border: 1px solid var(--border-structural);
-    border-bottom-width: 2px;
+    box-shadow:
+      inset 0 0 0 1px var(--border-structural),
+      inset 0 -2px 0 var(--border-structural);
     border-radius: var(--radius-sm);
     color: var(--text-primary);
     font-family: var(--font-mono);

--- a/src/lib/components/ShortcutsOverlay.svelte
+++ b/src/lib/components/ShortcutsOverlay.svelte
@@ -60,7 +60,7 @@
       onclick={(e) => e.stopPropagation()}
       onkeydown={(e) => { e.stopPropagation(); if (e.key === 'Escape') onClose(); }}
     >
-      <div class="dialog-header">
+      <div class="dialog-header lattice-forced-colors-boundary">
         <span class="dialog-icon"><Keyboard size={18} weight="light" /></span>
         <h2>Keyboard Shortcuts</h2>
         <button

--- a/src/lib/components/StatusPanel.svelte
+++ b/src/lib/components/StatusPanel.svelte
@@ -424,7 +424,7 @@
         </section>
 
         {#if isSessionActive($activeSession.state)}
-          <section class="section actions-section">
+          <section class="section actions-section lattice-forced-colors-boundary">
             <div class="operator-controls">
               {#if serdeEnumVariantName($activeSession.state) === 'QaInProgress'}
                 <button class="lattice-btn lattice-btn--secondary lattice-btn--compact" onclick={() => showSkipQaConfirm = true}>Skip QA</button>

--- a/src/lib/components/StatusPanel.svelte
+++ b/src/lib/components/StatusPanel.svelte
@@ -826,7 +826,7 @@
   .actions-section {
     margin-top: auto;
     padding-top: 12px;
-    box-shadow: inset 0 1px 0 rgba(0, 0, 0, 0.45);
+    box-shadow: var(--edge-seam-top);
   }
 
   .close-session-action {

--- a/src/lib/components/artifacts/ArtifactBrowser.svelte
+++ b/src/lib/components/artifacts/ArtifactBrowser.svelte
@@ -75,7 +75,7 @@
         padding: 16px;
         /* Workspace control strip, not a standalone structural panel. */
         background: var(--color-surface);
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
         display: flex;
         justify-content: space-between;
         align-items: center;
@@ -124,7 +124,7 @@
     .column-header {
         padding: 10px 16px;
         background: var(--color-surface-hover);
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
         font-weight: bold;
         color: var(--color-text);
         font-size: 0.9rem;

--- a/src/lib/components/artifacts/ArtifactBrowser.svelte
+++ b/src/lib/components/artifacts/ArtifactBrowser.svelte
@@ -22,7 +22,7 @@
 </script>
 
 <div class="artifact-browser">
-    <div class="browser-header">
+    <div class="browser-header lattice-forced-colors-boundary">
         <h3>Artifact Browser</h3>
         <div class="cell-filters">
             <span class="label">Filter Cells:</span>
@@ -45,7 +45,7 @@
         {:else}
             {#each displayedCells as cell}
                 <div class="cell-column lattice-panel">
-                    <div class="column-header">
+                    <div class="column-header lattice-forced-colors-boundary">
                         Cell: {cell.id.substring(0, 8)}
                     </div>
                     <div class="column-content lattice-scroll-content">

--- a/src/lib/components/artifacts/ArtifactSummary.svelte
+++ b/src/lib/components/artifacts/ArtifactSummary.svelte
@@ -56,13 +56,13 @@
 
     {#if !compact && showDetails}
         {#if artifact.test_results}
-            <div class="detail-section">
+            <div class="detail-section lattice-forced-colors-boundary">
                 <div class="detail-header">Tests</div>
                 <TestResultsPanel results={artifact.test_results} />
             </div>
         {/if}
 
-        <div class="detail-section">
+        <div class="detail-section lattice-forced-colors-boundary">
             <div class="detail-header">Changes</div>
             <DiffSummaryPanel changedFiles={artifact.changed_files} diffSummary={artifact.diff_summary} />
         </div>

--- a/src/lib/components/artifacts/ArtifactSummary.svelte
+++ b/src/lib/components/artifacts/ArtifactSummary.svelte
@@ -15,7 +15,7 @@
 </script>
 
 {#if artifact}
-<div class="artifact-summary" class:compact class:show-details={showDetails}>
+<div class="artifact-summary lattice-forced-colors-boundary" class:compact class:show-details={showDetails}>
     <div class="header">
         <div class="main-stats">
             <div class="stat">
@@ -94,7 +94,7 @@
         background: var(--bg-sunken);
         padding: 12px;
         border-radius: var(--radius-lg);
-        border: 1px solid color-mix(in srgb, var(--text-primary) 5%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 5%, transparent);
     }
 
     .artifact-summary.compact {
@@ -188,7 +188,7 @@
         flex-direction: column;
         gap: 8px;
         margin-top: 8px;
-        border-top: 1px solid color-mix(in srgb, var(--text-primary) 5%, transparent);
+        box-shadow: var(--edge-seam-top);
         padding-top: 12px;
     }
 

--- a/src/lib/components/artifacts/DiffSummaryPanel.svelte
+++ b/src/lib/components/artifacts/DiffSummaryPanel.svelte
@@ -6,7 +6,7 @@
     $: lines = diffSummary ? diffSummary.split('\n') : [];
 </script>
 
-<div class="diff-summary-panel lattice-scroll-content">
+<div class="diff-summary-panel lattice-forced-colors-boundary lattice-scroll-content">
     {#if diffSummary}
         <pre class="diff-summary-text">{diffSummary}</pre>
     {:else}
@@ -27,7 +27,7 @@
         background: var(--bg-sunken);
         border-radius: var(--radius-lg);
         padding: 12px;
-        border: 1px solid color-mix(in srgb, var(--text-primary) 5%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 5%, transparent);
         overflow-x: auto;
     }
 

--- a/src/lib/components/artifacts/TestResultsPanel.svelte
+++ b/src/lib/components/artifacts/TestResultsPanel.svelte
@@ -11,16 +11,16 @@
 
 <div class="test-results-panel">
     <div class="summary">
-        <div class="summary-item" class:pass={passed > 0}>
+        <div class="summary-item lattice-forced-colors-boundary" class:pass={passed > 0}>
             <span class="count">{passed}</span>
             <span class="label">Passed</span>
         </div>
-        <div class="summary-item" class:fail={failed > 0}>
+        <div class="summary-item lattice-forced-colors-boundary" class:fail={failed > 0}>
             <span class="count">{failed}</span>
             <span class="label">Failed</span>
         </div>
         {#if skipped > 0}
-            <div class="summary-item">
+            <div class="summary-item lattice-forced-colors-boundary">
                 <span class="count">{skipped}</span>
                 <span class="label">Skipped</span>
             </div>
@@ -31,7 +31,7 @@
         <div class="failures-list">
             <div class="failures-header">Failure Details</div>
             {#each failures as failure}
-                <div class="failure-item">
+                <div class="failure-item lattice-forced-colors-boundary">
                     <div class="test-name">
                         <X size={14} weight="light" />
                         {failure.name || 'Unknown test'}
@@ -66,15 +66,15 @@
         display: flex;
         flex-direction: column;
         align-items: center;
-        border: 1px solid color-mix(in srgb, var(--text-primary) 5%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--text-primary) 5%, transparent);
     }
 
     .summary-item.pass {
-        border-color: color-mix(in srgb, var(--status-success) 20%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-success) 20%, transparent);
     }
 
     .summary-item.fail {
-        border-color: color-mix(in srgb, var(--status-error) 20%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 20%, transparent);
     }
 
     .count {
@@ -110,7 +110,7 @@
 
     .failure-item {
         background: color-mix(in srgb, var(--status-error) 5%, transparent);
-        border: 1px solid color-mix(in srgb, var(--status-error) 10%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 10%, transparent);
         border-radius: var(--radius-lg);
         padding: 8px;
     }

--- a/src/lib/components/composer/Composer.svelte
+++ b/src/lib/components/composer/Composer.svelte
@@ -219,7 +219,7 @@
 
     const before = document.createTextNode(beforeText);
     const token = document.createElement('span');
-    token.className = `composer-token ${kind}`;
+    token.className = `composer-token lattice-forced-colors-boundary ${kind}`;
     token.dataset.tokenValue = value;
     token.contentEditable = 'false';
     token.textContent = display;
@@ -395,7 +395,7 @@
     max-width: 100%;
     margin: 0 2px;
     padding: 1px 6px;
-    border: 1px solid color-mix(in srgb, var(--accent-cyan) 45%, var(--border-structural));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cyan) 45%, var(--border-structural));
     border-radius: var(--radius-sm);
     background: color-mix(in srgb, var(--accent-cyan) 12%, transparent);
     color: var(--accent-cyan);
@@ -407,7 +407,7 @@
   }
 
   .composer :global(.composer-token.command) {
-    border-color: color-mix(in srgb, var(--accent-amber) 45%, var(--border-structural));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-amber) 45%, var(--border-structural));
     background: color-mix(in srgb, var(--accent-amber) 12%, transparent);
     color: var(--accent-amber);
   }

--- a/src/lib/components/fusion/FusionComparisonView.svelte
+++ b/src/lib/components/fusion/FusionComparisonView.svelte
@@ -44,7 +44,7 @@
     <div class="grid" style="grid-template-columns: repeat({Math.max(1, candidates.length)}, 1fr);">
         {#each candidates as cell (cell.id)}
             <div class="candidate-card lattice-panel" class:completed={cell.status === 'completed'} class:failed={cell.status === 'failed'}>
-                <div class="card-header">
+                <div class="card-header lattice-forced-colors-boundary">
                     <div class="status-row">
                         <span class="status-badge {getStatusClass(cell.status)}" title={cell.status}>
                             <svelte:component 
@@ -121,7 +121,7 @@
 
     .card-header {
         padding: 16px;
-        border-bottom: 1px solid color-mix(in srgb, var(--text-primary) 5%, transparent);
+        box-shadow: var(--edge-seam);
         display: flex;
         flex-direction: column;
         gap: 8px;

--- a/src/lib/components/fusion/ResolverPanel.svelte
+++ b/src/lib/components/fusion/ResolverPanel.svelte
@@ -30,7 +30,7 @@
     <Skeleton loading={loading} skeleton={resolverSkeleton} class="resolver-loading">
         {#if output}
             <div class="output-card lattice-forced-colors-boundary">
-                <div class="card-header">
+                <div class="card-header lattice-forced-colors-boundary">
                     <span class="label">Resolver Decision</span>
                     <div class="selected-badge">
                         Selected: <span class="candidate-name status-badge status-success">{output.selected_candidate}</span>
@@ -70,7 +70,7 @@
                 {/if}
             </div>
         {:else if error}
-            <div class="error-state" role="alert">{error}</div>
+            <div class="error-state lattice-forced-colors-boundary" role="alert">{error}</div>
         {:else}
             <div class="empty-state">
                 <div class="icon" aria-hidden="true">Resolver</div>
@@ -108,7 +108,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        border-bottom: 1px solid color-mix(in srgb, var(--accent-cyan) 10%, transparent);
+        box-shadow: var(--edge-seam);
         padding-bottom: 12px;
     }
 
@@ -210,7 +210,7 @@
         border-radius: var(--radius-sm);
         /* Semantic error treatment intentionally remains state-tinted. */
         background: color-mix(in srgb, var(--status-error) 12%, transparent);
-        border: 1px solid color-mix(in srgb, var(--status-error) 30%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 30%, transparent);
         color: var(--status-error);
         text-align: center;
     }

--- a/src/lib/components/renderers/Approval.svelte
+++ b/src/lib/components/renderers/Approval.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<div class="approval-widget" class:destructive={approval.destructive}>
+<div class="approval-widget lattice-forced-colors-boundary" class:destructive={approval.destructive}>
   <div class="approval-body">
     <div class="approval-title">{approval.title ?? 'Approval required'}</div>
     {#if approval.description}
@@ -67,7 +67,7 @@
     gap: 10px;
     /* Tool results are nested work products, so their body uses the shared sunken tone. */
     background: var(--bg-sunken);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-left: 3px solid var(--accent-cyan);
     border-radius: var(--radius-lg);
     padding: 12px;

--- a/src/lib/components/renderers/Chart.svelte
+++ b/src/lib/components/renderers/Chart.svelte
@@ -205,7 +205,7 @@
   }
 </script>
 
-<div class="chart-widget" data-testid="chart-widget">
+<div class="chart-widget lattice-forced-colors-boundary" data-testid="chart-widget">
   {#if chart.title}
     <div class="chart-title">{chart.title}</div>
   {/if}
@@ -276,7 +276,7 @@
   .chart-widget {
     /* Tool results are nested work products, so their body uses the shared sunken tone. */
     background: var(--bg-sunken);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-lg);
     overflow: hidden;
   }
@@ -288,7 +288,7 @@
     color: var(--text-primary);
     /* The opaque title strip remains table-like renderer chrome, not a structural panel. */
     background: var(--bg-surface);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .chart-frame {

--- a/src/lib/components/renderers/Chart.svelte
+++ b/src/lib/components/renderers/Chart.svelte
@@ -207,7 +207,7 @@
 
 <div class="chart-widget lattice-forced-colors-boundary" data-testid="chart-widget">
   {#if chart.title}
-    <div class="chart-title">{chart.title}</div>
+    <div class="chart-title lattice-forced-colors-boundary">{chart.title}</div>
   {/if}
 
   {#if hasPoints}

--- a/src/lib/components/renderers/DataTable.svelte
+++ b/src/lib/components/renderers/DataTable.svelte
@@ -75,7 +75,7 @@
 
 <div class="data-table-widget lattice-forced-colors-boundary">
   {#if table.rows.length > ROW_CAP}
-    <div class="notice">Showing first {ROW_CAP} of {table.rows.length} rows.</div>
+    <div class="notice lattice-forced-colors-boundary">Showing first {ROW_CAP} of {table.rows.length} rows.</div>
   {/if}
   {#if columns.length === 0}
     <div class="empty">No tabular data.</div>

--- a/src/lib/components/renderers/DataTable.svelte
+++ b/src/lib/components/renderers/DataTable.svelte
@@ -73,7 +73,7 @@
   }
 </script>
 
-<div class="data-table-widget">
+<div class="data-table-widget lattice-forced-colors-boundary">
   {#if table.rows.length > ROW_CAP}
     <div class="notice">Showing first {ROW_CAP} of {table.rows.length} rows.</div>
   {/if}
@@ -114,7 +114,7 @@
   .data-table-widget {
     /* Tool results are nested work products, so their body uses the shared sunken tone. */
     background: var(--bg-sunken);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-lg);
     overflow: hidden;
   }
@@ -124,7 +124,7 @@
     font-size: 10px;
     color: var(--text-secondary);
     background: color-mix(in srgb, var(--accent-amber) 8%, transparent);
-    border-bottom: 1px solid var(--border-structural);
+    box-shadow: var(--edge-seam);
   }
 
   .empty {
@@ -156,13 +156,12 @@
 
   td {
     padding: 4px 8px;
-    border-bottom: 1px solid color-mix(in srgb, var(--border-structural) 50%, transparent);
     color: var(--text-primary);
     word-break: break-word;
   }
 
   tbody tr:last-child td {
-    border-bottom: none;
+    box-shadow: none;
   }
 
   tbody tr:hover td {

--- a/src/lib/components/renderers/Diff.svelte
+++ b/src/lib/components/renderers/Diff.svelte
@@ -110,7 +110,7 @@
   }
 </script>
 
-<div class="diff-widget">
+<div class="diff-widget lattice-forced-colors-boundary">
   {#if renderable}
     <div class="diff-body lattice-scroll-content">
       {#each lines as line, i (i)}
@@ -129,7 +129,7 @@
   .diff-widget {
     /* Tool results are nested work products, so their body uses the shared sunken tone. */
     background: var(--bg-sunken);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-lg);
     overflow: hidden;
   }

--- a/src/lib/components/renderers/ToolRenderHost.svelte
+++ b/src/lib/components/renderers/ToolRenderHost.svelte
@@ -69,11 +69,11 @@
     <svelte:boundary>
       <Widget data={widgetData} onapprove={forwardApprove} onreject={forwardReject} />
       {#snippet failed()}
-        <pre class="tool-render-fallback lattice-scroll-content">{fallbackJson}</pre>
+        <pre class="tool-render-fallback lattice-forced-colors-boundary lattice-scroll-content">{fallbackJson}</pre>
       {/snippet}
     </svelte:boundary>
   {:else}
-    <pre class="tool-render-fallback lattice-scroll-content">{fallbackJson}</pre>
+    <pre class="tool-render-fallback lattice-forced-colors-boundary lattice-scroll-content">{fallbackJson}</pre>
   {/if}
 </div>
 
@@ -90,7 +90,7 @@
     color: var(--text-secondary);
     /* Raw tool output is a nested code work product, not a structural panel. */
     background: var(--bg-sunken);
-    border: 1px solid var(--border-structural);
+    box-shadow: inset 0 0 0 1px var(--border-structural);
     border-radius: var(--radius-sm);
     overflow-x: auto;
     white-space: pre-wrap;

--- a/src/lib/components/replay/ReplayView.svelte
+++ b/src/lib/components/replay/ReplayView.svelte
@@ -65,10 +65,10 @@
 
     <div class="state-grid">
         <div class="state-section">
-            <h4>Cells</h4>
+            <h4 class="lattice-forced-colors-boundary">Cells</h4>
             <div class="grid">
                 {#each Object.entries(state.cells) as [id, status]}
-                    <div class="state-chip">
+                    <div class="state-chip lattice-forced-colors-boundary">
                         <span class="label">{id.substring(0, 8)}</span>
                         <span class="status-badge {getStatusClass(status)}">{status}</span>
                     </div>
@@ -77,10 +77,10 @@
         </div>
 
         <div class="state-section">
-            <h4>Agents</h4>
+            <h4 class="lattice-forced-colors-boundary">Agents</h4>
             <div class="grid">
                 {#each Object.entries(state.agents) as [id, status]}
-                    <div class="state-chip">
+                    <div class="state-chip lattice-forced-colors-boundary">
                         <span class="label">{id.substring(0, 8)}</span>
                         <span class="status-badge {getStatusClass(status)}">{status}</span>
                     </div>
@@ -117,7 +117,7 @@
         color: var(--text-secondary);
         text-transform: uppercase;
         font-size: 0.75rem;
-        border-bottom: 1px solid var(--border-structural);
+        box-shadow: var(--edge-seam);
         padding-bottom: 4px;
     }
 
@@ -134,7 +134,7 @@
         padding: 6px 12px;
         /* Replay entity rows are compact state records, not structural panels. */
         background: var(--bg-surface);
-        border: 1px solid var(--border-structural);
+        box-shadow: var(--edge-seam), var(--edge-lip);
         border-radius: var(--radius-sm);
         font-size: 0.85rem;
     }

--- a/src/lib/components/session/SessionHeader.svelte
+++ b/src/lib/components/session/SessionHeader.svelte
@@ -292,15 +292,15 @@
     }
 </script>
 
-<div class="session-header">
+<div class="session-header lattice-forced-colors-boundary">
     {#if session}
         <div class="main-info">
             <div class="top-row">
-                <span class="mode-badge {mode}">{mode}</span>
+                <span class="mode-badge lattice-forced-colors-boundary {mode}">{mode}</span>
                 <h1 class="session-name">{session.name || session.id}</h1>
                 <span class="status-badge {getStatusClass(status)}">{status.replaceAll('_', ' ')}</span>
                 {#if showWorktreeChip}
-                    <span class="worktree-chip" title={worktreeTooltip}>
+                    <span class="worktree-chip lattice-forced-colors-boundary" title={worktreeTooltip}>
                         <GitBranch size={14} weight="light" aria-hidden="true" />
                         <span class="worktree-label">{worktreeChipLabel}</span>
                     </span>
@@ -359,7 +359,7 @@
                 {/if}
 
                 {#if previewOpen}
-                    <div class="preview-live" aria-live="polite">
+                    <div class="preview-live lattice-forced-colors-boundary" aria-live="polite">
                         <span class="preview-live-mode">{previewDocked ? 'Docked' : 'Popped out'}</span>
                         <div class="preview-live-url" title={previewCurrentUrl}>
                             <Skeleton loading={!previewStatusResolved && !previewUrlCopied} layout="inline">
@@ -443,7 +443,7 @@
 <style>
     .session-header {
         background: var(--bg-void);
-        border-bottom: 1px solid var(--border-structural);
+        box-shadow: var(--edge-seam);
         padding: 12px 20px;
         display: flex;
         justify-content: space-between;
@@ -481,7 +481,7 @@
         /* A compact mode badge uses a neutral semantic backing, not a panel surface. */
         background: var(--bg-surface);
         color: var(--text-primary);
-        border: 1px solid var(--border-structural);
+        box-shadow: inset 0 0 0 1px var(--border-structural);
     }
 
     .mode-badge.hive { background: var(--status-warning); color: var(--bg-void); }
@@ -496,7 +496,7 @@
         max-width: min(240px, 38vw);
         padding: 2px 8px;
         border-radius: var(--radius-sm);
-        border: 1px solid var(--border-structural);
+        box-shadow: inset 0 0 0 1px var(--border-structural);
         /* Worktree metadata is a compact chip, not a structural panel. */
         background: var(--bg-elevated);
         color: var(--text-muted);
@@ -559,7 +559,7 @@
         max-width: min(360px, 42vw);
         height: 24px;
         padding: 0 4px 0 8px;
-        border: 1px solid var(--border-structural);
+        box-shadow: inset 0 0 0 1px var(--border-structural);
         border-radius: var(--radius-sm);
         /* Live preview metadata is a compact control chip, not a structural panel. */
         background: var(--bg-elevated);

--- a/src/lib/components/session/SessionOverview.svelte
+++ b/src/lib/components/session/SessionOverview.svelte
@@ -111,7 +111,7 @@
             </div>
         {:else}
             <div class="terminal-section lattice-panel">
-                <div class="terminal-controls">
+                <div class="terminal-controls lattice-forced-colors-boundary">
                     <div class="tab-bar" role="tablist" aria-label="Session view">
                         <button type="button" role="tab" class="lattice-tab" class:lattice-tab--active={activeView === 'terminal'} aria-selected={activeView === 'terminal'} onclick={() => activeView = 'terminal'}>Terminal</button>
                         <button type="button" role="tab" class="lattice-tab" class:lattice-tab--active={activeView === 'observability'} aria-selected={activeView === 'observability'} onclick={() => activeView = 'observability'}>Observability</button>
@@ -129,10 +129,10 @@
                     {#if activeView === 'observability'}
                         <div class="observability-container">
                             <div class="obs-main">
-                                <div class="obs-timeline">
+                                <div class="obs-timeline lattice-forced-colors-boundary">
                                     <TimelineView />
                                 </div>
-                                <div class="obs-replay">
+                                <div class="obs-replay lattice-forced-colors-boundary">
                                     <ReplayView />
                                 </div>
                             </div>
@@ -201,7 +201,7 @@
         display: flex;
         justify-content: space-between;
         align-items: center;
-        border-bottom: 1px solid var(--border-structural);
+        box-shadow: var(--edge-seam);
     }
 
     .tab-bar {
@@ -239,6 +239,6 @@
 
     .obs-timeline, .obs-replay {
         overflow: hidden;
-        border-right: 1px solid var(--border-structural);
+        box-shadow: inset -1px 0 0 rgba(0, 0, 0, 0.45);
     }
 </style>

--- a/src/lib/components/templates/TemplateEditor.svelte
+++ b/src/lib/components/templates/TemplateEditor.svelte
@@ -75,12 +75,12 @@
     <div class="header">
         <h3>{is_builtin ? 'Clone Template' : (template ? 'Edit Template' : 'New Template')}</h3>
         {#if is_builtin}
-            <div class="info-badge">Built-in templates cannot be modified. Saving will create a new custom template.</div>
+            <div class="info-badge lattice-forced-colors-boundary">Built-in templates cannot be modified. Saving will create a new custom template.</div>
         {/if}
     </div>
 
     {#if error}
-        <div class="error-banner" role="alert">{error}</div>
+        <div class="error-banner lattice-forced-colors-boundary" role="alert">{error}</div>
     {/if}
 
     <div class="form-section">
@@ -127,7 +127,7 @@
 
         <div class="cells-list lattice-scroll-chrome">
             {#each cells as cell, i}
-                <div class="cell-editor-card">
+                <div class="cell-editor-card lattice-panel">
                     <div class="card-header">
                         <span class="cell-num">Cell {i + 1}</span>
                         <button type="button" class="lattice-btn lattice-btn--ghost lattice-btn--danger lattice-btn--compact" on:click={() => removeCell(i)}>Remove</button>
@@ -158,7 +158,7 @@
         </div>
     </div>
 
-    <div class="actions">
+    <div class="actions lattice-forced-colors-boundary">
         <button type="button" class="lattice-btn lattice-btn--secondary" on:click={handleCancel}>Cancel</button>
         <button type="button" class="lattice-btn lattice-btn--primary" on:click={handleSave} disabled={!name}>Save Template</button>
     </div>
@@ -185,14 +185,14 @@
         background: color-mix(in srgb, var(--accent-cyan) 10%, transparent);
         padding: 6px 10px;
         border-radius: var(--radius-sm);
-        border: 1px solid color-mix(in srgb, var(--accent-cyan) 20%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cyan) 20%, transparent);
     }
 
     .error-banner {
         padding: 10px 12px;
         border-radius: var(--radius-sm);
         background: color-mix(in srgb, var(--status-error) 12%, transparent);
-        border: 1px solid color-mix(in srgb, var(--status-error) 35%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--status-error) 35%, transparent);
         color: var(--status-error);
         font-size: 12px;
     }
@@ -254,7 +254,6 @@
 
     .cell-editor-card {
         background: color-mix(in srgb, var(--text-primary) 3%, transparent);
-        border: 1px solid color-mix(in srgb, var(--text-primary) 8%, transparent);
         border-radius: var(--radius-md);
         padding: 12px;
         display: flex;
@@ -281,7 +280,7 @@
         gap: 12px;
         margin-top: 12px;
         padding-top: 20px;
-        border-top: 1px solid color-mix(in srgb, var(--text-primary) 10%, transparent);
+        box-shadow: var(--edge-lip);
     }
 
 </style>

--- a/src/lib/components/templates/TemplateEditor.svelte
+++ b/src/lib/components/templates/TemplateEditor.svelte
@@ -280,7 +280,7 @@
         gap: 12px;
         margin-top: 12px;
         padding-top: 20px;
-        box-shadow: var(--edge-lip);
+        box-shadow: var(--edge-seam-top);
     }
 
 </style>

--- a/src/lib/components/templates/TemplatePicker.svelte
+++ b/src/lib/components/templates/TemplatePicker.svelte
@@ -25,7 +25,7 @@
 {#snippet templateGridSkeleton()}
     <div class="templates-grid lattice-scroll-chrome">
         {#each [0, 1, 2] as _}
-            <div class="template-skeleton-card">
+            <div class="template-skeleton-card lattice-forced-colors-boundary">
                 <SkelBar width="44px" height="44px" radius="md" />
                 <div class="template-skeleton-info">
                     <SkelBar width="62%" height="1rem" />
@@ -72,7 +72,11 @@
                         on:click={() => selectTemplate(template)}
                         title={template.description}
                     >
-                        <div class="card-icon" class:builtin={template.is_builtin}>
+                        <div
+                            class="card-icon"
+                            class:builtin={template.is_builtin}
+                            class:lattice-forced-colors-boundary={template.is_builtin}
+                        >
                             {#if template.mode === 'hive'}
                                 <Hexagon size={24} weight="light" />
                             {:else if template.mode === 'debate'}
@@ -147,7 +151,7 @@
         padding: 12px;
         display: flex;
         gap: 12px;
-        border: 1px solid var(--border-structural);
+        box-shadow: inset 0 0 0 1px var(--border-structural);
         border-radius: var(--radius-md);
     }
 
@@ -178,7 +182,7 @@
     }
 
     .card-icon.builtin {
-        border: 1px solid color-mix(in srgb, var(--accent-cyan) 30%, transparent);
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent-cyan) 30%, transparent);
     }
 
     .card-info {

--- a/src/lib/components/timeline/EventDetailsModal.svelte
+++ b/src/lib/components/timeline/EventDetailsModal.svelte
@@ -59,7 +59,7 @@
         aria-label="Event details"
         tabindex="-1"
     >
-        <div class="modal-header">
+        <div class="modal-header lattice-forced-colors-boundary">
             <h3>Event Details</h3>
             <div class="header-actions">
                 <button type="button" class="lattice-btn lattice-btn--secondary lattice-btn--compact" on:click={copyToClipboard}>Copy JSON</button>
@@ -81,7 +81,7 @@
             </div>
 
             <div class="payload-section">
-                <h4>Payload</h4>
+                <h4 class="lattice-forced-colors-boundary">Payload</h4>
                 <pre class="lattice-scroll-content">{formatJSON(event.payload)}</pre>
             </div>
         </div>
@@ -125,7 +125,7 @@
         justify-content: space-between;
         align-items: center;
         padding: 16px;
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
     }
 
     .modal-header h3 {
@@ -169,7 +169,7 @@
     .payload-section h4 {
         margin: 0 0 12px 0;
         color: var(--color-text-muted);
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
         padding-bottom: 4px;
     }
 

--- a/src/lib/components/timeline/EventListItem.svelte
+++ b/src/lib/components/timeline/EventListItem.svelte
@@ -35,7 +35,7 @@
 </script>
 
 <button type="button" class="lattice-btn lattice-btn--row" on:click={() => dispatch('select', event)}>
-    <div class="event-item">
+    <div class="event-item lattice-forced-colors-boundary">
         <div class="severity-indicator" style="background-color: {getSeverityColor(event.severity)}"></div>
         
         <div class="event-time">{formatTime(event.timestamp)}</div>
@@ -46,10 +46,10 @@
 
         <div class="event-source">
             {#if event.cell_id}
-                <span class="badge cell-badge">{event.cell_id.substring(0, 8)}</span>
+                <span class="badge cell-badge lattice-forced-colors-boundary">{event.cell_id.substring(0, 8)}</span>
             {/if}
             {#if event.agent_id}
-                <span class="badge agent-badge">{event.agent_id.substring(0, 8)}</span>
+                <span class="badge agent-badge lattice-forced-colors-boundary">{event.agent_id.substring(0, 8)}</span>
             {/if}
         </div>
 
@@ -66,7 +66,7 @@
         gap: 12px;
         align-items: center;
         width: 100%;
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
         font-family: var(--font-mono);
         font-size: 0.8rem;
     }
@@ -95,7 +95,7 @@
         font-size: 0.7rem;
         background: var(--color-accent-dim);
         color: var(--color-accent);
-        border: 1px solid var(--color-accent-dim);
+        box-shadow: inset 0 0 0 1px var(--color-accent-dim);
     }
 
     .cell-badge {

--- a/src/lib/components/timeline/TimelineView.svelte
+++ b/src/lib/components/timeline/TimelineView.svelte
@@ -23,7 +23,7 @@
 <div class="timeline-container">
     <EventFilterPanel />
 
-    <div class="event-list-header">
+    <div class="event-list-header lattice-forced-colors-boundary">
         <div class="header-item">Time</div>
         <div class="header-item">Type</div>
         <div class="header-item">Source</div>
@@ -67,7 +67,7 @@
         gap: 12px;
         padding: 8px 12px;
         background: var(--color-surface-hover);
-        border-bottom: 1px solid var(--color-border);
+        box-shadow: var(--edge-seam);
         font-family: var(--font-mono);
         font-size: 0.7rem;
         font-weight: bold;

--- a/src/lib/styles/lattice-tokens.css
+++ b/src/lib/styles/lattice-tokens.css
@@ -97,6 +97,7 @@
   /* ── Edges — a lit top lip and an inset seam replace the 1px rule ── */
   --edge-lip:  inset 0 1px 0 rgba(255, 255, 255, 0.055);
   --edge-seam: inset 0 -1px 0 rgba(0, 0, 0, 0.45);
+  --edge-seam-top: inset 0 1px 0 rgba(0, 0, 0, 0.45);
 
   /* ── Elevation — occlusion shadow; must read on --bg-void ──────── */
   --elev-1: 0 1px 2px rgba(0, 0, 0, 0.55), 0 2px 6px  rgba(0, 0, 0, 0.35);


### PR DESCRIPTION
Closes #205. Closes #203.

Two independent, already-triaged issues. They share no file, no build target, and no test surface — they are together because they were the open queue, not because they are coupled. Reviewers can read the two commits separately.

## #205 — Quiescence reflects work, not liveness

`update_heartbeat` bumped `Session::last_activity_at` on **every** heartbeat regardless of status, and `can_complete_session` measures the 10-minute quiescence window off that same field. A worker parked in its post-completion idle loop therefore refreshed the clock forever, so a finished session could never reach quiescence and `POST /complete` never succeeded.

The fix gates the session-level bump on a named predicate — `status_counts_as_session_activity(status) = status != "completed"` — applied at **both** mutation sites: `update_heartbeat`, and the clone-time recompute in `list_sessions`. The second is not a correctness bug (it mutates a clone) but it feeds `GET /api/sessions`, so leaving it would have produced a fix that works and *looks* broken: "active 3s ago" beside a fully drained clock.

Three things worth a reviewer's attention:

**Why gating on `completed` alone is sufficient.** The prompt contract already pins the idle loop to `completed` and explicitly forbids downgrading it to `working`/`idle` without a new ACTIVE assignment. That instruction is what makes this fix complete rather than merely probable, so it is deliberately left untouched.

**Stall detection is untouched.** The per-agent `AgentHeartbeatInfo` write stays unconditional. `get_stalled_agents` reads `info.last_activity` — a different field from `Session::last_activity_at` — and already filters completed agents. An agent silent mid-work is still flagged.

**`idle` had to be disambiguated, and that is not cosmetic.** It carried two opposite meanings: *"done, release the session"* in the Queen's prompt tail, and *"alive, blocked on another actor"* for the Prince while a QA verdict is pending. Exempting `idle` would strand the Prince; not exempting it would strand the Queen. The Queen's done-signal is now `completed`, and the prompt states explicitly that she holds the session open by continuing to heartbeat `working` while she intends further waves — including across wave boundaries while deliberating with no principal active. Without this half the bug remains: a finished Queen would hold the clock open forever.

Completion is never automatic — `mark_session_completed` is only ever reached through `POST /complete`. A drained clock makes completion *permitted*, never *performed*.

Seven regression tests sit beside `test_complete_session_returns_conflict_when_not_quiescent`, including two that pin the Queen's authority over "done": a mid-wave Queen beating `working` cannot be completed out from under her (409, window reset), and her `completed` beat is what releases the session — not worker silence. The pre-existing `test_list_sessions_reflects_fresh_heartbeat_activity_and_persists_it` is unmodified and stays green; it posts `working`, so it was the canary for the change going wider than intended.

## #203 — Lattice `1px solid` sweep

Mechanical completion of the lattice v2 wave: the borders no workstream of #198–#201 claimed. **98 → 10.**

**The issue's baseline of 97 is wrong; the real number is 98.** Measured at PR #202's merge commit `f5119aa` and at `HEAD`, with PR #204 adding zero occurrences. A transcription error in the issue, not drift. The issue's other arithmetic (92 + 9 = 101) does not reconcile either; a measured file-level partition replaced it — 36 + 52 + 10 = 98, every file accounted for.

Border-for-shadow substitution only. No layout, spacing, or colour changes; no view redesigned. Two shapes:

- **Full-box borders** → `inset 0 0 0 1px` in the *same colour*. Visually identical.
- **Directional borders** → seam shadows (`--edge-seam`, `--edge-seam-top`). This recolours a structural grey line to a dark overlay. It is the idiom PR #202 established and what #203 asked for, but it is a genuine tonal shift and reviewers should look at it as such.

Adds **`--edge-seam-top`** to `lattice-tokens.css`. `--edge-seam` is the *bottom* seam (negative offset) and no top-edge counterpart existed, so the longhand `inset 0 1px 0 rgba(0,0,0,0.45)` had been inlined — 3 occurrences predating this wave, 11 more added by it. All 14 now use the token.

All ten protected occurrences survive **verbatim at identical line numbers**, verified by diff against a pre-wave snapshot. Note `.status-*`'s `1px solid transparent` is not merely a layout placeholder as the issue describes — it is also the visible border for `.status-success` et al., and removing it would collapse every status chip.

The three failure modes PR #202's cross-review found were checked explicitly: no nested `.lattice-panel` (only one was added wave-wide); the single local `box-shadow` on a `.lattice-panel` element (`LaunchDialog .node`) restates the full stack in canonical order — identity inset, elevation, edge lip; and zero `transition: … border-color` introduced, matching the zero that existed before.

## Validation

| Gate | Result |
|---|---|
| `cargo check --tests` | Pass (compiles at 0.42.1) |
| `cargo clippy` | **Not run** — not installed for `stable-x86_64-pc-windows-msvc` on this machine; CI-only |
| `npm run check` | 0 errors, 0 warnings |
| `npm test` | 30 files, 153 tests |
| `git diff package-lock.json` | Empty |
| `cargo test` | **Not run locally** — fails on this machine with `STATUS_ENTRYPOINT_NOT_FOUND`; CI is the real gate |

## Known gap — the visual smoke was not performed

Stated plainly because #203's entire risk profile is visual.

The session-bound views (`DebatePanel`, `SessionFilesView`, `FusionPanel`, `PlanView`, `ConversationViewer`, and most of the long-tail files) could not be visually verified. The session list is served by Tauri IPC into the app's **own** in-process controller, and a second instance cannot bind port 18800 while the primary app holds it; session views are not URL-addressable either. Smoking them would have required stopping the running application. The operator was given the choice and elected to ship and rely on review.

What *was* verified for those views: the static G2 audit (protected set, nesting, shadow-order, transitions) and per-file before/after counts. `LaunchDialog.svelte` — the highest-risk file in the wave — was smoked in both default and `forced-colors` rendering.

**Reviewers: treat the unsmoked views as the weakest evidence in this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Completed heartbeats now keep agents active for stall detection without extending session quiescence timers.
  - Working and idle heartbeats continue to extend session activity timers.

- **Accessibility**
  - Improved compatibility with forced-color display modes across panels, dialogs, status indicators, and content widgets.

- **Style**
  - Refined visual separators, outlines, badges, and error states for more consistent themed presentation.

- **Release**
  - Updated the application to version 0.42.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->