### PR TITLE
fix(#207): per-agent codex store isolation, startup liveness verification, reclaimable dead slots

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.42.1"
+version = "0.42.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.42.1"
+version = "0.42.2"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/cli/agent_store.rs
+++ b/src-tauri/src/cli/agent_store.rs
@@ -1,0 +1,187 @@
+//! Per-agent CLI state isolation (#207).
+//!
+//! Codex keeps its SQLite state — `state_5.sqlite`, `logs_2.sqlite`, `goals_1.sqlite`,
+//! `memories_1.sqlite`, `queue_1.sqlite` — in one directory shared by every process that
+//! inherits the operator's environment. Workers spawned together therefore race the same
+//! lock, and once that store is large enough the losers die during startup with
+//! `failed to initialize state runtime ... (code: 5) database is locked`.
+//!
+//! `sqlite_home` relocates only that store. Credentials (`auth.json`) and configuration
+//! (`config.toml`) deliberately stay in the single shared `CODEX_HOME`. Giving each worker
+//! a whole private home instead would copy OAuth tokens into per-session directories and
+//! let N copies refresh — and rotate — the same refresh token against each other. Verified
+//! against codex-cli 0.147.0: with `sqlite_home` set, every `*.sqlite` lands in the
+//! override directory and the shared home stays DB-free.
+
+use std::path::{Path, PathBuf};
+
+/// Root directory holding every per-agent CLI state store.
+///
+/// Follows the same temp-dir convention the Windows batch writer already uses. These
+/// stores are regenerable caches, and keeping worker traffic out of the operator's real
+/// `~/.codex` is what stops that store from growing without bound.
+pub fn store_root() -> PathBuf {
+    std::env::temp_dir().join("hive-manager").join("cli-state")
+}
+
+/// State-store directory for a single agent.
+pub fn store_dir_for(agent_id: &str) -> PathBuf {
+    store_root().join(sanitize_component(agent_id))
+}
+
+/// Flags that point `command` at its own state store.
+///
+/// Returns empty for every CLI that has no shared-store problem, so non-codex agents keep
+/// their argv byte-for-byte identical.
+pub fn isolation_args(command: &str, store_dir: &Path) -> Vec<String> {
+    if !is_codex(command) {
+        return Vec::new();
+    }
+
+    // Two argv entries rather than one pre-joined string: the Windows batch writer quotes
+    // any single arg containing a space, which is what lets a store path under
+    // `D:\Code Projects\...` survive. Passing `-c sqlite_home=<path>` unquoted splits at
+    // the space and silently consumes the positional prompt slot.
+    vec![
+        "-c".to_string(),
+        format!("sqlite_home={}", store_dir.display()),
+    ]
+}
+
+/// Whether `command` is a CLI with a shared-store contention problem — i.e. codex,
+/// tolerating a full path or an `.exe` suffix. Callers use this both to inject the
+/// isolation flags and to stagger spawns.
+pub fn has_contended_store(command: &str) -> bool {
+    is_codex(command)
+}
+
+/// Whether `command` names the codex CLI, tolerating a full path or an `.exe` suffix.
+fn is_codex(command: &str) -> bool {
+    Path::new(command)
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| stem.eq_ignore_ascii_case("codex"))
+}
+
+/// How long an untouched per-agent store survives before the startup janitor removes it.
+const STALE_STORE_RETENTION: std::time::Duration =
+    std::time::Duration::from_secs(7 * 24 * 60 * 60);
+
+/// Best-effort removal of per-agent stores that have not been touched within the
+/// retention window (#207 fix 6, for the stores this app creates).
+///
+/// These are regenerable caches keyed by agent id; a finished session never touches its
+/// stores again, so anything old is garbage. Without this the fix for unbounded growth of
+/// `~/.codex` would just relocate the growth here. Every failure is skipped silently — a
+/// janitor must never take the app down.
+pub fn cleanup_stale_stores() {
+    let root = store_root();
+    let Ok(entries) = std::fs::read_dir(&root) else {
+        return;
+    };
+
+    let now = std::time::SystemTime::now();
+    let mut removed = 0usize;
+    for entry in entries.flatten() {
+        let Ok(metadata) = entry.metadata() else {
+            continue;
+        };
+        if !metadata.is_dir() {
+            continue;
+        }
+        let expired = metadata
+            .modified()
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age > STALE_STORE_RETENTION);
+        if expired && std::fs::remove_dir_all(entry.path()).is_ok() {
+            removed += 1;
+        }
+    }
+
+    if removed > 0 {
+        tracing::info!(
+            removed,
+            root = %root.display(),
+            "removed stale per-agent CLI state stores"
+        );
+    }
+}
+
+/// Agent ids are `{session-uuid}-worker-{n}` today, but they reach the filesystem here, so
+/// anything outside a conservative allowlist collapses to `_`.
+fn sanitize_component(raw: &str) -> String {
+    let cleaned: String = raw
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    if cleaned.is_empty() {
+        "agent".to_string()
+    } else {
+        cleaned
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codex_gets_a_private_sqlite_home() {
+        let args = isolation_args("codex", Path::new("/tmp/store"));
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0], "-c");
+        assert!(args[1].starts_with("sqlite_home="));
+        assert!(args[1].contains("store"));
+    }
+
+    #[test]
+    fn the_store_path_stays_one_argv_entry_so_spaces_survive_quoting() {
+        // Regression guard for the failure that makes codex exit 2 with
+        // "unexpected argument": if the path were pre-joined onto `-c`, or split here,
+        // a store under `D:\Code Projects\...` would break the positional prompt.
+        let args = isolation_args("codex", Path::new(r"D:\Code Projects\hive\store"));
+        assert_eq!(args.len(), 2);
+        assert!(args[1].contains("Code Projects"));
+    }
+
+    #[test]
+    fn non_codex_clis_are_left_untouched() {
+        for cli in ["claude", "droid", "cursor", "opencode", "qwen", "agy"] {
+            assert!(
+                isolation_args(cli, Path::new("/tmp/store")).is_empty(),
+                "{cli} should not be given codex flags"
+            );
+        }
+    }
+
+    #[test]
+    fn codex_is_detected_through_a_path_or_exe_suffix() {
+        let store = Path::new("/tmp/store");
+        assert!(!isolation_args("codex.exe", store).is_empty());
+        assert!(!isolation_args(r"C:\npm\bin\codex.exe", store).is_empty());
+        assert!(!isolation_args("CODEX", store).is_empty());
+    }
+
+    #[test]
+    fn each_agent_id_maps_to_its_own_directory() {
+        let a = store_dir_for("sess-worker-1");
+        let b = store_dir_for("sess-worker-2");
+        assert_ne!(a, b);
+        assert!(a.starts_with(store_root()));
+    }
+
+    #[test]
+    fn path_separators_in_an_agent_id_cannot_escape_the_store_root() {
+        let escaped = store_dir_for("../../etc/passwd");
+        assert!(escaped.starts_with(store_root()));
+        assert_eq!(escaped.components().count(), store_root().components().count() + 1);
+    }
+}

--- a/src-tauri/src/cli/agent_store.rs
+++ b/src-tauri/src/cli/agent_store.rs
@@ -24,6 +24,29 @@ pub fn store_root() -> PathBuf {
     std::env::temp_dir().join("hive-manager").join("cli-state")
 }
 
+/// Restrict the store root to the current user on platforms with a shared, world-writable
+/// temp directory. On Windows, `%TEMP%` is already per-user; on Unix, `/tmp` is shared and
+/// the per-agent paths are predictable, so without this another local user could pre-own
+/// them. Best-effort: isolation still works if the chmod fails, it is just less private.
+#[cfg(unix)]
+fn restrict_to_current_user(dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn restrict_to_current_user(_dir: &Path) {}
+
+/// Create the per-agent store directory, tightening permissions on the shared root.
+pub fn ensure_store_dir(store_dir: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(store_dir)?;
+    if let Some(root) = store_dir.parent() {
+        restrict_to_current_user(root);
+    }
+    restrict_to_current_user(store_dir);
+    Ok(())
+}
+
 /// State-store directory for a single agent.
 pub fn store_dir_for(agent_id: &str) -> PathBuf {
     store_root().join(sanitize_component(agent_id))
@@ -89,9 +112,18 @@ pub fn cleanup_stale_stores() {
         if !metadata.is_dir() {
             continue;
         }
-        let expired = metadata
-            .modified()
-            .ok()
+        // Age by the newest timestamp of the directory AND everything inside it: a
+        // directory's own mtime does not move when SQLite writes into an existing file,
+        // so judging the directory alone could reap a store that is still in active use
+        // (e.g. by a long-lived process from a prior session).
+        let newest = std::fs::read_dir(entry.path())
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|child| child.metadata().ok()?.modified().ok())
+            .chain(metadata.modified().ok())
+            .max();
+        let expired = newest
             .and_then(|modified| now.duration_since(modified).ok())
             .is_some_and(|age| age > STALE_STORE_RETENTION);
         if expired && std::fs::remove_dir_all(entry.path()).is_ok() {

--- a/src-tauri/src/cli/mod.rs
+++ b/src-tauri/src/cli/mod.rs
@@ -1,4 +1,5 @@
 // CLI registry module - infrastructure for future CLI management features
+pub mod agent_store;
 pub mod health;
 mod registry;
 

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -344,22 +344,26 @@ pub async fn add_worker(
 
         // Free the slot so a retry respawns worker-N in place instead of advancing the
         // index and orphaning the original branch/task-file paths.
-        let discard = {
+        let slot_freed = {
             let controller = state.session_controller.read();
-            controller.discard_worker_slot(&session_id, &agent_info.id)
+            match controller.discard_worker_slot(&session_id, &agent_info.id) {
+                Ok(_) => true,
+                Err(error) => {
+                    tracing::warn!(
+                        worker_id = %agent_info.id,
+                        %error,
+                        "failed to discard the dead worker's roster slot"
+                    );
+                    false
+                }
+            }
         };
-        if let Err(error) = discard {
-            tracing::warn!(
-                worker_id = %agent_info.id,
-                %error,
-                "failed to discard the dead worker's roster slot"
-            );
-        }
 
         let mut details: HashMap<String, Value> = HashMap::new();
         details.insert("worker_id".to_string(), json!(predicted_worker_id));
         details.insert("session_id".to_string(), json!(session_id));
         details.insert("reason".to_string(), json!("failed_to_start"));
+        details.insert("slot_freed".to_string(), json!(slot_freed));
         details.insert("cli_output".to_string(), json!(tail_for_api(&cli_output)));
 
         match state
@@ -386,11 +390,19 @@ pub async fn add_worker(
         }
 
         return Err(ApiError::internal_with_details(
-            format!(
-                "Worker {} spawned but its process died during startup; the slot has \
-                 been freed for an in-place retry",
-                predicted_worker_id
-            ),
+            if slot_freed {
+                format!(
+                    "Worker {} spawned but its process died during startup; the slot has \
+                     been freed for an in-place retry",
+                    predicted_worker_id
+                )
+            } else {
+                format!(
+                    "Worker {} spawned but its process died during startup; its roster \
+                     slot could NOT be freed, so an in-place retry is not yet possible",
+                    predicted_worker_id
+                )
+            },
             details,
         ));
     }
@@ -539,7 +551,10 @@ pub async fn release_worker(
     }
 
     // Rostered but dead: discard the roster entry (and its launch artifacts) so the
-    // index becomes reusable, then release the claim below as usual.
+    // index becomes reusable, then release the claim below as usual. The discard
+    // refuses lanes that produced work (a completion commit, commits past base, or a
+    // dirty worktree) — that refusal is a conflict the caller must resolve, not a
+    // server fault.
     let discarded_rostered_slot = rostered;
     if rostered {
         let discard = {
@@ -547,10 +562,10 @@ pub async fn release_worker(
             controller.discard_worker_slot(&session_id, &worker_id)
         };
         if let Err(error) = discard {
-            return Err(ApiError::internal(format!(
-                "Worker {} has no live process but its roster slot could not be discarded: {}",
-                worker_id, error
-            )));
+            let mut details: HashMap<String, Value> = HashMap::new();
+            details.insert("reason".to_string(), json!("slot_has_work"));
+            details.insert("worker_id".to_string(), json!(worker_id));
+            return Err(ApiError::conflict_with_details(error, details));
         }
     }
 

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::{validate_cli, validate_session_id};
 use crate::cli::CliRegistry;
@@ -21,6 +22,20 @@ use crate::session::{AddWorkerError, AddWorkerRejectionReason, SessionController
 /// A session that simply is not accepting workers right now is a conflict the
 /// caller can act on, not an internal error — the old blanket 500 gave the Queen
 /// nothing to work with.
+/// Last portion of a CLI's captured output, sized for an API error payload (#207).
+fn tail_for_api(output: &str) -> String {
+    const MAX_BYTES: usize = 2000;
+    let trimmed = output.trim();
+    if trimmed.len() <= MAX_BYTES {
+        return trimmed.to_string();
+    }
+    let mut start = trimmed.len() - MAX_BYTES;
+    while !trimmed.is_char_boundary(start) {
+        start += 1;
+    }
+    trimmed[start..].to_string()
+}
+
 fn add_worker_error_to_api(err: AddWorkerError) -> ApiError {
     match err {
         AddWorkerError::SessionNotFound(id) => {
@@ -297,6 +312,89 @@ pub async fn add_worker(
         }
     };
 
+    // #207 fix 2: the spawn call returning is not evidence the worker is running. In the
+    // field, codex processes died within moments of starting ("database is locked") while
+    // the roster reported them Running for ~50 minutes. Hold the response until the
+    // process has survived a short startup grace window; if it dies inside the window,
+    // fail loudly with the CLI's own output and recover the slot in place.
+    let startup_grace = Duration::from_millis(if cfg!(test) { 250 } else { 1500 });
+    let startup_poll = Duration::from_millis(50);
+    let started_at = std::time::Instant::now();
+    let died_during_startup = loop {
+        let alive = { state.pty_manager.read().is_alive(&agent_info.id) };
+        if !alive {
+            break true;
+        }
+        if started_at.elapsed() >= startup_grace {
+            break false;
+        }
+        tokio::time::sleep(startup_poll).await;
+    };
+
+    if died_during_startup {
+        // Give the reader thread a beat to drain the PTY's final bytes, then capture the
+        // output BEFORE killing: kill() drops the session, and with it the only record of
+        // why the CLI died.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        let cli_output = { state.pty_manager.read().recent_output(&agent_info.id) }
+            .unwrap_or_default();
+        {
+            let _ = state.pty_manager.read().kill(&agent_info.id);
+        }
+
+        // Free the slot so a retry respawns worker-N in place instead of advancing the
+        // index and orphaning the original branch/task-file paths.
+        let discard = {
+            let controller = state.session_controller.read();
+            controller.discard_worker_slot(&session_id, &agent_info.id)
+        };
+        if let Err(error) = discard {
+            tracing::warn!(
+                worker_id = %agent_info.id,
+                %error,
+                "failed to discard the dead worker's roster slot"
+            );
+        }
+
+        let mut details: HashMap<String, Value> = HashMap::new();
+        details.insert("worker_id".to_string(), json!(predicted_worker_id));
+        details.insert("session_id".to_string(), json!(session_id));
+        details.insert("reason".to_string(), json!("failed_to_start"));
+        details.insert("cli_output".to_string(), json!(tail_for_api(&cli_output)));
+
+        match state
+            .queue_manager
+            .release_after_failed_spawn(&session_id, &predicted_worker_id, &queue_id, epoch)
+            .await
+        {
+            Ok(ReleaseAfterFailure::Exhausted { attempts }) => {
+                details.insert("attempts".to_string(), json!(attempts));
+                return Err(ApiError::conflict_with_details(
+                    format!(
+                        "Worker {} failed to start {} times and has been retired",
+                        predicted_worker_id, attempts
+                    ),
+                    details,
+                ));
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                worker_id = %predicted_worker_id,
+                error = %e,
+                "failed to release the queue claim after a startup death"
+            ),
+        }
+
+        return Err(ApiError::internal_with_details(
+            format!(
+                "Worker {} spawned but its process died during startup; the slot has \
+                 been freed for an in-place retry",
+                predicted_worker_id
+            ),
+            details,
+        ));
+    }
+
     // From here to the response there must be NO fallible early return: the PTY
     // is live, and releasing the claim past this point is a double-spawn vector.
     let (worker_id, worker_index) = {
@@ -396,17 +494,28 @@ pub async fn release_worker(
     super::validate_agent_id(&worker_id)?;
 
     // Scope every !Send guard before the await below.
-    let (rostered, live_pty) = {
+    let (rostered, is_worker_slot, live_pty) = {
         let controller = state.session_controller.read();
         let session = controller
             .get_session(&session_id)
             .ok_or_else(|| ApiError::not_found(format!("Session {} not found", session_id)))?;
-        let rostered = session.agents.iter().any(|a| a.id == worker_id);
+        let rostered_agent = session.agents.iter().find(|a| a.id == worker_id);
+        let rostered = rostered_agent.is_some();
+        let is_worker_slot = rostered_agent
+            .map(|a| matches!(a.role, AgentRole::Worker { .. }))
+            .unwrap_or(false);
         let live_pty = state.pty_manager.read().is_alive(&worker_id);
-        (rostered, live_pty)
+        (rostered, is_worker_slot, live_pty)
     };
 
-    if rostered {
+    // #207 fix 4: for WORKER slots, refusal now requires a live process, not mere roster
+    // membership. Under the old rules a worker whose CLI died at startup — still
+    // rostered, reported Running, no process behind it — could never be recovered in
+    // place: release refused with "rostered", DELETE moved it to Completed but kept the
+    // entry, and a re-spawn advanced the index, orphaning the original task-file paths.
+    // Non-worker roster members (queen, evaluator, prince, QA) keep the unconditional
+    // refusal: this route recovers worker slots, nothing else.
+    if rostered && (live_pty || !is_worker_slot) {
         let mut details: HashMap<String, Value> = HashMap::new();
         details.insert("reason".to_string(), json!("rostered"));
         details.insert("worker_id".to_string(), json!(worker_id));
@@ -429,6 +538,22 @@ pub async fn release_worker(
         ));
     }
 
+    // Rostered but dead: discard the roster entry (and its launch artifacts) so the
+    // index becomes reusable, then release the claim below as usual.
+    let discarded_rostered_slot = rostered;
+    if rostered {
+        let discard = {
+            let controller = state.session_controller.read();
+            controller.discard_worker_slot(&session_id, &worker_id)
+        };
+        if let Err(error) = discard {
+            return Err(ApiError::internal(format!(
+                "Worker {} has no live process but its roster slot could not be discarded: {}",
+                worker_id, error
+            )));
+        }
+    }
+
     let outcome = state
         .queue_manager
         .release_claim(&session_id, &worker_id)
@@ -444,6 +569,7 @@ pub async fn release_worker(
                 "released": true,
                 "previous_status": previous.as_tag(),
                 "new_status": "queued",
+                "discarded_rostered_slot": discarded_rostered_slot,
             })),
         )),
         ReleaseOutcome::AlreadyQueued => Ok((
@@ -454,6 +580,7 @@ pub async fn release_worker(
                 "released": false,
                 "previous_status": "queued",
                 "new_status": "queued",
+                "discarded_rostered_slot": discarded_rostered_slot,
             })),
         )),
         ReleaseOutcome::Terminal { status } => Ok((
@@ -464,6 +591,21 @@ pub async fn release_worker(
                 "released": false,
                 "previous_status": status.as_tag(),
                 "new_status": status.as_tag(),
+                "discarded_rostered_slot": discarded_rostered_slot,
+            })),
+        )),
+        // Launch-time workers predate the durable queue and have no row; if we just
+        // discarded such a worker's dead slot, that recovery is the meaningful outcome
+        // and deserves a 200, not a 404 (#207).
+        ReleaseOutcome::NoRow if discarded_rostered_slot => Ok((
+            StatusCode::OK,
+            Json(json!({
+                "session_id": session_id,
+                "worker_id": worker_id,
+                "released": false,
+                "previous_status": "none",
+                "new_status": "none",
+                "discarded_rostered_slot": true,
             })),
         )),
         ReleaseOutcome::NoRow => Err(ApiError::not_found(format!(

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -9058,8 +9058,12 @@ async fn release_recovers_a_leaked_claim() {
     assert_eq!(snap.rows[0].attempts, 0, "the spawn budget must be reset");
 }
 
-/// The release route must refuse a worker that is genuinely on the roster —
-/// releasing it would strand the row, since the index allocator targets N+1.
+/// The release route must refuse a worker that is on the roster AND has a live
+/// process — releasing it would strand the row behind a running agent.
+///
+/// #207 narrowed this guard: roster membership alone no longer refuses, because a
+/// rostered entry with no live process is exactly the dead slot the route must be
+/// able to recover (see `release_frees_a_dead_rostered_slot_for_in_place_respawn`).
 #[tokio::test]
 async fn release_refuses_a_rostered_worker() {
     let storage_dir = TempDir::new().unwrap();
@@ -9073,6 +9077,14 @@ async fn release_refuses_a_rostered_worker() {
         temp_dir.path().to_str().unwrap(),
         &[&worker],
     ));
+    register_live_pty(
+        &state,
+        &worker,
+        AgentRole::Worker {
+            index: 1,
+            parent: None,
+        },
+    );
 
     state
         .queue_manager
@@ -9106,6 +9118,254 @@ async fn release_refuses_a_rostered_worker() {
         1,
         "a refused release must leave the row untouched"
     );
+}
+
+// ----------------------------------------------------------------------------
+// #207 — startup death detection + in-place slot recovery
+// ----------------------------------------------------------------------------
+
+/// #207 fix 2. A worker whose CLI dies during startup must be reported
+/// `failed_to_start` with the CLI's own output — not `Running`.
+///
+/// This pins the exact field failure: codex died in moments with "database is
+/// locked" while the roster said Running for ~50 minutes. The stub PTY treats the
+/// `--stub-die-on-start` flag as an immediate startup death, exercising the full
+/// HTTP path through the startup-grace poll.
+#[tokio::test]
+async fn add_worker_that_dies_during_startup_is_failed_to_start_not_running() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("doa-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    // A research (no-git) session spawns straight from the project dir, so the spawn
+    // itself succeeds and only the startup verification can catch the death.
+    session.no_git = true;
+    controller.read().insert_test_session(session);
+
+    let post = |body: serde_json::Value| {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/sessions/{}/workers", session_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        }
+    };
+
+    let res = post(serde_json::json!({
+        "role_type": "researcher",
+        "cli": "claude",
+        "flags": ["--stub-die-on-start"],
+    }))
+    .await;
+    assert_eq!(res.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "failed_to_start");
+    assert!(
+        body["cli_output"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("database is locked"),
+        "the CLI's dying words must be surfaced, got: {}",
+        body["cli_output"]
+    );
+
+    // The dead slot must be fully recovered: roster empty, claim released.
+    {
+        let controller = controller.read();
+        let session = controller.get_session(&session_id).unwrap();
+        assert!(
+            session.agents.is_empty(),
+            "a worker that never ran must not stay on the roster"
+        );
+    }
+    let snap = state.queue_manager.queue_snapshot(&session_id).unwrap();
+    assert_eq!(snap.running, 0, "the claim must be released");
+    assert_eq!(snap.queued, 1, "the row must be claimable again");
+    assert_eq!(snap.rows[0].attempts, 1, "the failed start must burn one attempt");
+
+    // And a retry must reuse worker-1 in place, not advance to worker-2.
+    let res = post(serde_json::json!({ "role_type": "researcher", "cli": "claude" })).await;
+    assert_eq!(res.status(), StatusCode::CREATED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        body["worker_id"],
+        format!("{}-worker-1", session_id),
+        "recovery must respawn the original slot"
+    );
+}
+
+/// #207 fix 4. A rostered worker with no live process is a dead slot; release must
+/// recover it — discard the roster entry, release the claim — so the index can be
+/// respawned in place instead of advancing to N+1.
+#[tokio::test]
+async fn release_frees_a_dead_rostered_slot_for_in_place_respawn() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("deadslot-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let worker_1 = format!("{}-worker-1", session_id);
+    let worker_2 = format!("{}-worker-2", session_id);
+    let mut session = make_test_session_with_agents(
+        &session_id,
+        temp_dir.path().to_str().unwrap(),
+        &[&worker_1, &worker_2],
+    );
+    session.no_git = true;
+    controller.read().insert_test_session(session);
+    // worker-1 is genuinely alive; worker-2 has no PTY at all — the phantom.
+    register_live_pty(
+        &state,
+        &worker_1,
+        AgentRole::Worker {
+            index: 1,
+            parent: None,
+        },
+    );
+
+    state
+        .queue_manager
+        .enqueue_worker(&worker_2, &session_id, &worker_2, "backend", "claude", serde_json::json!({}), None)
+        .await
+        .unwrap();
+    state
+        .queue_manager
+        .claim_and_spawn(&worker_2, &session_id, &worker_2)
+        .await
+        .unwrap();
+
+    let res = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/workers/{}/release",
+                    session_id, worker_2
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::OK);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["released"], true);
+    assert_eq!(body["discarded_rostered_slot"], true);
+
+    // The roster keeps the live worker and drops the phantom.
+    {
+        let controller = controller.read();
+        let session = controller.get_session(&session_id).unwrap();
+        let ids: Vec<&str> = session.agents.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, vec![worker_1.as_str()]);
+    }
+    let snap = state.queue_manager.queue_snapshot(&session_id).unwrap();
+    assert_eq!(snap.running, 0);
+    assert_eq!(snap.queued, 1, "the row must be claimable again");
+
+    // The freed index is handed out again: the next spawn is worker-2, not worker-3.
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "role_type": "researcher", "cli": "claude" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["worker_id"], worker_2);
+}
+
+/// #207. The index allocator hands out the lowest unused worker index, keyed on the
+/// roster's role indices — with workers 1 and 3 present, the next spawn is 2.
+///
+/// The old count-based allocator would return 3 here and collide with the live
+/// worker-3 (mutation check: `count + 1` fails this test).
+#[tokio::test]
+async fn add_worker_fills_the_lowest_free_worker_slot() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("gapfill-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.no_git = true;
+    session.agents = vec![
+        make_test_agent(
+            &format!("{}-worker-1", session_id),
+            AgentRole::Worker {
+                index: 1,
+                parent: None,
+            },
+        ),
+        make_test_agent(
+            &format!("{}-worker-3", session_id),
+            AgentRole::Worker {
+                index: 3,
+                parent: None,
+            },
+        ),
+    ];
+    controller.read().insert_test_session(session);
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::json!({ "role_type": "researcher", "cli": "claude" }).to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CREATED);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["worker_id"], format!("{}-worker-2", session_id));
 }
 
 /// #175(f). A heartbeat from an id with no roster entry, no PTY and no queue row

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -9175,6 +9175,10 @@ async fn add_worker_that_dies_during_startup_is_failed_to_start_not_running() {
     )
     .unwrap();
     assert_eq!(body["reason"], "failed_to_start");
+    assert_eq!(
+        body["slot_freed"], true,
+        "the response must confirm the slot was actually recovered"
+    );
     assert!(
         body["cli_output"]
             .as_str()
@@ -9311,6 +9315,75 @@ async fn release_frees_a_dead_rostered_slot_for_in_place_respawn() {
     )
     .unwrap();
     assert_eq!(body["worker_id"], worker_2);
+}
+
+/// #207. Dead-slot recovery must never destroy work: a rostered worker with a
+/// recorded completion commit is refused even though its process is gone, because
+/// discarding would force-delete its branch.
+#[tokio::test]
+async fn release_refuses_a_dead_worker_that_produced_work() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, _storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("haswork-{}", uuid::Uuid::new_v4());
+    let temp_dir = TempDir::new().unwrap();
+    let worker = format!("{}-worker-1", session_id);
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    let mut finished = make_test_agent(
+        &worker,
+        AgentRole::Worker {
+            index: 1,
+            parent: None,
+        },
+    );
+    finished.commit_sha = Some("abc123def".to_string());
+    session.agents = vec![finished];
+    controller.read().insert_test_session(session);
+
+    state
+        .queue_manager
+        .enqueue_worker(&worker, &session_id, &worker, "backend", "claude", serde_json::json!({}), None)
+        .await
+        .unwrap();
+    state
+        .queue_manager
+        .claim_and_spawn(&worker, &session_id, &worker)
+        .await
+        .unwrap();
+
+    let res = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/workers/{}/release",
+                    session_id, worker
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(res.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "slot_has_work");
+
+    // Nothing was half-done: roster intact, queue row untouched.
+    {
+        let controller = controller.read();
+        let session = controller.get_session(&session_id).unwrap();
+        assert_eq!(session.agents.len(), 1, "the finished worker must stay rostered");
+    }
+    assert_eq!(
+        state.queue_manager.queue_snapshot(&session_id).unwrap().running,
+        1,
+        "a refused release must leave the row untouched"
+    );
 }
 
 /// #207. The index allocator hands out the lowest unused worker index, keyed on the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -90,6 +90,10 @@ pub fn run() {
     let shared_config = Arc::new(tokio::sync::RwLock::new(config));
     let event_bus = EventBus::new(storage.base_dir().clone());
 
+    // #207: sweep per-agent CLI state stores left behind by finished sessions. Off the
+    // startup path — it walks and deletes directories — and best-effort by design.
+    std::thread::spawn(crate::cli::agent_store::cleanup_stale_stores);
+
     // Create shared state
     let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
     let session_controller = Arc::new(RwLock::new(SessionController::new(Arc::clone(

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -120,7 +120,7 @@ impl PtyManager {
         let isolation_flags = if isolation_flags.is_empty() {
             isolation_flags
         } else {
-            match std::fs::create_dir_all(&store_dir) {
+            match agent_store::ensure_store_dir(&store_dir) {
                 Ok(()) => isolation_flags,
                 Err(error) => {
                     tracing::warn!(

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -6,6 +6,7 @@ use parking_lot::{Mutex, RwLock};
 use serde::Serialize;
 
 use super::session::{AgentRole, AgentStatus, PtyError, PtySession, read_from_reader};
+use crate::cli::agent_store;
 use crate::tauri_shim::{AppHandle, Emitter};
 
 #[derive(Clone, Serialize)]
@@ -20,11 +21,25 @@ pub struct PtyStatusChange {
     pub status: AgentStatus,
 }
 
+/// Minimum spacing between consecutive codex spawns (#207 fix 3).
+///
+/// Per-agent store isolation removes the shared-SQLite lock by construction; this gap is
+/// the defense-in-depth layer for the startup burst itself, where several codex processes
+/// initializing at once amplified contention in the field failure. Kept short — it bounds
+/// concurrent startups, it does not serialize the workers' actual runs.
+#[cfg(not(test))]
+const CODEX_SPAWN_GAP: Duration = Duration::from_millis(750);
+#[cfg(test)]
+const CODEX_SPAWN_GAP: Duration = Duration::from_millis(10);
+
 pub struct PtyManager {
     sessions: Arc<RwLock<HashMap<String, Arc<PtySession>>>>,
     /// Serialize create/kill so a same-id kill cannot pass between process spawn and
     /// insertion, and a duplicate create cannot replace a still-live process handle.
     lifecycle: Mutex<()>,
+    /// When the most recent codex spawn happened. Held on its own mutex so a spawn
+    /// waiting out the stagger gap does not block kill/status/list.
+    last_codex_spawn: Mutex<Option<std::time::Instant>>,
     app_handle: Option<AppHandle>,
 }
 
@@ -37,6 +52,7 @@ impl PtyManager {
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             lifecycle: Mutex::new(()),
+            last_codex_spawn: Mutex::new(None),
             app_handle: None,
         }
     }
@@ -55,6 +71,19 @@ impl PtyManager {
         cols: u16,
         rows: u16,
     ) -> Result<String, PtyError> {
+        // #207 fix 3: stagger codex starts. Taken before the lifecycle lock so a spawn
+        // waiting out the gap does not stall kill/create of unrelated agents.
+        if agent_store::has_contended_store(command) {
+            let mut last = self.last_codex_spawn.lock();
+            if let Some(previous) = *last {
+                let since = previous.elapsed();
+                if since < CODEX_SPAWN_GAP {
+                    thread::sleep(CODEX_SPAWN_GAP - since);
+                }
+            }
+            *last = Some(std::time::Instant::now());
+        }
+
         let _lifecycle_guard = self.lifecycle.lock();
         let existing = { self.sessions.read().get(&id).cloned() };
         if let Some(existing) = existing {
@@ -76,7 +105,51 @@ impl PtyManager {
             }
         }
 
-        let session = Arc::new(PtySession::new(id.clone(), role, command, args, cwd, cols, rows)?);
+        // #207: give this agent its own CLI state store before spawning. Codex keeps its
+        // SQLite state in one directory shared by every process that inherits the
+        // operator's environment, so workers started together race that lock and the
+        // losers die during startup with "database is locked". This is the one choke
+        // point every agent spawn passes through, which is why the flags are injected
+        // here rather than at each of the caller sites.
+        //
+        // Best-effort by design: if the store directory cannot be created we spawn on the
+        // shared store anyway rather than turn a contention mitigation into a hard spawn
+        // failure. The warning is the signal that isolation was lost.
+        let store_dir = agent_store::store_dir_for(&id);
+        let isolation_flags = agent_store::isolation_args(command, &store_dir);
+        let isolation_flags = if isolation_flags.is_empty() {
+            isolation_flags
+        } else {
+            match std::fs::create_dir_all(&store_dir) {
+                Ok(()) => isolation_flags,
+                Err(error) => {
+                    tracing::warn!(
+                        agent = %id,
+                        store = %store_dir.display(),
+                        %error,
+                        "could not create a private CLI state store; falling back to the shared store"
+                    );
+                    Vec::new()
+                }
+            }
+        };
+
+        // Isolation flags go in front so the CLI's trailing positional prompt stays last.
+        let effective_args: Vec<&str> = isolation_flags
+            .iter()
+            .map(String::as_str)
+            .chain(args.iter().copied())
+            .collect();
+
+        let session = Arc::new(PtySession::new(
+            id.clone(),
+            role,
+            command,
+            &effective_args,
+            cwd,
+            cols,
+            rows,
+        )?);
 
         // Insert session BEFORE spawning reader thread (fixes race condition)
         {
@@ -84,10 +157,16 @@ impl PtyManager {
             sessions.insert(id.clone(), Arc::clone(&session));
         }
 
-        // Start the output reader thread
-        if let Some(ref app_handle) = self.app_handle {
+        // Start the output reader thread.
+        //
+        // #207: this runs whether or not a UI is attached. It used to be gated on
+        // `app_handle`, so in headless HTTP mode — and in every test — nothing ever read
+        // the PTY and a CLI that died during startup had its error text discarded by the
+        // OS, leaving no way to explain the failure. The bytes now always feed the
+        // session's rolling diagnostic buffer; emitting to the UI is the optional part.
+        {
             let session_clone = Arc::clone(&session);
-            let app_handle_clone = app_handle.clone();
+            let app_handle_clone = self.app_handle.clone();
             let id_clone = id.clone();
             let sessions_ref = Arc::clone(&self.sessions);
 
@@ -119,21 +198,27 @@ impl PtyManager {
 
                     if bytes_read > 0 {
                         tracing::debug!("PTY {} read {} bytes", id_clone, bytes_read);
-                        let output = PtyOutput {
-                            id: id_clone.clone(),
-                            data: buf[..bytes_read].to_vec(),
-                        };
-                        if let Err(e) = app_handle_clone.emit("pty-output", output) {
-                            tracing::error!("Failed to emit pty-output: {}", e);
+                        session_clone.record_output(&buf[..bytes_read]);
+
+                        if let Some(ref app_handle) = app_handle_clone {
+                            let output = PtyOutput {
+                                id: id_clone.clone(),
+                                data: buf[..bytes_read].to_vec(),
+                            };
+                            if let Err(e) = app_handle.emit("pty-output", output) {
+                                tracing::error!("Failed to emit pty-output: {}", e);
+                            }
                         }
                     }
                 }
 
                 // Session ended - emit status change
-                let _ = app_handle_clone.emit("pty-status", PtyStatusChange {
-                    id: id_clone,
-                    status: AgentStatus::Completed,
-                });
+                if let Some(ref app_handle) = app_handle_clone {
+                    let _ = app_handle.emit("pty-status", PtyStatusChange {
+                        id: id_clone,
+                        status: AgentStatus::Completed,
+                    });
+                }
             });
         }
 
@@ -215,6 +300,24 @@ impl PtyManager {
             .unwrap_or(false)
     }
 
+    /// Retained tail of an agent's output (#207).
+    ///
+    /// A PTY merges stdout and stderr, so for a CLI that dies during startup this is the
+    /// only place its error text survives — it is what turns "worker failed to start"
+    /// into "database is locked".
+    pub fn recent_output(&self, id: &str) -> Option<String> {
+        let sessions = self.sessions.read();
+        sessions.get(id).map(|session| session.recent_output())
+    }
+
+    /// Test hook: the argv a session was actually spawned with, so store isolation can be
+    /// asserted at the spawn rather than only in the helper that computes the flags.
+    #[cfg(all(test, windows))]
+    pub fn spawn_args_for_test(&self, id: &str) -> Option<Vec<String>> {
+        let sessions = self.sessions.read();
+        sessions.get(id).map(|session| session.args().to_vec())
+    }
+
     pub fn list_sessions(&self) -> Vec<(String, AgentRole, AgentStatus)> {
         let sessions = self.sessions.read();
         sessions
@@ -228,5 +331,91 @@ impl PtyManager {
 impl Default for PtyManager {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// The stub PTY session records its argv, so these run only where the stub is active.
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    fn worker_role() -> AgentRole {
+        AgentRole::Worker {
+            index: 1,
+            parent: None,
+        }
+    }
+
+    /// #207: the spawn itself — not just the helper that computes the flags — must carry
+    /// the private store, and the flags must precede the positional prompt.
+    #[test]
+    fn codex_spawns_carry_a_private_sqlite_home() {
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                "iso-codex-agent".to_string(),
+                worker_role(),
+                "codex",
+                &["exec", "do the thing"],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        let args = manager.spawn_args_for_test("iso-codex-agent").unwrap();
+        assert_eq!(args[0], "-c");
+        assert!(args[1].starts_with("sqlite_home="), "got: {}", args[1]);
+        assert!(args[1].contains("iso-codex-agent"), "got: {}", args[1]);
+        assert_eq!(
+            args.last().map(String::as_str),
+            Some("do the thing"),
+            "the positional prompt must stay last"
+        );
+    }
+
+    /// #207: only the CLI with the shared-store problem is touched.
+    #[test]
+    fn non_codex_spawns_keep_their_argv_untouched() {
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                "plain-claude-agent".to_string(),
+                worker_role(),
+                "claude",
+                &["-p", "hello"],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        let args = manager.spawn_args_for_test("plain-claude-agent").unwrap();
+        assert_eq!(args, vec!["-p".to_string(), "hello".to_string()]);
+    }
+
+    /// #207: a session that dies during startup reports dead and keeps its final output
+    /// available for diagnostics until it is killed/removed.
+    #[test]
+    fn a_startup_death_is_visible_and_its_output_survives() {
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                "doa-agent".to_string(),
+                worker_role(),
+                "claude",
+                &["--stub-die-on-start"],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        assert!(!manager.is_alive("doa-agent"));
+        let output = manager.recent_output("doa-agent").unwrap();
+        assert!(output.contains("database is locked"), "got: {output}");
+
+        manager.kill("doa-agent").unwrap();
+        assert!(manager.recent_output("doa-agent").is_none());
     }
 }

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use parking_lot::Mutex;
 use thiserror::Error;
@@ -179,6 +180,9 @@ fn sanitize_bracketed_paste(data: &[u8]) -> Cow<'_, [u8]> {
     Cow::Owned(sanitized)
 }
 
+/// How much of the child's most recent output to retain for failure diagnostics.
+const RECENT_OUTPUT_CAPACITY: usize = 8 * 1024;
+
 pub struct PtySession {
     pub role: AgentRole,
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
@@ -186,6 +190,14 @@ pub struct PtySession {
     reader: Arc<Mutex<SendReader>>,
     child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
     master: Arc<Mutex<MasterPtyHandle>>,
+    /// Bounded tail of everything the child wrote to the PTY.
+    ///
+    /// A PTY merges stdout and stderr, and before #207 those bytes were forwarded to the
+    /// UI and otherwise discarded — with no app handle (headless HTTP mode, and every
+    /// test) no reader thread ran at all, so a CLI that died during startup left no trace
+    /// in the process, on disk, or in the DB. Startup verification needs this text to say
+    /// *why* a worker failed instead of just that it did.
+    recent_output: Arc<Mutex<VecDeque<u8>>>,
 }
 
 // Make PtySession Send + Sync
@@ -277,7 +289,30 @@ impl PtySession {
             reader: Arc::new(Mutex::new(SendReader(reader))),
             child: Arc::new(Mutex::new(Some(child))),
             master: Arc::new(Mutex::new(MasterPtyHandle(master))),
+            recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(
+                RECENT_OUTPUT_CAPACITY,
+            ))),
         })
+    }
+
+    /// Append `bytes` to the rolling diagnostic tail, evicting the oldest bytes once the
+    /// buffer is full. Called by the reader thread for every chunk, whether or not the UI
+    /// is attached.
+    pub fn record_output(&self, bytes: &[u8]) {
+        let mut buffer = self.recent_output.lock();
+        for byte in bytes {
+            if buffer.len() == RECENT_OUTPUT_CAPACITY {
+                buffer.pop_front();
+            }
+            buffer.push_back(*byte);
+        }
+    }
+
+    /// The retained tail of the child's output, lossily decoded.
+    pub fn recent_output(&self) -> String {
+        let buffer = self.recent_output.lock();
+        let bytes: Vec<u8> = buffer.iter().copied().collect();
+        String::from_utf8_lossy(&bytes).into_owned()
     }
 
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -3,6 +3,7 @@
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::sync::Arc;
 use thiserror::Error;
@@ -149,11 +150,19 @@ fn sanitize_bracketed_paste(data: &[u8]) -> Cow<'_, [u8]> {
     Cow::Owned(sanitized)
 }
 
+const RECENT_OUTPUT_CAPACITY: usize = 8 * 1024;
+
 pub struct PtySession {
     pub role: AgentRole,
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
     writer: Arc<Mutex<SendWriter>>,
     reader: Arc<Mutex<SendReader>>,
+    /// The argv this session was created with. The real session hands these to the OS and
+    /// forgets them; retaining them here is what lets tests assert that per-agent store
+    /// isolation (#207) actually reached the spawn rather than just the helper that
+    /// computes it.
+    args: Vec<String>,
+    recent_output: Arc<Mutex<VecDeque<u8>>>,
 }
 
 unsafe impl Send for PtySession {}
@@ -164,19 +173,58 @@ impl PtySession {
         _id: String,
         role: AgentRole,
         _command: &str,
-        _args: &[&str],
+        args: &[&str],
         _cwd: Option<&str>,
         _cols: u16,
         _rows: u16,
     ) -> Result<Self, PtyError> {
-        Ok(Self {
+        let session = Self {
             role,
             status: Arc::new(parking_lot::RwLock::new(AgentStatus::Starting)),
             writer: Arc::new(Mutex::new(SendWriter(Box::new(std::io::sink())))),
             reader: Arc::new(Mutex::new(SendReader(Box::new(std::io::Cursor::new(
                 Vec::new(),
             ))))),
-        })
+            args: args.iter().map(|arg| arg.to_string()).collect(),
+            recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(
+                RECENT_OUTPUT_CAPACITY,
+            ))),
+        };
+
+        // #207 test fixture: a flag-borne sentinel is the only way an integration test
+        // can produce a spawn that "succeeds" and then dies during startup — the field
+        // failure mode. It flows in through AgentConfig.flags, so the full HTTP path is
+        // exercised. The canned output mirrors the real codex lock error so tests can
+        // assert the text is surfaced.
+        if session.args.iter().any(|arg| arg == "--stub-die-on-start") {
+            *session.status.write() = AgentStatus::Completed;
+            session.record_output(
+                b"failed to initialize state runtime: failed to open log DB: \
+                  (code: 5) database is locked (stub)",
+            );
+        }
+
+        Ok(session)
+    }
+
+    pub fn args(&self) -> &[String] {
+        &self.args
+    }
+
+    pub fn record_output(&self, bytes: &[u8]) {
+        let mut buffer = self.recent_output.lock();
+        for byte in bytes {
+            if buffer.len() == RECENT_OUTPUT_CAPACITY {
+                buffer.pop_front();
+            }
+            buffer.push_back(*byte);
+        }
+    }
+
+    pub fn recent_output(&self) -> String {
+        let buffer = self.recent_output.lock();
+        let bytes: Vec<u8> = buffer.iter().copied().collect();
+        String::from_utf8_lossy(&bytes).into_owned()
     }
 
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -2558,6 +2558,30 @@ impl SessionController {
         }
     }
 
+    /// Whether a worktree has uncommitted changes (`git status --porcelain` non-empty).
+    ///
+    /// Fails safe: if git cannot answer, report dirty so a discard refuses rather than
+    /// destroys.
+    fn worktree_has_local_changes(worktree_path: &Path) -> bool {
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
+            .arg(worktree_path)
+            .arg("status")
+            .arg("--porcelain");
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            const CREATE_NO_WINDOW: u32 = 0x08000000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
+        match cmd.output() {
+            Ok(output) if output.status.success() => !output.stdout.trim_ascii().is_empty(),
+            _ => true,
+        }
+    }
+
     fn delete_branch(project_path: &Path, branch_name: &str) {
         let mut cmd = Command::new("git");
         cmd.arg("-C")
@@ -13155,19 +13179,24 @@ phases and do EXACTLY this, then stop:
     ///
     /// The caller is responsible for making sure the process is actually dead first
     /// (kill it or verify `is_alive` is false); this method only cleans up.
+    ///
+    /// Discarding is refused unless the lane provably produced nothing: no recorded
+    /// completion commit, and — for isolated git lanes — a branch tip still at the
+    /// recorded base with a clean worktree. `rollback_worker_launch_artifacts`
+    /// force-deletes the worker branch, so without these guards a release aimed at a
+    /// phantom could destroy a finished worker's committed work.
     pub fn discard_worker_slot(&self, session_id: &str, worker_id: &str) -> Result<u8, String> {
-        let (session, worker_index) = {
+        let (session, worker_index, worker_commit_sha, worker_base_commit_sha) = {
             let sessions = self.sessions.read();
             let session = sessions
                 .get(session_id)
                 .cloned()
                 .ok_or_else(|| format!("Session not found: {}", session_id))?;
-            let index = session
+            let agent = session
                 .agents
                 .iter()
-                .find_map(|a| match (&a.role, a.id == worker_id) {
-                    (AgentRole::Worker { index, .. }, true) => Some(*index),
-                    _ => None,
+                .find(|a| {
+                    a.id == worker_id && matches!(a.role, AgentRole::Worker { .. })
                 })
                 .ok_or_else(|| {
                     format!(
@@ -13175,8 +13204,25 @@ phases and do EXACTLY this, then stop:
                         worker_id, session_id
                     )
                 })?;
-            (session, index)
+            let index = match agent.role {
+                AgentRole::Worker { index, .. } => index,
+                _ => unreachable!("filtered to Worker above"),
+            };
+            (
+                session.clone(),
+                index,
+                agent.commit_sha.clone(),
+                agent.base_commit_sha.clone(),
+            )
         };
+
+        if worker_commit_sha.is_some() {
+            return Err(format!(
+                "Worker {} has a recorded completion commit; refusing to discard a slot \
+                 that produced work",
+                worker_id
+            ));
+        }
 
         let uses_shared_workspace = !session.no_git
             && matches!(&session.session_type, SessionType::Hive { .. })
@@ -13208,6 +13254,42 @@ phases and do EXACTLY this, then stop:
             .join(".hive-manager")
             .join("prompts")
             .join(format!("worker-{}-prompt.md", worker_index));
+
+        // For isolated git lanes, prove the lane is empty before destroying it. A worker
+        // killed mid-run has commits past its base or a dirty worktree; a phantom that
+        // never executed an instruction has neither.
+        if creates_worker_worktree && worker_cwd.exists() {
+            match current_head(&worker_cwd) {
+                Ok(tip) => match &worker_base_commit_sha {
+                    Some(base) if *base == tip => {}
+                    Some(base) => {
+                        return Err(format!(
+                            "Worker {} branch has advanced past its base ({} -> {}); \
+                             refusing to discard a slot that produced work",
+                            worker_id, base, tip
+                        ));
+                    }
+                    None => {
+                        return Err(format!(
+                            "Worker {} has no recorded base commit to compare against; \
+                             refusing to discard — clean up the worktree manually if the \
+                             lane is truly empty",
+                            worker_id
+                        ));
+                    }
+                },
+                // No resolvable HEAD (worktree half-created) — nothing to preserve.
+                Err(_) => {}
+            }
+
+            if Self::worktree_has_local_changes(&worker_cwd) {
+                return Err(format!(
+                    "Worker {} worktree has uncommitted changes; refusing to discard a \
+                     slot that produced work",
+                    worker_id
+                ));
+            }
+        }
 
         Self::rollback_worker_launch_artifacts(
             &session.project_path,

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -13124,12 +13124,116 @@ phases and do EXACTLY this, then stop:
     /// The worker index the next spawn will take. One definition, used by both
     /// the handler's reservation and `add_worker` itself.
     pub(crate) fn next_worker_index(session: &Session) -> u8 {
-        let existing = session
+        // #207: first unused index, not roster-count + 1. Counting breaks the moment a
+        // slot is discarded (a dead-on-arrival worker, or an operator release of a dead
+        // slot): with workers 1 and 3 on the roster a count would hand out 3 again and
+        // collide with the live worker-3, while the freed worker-2 — whose branch, task
+        // file, and queue row all key on its index — could never be respawned in place.
+        let used: std::collections::HashSet<u8> = session
             .agents
             .iter()
-            .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
-            .count();
-        (existing + 1) as u8
+            .filter_map(|a| match a.role {
+                AgentRole::Worker { index, .. } => Some(index),
+                _ => None,
+            })
+            .collect();
+        (1..=u8::MAX)
+            .find(|candidate| !used.contains(candidate))
+            .unwrap_or(u8::MAX)
+    }
+
+    /// Remove a dead worker's roster entry and launch artifacts so its slot can be
+    /// respawned in place (#207).
+    ///
+    /// This is the recovery half of startup verification: a worker whose CLI died
+    /// during startup — or one the operator releases after its process is gone — keeps
+    /// its roster entry under the old rules, which both misreports it as `Running`
+    /// forever and permanently burns its index. Discarding the entry lets
+    /// `next_worker_index` hand the same slot out again, so the retry reuses the
+    /// original branch name, task-file path, and durable queue row instead of
+    /// advancing to worker-N+1 and orphaning all three.
+    ///
+    /// The caller is responsible for making sure the process is actually dead first
+    /// (kill it or verify `is_alive` is false); this method only cleans up.
+    pub fn discard_worker_slot(&self, session_id: &str, worker_id: &str) -> Result<u8, String> {
+        let (session, worker_index) = {
+            let sessions = self.sessions.read();
+            let session = sessions
+                .get(session_id)
+                .cloned()
+                .ok_or_else(|| format!("Session not found: {}", session_id))?;
+            let index = session
+                .agents
+                .iter()
+                .find_map(|a| match (&a.role, a.id == worker_id) {
+                    (AgentRole::Worker { index, .. }, true) => Some(*index),
+                    _ => None,
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "Worker {} is not a rostered worker of session {}",
+                        worker_id, session_id
+                    )
+                })?;
+            (session, index)
+        };
+
+        let uses_shared_workspace = !session.no_git
+            && matches!(&session.session_type, SessionType::Hive { .. })
+            && session.execution_policy.workspace_strategy == WorkspaceStrategy::SharedCell;
+        let creates_worker_worktree = !session.no_git && !uses_shared_workspace;
+        let worker_cell_name = format!("worker-{worker_index}");
+
+        // Mirror add_worker's artifact layout exactly: task file (strategy-dependent),
+        // prompt file under the worker cwd, and the per-worker worktree + branch.
+        let task_file_path =
+            Self::task_file_path_for_session_worker(&session, worker_index as usize)?;
+        let worker_cwd = if session.no_git {
+            session.project_path.clone()
+        } else if uses_shared_workspace {
+            session
+                .worktree_path
+                .as_ref()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| session.project_path.clone())
+        } else {
+            session
+                .project_path
+                .join(".hive-manager")
+                .join("worktrees")
+                .join(session_id)
+                .join(&worker_cell_name)
+        };
+        let prompt_file = worker_cwd
+            .join(".hive-manager")
+            .join("prompts")
+            .join(format!("worker-{}-prompt.md", worker_index));
+
+        Self::rollback_worker_launch_artifacts(
+            &session.project_path,
+            session_id,
+            &worker_cell_name,
+            &task_file_path,
+            Some(&prompt_file),
+            creates_worker_worktree,
+        );
+
+        {
+            let mut sessions = self.sessions.write();
+            if let Some(session) = sessions.get_mut(session_id) {
+                session.agents.retain(|a| a.id != worker_id);
+            }
+        }
+        self.update_session_storage(session_id);
+        self.emit_session_update(session_id);
+
+        tracing::info!(
+            session = %session_id,
+            worker = %worker_id,
+            index = worker_index,
+            "discarded dead worker slot; index is reusable"
+        );
+        Ok(worker_index)
     }
 
     /// Read-only reservation used by the HTTP handler before it touches the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Closes #207.

## What happened in the field

3 codex principals spawned within ~2s; only one acquired the shared `~/.codex` SQLite lock. The other two died at startup with `database is locked` — and the manager reported all three as `Running` the entire time, costing a Queen ~50 minutes on lanes that never executed an instruction. The dead slots could not be recovered in place: release refused with `rostered`, and re-spawning advanced the index, orphaning the original task-file paths.

## Verification that drove the design (codex-cli 0.147.0, live probes)

The issue flagged one blocking unknown — whether a fresh per-worker `CODEX_HOME` inherits authentication. It does not, and the failure mode is worse than unauthenticated: with `OPENAI_API_KEY` exported in the operator's environment, an empty `CODEX_HOME` **silently falls back to API-key auth** instead of the ChatGPT plan — misbilling, not failing loudly.

The better mechanism: **`sqlite_home` is a first-class codex config key** that relocates *only* the SQLite store (`state_5`, `logs_2`, `goals_1`, `memories_1`, `queue_1`). Verified end-to-end with a real `codex exec` on `gpt-5.6-sol`: every DB landed in the override dir, the shared home stayed DB-free, `auth.json` was not rewritten (hash-identical), so one shared credential file keeps a single writer and the token-rotation question never arises. Also verified: the store path must survive as a single quoted argv entry — unquoted, a path containing a space (`D:\Code Projects\...`) splits and eats the positional prompt.

## The fixes

1. **Per-agent store isolation (root fix)** — `PtyManager::create_session` (the one choke point all 21 spawn sites pass through) injects `-c sqlite_home=<per-agent dir>` for codex spawns. Non-codex CLIs keep their argv byte-for-byte. Respawns reuse their store (same agent id). Best-effort: if the store dir can't be created, spawn proceeds on the shared store with a warning rather than hard-failing.
2. **Post-spawn liveness verification** — `add_worker` holds the response through a startup grace window (1.5s, polling). A worker that dies inside it returns `failed_to_start` **with the CLI's dying words** (`cli_output` in the error details), the roster slot is discarded, and the queue claim is released (attempt-capped) so a retry respawns the same index in place. The PTY reader thread now runs even headless, feeding a bounded 8KB output tail — previously a startup death left zero forensic trace.
3. **Spawn stagger** — a short serialized gap (750ms) between codex starts at the same choke point, as defense-in-depth for startup bursts.
4. **Dead slots reclaimable** — the release route now refuses only workers with a *live* process. A rostered worker with no process behind it is discarded and its claim released (`discarded_rostered_slot: true`); non-worker roster members (queen/evaluator/prince/QA) keep the unconditional refusal. `next_worker_index` allocates the lowest unused index instead of count+1, so recovered slots respawn in place without colliding with live higher-numbered workers.
5. **Orphan reaping — deferred.** Isolation removes the mechanism by which stale processes degrade *new* sessions (they no longer share a store with anything). Reaping live OS processes from prior sessions needs process enumeration + an ownership policy and deserves its own issue.
6. **Store growth** — a startup janitor removes per-agent stores untouched for 7 days. The operator's own `~/.codex` growth (928 MB observed) is codex's file, not ours — worker traffic no longer feeds it, which was the part we could own. `codex doctor` reports store health for manual maintenance.

## Honest limits

- The startup window catches deaths within ~1.5s of spawn (the observed failure mode). A worker that dies *later* still relies on the 90s queue reclaim; the roster overlay for later deaths is untouched here.
- I could not reproduce the lock contention on a fresh store (4 concurrent codex sharing one `sqlite_home` all exited 0) — the field failure required the degraded state (928 MB log DB + 17 stale processes holding connections). Isolation removes the shared resource by construction, so the class is fixed regardless, but the repro honesty matters: the A/B probe proves the mechanism, not the failure.

## Tests

608 passed, 0 failed (full suite, local). New pins:
- `add_worker_that_dies_during_startup_is_failed_to_start_not_running` — the exact field failure, via a stub death sentinel through the full HTTP path: `failed_to_start`, `database is locked` surfaced, roster empty, claim released, retry reuses worker-1.
- `release_frees_a_dead_rostered_slot_for_in_place_respawn` — phantom discarded, live sibling kept, freed index handed out next.
- `add_worker_fills_the_lowest_free_worker_slot` — mutation check: `count+1` fails it.
- `release_refuses_a_rostered_worker` — updated to pin the narrowed (live-process) refusal.
- Manager-level argv pins: codex gets `sqlite_home` injected ahead of the positional prompt; claude untouched; startup-death output survives until kill.
- `agent_store` unit tests incl. the space-quoting regression guard and path-traversal sanitization.

## Topology note (from the issue, no code)

For tightly coupled lanes, native codex subagents (the `[agents]` roster in `config.toml`) inside one session avoid the multi-process store problem entirely. Independent Hive workers now each get their own store, so the constraint "independent workers must never share one SQLite directory" is enforced by construction rather than by operator discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex sessions now use isolated state, reducing conflicts between concurrent agents.
  * Worker slots can be recovered and reused after failed or disconnected launches.
  * Startup failures now provide clearer diagnostic output and automatic cleanup.
* **Bug Fixes**
  * Improved handling of early CLI exits and stalled worker sessions.
  * Prevented stale agent state from affecting future sessions.
  * Worker allocation now consistently uses the lowest available slot.
* **Chores**
  * Updated the application version to 0.42.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->