### PR TITLE
fix: close #223, #224, add the #225 reachability gate; land #221 structurally

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -22,6 +22,17 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
+
+      # Advisory: codegraph does not parse .svelte; baseline is 65 .svelte vs 69 .ts,
+      # and all 3/3 uncapped `certain` findings are false positives.
+      # Policy and promotion criteria: docs/reachability-gate.md
+      - name: Reachability (advisory)
+        run: python tools/codegraph/ci_gate.py --lang ts --root . --advisory
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           python-version: '3.13'
 
+      # Analyzer provenance and update policy: docs/reachability-gate.md
+      - name: Verify vendored codegraph
+        working-directory: ${{ github.workspace }}
+        run: python tools/codegraph/verify_vendor.py
+
       # Reachability policy and rationale: docs/reachability-gate.md
       - name: Reachability
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -26,6 +26,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Setup Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.13'
+
+      # Reachability policy and rationale: docs/reachability-gate.md
+      - name: Reachability
+        working-directory: ${{ github.workspace }}
+        run: python tools/codegraph/ci_gate.py --lang rs --root .
+
       - name: Install Rust stable
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8
 

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ nul
 PLANNING DOCS/
 dist-local/
 .claude/scheduled_tasks.lock
+
+# Python bytecode (tools/codegraph is stdlib Python, run directly)
+__pycache__/
+*.pyc

--- a/docs/reachability-gate.md
+++ b/docs/reachability-gate.md
@@ -30,7 +30,12 @@ The underlying limitation is structural: the analyzer sees 69 `.ts` files but do
 
 ## Updating the analyzer
 
-The three analyzer files are vendored from `~/.claude/tools/codegraph/`, and each provenance header records its source path, copy date, and the SHA-256 of the original upstream bytes. The repository copy deliberately uses LF line endings, so its whole-file hash can differ from that upstream hash even when the analyzer body has not drifted. `tools/codegraph/vendor-manifest.json` records both identities: the original upstream-byte hash and the exact LF-vendored-file hash.
+The three analyzer files are vendored from `~/.claude/tools/codegraph/`, and each provenance header records its source path, copy date, and the SHA-256 of the original upstream bytes. Manifest schema v2 records two deliberately different identities:
+
+- `upstream_sha256` is the exact original upstream byte stream, including its original line endings. It cross-checks the provenance header.
+- `normalized_sha256` is the complete vendored file after converting CRLF and lone CR line endings to LF. It detects content changes consistently even when Git materializes CRLF on Windows.
+
+The repository authors the files with LF, but verification does not depend on checkout settings. Python line endings are not semantic, so the verifier normalizes them before hashing while retaining every other byte, including the repository provenance header.
 
 Verify all three files and cross-check each header against the manifest with one command from the repository root:
 
@@ -38,6 +43,6 @@ Verify all three files and cross-check each header against the manifest with one
 python tools/codegraph/verify_vendor.py
 ```
 
-A clean run prints `OK` for all three files and `Verified 3 vendored files.` Do not patch vendored analyzer logic in this repository. Replace the copies from upstream as a unit, retain LF line endings, update both hashes in the manifest, and keep repository-specific exit policy in `ci_gate.py`.
+A clean run prints `OK` for all three files and `Verified 3 vendored files.` Do not patch vendored analyzer logic in this repository. Replace the copies from upstream as a unit, author them with LF line endings, update the raw-upstream and normalized-content hashes in the manifest, and keep repository-specific exit policy in `ci_gate.py`.
 
 The verifier discovers vendored analyzers independently from their provenance headers and requires that set to match the manifest exactly. This fails closed when a vendored file is omitted from the manifest or a stale manifest entry remains. Missing or malformed manifests, unsafe paths, and invalid SHA-256 values produce concise errors rather than tracebacks.

--- a/docs/reachability-gate.md
+++ b/docs/reachability-gate.md
@@ -1,0 +1,37 @@
+# Reachability gate
+
+Compilation and tests prove that code can run correctly; they do not prove that production code can reach it. The reachability check builds a static module graph and reports modules that are not reachable from a language entrypoint. Its CI wrapper is `tools/codegraph/ci_gate.py`, which prints every finding as `path:tier:why` and supplies the failing exit codes that the vendored analyzer does not consistently provide.
+
+## Blocking policy
+
+Rust reachability is a blocking check in `.github/workflows/rust-tests.yml`:
+
+```text
+python tools/codegraph/ci_gate.py --lang rs --root .
+```
+
+Only a `certain` finding fails the check. `certain` means the analyzer found no importer, no entrypoint, and no repository-wide textual reference (or, for Rust, a source file is never mounted into a crate). The lower-confidence `unwired`, `likely`, and `suspect` tiers remain visible for review but do not block CI because dynamic loading, framework conventions, and incomplete static evidence can make them false positives.
+
+An empty parse is a failure, not a clean result. A zero-module graph or a `NO <LANG> MODULES FOUND` sentinel usually means the wrong root or parser was selected. Treating that result as success would silently disable the gate.
+
+## Worktree exclusion is correctness
+
+The vendored analyzers skip `worktrees`, `.hive-manager`, `.claude`, and `.worktrees`, along with generated and dependency roots. Agent worktrees contain near-complete copies of the repository. If those copies enter one graph, cloned modules can appear to import each other and make genuinely unreachable production modules look reachable. Excluding them prevents false negatives; it is not merely an output-cleanliness optimization. Workflow commands must not override the analyzers' `SKIP_DIRS` sets.
+
+## TypeScript advisory
+
+The frontend workflow runs the same wrapper with `--lang ts --advisory`, so it reports findings without failing the job. The measured baseline is 72 modules and 15 unreached findings, all `suspect` because one unbounded dynamic import caps confidence. If that dynamic import is adjudicated, the analyzer reports three `certain` findings, and all three are false positives: two modules are imported by `.svelte` components and `src/routes/+layout.ts` is a SvelteKit convention entrypoint.
+
+The underlying limitation is structural: the analyzer sees 69 `.ts` files but does not parse the repository's 65 `.svelte` files, leaving roughly half of the frontend import graph invisible. TypeScript reachability becomes blocking only when the analyzer has a `.svelte`-aware parser, or when the frontend import graph is otherwise made visible to it. Until that named promotion condition is met and the baseline is remeasured, `--advisory` is deliberate policy.
+
+## Updating the analyzer
+
+The three analyzer files are vendored from `~/.claude/tools/codegraph/`, and each provenance header records its source path, copy date, and the SHA-256 of the original upstream bytes. The repository copy deliberately uses LF line endings, so its whole-file hash can differ from that upstream hash even when the analyzer body has not drifted. `tools/codegraph/vendor-manifest.json` records both identities: the original upstream-byte hash and the exact LF-vendored-file hash.
+
+Verify all three files and cross-check each header against the manifest with one command from the repository root:
+
+```text
+python tools/codegraph/verify_vendor.py
+```
+
+A clean run prints `OK` for all three files and `Verified 3 vendored files.` Do not patch vendored analyzer logic in this repository. Replace the copies from upstream as a unit, retain LF line endings, update both hashes in the manifest, and keep repository-specific exit policy in `ci_gate.py`.

--- a/docs/reachability-gate.md
+++ b/docs/reachability-gate.md
@@ -10,9 +10,13 @@ Rust reachability is a blocking check in `.github/workflows/rust-tests.yml`:
 python tools/codegraph/ci_gate.py --lang rs --root .
 ```
 
+The reachability analysis is language-specific: the blocking invocation graphs Rust modules only. It cannot prove that Python helpers such as `verify_vendor.py` are called by a workflow. The Rust workflow therefore runs vendor verification as a separate, explicitly named blocking step before reachability. Separate steps make provenance drift and unreachable Rust code distinct CI failures.
+
 Only a `certain` finding fails the check. `certain` means the analyzer found no importer, no entrypoint, and no repository-wide textual reference (or, for Rust, a source file is never mounted into a crate). The lower-confidence `unwired`, `likely`, and `suspect` tiers remain visible for review but do not block CI because dynamic loading, framework conventions, and incomplete static evidence can make them false positives.
 
 An empty parse is a failure, not a clean result. A zero-module graph or a `NO <LANG> MODULES FOUND` sentinel usually means the wrong root or parser was selected. Treating that result as success would silently disable the gate.
+
+Each analyzer subprocess has a 120-second timeout. Current graphs complete well inside that bound, while two minutes leaves substantial room for slower hosted runners and still turns a stalled scan into a named gate error. The wrapper currently runs `stats` and `dead --json` separately, rebuilding the graph twice; consolidating those upstream operations is a possible performance follow-up, not part of the repository wrapper's correctness policy.
 
 ## Worktree exclusion is correctness
 
@@ -35,3 +39,5 @@ python tools/codegraph/verify_vendor.py
 ```
 
 A clean run prints `OK` for all three files and `Verified 3 vendored files.` Do not patch vendored analyzer logic in this repository. Replace the copies from upstream as a unit, retain LF line endings, update both hashes in the manifest, and keep repository-specific exit policy in `ci_gate.py`.
+
+The verifier discovers vendored analyzers independently from their provenance headers and requires that set to match the manifest exactly. This fails closed when a vendored file is omitted from the manifest or a stale manifest entry remains. Missing or malformed manifests, unsafe paths, and invalid SHA-256 values produce concise errors rather than tracebacks.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.43.0"
+version = "0.43.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -5,8 +5,11 @@ use schemars::schema::RootSchema;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 
-use crate::coordination::{CoordinationMessage, MessageType, StateManager, WorkerStateInfo};
+use crate::coordination::{
+    CoordinationMessage, InjectionError, MessageType, StateManager, WorkerStateInfo,
+};
 use crate::orchestrator::work_graph::TaskId;
 use crate::pty::{AgentConfig, AgentRole, WorkerRole};
 use crate::tauri_shim::Emitter;
@@ -151,6 +154,17 @@ fn require_frontend(ctx: &ActionContext) -> Result<(), ActionError> {
     }
 }
 
+async fn run_blocking_injection<T, F>(operation: F) -> Result<T, ActionError>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, InjectionError> + Send + 'static,
+{
+    tokio::task::spawn_blocking(operation)
+        .await
+        .map_err(|error| ActionError::internal(format!("Injection task failed: {error}")))?
+        .map_err(|error| ActionError::internal(error.to_string()))
+}
+
 struct QueenInject;
 
 #[async_trait]
@@ -166,16 +180,17 @@ impl Action for QueenInject {
     async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
         require_frontend(ctx)?;
         let request: QueenInjectRequest = deserialize_input(input)?;
-        let manager = ctx.state.injection_manager.read();
-        manager
-            .queen_inject(
+        let manager = Arc::clone(&ctx.state.injection_manager);
+        run_blocking_injection(move || {
+            manager.read().queen_inject(
                 &request.session_id,
                 &request.queen_id,
                 &request.target_worker_id,
                 &request.message,
                 true,
             )
-            .map_err(|e| ActionError::internal(e.to_string()))?;
+        })
+        .await?;
         Ok(Value::Null)
     }
 }
@@ -209,15 +224,16 @@ impl Action for QueenSwitchBranch {
                 .ok_or_else(|| ActionError::not_found("Session not found"))?
         };
 
-        let manager = ctx.state.injection_manager.read();
-        let results = manager
-            .queen_switch_branch(
+        let manager = Arc::clone(&ctx.state.injection_manager);
+        let results = run_blocking_injection(move || {
+            manager.read().queen_switch_branch(
                 &parsed.session_id,
                 &parsed.queen_id,
                 &worker_ids,
                 &parsed.branch,
             )
-            .map_err(|e| ActionError::internal(e.to_string()))?;
+        })
+        .await?;
 
         serialize_output(
             results
@@ -244,15 +260,16 @@ impl Action for OperatorInject {
     async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
         require_frontend(ctx)?;
         let request: OperatorInjectRequest = deserialize_input(input)?;
-        let manager = ctx.state.injection_manager.read();
-        manager
-            .operator_inject(
+        let manager = Arc::clone(&ctx.state.injection_manager);
+        run_blocking_injection(move || {
+            manager.read().operator_inject(
                 &request.session_id,
                 &request.target_agent_id,
                 &request.message,
                 true,
             )
-            .map_err(|e| ActionError::internal(e.to_string()))?;
+        })
+        .await?;
         Ok(Value::Null)
     }
 }
@@ -472,16 +489,21 @@ impl Action for AssignTask {
     async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
         require_frontend(ctx)?;
         let parsed: AssignTaskInput = deserialize_input(input)?;
-        let coord_manager = ctx.state.injection_manager.read();
-        coord_manager
-            .queen_inject(
-                &parsed.session_id,
-                &parsed.queen_id,
-                &parsed.worker_id,
-                &parsed.task,
+        let manager = Arc::clone(&ctx.state.injection_manager);
+        let injection_session_id = parsed.session_id.clone();
+        let queen_id = parsed.queen_id.clone();
+        let worker_id = parsed.worker_id.clone();
+        let task = parsed.task.clone();
+        run_blocking_injection(move || {
+            manager.read().queen_inject(
+                &injection_session_id,
+                &queen_id,
+                &worker_id,
+                &task,
                 true,
             )
-            .map_err(|e| ActionError::internal(e.to_string()))?;
+        })
+        .await?;
 
         let session_path = ctx.state.storage.session_dir(&parsed.session_id);
         let state_manager = StateManager::new(session_path);
@@ -969,7 +991,22 @@ fn extract_assignee(text: &str) -> (String, Option<String>) {
 
 #[cfg(test)]
 mod tests {
-    use super::{extract_assignee, extract_priority, parse_task_line};
+    use super::{
+        extract_assignee, extract_priority, parse_task_line, run_blocking_injection,
+    };
+    use crate::coordination::InjectionError;
+
+    #[tokio::test]
+    async fn blocking_injection_preserves_operation_error_message() {
+        let expected = InjectionError::NotAuthorized("denied".to_string());
+        let expected_message = expected.to_string();
+
+        let error = run_blocking_injection(move || Err::<(), _>(expected))
+            .await
+            .unwrap_err();
+
+        assert_eq!(error.message, expected_message);
+    }
 
     #[test]
     fn extract_priority_strips_detected_token_case_insensitively() {

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -173,6 +173,7 @@ impl Action for QueenInject {
                 &request.queen_id,
                 &request.target_worker_id,
                 &request.message,
+                true,
             )
             .map_err(|e| ActionError::internal(e.to_string()))?;
         Ok(Value::Null)
@@ -249,6 +250,7 @@ impl Action for OperatorInject {
                 &request.session_id,
                 &request.target_agent_id,
                 &request.message,
+                true,
             )
             .map_err(|e| ActionError::internal(e.to_string()))?;
         Ok(Value::Null)
@@ -477,6 +479,7 @@ impl Action for AssignTask {
                 &parsed.queen_id,
                 &parsed.worker_id,
                 &parsed.task,
+                true,
             )
             .map_err(|e| ActionError::internal(e.to_string()))?;
 

--- a/src-tauri/src/actions/pty.rs
+++ b/src-tauri/src/actions/pty.rs
@@ -6,7 +6,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::pty::AgentRole;
+use crate::pty::{AgentRole, PtyManager};
 
 use super::error::ActionError;
 use super::registry::{Action, ActionRegistry};
@@ -267,6 +267,12 @@ impl Action for WritePty {
 
 struct PastePty;
 
+fn paste_to_pty(pty_manager: &PtyManager, id: &str, data: &[u8]) -> Result<(), ActionError> {
+    pty_manager
+        .write_bracketed(id, data)
+        .map_err(|e| ActionError::internal(e.to_string()))
+}
+
 #[async_trait]
 impl Action for PastePty {
     fn name(&self) -> &'static str {
@@ -286,14 +292,26 @@ impl Action for PastePty {
         require_frontend(ctx)?;
         let parsed: PtyDataInput = deserialize_input(input)?;
         let pty_manager = ctx.state.pty_manager.read();
-        pty_manager
-            .write_bracketed(&parsed.id, parsed.data.as_bytes())
-            .map_err(|e| ActionError::internal(e.to_string()))?;
+        paste_to_pty(&pty_manager, &parsed.id, parsed.data.as_bytes())?;
         Ok(Value::Null)
     }
 }
 
 struct InjectPty;
+
+fn inject_to_pty(
+    pty_manager: &PtyManager,
+    id: &str,
+    message: &[u8],
+    send_enter: bool,
+) -> Result<(), ActionError> {
+    let result = if send_enter {
+        pty_manager.submit(id, message)
+    } else {
+        pty_manager.write_bracketed(id, message)
+    };
+    result.map_err(|e| ActionError::internal(e.to_string()))
+}
 
 #[async_trait]
 impl Action for InjectPty {
@@ -322,16 +340,12 @@ impl Action for InjectPty {
             parsed.send_enter
         );
 
-        if parsed.send_enter {
-            let message_with_enter = format!("{}\r", parsed.message);
-            pty_manager
-                .write_bracketed(&parsed.id, message_with_enter.as_bytes())
-                .map_err(|e| ActionError::internal(e.to_string()))?;
-        } else {
-            pty_manager
-                .write_bracketed(&parsed.id, parsed.message.as_bytes())
-                .map_err(|e| ActionError::internal(e.to_string()))?;
-        }
+        inject_to_pty(
+            &pty_manager,
+            &parsed.id,
+            parsed.message.as_bytes(),
+            parsed.send_enter,
+        )?;
 
         Ok(Value::Null)
     }
@@ -438,4 +452,67 @@ pub fn register(registry: &mut ActionRegistry) {
     registry.register(Box::new(KillPty));
     registry.register(Box::new(PtyStatus));
     registry.register(Box::new(ListPtys));
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::{inject_to_pty, paste_to_pty};
+    use crate::pty::{AgentRole, PtyManager};
+
+    const AGENT_ID: &str = "pty-action-test-worker";
+    const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
+    const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+
+    fn test_manager() -> PtyManager {
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                AGENT_ID.to_string(),
+                AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+        manager
+    }
+
+    #[test]
+    fn pty_inject_send_enter_writes_payload_then_bare_enter() {
+        let manager = test_manager();
+
+        inject_to_pty(&manager, AGENT_ID, b"hello", true).unwrap();
+
+        let writes = manager.write_records_for_test(AGENT_ID).unwrap();
+        assert_eq!(writes, vec![b"hello".to_vec(), b"\r".to_vec()]);
+        assert!(!writes.iter().any(|write| {
+            write.as_slice() == BRACKETED_PASTE_START
+                || write.as_slice() == BRACKETED_PASTE_END
+        }));
+        assert!(!writes[0].contains(&b'\r'));
+        assert_eq!(writes[1], b"\r");
+    }
+
+    #[test]
+    fn pty_paste_stays_bracketed_without_enter() {
+        let manager = test_manager();
+
+        paste_to_pty(&manager, AGENT_ID, b"hello").unwrap();
+
+        let writes = manager.write_records_for_test(AGENT_ID).unwrap();
+        assert_eq!(
+            writes,
+            vec![
+                BRACKETED_PASTE_START.to_vec(),
+                b"hello".to_vec(),
+                BRACKETED_PASTE_END.to_vec()
+            ]
+        );
+        assert_ne!(writes.last().unwrap().as_slice(), b"\r");
+    }
 }

--- a/src-tauri/src/actions/pty.rs
+++ b/src-tauri/src/actions/pty.rs
@@ -5,6 +5,9 @@ use schemars::schema::RootSchema;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use crate::pty::{AgentRole, PtyManager};
 
@@ -313,6 +316,20 @@ fn inject_to_pty(
     result.map_err(|e| ActionError::internal(e.to_string()))
 }
 
+async fn inject_to_pty_blocking(
+    pty_manager: Arc<RwLock<PtyManager>>,
+    id: String,
+    message: Vec<u8>,
+    send_enter: bool,
+) -> Result<(), ActionError> {
+    tokio::task::spawn_blocking(move || {
+        let pty_manager = pty_manager.read();
+        inject_to_pty(&pty_manager, &id, &message, send_enter)
+    })
+    .await
+    .map_err(|error| ActionError::internal(format!("PTY injection task failed: {error}")))?
+}
+
 #[async_trait]
 impl Action for InjectPty {
     fn name(&self) -> &'static str {
@@ -331,7 +348,6 @@ impl Action for InjectPty {
     async fn run(&self, ctx: &ActionContext, input: Value) -> Result<Value, ActionError> {
         require_frontend(ctx)?;
         let parsed: InjectInput = deserialize_input(input)?;
-        let pty_manager = ctx.state.pty_manager.read();
 
         tracing::info!(
             "inject_to_pty: id={}, message_len={}, send_enter={}",
@@ -340,12 +356,13 @@ impl Action for InjectPty {
             parsed.send_enter
         );
 
-        inject_to_pty(
-            &pty_manager,
-            &parsed.id,
-            parsed.message.as_bytes(),
+        inject_to_pty_blocking(
+            Arc::clone(&ctx.state.pty_manager),
+            parsed.id,
+            parsed.message.into_bytes(),
             parsed.send_enter,
-        )?;
+        )
+        .await?;
 
         Ok(Value::Null)
     }
@@ -456,8 +473,10 @@ pub fn register(registry: &mut ActionRegistry) {
 
 #[cfg(all(test, windows))]
 mod tests {
-    use super::{inject_to_pty, paste_to_pty};
+    use super::{inject_to_pty, inject_to_pty_blocking, paste_to_pty};
     use crate::pty::{AgentRole, PtyManager};
+    use parking_lot::RwLock;
+    use std::sync::Arc;
 
     const AGENT_ID: &str = "pty-action-test-worker";
     const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
@@ -514,5 +533,19 @@ mod tests {
             ]
         );
         assert_ne!(writes.last().unwrap().as_slice(), b"\r");
+    }
+
+    #[tokio::test]
+    async fn blocking_pty_inject_preserves_operation_error_message() {
+        let error = inject_to_pty_blocking(
+            Arc::new(RwLock::new(PtyManager::new())),
+            "missing-agent".to_string(),
+            b"hello".to_vec(),
+            true,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error.message, "PTY session not found: missing-agent");
     }
 }

--- a/src-tauri/src/coordination/injection.rs
+++ b/src-tauri/src/coordination/injection.rs
@@ -54,6 +54,7 @@ impl InjectionManager {
         queen_id: &str,
         target_worker_id: &str,
         message: &str,
+        submit: bool,
     ) -> Result<(), InjectionError> {
         // Validate sender is Queen (ID should end with -queen)
         if !queen_id.ends_with("-queen") {
@@ -87,7 +88,7 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Only persist watcher-visible state after PTY delivery succeeds.
-        self.write_to_agent(target_worker_id, message)?;
+        self.write_to_agent(target_worker_id, message, submit)?;
 
         if target_worker_id.ends_with("-evaluator") {
             self.write_session_peer_message(session_id, |state| {
@@ -110,6 +111,7 @@ impl InjectionManager {
         evaluator_id: &str,
         target_agent_id: &str,
         message: &str,
+        submit: bool,
     ) -> Result<(), InjectionError> {
         if !evaluator_id.ends_with("-evaluator") {
             return Err(InjectionError::NotAuthorized(
@@ -148,7 +150,7 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Only persist watcher-visible state after PTY delivery succeeds.
-        self.write_to_agent(target_agent_id, message)?;
+        self.write_to_agent(target_agent_id, message, submit)?;
 
         if target_is_queen {
             self.write_session_peer_message(session_id, |state| {
@@ -190,7 +192,7 @@ impl InjectionManager {
 
         let mut results = Vec::new();
         for worker_id in worker_ids {
-            let result = self.write_to_agent(worker_id, &git_command);
+            let result = self.write_to_agent(worker_id, &git_command, true);
 
             let status = if result.is_ok() { "initiated" } else { "failed" };
             let log_msg = format!(
@@ -207,8 +209,13 @@ impl InjectionManager {
         Ok(results)
     }
 
-    /// Write a message to an agent's PTY and press Enter to submit
-    pub fn write_to_agent(&self, agent_id: &str, message: &str) -> Result<(), InjectionError> {
+    /// Write a message to an agent's PTY, optionally pressing Enter to submit it.
+    pub fn write_to_agent(
+        &self,
+        agent_id: &str,
+        message: &str,
+        submit: bool,
+    ) -> Result<(), InjectionError> {
         let pty_manager = self.pty_manager.read();
 
         // Strip any existing line endings first
@@ -218,16 +225,14 @@ impl InjectionManager {
         tracing::info!("Target agent: {}", agent_id);
         tracing::info!("Message: {:?}", clean_message);
         tracing::info!("Message bytes: {:?}", clean_message.as_bytes());
+        tracing::info!("Submit: {}", submit);
 
-        // Write the message content with Enter appended
-        // On Windows ConPTY, Enter is typically just \r, but some apps need \n
-        // We'll send both \r\n to maximize compatibility
-        let message_with_enter = format!("{}\r\n", clean_message);
-
-        tracing::info!("Full message with enter: {:?}", message_with_enter.as_bytes());
-
-        pty_manager
-            .write(agent_id, message_with_enter.as_bytes())
+        let write_result = if submit {
+            pty_manager.submit(agent_id, clean_message.as_bytes())
+        } else {
+            pty_manager.write(agent_id, clean_message.as_bytes())
+        };
+        write_result
             .map_err(|e| InjectionError::PtyError(format!("Failed to write: {}", e)))?;
 
         tracing::info!("=== INJECTION COMPLETE ===");
@@ -241,6 +246,7 @@ impl InjectionManager {
         session_id: &str,
         target_agent_id: &str,
         message: &str,
+        submit: bool,
     ) -> Result<(), InjectionError> {
         // Log to coordination.log
         let coord_message = CoordinationMessage::system(
@@ -253,7 +259,7 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Write to agent's PTY stdin
-        self.write_to_agent(target_agent_id, message)?;
+        self.write_to_agent(target_agent_id, message, submit)?;
 
         // Emit event for UI
         if let Some(ref app_handle) = self.app_handle {
@@ -386,7 +392,7 @@ impl InjectionManager {
         message: &str,
     ) -> Result<(), InjectionError> {
         for worker_id in worker_ids {
-            self.queen_inject(session_id, queen_id, worker_id, message)?;
+            self.queen_inject(session_id, queen_id, worker_id, message, true)?;
         }
         Ok(())
     }

--- a/src-tauri/src/http/handlers/agents.rs
+++ b/src-tauri/src/http/handlers/agents.rs
@@ -118,7 +118,7 @@ pub async fn send_agent_input(
     state
         .injection_manager
         .read()
-        .operator_inject(&session_id, &agent_id, &req.input)
+        .operator_inject(&session_id, &agent_id, &req.input, true)
         .map_err(|error| match error {
             InjectionError::SessionNotFound(id) => {
                 ApiError::not_found(format!("Session {} not found", id))

--- a/src-tauri/src/http/handlers/agents.rs
+++ b/src-tauri/src/http/handlers/agents.rs
@@ -115,22 +115,31 @@ pub async fn send_agent_input(
         }
     }
 
-    state
-        .injection_manager
-        .read()
-        .operator_inject(&session_id, &agent_id, &req.input, true)
-        .map_err(|error| match error {
-            InjectionError::SessionNotFound(id) => {
-                ApiError::not_found(format!("Session {} not found", id))
-            }
-            InjectionError::AgentNotFound(id) => {
-                ApiError::not_found(format!("Agent {} not found", id))
-            }
-            InjectionError::NotAuthorized(msg) => ApiError::bad_request(msg),
-            InjectionError::PtyError(msg) | InjectionError::StorageError(msg) => {
-                ApiError::internal(msg)
-            }
-        })?;
+    let manager = Arc::clone(&state.injection_manager);
+    let injection_session_id = session_id.clone();
+    let injection_agent_id = agent_id.clone();
+    let injection_result = tokio::task::spawn_blocking(move || {
+        manager.read().operator_inject(
+            &injection_session_id,
+            &injection_agent_id,
+            &req.input,
+            true,
+        )
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
+    injection_result.map_err(|error| match error {
+        InjectionError::SessionNotFound(id) => {
+            ApiError::not_found(format!("Session {} not found", id))
+        }
+        InjectionError::AgentNotFound(id) => {
+            ApiError::not_found(format!("Agent {} not found", id))
+        }
+        InjectionError::NotAuthorized(msg) => ApiError::bad_request(msg),
+        InjectionError::PtyError(msg) | InjectionError::StorageError(msg) => {
+            ApiError::internal(msg)
+        }
+    })?;
 
     Ok((
         StatusCode::CREATED,

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -9,10 +9,16 @@ use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use super::{validate_agent_id, validate_session_id};
 
+fn default_submit() -> bool {
+    true
+}
+
 #[derive(Deserialize)]
 pub struct OperatorInjectRequest {
     pub target_agent_id: String,
     pub message: String,
+    #[serde(default = "default_submit")]
+    pub submit: bool,
 }
 
 #[derive(Deserialize)]
@@ -20,6 +26,8 @@ pub struct QueenInjectRequest {
     pub queen_id: String,
     pub target_worker_id: String,
     pub message: String,
+    #[serde(default = "default_submit")]
+    pub submit: bool,
 }
 
 #[derive(Deserialize)]
@@ -27,6 +35,8 @@ pub struct EvaluatorInjectRequest {
     pub evaluator_id: String,
     pub target_agent_id: String,
     pub message: String,
+    #[serde(default = "default_submit")]
+    pub submit: bool,
 }
 
 pub async fn operator_inject(
@@ -43,6 +53,7 @@ pub async fn operator_inject(
             &id,
             &payload.target_agent_id,
             &payload.message,
+            payload.submit,
         )
         .map_err(|e| ApiError::internal(e.to_string()))?;
 
@@ -68,6 +79,7 @@ pub async fn queen_inject(
             &payload.queen_id,
             &payload.target_worker_id,
             &payload.message,
+            payload.submit,
         )
         .map_err(map_injection_error)?;
 
@@ -93,6 +105,7 @@ pub async fn evaluator_inject(
             &payload.evaluator_id,
             &payload.target_agent_id,
             &payload.message,
+            payload.submit,
         )
         .map_err(map_injection_error)?;
 
@@ -110,5 +123,164 @@ fn map_injection_error(error: crate::coordination::InjectionError) -> ApiError {
         crate::coordination::InjectionError::AgentNotFound(message)
         | crate::coordination::InjectionError::SessionNotFound(message) => ApiError::not_found(message),
         other => ApiError::internal(other.to_string()),
+    }
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+    use crate::coordination::{InjectionManager, QueueManager};
+    use crate::events::EventBus;
+    use crate::pty::{AgentRole, PtyManager};
+    use crate::session::SessionController;
+    use crate::storage::{ApplicationStateDb, QueueRepo, SessionStorage};
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::post,
+        Router,
+    };
+    use parking_lot::RwLock;
+    use serde_json::{json, Value};
+    use tempfile::TempDir;
+    use tower::ServiceExt;
+
+    const AGENT_ID: &str = "inject-test-worker-1";
+
+    fn setup_test_app() -> (TempDir, Router, Arc<AppState>) {
+        let temp_dir = TempDir::new().unwrap();
+        let storage = Arc::new(
+            SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap(),
+        );
+        let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
+        let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+        pty_manager
+            .write()
+            .create_session(
+                AGENT_ID.to_string(),
+                AgentRole::Worker {
+                    index: 1,
+                    parent: None,
+                },
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+        let session_controller = Arc::new(RwLock::new(SessionController::new(
+            pty_manager.clone(),
+        )));
+        session_controller.write().set_storage(storage.clone());
+        let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+            pty_manager.clone(),
+            SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap(),
+        )));
+        let event_bus = EventBus::new(storage.base_dir().clone());
+        let app_state_db = Arc::new(ApplicationStateDb::open_in_memory().unwrap());
+        let queue_repo = Arc::new(QueueRepo::new(app_state_db.clone()));
+        queue_repo.ensure_schema().unwrap();
+        let queue_manager = Arc::new(QueueManager::new(queue_repo, event_bus.clone()));
+        let state = Arc::new(AppState::new(
+            config,
+            pty_manager,
+            session_controller,
+            injection_manager,
+            storage,
+            event_bus,
+            app_state_db,
+            queue_manager,
+            None,
+        ));
+        let app = Router::new()
+            .route("/api/sessions/{id}/inject", post(operator_inject))
+            .with_state(state.clone());
+
+        (temp_dir, app, state)
+    }
+
+    async fn post_operator_inject(app: Router, body: Value) -> StatusCode {
+        app.oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/sessions/inject-test/inject")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+        .status()
+    }
+
+    #[tokio::test]
+    async fn operator_inject_omitted_submit_defaults_to_true() {
+        let (_temp_dir, app, state) = setup_test_app();
+
+        let status = post_operator_inject(
+            app,
+            json!({ "target_agent_id": AGENT_ID, "message": "hello\r\n" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            state
+                .pty_manager
+                .read()
+                .write_records_for_test(AGENT_ID)
+                .unwrap(),
+            vec![b"hello".to_vec(), b"\r".to_vec()]
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_inject_submit_false_writes_payload_without_enter() {
+        let (_temp_dir, app, state) = setup_test_app();
+
+        let status = post_operator_inject(
+            app,
+            json!({
+                "target_agent_id": AGENT_ID,
+                "message": "draft\r\n",
+                "submit": false
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            state
+                .pty_manager
+                .read()
+                .write_records_for_test(AGENT_ID)
+                .unwrap(),
+            vec![b"draft".to_vec()]
+        );
+    }
+
+    #[tokio::test]
+    async fn operator_inject_multiline_preserves_newlines_and_submits_once() {
+        let (_temp_dir, app, state) = setup_test_app();
+
+        let status = post_operator_inject(
+            app,
+            json!({
+                "target_agent_id": AGENT_ID,
+                "message": "line one\nline two\r\n"
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        let writes = state
+            .pty_manager
+            .read()
+            .write_records_for_test(AGENT_ID)
+            .unwrap();
+        assert_eq!(writes, vec![b"line one\nline two".to_vec(), b"\r".to_vec()]);
+        assert_eq!(writes.iter().filter(|write| write.as_slice() == b"\r").count(), 1);
+        assert!(!writes[1].contains(&b'\n'));
     }
 }

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -2,12 +2,14 @@ use axum::{
     extract::{Path, State},
     Json,
 };
-use std::sync::Arc;
-use serde_json::{json, Value};
 use serde::Deserialize;
+use serde_json::{json, Value};
+use std::sync::Arc;
+
+use super::{validate_agent_id, validate_session_id};
+use crate::coordination::InjectionError;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
-use super::{validate_agent_id, validate_session_id};
 
 fn default_submit() -> bool {
     true
@@ -47,15 +49,19 @@ pub async fn operator_inject(
     validate_session_id(&id)?;
     validate_agent_id(&payload.target_agent_id)?;
 
-    let manager = state.injection_manager.read();
-    manager
-        .operator_inject(
-            &id,
+    let manager = Arc::clone(&state.injection_manager);
+    let injection_session_id = id.clone();
+    let injection_result = tokio::task::spawn_blocking(move || {
+        manager.read().operator_inject(
+            &injection_session_id,
             &payload.target_agent_id,
             &payload.message,
             payload.submit,
         )
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
+    injection_result.map_err(|error| ApiError::internal(error.to_string()))?;
 
     Ok(Json(json!({
         "status": "success",
@@ -72,16 +78,20 @@ pub async fn queen_inject(
     validate_agent_id(&payload.queen_id)?;
     validate_agent_id(&payload.target_worker_id)?;
 
-    let manager = state.injection_manager.read();
-    manager
-        .queen_inject(
-            &id,
+    let manager = Arc::clone(&state.injection_manager);
+    let injection_session_id = id.clone();
+    let injection_result = tokio::task::spawn_blocking(move || {
+        manager.read().queen_inject(
+            &injection_session_id,
             &payload.queen_id,
             &payload.target_worker_id,
             &payload.message,
             payload.submit,
         )
-        .map_err(map_injection_error)?;
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
+    injection_result.map_err(map_injection_error)?;
 
     Ok(Json(json!({
         "status": "success",
@@ -98,16 +108,20 @@ pub async fn evaluator_inject(
     validate_agent_id(&payload.evaluator_id)?;
     validate_agent_id(&payload.target_agent_id)?;
 
-    let manager = state.injection_manager.read();
-    manager
-        .evaluator_inject(
-            &id,
+    let manager = Arc::clone(&state.injection_manager);
+    let injection_session_id = id.clone();
+    let injection_result = tokio::task::spawn_blocking(move || {
+        manager.read().evaluator_inject(
+            &injection_session_id,
             &payload.evaluator_id,
             &payload.target_agent_id,
             &payload.message,
             payload.submit,
         )
-        .map_err(map_injection_error)?;
+    })
+    .await
+    .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
+    injection_result.map_err(map_injection_error)?;
 
     Ok(Json(json!({
         "status": "success",
@@ -115,13 +129,14 @@ pub async fn evaluator_inject(
     })))
 }
 
-fn map_injection_error(error: crate::coordination::InjectionError) -> ApiError {
+fn map_injection_error(error: InjectionError) -> ApiError {
     match error {
-        crate::coordination::InjectionError::NotAuthorized(message) => {
+        InjectionError::NotAuthorized(message) => {
             ApiError::new(axum::http::StatusCode::FORBIDDEN, message)
         }
-        crate::coordination::InjectionError::AgentNotFound(message)
-        | crate::coordination::InjectionError::SessionNotFound(message) => ApiError::not_found(message),
+        InjectionError::AgentNotFound(message) | InjectionError::SessionNotFound(message) => {
+            ApiError::not_found(message)
+        }
         other => ApiError::internal(other.to_string()),
     }
 }
@@ -282,5 +297,18 @@ mod tests {
         assert_eq!(writes, vec![b"line one\nline two".to_vec(), b"\r".to_vec()]);
         assert_eq!(writes.iter().filter(|write| write.as_slice() == b"\r").count(), 1);
         assert!(!writes[1].contains(&b'\n'));
+    }
+
+    #[tokio::test]
+    async fn operator_inject_blocking_path_preserves_pty_error_status() {
+        let (_temp_dir, app, _state) = setup_test_app();
+
+        let status = post_operator_inject(
+            app,
+            json!({ "target_agent_id": "missing-agent", "message": "hello" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/src-tauri/src/http/tests_wg_queue.rs
+++ b/src-tauri/src/http/tests_wg_queue.rs
@@ -25,9 +25,9 @@ use crate::orchestrator::work_graph::{
     BindingRef, EdgeKind, EdgeProvenance, NodeContract, NodeKind, NodeStatus, TaskGraph,
     WorkEdge, WorkNode,
 };
-use crate::pty::PtyManager;
+use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager};
 use crate::session::{
-    AuthStrategy, Session, SessionController, SessionState, SessionType,
+    AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
 };
 use crate::storage::queue::{
     QueueConflictAction, QueueConflictCoverage, QueueConflictRow, QueueResolutionUpdate,
@@ -1174,6 +1174,222 @@ async fn post_task_worker(app: &axum::Router, task_id: &str) -> axum::response::
         )
         .await
         .unwrap()
+}
+
+async fn post_heartbeat(
+    app: &axum::Router,
+    session_id: &str,
+    agent_id: &str,
+    status: &str,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{session_id}/heartbeat"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "agent_id": agent_id,
+                        "status": status,
+                        "summary": format!("HTTP {status} heartbeat")
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn post_queen_injection(
+    app: &axum::Router,
+    session_id: &str,
+    queen_id: &str,
+    worker_id: &str,
+) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{session_id}/inject/queen"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    serde_json::to_vec(&json!({
+                        "queen_id": queen_id,
+                        "target_worker_id": worker_id,
+                        "message": "The task file contains a released follow-up assignment",
+                        "submit": true
+                    }))
+                    .unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn http_reassignment_refreshes_finalized_liveness_and_restores_stall_coverage() {
+    let temp = tempfile::tempdir().unwrap();
+    let (app, state, controller) = dependency_http_fixture(&temp);
+    let session_id = "http-heartbeat-reassignment";
+    let worker_id = format!("{session_id}-worker-1");
+    let queen_id = format!("{session_id}-queen");
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    state.storage.create_session_dir(session_id).unwrap();
+
+    let task_file = project
+        .join(".hive-manager")
+        .join(session_id)
+        .join("tasks")
+        .join("worker-1-task.md");
+    std::fs::create_dir_all(task_file.parent().unwrap()).unwrap();
+    std::fs::write(&task_file, "# Task\n\n## Status: COMPLETED\n").unwrap();
+
+    let mut session = quiet_hive_session(session_id, &project);
+    session.agents.push(AgentInfo {
+        id: worker_id.clone(),
+        role: AgentRole::Worker {
+            index: 1,
+            parent: Some(queen_id.clone()),
+        },
+        status: AgentStatus::Running,
+        config: AgentConfig::default(),
+        parent_id: Some(queen_id.clone()),
+        commit_sha: None,
+        base_commit_sha: None,
+    });
+    controller.read().insert_test_session(session);
+    state
+        .pty_manager
+        .write()
+        .create_session(
+            worker_id.clone(),
+            AgentRole::Worker {
+                index: 1,
+                parent: Some(queen_id.clone()),
+            },
+            "claude",
+            &[],
+            project.to_str(),
+            80,
+            24,
+        )
+        .unwrap();
+
+    state
+        .queue_manager
+        .enqueue_worker(
+            "run-reassignment",
+            session_id,
+            &worker_id,
+            "backend",
+            "claude",
+            json!({}),
+            Some("T14".to_string()),
+        )
+        .await
+        .unwrap();
+    assert!(matches!(
+        state
+            .queue_manager
+            .claim_and_spawn("run-reassignment", session_id, &worker_id)
+            .await
+            .unwrap(),
+        ClaimOutcome::Claimed { .. }
+    ));
+
+    // Post a bare alias so the HTTP handler must resolve it to the roster/queue identity.
+    assert_eq!(
+        post_heartbeat(&app, session_id, "worker-1", "completed")
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    let completed_row = state
+        .queue_manager
+        .repo()
+        .get_row("run-reassignment")
+        .unwrap()
+        .unwrap();
+    assert_eq!(completed_row.status, QueueStatus::Finalized);
+    let completed_heartbeat = completed_row.heartbeat_at.expect("completed liveness");
+
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+    assert!(
+        controller
+            .read()
+            .get_stalled_agents(session_id, std::time::Duration::ZERO)
+            .is_empty(),
+        "a completed agent with no later assignment must stay silent"
+    );
+
+    // Reassignment is durable direction in the standing task file; injection only wakes the
+    // existing agent loop. Coverage must resume even if that injection were never submitted.
+    std::fs::write(
+        &task_file,
+        "# Task\n\n## Status: ACTIVE\n\n## Wave 2 Assignment — RELEASED\n",
+    )
+    .unwrap();
+    assert_eq!(
+        post_queen_injection(&app, session_id, &queen_id, &worker_id)
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    assert_eq!(
+        controller
+            .read()
+            .get_stalled_agents(session_id, std::time::Duration::ZERO)
+            .into_iter()
+            .map(|(agent_id, _)| agent_id)
+            .collect::<Vec<_>>(),
+        vec![worker_id.clone()],
+        "the task-file reassignment must make the stale completed heartbeat eligible"
+    );
+
+    assert_eq!(
+        post_heartbeat(&app, session_id, "worker-1", "working")
+            .await
+            .status(),
+        StatusCode::OK
+    );
+    let refreshed_row = state
+        .queue_manager
+        .repo()
+        .get_row("run-reassignment")
+        .unwrap()
+        .unwrap();
+    assert_eq!(refreshed_row.status, QueueStatus::Finalized);
+    assert_eq!(refreshed_row.last_status.as_deref(), Some("completed"));
+    assert!(
+        refreshed_row.heartbeat_at.unwrap() > completed_heartbeat,
+        "the finalized row must expose the reassigned agent's fresh liveness"
+    );
+
+    let heartbeat_info = controller.read().get_heartbeat_info(session_id);
+    assert!(!heartbeat_info.contains_key("worker-1"));
+    assert_eq!(heartbeat_info[&worker_id].status, "working");
+    assert!(
+        controller
+            .read()
+            .get_stalled_agents(session_id, std::time::Duration::ZERO)
+            .is_empty(),
+        "the reassigned agent is fresh immediately after its working heartbeat"
+    );
+    std::thread::sleep(std::time::Duration::from_millis(1_100));
+    assert_eq!(
+        controller
+            .read()
+            .get_stalled_agents(session_id, std::time::Duration::ZERO)
+            .into_iter()
+            .map(|(agent_id, _)| agent_id)
+            .collect::<Vec<_>>(),
+        vec![worker_id],
+        "stall coverage must keep applying after the reassigned agent's working heartbeat"
+    );
 }
 
 #[tokio::test]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -435,6 +435,70 @@ mod tests {
         assert!(!writes[1].contains(&b'\n'));
     }
 
+    #[test]
+    fn submit_blocks_a_concurrent_writer_until_after_enter() {
+        let manager = Arc::new(PtyManager::new());
+        manager
+            .create_session(
+                "atomic-submit-agent".to_string(),
+                worker_role(),
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        let session = manager
+            .sessions
+            .read()
+            .get("atomic-submit-agent")
+            .cloned()
+            .unwrap();
+        session.pause_submit_after_payload_for_test();
+
+        let (start_writer_tx, start_writer_rx) = std::sync::mpsc::channel();
+        let (writer_attempted_tx, writer_attempted_rx) = std::sync::mpsc::channel();
+        let (writer_done_tx, writer_done_rx) = std::sync::mpsc::channel();
+        let concurrent_manager = Arc::clone(&manager);
+        let concurrent_writer = thread::spawn(move || {
+            start_writer_rx.recv().unwrap();
+            writer_attempted_tx.send(()).unwrap();
+            concurrent_manager
+                .write("atomic-submit-agent", b"interloper")
+                .unwrap();
+            writer_done_tx.send(()).unwrap();
+        });
+
+        let submit_manager = Arc::clone(&manager);
+        let submitter = thread::spawn(move || {
+            submit_manager
+                .submit("atomic-submit-agent", b"payload")
+                .unwrap();
+        });
+
+        assert!(session.wait_for_submit_payload_for_test());
+        start_writer_tx.send(()).unwrap();
+        writer_attempted_rx.recv().unwrap();
+        let interleaved = writer_done_rx.recv_timeout(Duration::from_millis(100)).is_ok();
+        session.resume_submit_for_test();
+        submitter.join().unwrap();
+        concurrent_writer.join().unwrap();
+
+        assert!(!interleaved, "concurrent write completed before Enter");
+        assert_eq!(
+            manager
+                .write_records_for_test("atomic-submit-agent")
+                .unwrap(),
+            vec![
+                b"payload".to_vec(),
+                b"\r".to_vec(),
+                b"interloper".to_vec()
+            ]
+        );
+    }
+
     /// #207: a session that dies during startup reports dead and keeps its final output
     /// available for diagnostics until it is killed/removed.
     #[test]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -499,6 +499,56 @@ mod tests {
         );
     }
 
+    #[test]
+    fn abandoned_submit_pause_times_out_after_test_thread_panics() {
+        let manager = Arc::new(PtyManager::new());
+        manager
+            .create_session(
+                "abandoned-submit-pause-agent".to_string(),
+                worker_role(),
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        let session = manager
+            .sessions
+            .read()
+            .get("abandoned-submit-pause-agent")
+            .cloned()
+            .unwrap();
+        session.pause_submit_after_payload_for_test();
+
+        let (submit_done_tx, submit_done_rx) = std::sync::mpsc::channel();
+        let submit_manager = Arc::clone(&manager);
+        let submitter = thread::spawn(move || {
+            submit_manager
+                .submit("abandoned-submit-pause-agent", b"payload")
+                .unwrap();
+            submit_done_tx.send(()).unwrap();
+        });
+
+        let pause_controller = thread::spawn(move || {
+            assert!(session.wait_for_submit_payload_for_test());
+            panic!("simulated test panic before resume");
+        });
+        assert!(pause_controller.join().is_err());
+        submit_done_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("submit stayed blocked after the test-side resume was abandoned");
+        submitter.join().unwrap();
+
+        assert_eq!(
+            manager
+                .write_records_for_test("abandoned-submit-pause-agent")
+                .unwrap(),
+            vec![b"payload".to_vec(), b"\r".to_vec()]
+        );
+    }
+
     /// #207: a session that dies during startup reports dead and keeps its final output
     /// available for diagnostics until it is killed/removed.
     #[test]

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -246,6 +246,16 @@ impl PtyManager {
         session.write(data)
     }
 
+    /// Write a payload and then a discrete bare Enter to submit it.
+    pub fn submit(&self, id: &str, data: &[u8]) -> Result<(), PtyError> {
+        tracing::debug!("PtyManager::submit called for session: {}", id);
+        let sessions = self.sessions.read();
+        let session = sessions
+            .get(id)
+            .ok_or_else(|| PtyError::NotFound(id.to_string()))?;
+        session.submit(data)
+    }
+
     /// Write with bracketed paste mode wrapping for large pastes
     pub fn write_bracketed(&self, id: &str, data: &[u8]) -> Result<(), PtyError> {
         tracing::debug!("PtyManager::write_bracketed called for session: {} ({} bytes)", id, data.len());
@@ -316,6 +326,12 @@ impl PtyManager {
     pub fn spawn_args_for_test(&self, id: &str) -> Option<Vec<String>> {
         let sessions = self.sessions.read();
         sessions.get(id).map(|session| session.args().to_vec())
+    }
+
+    #[cfg(all(test, windows))]
+    pub fn write_records_for_test(&self, id: &str) -> Option<Vec<Vec<u8>>> {
+        let sessions = self.sessions.read();
+        sessions.get(id).map(|session| session.write_records())
     }
 
     pub fn list_sessions(&self) -> Vec<(String, AgentRole, AgentStatus)> {
@@ -392,6 +408,31 @@ mod tests {
 
         let args = manager.spawn_args_for_test("plain-claude-agent").unwrap();
         assert_eq!(args, vec!["-p".to_string(), "hello".to_string()]);
+    }
+
+    #[test]
+    fn submit_writes_payload_then_bare_enter_separately() {
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                "submit-agent".to_string(),
+                worker_role(),
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        manager.submit("submit-agent", b"hello").unwrap();
+
+        let writes = manager.write_records_for_test("submit-agent").unwrap();
+        assert_eq!(writes, vec![b"hello".to_vec(), b"\r".to_vec()]);
+        assert!(!writes[0].ends_with(b"\r"));
+        assert!(!writes[0].ends_with(b"\n"));
+        assert_eq!(writes[1], b"\r");
+        assert!(!writes[1].contains(&b'\n'));
     }
 
     /// #207: a session that dies during startup reports dead and keeps its final output

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -3,6 +3,7 @@ use std::io::{Read, Write};
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::sync::Arc;
+use std::time::Duration;
 use parking_lot::Mutex;
 use thiserror::Error;
 
@@ -141,6 +142,9 @@ impl MasterPtyHandle {
 
 /// Maximum chunk size for PTY writes (16KB) - respects Windows pipe buffer limits
 const CHUNK_SIZE: usize = 16 * 1024;
+
+/// Provisional until the live CLI matrix in #226 determines whether a gap is needed.
+const SUBMIT_GAP: Duration = Duration::from_millis(50);
 
 /// Bracketed paste mode escape sequences
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
@@ -335,6 +339,15 @@ impl PtySession {
 
         tracing::debug!("PTY write complete");
         Ok(())
+    }
+
+    /// Write a payload, then deliver Enter as a discrete bare carriage return.
+    pub fn submit(&self, data: &[u8]) -> Result<(), PtyError> {
+        self.write(data)?;
+        // `write` releases the writer mutex before returning, so the gap never
+        // holds that exclusive lock and the Enter is a distinct PTY write.
+        std::thread::sleep(SUBMIT_GAP);
+        self.write(b"\r")
     }
 
     /// Write with bracketed paste mode wrapping - used for paste operations

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::io::{Read, Write};
 use std::borrow::Cow;
 use std::collections::VecDeque;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use parking_lot::Mutex;
 use thiserror::Error;
@@ -143,8 +143,29 @@ impl MasterPtyHandle {
 /// Maximum chunk size for PTY writes (16KB) - respects Windows pipe buffer limits
 const CHUNK_SIZE: usize = 16 * 1024;
 
-/// Provisional until the live CLI matrix in #226 determines whether a gap is needed.
+/// Unvalidated default; override with `HIVE_PTY_SUBMIT_GAP_MS` for the #226 sweep.
+///
+/// Under load, measured payload/Enter separations of 1.2-2.7 s failed twice,
+/// while roughly 4-5 s succeeded twice and 65 s succeeded once. Agent busy
+/// state was uncontrolled, so those observations do not justify replacing the
+/// compiled 50 ms default with another guess.
 const SUBMIT_GAP: Duration = Duration::from_millis(50);
+const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
+static RUNTIME_SUBMIT_GAP: OnceLock<Duration> = OnceLock::new();
+
+fn submit_gap_from_override(value: Option<&str>) -> Duration {
+    value
+        .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(SUBMIT_GAP)
+}
+
+fn submit_gap() -> Duration {
+    *RUNTIME_SUBMIT_GAP.get_or_init(|| {
+        let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
+        submit_gap_from_override(override_value.as_deref())
+    })
+}
 
 /// Bracketed paste mode escape sequences
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
@@ -209,6 +230,24 @@ unsafe impl Send for PtySession {}
 unsafe impl Sync for PtySession {}
 
 impl PtySession {
+    fn write_locked(writer: &mut SendWriter, data: &[u8]) -> Result<(), PtyError> {
+        // Write in chunks to respect Windows pipe buffer limits.
+        for chunk in data.chunks(CHUNK_SIZE) {
+            let result = writer.0.write_all(chunk);
+            if let Err(ref e) = result {
+                tracing::error!("PTY write_all failed: {}", e);
+                return Err(into_io_error(e));
+            }
+            let flush_result = writer.0.flush();
+            if let Err(ref e) = flush_result {
+                tracing::error!("PTY flush failed: {}", e);
+                return Err(into_io_error(e));
+            }
+        }
+
+        Ok(())
+    }
+
     pub fn new(
         _id: String,
         role: AgentRole,
@@ -322,20 +361,7 @@ impl PtySession {
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
         tracing::debug!("PTY write: {} bytes: {:?}", data.len(), String::from_utf8_lossy(data));
         let mut writer = self.writer.lock();
-
-        // Write in chunks to respect Windows pipe buffer limits
-        for chunk in data.chunks(CHUNK_SIZE) {
-            let result = writer.0.write_all(chunk);
-            if let Err(ref e) = result {
-                tracing::error!("PTY write_all failed: {}", e);
-                return Err(into_io_error(e));
-            }
-            let flush_result = writer.0.flush();
-            if let Err(ref e) = flush_result {
-                tracing::error!("PTY flush failed: {}", e);
-                return Err(into_io_error(e));
-            }
-        }
+        Self::write_locked(&mut writer, data)?;
 
         tracing::debug!("PTY write complete");
         Ok(())
@@ -343,11 +369,12 @@ impl PtySession {
 
     /// Write a payload, then deliver Enter as a discrete bare carriage return.
     pub fn submit(&self, data: &[u8]) -> Result<(), PtyError> {
-        self.write(data)?;
-        // `write` releases the writer mutex before returning, so the gap never
-        // holds that exclusive lock and the Enter is a distinct PTY write.
-        std::thread::sleep(SUBMIT_GAP);
-        self.write(b"\r")
+        let mut writer = self.writer.lock();
+        Self::write_locked(&mut writer, data)?;
+        // Keep the per-session writer locked so no concurrent write can be
+        // interleaved and accidentally submitted by this Enter.
+        std::thread::sleep(submit_gap());
+        Self::write_locked(&mut writer, b"\r")
     }
 
     /// Write with bracketed paste mode wrapping - used for paste operations

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -1,12 +1,12 @@
 //! Unit-test PTY session stub that avoids linking portable-pty on Windows.
 
-use parking_lot::Mutex;
+use parking_lot::{Condvar, Mutex};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::io::{Read, Write};
-use std::sync::Arc;
-use std::time::Duration;
+use std::sync::{Arc, OnceLock};
+use std::time::{Duration, Instant};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -114,13 +114,41 @@ unsafe impl Send for SendWriter {}
 unsafe impl Sync for SendWriter {}
 
 const CHUNK_SIZE: usize = 16 * 1024;
-/// Provisional until the live CLI matrix in #226 determines whether a gap is needed.
+/// Unvalidated default; override with `HIVE_PTY_SUBMIT_GAP_MS` for the #226 sweep.
+///
+/// Under load, measured payload/Enter separations of 1.2-2.7 s failed twice,
+/// while roughly 4-5 s succeeded twice and 65 s succeeded once. Agent busy
+/// state was uncontrolled, so those observations do not justify replacing the
+/// compiled 50 ms default with another guess.
 const SUBMIT_GAP: Duration = Duration::from_millis(50);
+const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
+static RUNTIME_SUBMIT_GAP: OnceLock<Duration> = OnceLock::new();
+
+fn submit_gap_from_override(value: Option<&str>) -> Duration {
+    value
+        .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(SUBMIT_GAP)
+}
+
+fn submit_gap() -> Duration {
+    *RUNTIME_SUBMIT_GAP.get_or_init(|| {
+        let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
+        submit_gap_from_override(override_value.as_deref())
+    })
+}
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
 struct RecordingWriter {
     writes: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+#[derive(Default)]
+struct SubmitGapControl {
+    pause: bool,
+    payload_written: bool,
+    resume: bool,
 }
 
 impl Write for RecordingWriter {
@@ -175,6 +203,7 @@ pub struct PtySession {
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
     writer: Arc<Mutex<SendWriter>>,
     write_records: Arc<Mutex<Vec<Vec<u8>>>>,
+    submit_gap_control: Arc<(Mutex<SubmitGapControl>, Condvar)>,
     reader: Arc<Mutex<SendReader>>,
     /// The argv this session was created with. The real session hands these to the OS and
     /// forgets them; retaining them here is what lets tests assert that per-agent store
@@ -188,6 +217,15 @@ unsafe impl Send for PtySession {}
 unsafe impl Sync for PtySession {}
 
 impl PtySession {
+    fn write_locked(writer: &mut SendWriter, data: &[u8]) -> Result<(), PtyError> {
+        for chunk in data.chunks(CHUNK_SIZE) {
+            writer.0.write_all(chunk)?;
+            writer.0.flush()?;
+        }
+
+        Ok(())
+    }
+
     pub fn new(
         _id: String,
         role: AgentRole,
@@ -205,6 +243,7 @@ impl PtySession {
                 writes: Arc::clone(&write_records),
             })))),
             write_records,
+            submit_gap_control: Arc::new((Mutex::new(SubmitGapControl::default()), Condvar::new())),
             reader: Arc::new(Mutex::new(SendReader(Box::new(std::io::Cursor::new(
                 Vec::new(),
             ))))),
@@ -250,21 +289,62 @@ impl PtySession {
         String::from_utf8_lossy(&bytes).into_owned()
     }
 
-    pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
-        let mut writer = self.writer.lock();
+    pub fn pause_submit_after_payload_for_test(&self) {
+        let (control, _) = &*self.submit_gap_control;
+        let mut control = control.lock();
+        control.pause = true;
+        control.payload_written = false;
+        control.resume = false;
+    }
 
-        for chunk in data.chunks(CHUNK_SIZE) {
-            writer.0.write_all(chunk)?;
-            writer.0.flush()?;
+    pub fn wait_for_submit_payload_for_test(&self) -> bool {
+        let (control, changed) = &*self.submit_gap_control;
+        let mut control = control.lock();
+        let deadline = Instant::now() + Duration::from_secs(1);
+
+        while !control.payload_written {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                return false;
+            }
+            changed.wait_for(&mut control, remaining);
         }
 
-        Ok(())
+        true
+    }
+
+    pub fn resume_submit_for_test(&self) {
+        let (control, changed) = &*self.submit_gap_control;
+        control.lock().resume = true;
+        changed.notify_all();
+    }
+
+    fn pause_submit_after_payload_if_requested(&self) {
+        let (control, changed) = &*self.submit_gap_control;
+        let mut control = control.lock();
+        if !control.pause {
+            return;
+        }
+
+        control.payload_written = true;
+        changed.notify_all();
+        while !control.resume {
+            changed.wait(&mut control);
+        }
+        *control = SubmitGapControl::default();
+    }
+
+    pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
+        let mut writer = self.writer.lock();
+        Self::write_locked(&mut writer, data)
     }
 
     pub fn submit(&self, data: &[u8]) -> Result<(), PtyError> {
-        self.write(data)?;
-        std::thread::sleep(SUBMIT_GAP);
-        self.write(b"\r")
+        let mut writer = self.writer.lock();
+        Self::write_locked(&mut writer, data)?;
+        self.pause_submit_after_payload_if_requested();
+        std::thread::sleep(submit_gap());
+        Self::write_locked(&mut writer, b"\r")
     }
 
     pub fn write_records(&self) -> Vec<Vec<u8>> {
@@ -333,7 +413,26 @@ pub fn read_from_reader(
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_bracketed_paste, BRACKETED_PASTE_END};
+    use super::{
+        sanitize_bracketed_paste, submit_gap_from_override, BRACKETED_PASTE_END, SUBMIT_GAP,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn submit_gap_override_parses_milliseconds() {
+        assert_eq!(
+            submit_gap_from_override(Some(" 4500 ")),
+            Duration::from_millis(4_500)
+        );
+        assert_eq!(submit_gap_from_override(Some("0")), Duration::ZERO);
+    }
+
+    #[test]
+    fn invalid_submit_gap_override_falls_back_to_default() {
+        assert_eq!(submit_gap_from_override(Some("not-a-number")), SUBMIT_GAP);
+        assert_eq!(submit_gap_from_override(Some("-1")), SUBMIT_GAP);
+        assert_eq!(submit_gap_from_override(None), SUBMIT_GAP);
+    }
 
     #[test]
     fn sanitize_bracketed_paste_removes_end_sequence_from_payload() {

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -123,6 +123,7 @@ const CHUNK_SIZE: usize = 16 * 1024;
 const SUBMIT_GAP: Duration = Duration::from_millis(50);
 const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
 static RUNTIME_SUBMIT_GAP: OnceLock<Duration> = OnceLock::new();
+const SUBMIT_GAP_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 
 fn submit_gap_from_override(value: Option<&str>) -> Duration {
     value
@@ -300,7 +301,7 @@ impl PtySession {
     pub fn wait_for_submit_payload_for_test(&self) -> bool {
         let (control, changed) = &*self.submit_gap_control;
         let mut control = control.lock();
-        let deadline = Instant::now() + Duration::from_secs(1);
+        let deadline = Instant::now() + SUBMIT_GAP_TEST_TIMEOUT;
 
         while !control.payload_written {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -326,10 +327,15 @@ impl PtySession {
             return;
         }
 
+        let deadline = Instant::now() + SUBMIT_GAP_TEST_TIMEOUT;
         control.payload_written = true;
         changed.notify_all();
         while !control.resume {
-            changed.wait(&mut control);
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            changed.wait_for(&mut control, remaining);
         }
         *control = SubmitGapControl::default();
     }

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::io::{Read, Write};
 use std::sync::Arc;
+use std::time::Duration;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,8 +114,25 @@ unsafe impl Send for SendWriter {}
 unsafe impl Sync for SendWriter {}
 
 const CHUNK_SIZE: usize = 16 * 1024;
+/// Provisional until the live CLI matrix in #226 determines whether a gap is needed.
+const SUBMIT_GAP: Duration = Duration::from_millis(50);
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
+
+struct RecordingWriter {
+    writes: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl Write for RecordingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.writes.lock().push(buf.to_vec());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
 
 fn find_subslice(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
     if needle.is_empty() || haystack.len() < needle.len() || start >= haystack.len() {
@@ -156,6 +174,7 @@ pub struct PtySession {
     pub role: AgentRole,
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
     writer: Arc<Mutex<SendWriter>>,
+    write_records: Arc<Mutex<Vec<Vec<u8>>>>,
     reader: Arc<Mutex<SendReader>>,
     /// The argv this session was created with. The real session hands these to the OS and
     /// forgets them; retaining them here is what lets tests assert that per-agent store
@@ -178,10 +197,14 @@ impl PtySession {
         _cols: u16,
         _rows: u16,
     ) -> Result<Self, PtyError> {
+        let write_records = Arc::new(Mutex::new(Vec::new()));
         let session = Self {
             role,
             status: Arc::new(parking_lot::RwLock::new(AgentStatus::Starting)),
-            writer: Arc::new(Mutex::new(SendWriter(Box::new(std::io::sink())))),
+            writer: Arc::new(Mutex::new(SendWriter(Box::new(RecordingWriter {
+                writes: Arc::clone(&write_records),
+            })))),
+            write_records,
             reader: Arc::new(Mutex::new(SendReader(Box::new(std::io::Cursor::new(
                 Vec::new(),
             ))))),
@@ -236,6 +259,16 @@ impl PtySession {
         }
 
         Ok(())
+    }
+
+    pub fn submit(&self, data: &[u8]) -> Result<(), PtyError> {
+        self.write(data)?;
+        std::thread::sleep(SUBMIT_GAP);
+        self.write(b"\r")
+    }
+
+    pub fn write_records(&self) -> Vec<Vec<u8>> {
+        self.write_records.lock().clone()
     }
 
     pub fn write_bracketed(&self, data: &[u8]) -> Result<(), PtyError> {

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -121,7 +121,7 @@ pub(crate) fn aggregate_cell_status_for_state(
         return CellStatus::Summarizing;
     }
 
-    if is_terminal_session_state(state) {
+    if session_state_overrides_agent_cell_status(state) {
         return session_state_to_cell_status(state);
     }
 
@@ -221,7 +221,11 @@ fn fusion_agent_matches_cell(
     }
 }
 
-fn is_terminal_session_state(state: &SessionState) -> bool {
+/// Answers "should this session state override per-agent cell-status aggregation?"
+///
+/// `aggregate_cell_status_for_state` calls this after handling `Closing` as a
+/// distinct summarizing display state.
+fn session_state_overrides_agent_cell_status(state: &SessionState) -> bool {
     matches!(
         state,
         SessionState::QaPassed
@@ -329,6 +333,85 @@ mod tests {
             aggregate_cell_status(&session, "variant:alpha"),
             CellStatus::Completed
         );
+    }
+
+    #[test]
+    fn terminal_state_concepts_have_exhaustive_distinct_memberships() {
+        use super::super::controller::session_state_has_stopped_accepting_work;
+        use super::super::transitions::SessionStateKind;
+
+        let states = [
+            SessionState::Planning,
+            SessionState::PlanReady,
+            SessionState::Starting,
+            SessionState::SpawningWorker(1),
+            SessionState::WaitingForWorker(1),
+            SessionState::SpawningPlanner(1),
+            SessionState::WaitingForPlanner(1),
+            SessionState::SpawningFusionVariant(1),
+            SessionState::WaitingForFusionVariants,
+            SessionState::SpawningDebateRound(1),
+            SessionState::WaitingForDebateRound(1),
+            SessionState::SpawningJudge,
+            SessionState::Judging,
+            SessionState::AwaitingVerdictSelection,
+            SessionState::MergingWinner,
+            SessionState::SpawningEvaluator,
+            SessionState::QaInProgress { iteration: Some(1) },
+            SessionState::QaPassed,
+            SessionState::QaFailed { iteration: 1 },
+            SessionState::QaMaxRetriesExceeded,
+            SessionState::PrinceRemediation,
+            SessionState::QaInconclusive,
+            SessionState::Running,
+            SessionState::Paused,
+            SessionState::Completed,
+            SessionState::Closing,
+            SessionState::Closed,
+            SessionState::Failed("test failure".to_string()),
+        ];
+
+        for state in states {
+            let expected = match state.kind() {
+                SessionStateKind::QaMaxRetriesExceeded
+                | SessionStateKind::Completed
+                | SessionStateKind::Closed
+                | SessionStateKind::Failed => (true, true),
+                SessionStateKind::QaPassed | SessionStateKind::QaFailed => (false, true),
+                SessionStateKind::Planning
+                | SessionStateKind::PlanReady
+                | SessionStateKind::Starting
+                | SessionStateKind::SpawningWorker
+                | SessionStateKind::WaitingForWorker
+                | SessionStateKind::SpawningPlanner
+                | SessionStateKind::WaitingForPlanner
+                | SessionStateKind::SpawningFusionVariant
+                | SessionStateKind::WaitingForFusionVariants
+                | SessionStateKind::SpawningDebateRound
+                | SessionStateKind::WaitingForDebateRound
+                | SessionStateKind::SpawningJudge
+                | SessionStateKind::Judging
+                | SessionStateKind::AwaitingVerdictSelection
+                | SessionStateKind::MergingWinner
+                | SessionStateKind::SpawningEvaluator
+                | SessionStateKind::QaInProgress
+                | SessionStateKind::PrinceRemediation
+                | SessionStateKind::QaInconclusive
+                | SessionStateKind::Running
+                | SessionStateKind::Paused
+                | SessionStateKind::Closing => (false, false),
+            };
+
+            assert_eq!(
+                (
+                    session_state_has_stopped_accepting_work(&state),
+                    session_state_overrides_agent_cell_status(&state),
+                ),
+                expected,
+                "predicate membership drifted for {:?}",
+                state.kind()
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -744,7 +744,12 @@ pub struct SessionController {
 unsafe impl Send for SessionController {}
 unsafe impl Sync for SessionController {}
 
-fn is_terminal_session_state(state: &SessionState) -> bool {
+/// Answers "has this session state stopped accepting new work?"
+///
+/// `validate_scratch_pty_session_locked` uses this alongside its explicit
+/// `Closing` check. `session_from_persisted` and
+/// `session_to_persisted_snapshot` use it to normalize the auth strategy.
+pub(super) fn session_state_has_stopped_accepting_work(state: &SessionState) -> bool {
     super::transitions::has_rule(
         state.kind(),
         state.kind(),
@@ -1694,6 +1699,11 @@ impl SessionController {
     }
 
     /// Get agents with no activity for longer than threshold.
+    ///
+    /// A `completed` heartbeat retires only the assignment that produced it. The task file is
+    /// the standing channel for later assignments, so a newer task-file modification proves that
+    /// the same worker has been reassigned even if the wake-up injection never submits. Keeping
+    /// completed agents exempt until that proof exists makes the never-reassigned case silent.
     pub fn get_stalled_agents(
         &self,
         session_id: &str,
@@ -1701,6 +1711,30 @@ impl SessionController {
     ) -> Vec<(String, DateTime<Utc>)> {
         let now = Utc::now();
         let threshold_secs = threshold.as_secs() as i64;
+        let task_file_updates = {
+            let sessions = self.sessions.read();
+            sessions
+                .get(session_id)
+                .map(|session| {
+                    session
+                        .agents
+                        .iter()
+                        .filter_map(|agent| {
+                            let AgentRole::Worker { index, .. } = &agent.role else {
+                                return None;
+                            };
+                            let task_file = Self::task_file_path_for_session_worker(
+                                session,
+                                *index as usize,
+                            )
+                            .ok()?;
+                            let modified = std::fs::metadata(task_file).ok()?.modified().ok()?;
+                            Some((agent.id.clone(), DateTime::<Utc>::from(modified)))
+                        })
+                        .collect::<HashMap<_, _>>()
+                })
+                .unwrap_or_default()
+        };
         let heartbeats = self.agent_heartbeats.read();
         let Some(agents) = heartbeats.get(session_id) else {
             return vec![];
@@ -1709,7 +1743,13 @@ impl SessionController {
             .iter()
             .filter_map(|(agent_id, info)| {
                 let elapsed = (now - info.last_activity).num_seconds();
-                if elapsed > threshold_secs && info.status != "completed" {
+                let reassigned_after_completion = info.status == "completed"
+                    && task_file_updates
+                        .get(agent_id)
+                        .is_some_and(|modified| modified > &info.last_activity);
+                if elapsed > threshold_secs
+                    && (info.status != "completed" || reassigned_after_completion)
+                {
                     Some((agent_id.clone(), info.last_activity))
                 } else {
                     None
@@ -2224,7 +2264,7 @@ impl SessionController {
         let session = sessions
             .get(session_id)
             .ok_or_else(|| format!("Session {session_id} not found for scratch PTY"))?;
-        if is_terminal_session_state(&session.state)
+        if session_state_has_stopped_accepting_work(&session.state)
             || matches!(session.state, SessionState::Closing)
         {
             return Err(format!(
@@ -6171,6 +6211,32 @@ Managed principals are visible Hive agents with their own lifecycle and task con
 
 Heartbeat while coordinating:
 {queen_heartbeat}
+
+## Messaging a Running Agent (inject)
+
+`POST /api/sessions/{session_id}/inject` writes a message into a running agent's terminal.
+
+**Known defect on builds at or below v0.43.0 (issues #221, #226): the message does NOT submit.** The payload and its newline share one PTY write, so the text lands in the agent's composer and waits for a keypress that never comes.
+
+**Workaround: send a second, empty message.** It writes only the newline, with no payload, which is a standalone Enter delivered as its own discrete write. That submits whatever is buffered:
+
+```bash
+# 1. the real message - lands in the composer, does NOT submit
+curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"target_agent_id":"{session_id}-worker-N","message":"your message here"}}'
+
+# 2. empty message == standalone Enter - THIS submits it
+curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
+  -H "Content-Type: application/json" \\
+  -d '{{"target_agent_id":"{session_id}-worker-N","message":""}}'
+```
+
+Measured against a live codex agent, operator-confirmed with no keypress: step 1 alone did not submit after 60 seconds; step 2 submitted it. Drop step 2 once the fix ships.
+
+**Never verify an inject by watching whether the agent acts.** With an operator present at the terminal, that observable cannot distinguish an auto-submit from a human pressing Enter. Either have the operator confirm no keypress, or use the two-step form and treat submission as caused by step 2.
+
+**Task files remain the primary channel for assignments.** Inject is for nudges and mid-flight corrections; workers re-read their task file, so durable direction belongs there.
 
 {topology_instructions}
 
@@ -13165,7 +13231,7 @@ The backend composed and persisted the following authoritative skeleton before l
             .collect();
 
         let state = parse_persisted_session_state(&persisted.state);
-        let auth_strategy = if is_terminal_session_state(&state) {
+        let auth_strategy = if session_state_has_stopped_accepting_work(&state) {
             AuthStrategy::None
         } else {
             AuthStrategy::from_persisted(&persisted.auth_strategy)
@@ -14797,7 +14863,7 @@ The backend composed and persisted the following authoritative skeleton before l
             .collect();
 
         let state_str = serialize_session_state(&session.state);
-        let auth_strategy = if is_terminal_session_state(&session.state) {
+        let auth_strategy = if session_state_has_stopped_accepting_work(&session.state) {
             AuthStrategy::None
         } else {
             session.auth_strategy.clone()
@@ -16214,6 +16280,16 @@ mod tests {
         assert!(prompt.contains("supported; encouraged (authorized)"));
         assert!(prompt.contains("do not drop effort or reasoning settings"));
         assert!(prompt.contains("Shared Cell Integration"));
+        // Inject workaround section (issues #221/#226): assert it renders AND that the
+        // literal JSON braces survive format! as SINGLE braces. A brace-escaping slip
+        // compiles fine but emits a broken command, so assert the rendered text.
+        assert!(prompt.contains("## Messaging a Running Agent (inject)"));
+        assert!(prompt.contains("the message does NOT submit"));
+        assert!(prompt.contains(
+            r#"-d '{"target_agent_id":"session-modern-worker-N","message":""}'"#
+        ));
+        assert!(!prompt.contains("{{"));
+        assert!(prompt.contains("Never verify an inject by watching whether the agent acts"));
         assert!(prompt.contains("Principals do not commit"));
         assert!(prompt.contains("backend-created hive/session-modern/primary branch"));
         assert!(prompt.contains("Managed principals are visible Hive agents"));

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -973,15 +973,16 @@ impl QueueRepo {
         })
     }
 
-    /// Record a heartbeat for a nonterminal row and advance the progress counters.
+    /// Record a heartbeat for an active or finalized row, advancing progress only while active.
     ///
     /// State machine: if the incoming `status` equals the stored `last_status`, the worker
     /// made no progress → `no_progress_count += 1`. If it changed (or there was no prior
     /// status), it is a continuation → `continuation_count += 1`, `no_progress_count = 0`,
     /// and `last_status` is updated. A `completed` heartbeat atomically moves a queued or
     /// running row to the existing terminal `finalized` state so stale-run maintenance cannot
-    /// reclaim verified work. Failed rows are never overwritten. Always refreshes
-    /// `heartbeat_at`. Returns `true` if a row was updated.
+    /// reclaim verified work. A finalized row keeps its lifecycle fields frozen while its
+    /// liveness timestamps remain fresh. Failed and blocked rows are never overwritten. Returns
+    /// `true` if an active or finalized row was updated.
     pub fn record_heartbeat(
         &self,
         session_id: &str,
@@ -998,14 +999,19 @@ impl QueueRepo {
                      heartbeat_at = ?3,
                      updated_at = ?3,
                      no_progress_count = CASE
-                         WHEN last_status IS NOT NULL AND last_status = ?4
-                         THEN no_progress_count + 1 ELSE 0 END,
+                         WHEN status IN ('queued', 'running')
+                              AND last_status IS NOT NULL AND last_status = ?4
+                         THEN no_progress_count + 1
+                         WHEN status IN ('queued', 'running') THEN 0
+                         ELSE no_progress_count END,
                      continuation_count = CASE
-                         WHEN last_status IS NULL OR last_status <> ?4
+                         WHEN status IN ('queued', 'running')
+                              AND (last_status IS NULL OR last_status <> ?4)
                          THEN continuation_count + 1 ELSE continuation_count END,
-                     last_status = ?4
+                     last_status = CASE
+                         WHEN status IN ('queued', 'running') THEN ?4 ELSE last_status END
                  WHERE session_id = ?1 AND worker_id = ?2
-                   AND status IN ('queued', 'running')",
+                    AND status IN ('queued', 'running', 'finalized')",
                 params![session_id, worker_id, now_ms, status],
             )?;
             Ok(conn.changes() >= 1)
@@ -1536,11 +1542,16 @@ mod tests {
         assert!(repo
             .record_heartbeat("s1", "s1-worker-1", "completed", 200)
             .unwrap());
+        assert!(repo
+            .record_heartbeat("s1", "s1-worker-1", "working", 300)
+            .unwrap());
 
         let completed = repo.get_row("r1").unwrap().unwrap();
         assert_eq!(completed.status, QueueStatus::Finalized);
         assert_eq!(completed.last_status.as_deref(), Some("completed"));
-        assert_eq!(completed.heartbeat_at, Some(200));
+        assert_eq!(completed.heartbeat_at, Some(300));
+        assert_eq!(completed.continuation_count, 1);
+        assert_eq!(completed.no_progress_count, 0);
         assert!(repo.reclaim_stuck(1_000, 2_000).unwrap().is_empty());
         assert!(repo.try_claim("r1", 1_000, 2_000).unwrap().is_none());
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/tools/codegraph/ci_gate.py
+++ b/tools/codegraph/ci_gate.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Turn codegraph reachability findings into a CI exit-code contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ANALYZER = Path(__file__).with_name("codegraph.py")
+MODULE_COUNT = re.compile(r"^modules:\s*(\d+)\s*$", re.MULTILINE)
+EMPTY_PARSE = re.compile(r"NO .+ MODULES FOUND")
+
+
+def run_codegraph(command: str, *, root: Path, lang: str) -> subprocess.CompletedProcess[str]:
+    arguments = [
+        sys.executable,
+        str(ANALYZER),
+        command,
+        "--root",
+        str(root),
+        "--lang",
+        lang,
+    ]
+    if command == "dead":
+        arguments.append("--json")
+    return subprocess.run(arguments, capture_output=True, text=True, check=False)
+
+
+def combined_output(process: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part.strip() for part in (process.stdout, process.stderr) if part.strip())
+
+
+def parse_findings(process: subprocess.CompletedProcess[str]) -> list[dict[str, Any]]:
+    try:
+        findings = json.loads(process.stdout)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"dead --json returned invalid JSON: {error.msg}") from error
+    if not isinstance(findings, list) or any(not isinstance(row, dict) for row in findings):
+        raise ValueError("dead --json returned an unexpected schema")
+    required = {"path", "tier", "why"}
+    if any(not required.issubset(row) for row in findings):
+        raise ValueError("dead --json omitted path, tier, or why")
+    return findings
+
+
+def report_error(message: str, *, advisory: bool) -> int:
+    print(f"reachability:error:{message}", file=sys.stderr)
+    if advisory:
+        print("Reachability advisory reported an error; continuing without failing.")
+        return 0
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", required=True, type=Path)
+    parser.add_argument("--lang", required=True, choices=("py", "ts", "rs"))
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="report policy findings and analyzer errors without failing",
+    )
+    args = parser.parse_args()
+
+    stats = run_codegraph("stats", root=args.root, lang=args.lang)
+    dead = run_codegraph("dead", root=args.root, lang=args.lang)
+    stats_output = combined_output(stats)
+    dead_output = combined_output(dead)
+    empty_parse = bool(EMPTY_PARSE.search(stats_output) or EMPTY_PARSE.search(dead_output))
+
+    count_match = MODULE_COUNT.search(stats.stdout)
+    module_count = int(count_match.group(1)) if count_match else 0
+    if empty_parse or module_count == 0:
+        detail = dead_output or stats_output or "analyzer reported zero modules"
+        print(f"reachability:empty:{detail}", file=sys.stderr)
+        if args.advisory:
+            print("Reachability advisory found no modules; continuing without failing.")
+            return 0
+        return 1
+
+    if stats.returncode != 0:
+        return report_error(
+            f"stats exited {stats.returncode}: {stats_output}", advisory=args.advisory
+        )
+    if dead.returncode != 0:
+        return report_error(
+            f"dead --json exited {dead.returncode}: {dead_output}", advisory=args.advisory
+        )
+
+    try:
+        findings = parse_findings(dead)
+    except ValueError as error:
+        return report_error(str(error), advisory=args.advisory)
+
+    for finding in findings:
+        print(f"{finding['path']}:{finding['tier']}:{finding['why']}")
+
+    certain_count = sum(finding["tier"] == "certain" for finding in findings)
+    print(
+        f"Reachability analyzed {module_count} {args.lang} modules: "
+        f"{len(findings)} finding(s), {certain_count} certain."
+    )
+    if certain_count and not args.advisory:
+        return 1
+    if args.advisory:
+        print("Reachability advisory complete; findings do not fail this job.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/codegraph/ci_gate.py
+++ b/tools/codegraph/ci_gate.py
@@ -13,6 +13,7 @@ from typing import Any
 
 
 ANALYZER = Path(__file__).with_name("codegraph.py")
+ANALYZER_TIMEOUT_SECONDS = 120
 MODULE_COUNT = re.compile(r"^modules:\s*(\d+)\s*$", re.MULTILINE)
 EMPTY_PARSE = re.compile(r"NO .+ MODULES FOUND")
 
@@ -29,7 +30,13 @@ def run_codegraph(command: str, *, root: Path, lang: str) -> subprocess.Complete
     ]
     if command == "dead":
         arguments.append("--json")
-    return subprocess.run(arguments, capture_output=True, text=True, check=False)
+    return subprocess.run(
+        arguments,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=ANALYZER_TIMEOUT_SECONDS,
+    )
 
 
 def combined_output(process: subprocess.CompletedProcess[str]) -> str:
@@ -68,8 +75,15 @@ def main() -> int:
     )
     args = parser.parse_args()
 
-    stats = run_codegraph("stats", root=args.root, lang=args.lang)
-    dead = run_codegraph("dead", root=args.root, lang=args.lang)
+    try:
+        stats = run_codegraph("stats", root=args.root, lang=args.lang)
+        dead = run_codegraph("dead", root=args.root, lang=args.lang)
+    except subprocess.TimeoutExpired as error:
+        command = error.cmd[2]
+        return report_error(
+            f"{command} timed out after {error.timeout:g} seconds",
+            advisory=args.advisory,
+        )
     stats_output = combined_output(stats)
     dead_output = combined_output(dead)
     empty_parse = bool(EMPTY_PARSE.search(stats_output) or EMPTY_PARSE.search(dead_output))

--- a/tools/codegraph/codegraph.py
+++ b/tools/codegraph/codegraph.py
@@ -1,0 +1,833 @@
+#!/usr/bin/env python3
+# Vendored from C:/Users/RDuff/.claude/tools/codegraph/codegraph.py on 2026-08-14; source SHA-256 8B5AE7CD70BD4AC2A5AF11D2A05AEE9CD608AF8E00A545C9B65D52EF53E77A0C; upstream commit unavailable (local source is not a Git worktree).
+"""codegraph — deterministic module-dependency graph for a repo. READ-ONLY.
+
+Phase 1: Python only. stdlib `ast`, zero dependencies.
+
+CONTRACT (from the spec):
+  * Deterministic. No LLM extraction anywhere. Parsers only.
+  * Read-only on the target repo. This tool never writes into it.
+  * Never silently drop an edge -- unresolved imports are RECORDED as
+    unresolved, because an incomplete graph that looks complete is the
+    failure that makes people stop trusting it.
+  * Report, never delete. No write authority over source, ever.
+
+The dominant risk is false-positive "dead" findings, so `dead` reports in
+confidence tiers and only `certain` is ever suggested for deletion. The
+acceptance bar is that `certain` is 100% true positives on human review.
+
+Usage:
+    python codegraph.py build   --root <repo> [--out graph.json]
+    python codegraph.py dead    --root <repo> [--tier certain|likely|suspect]
+    python codegraph.py touch   --root <repo> <path>
+    python codegraph.py stats   --root <repo>
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+from collections import defaultdict, deque
+from pathlib import Path
+
+# Directories never walked. Keep this list explicit and small.
+#
+# `worktrees` / `.claude` / `.hive-manager` are not hygiene -- they are
+# correctness. A repo with agent worktrees carries near-complete COPIES of
+# itself; on one real repo 1228 of 1287 modules were worktree duplicates. Those
+# copies import each other, so a module that is genuinely dead in the real tree
+# looks alive because its own clone imports it. Walking them does not just
+# inflate counts, it silently suppresses true findings.
+SKIP_DIRS = {
+    ".git", "__pycache__", "node_modules", ".venv", "venv", "env",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build",
+    ".next", ".turbo", "site-packages", ".tox", "htmlcov", "uploads",
+    "logs", ".idea", ".vscode",
+    "worktrees", ".claude", ".hive-manager", ".worktrees",
+    # Agent session artifacts: transcripts, plans and task files that name
+    # modules in PROSE. They are not code and not source of truth, but their
+    # mentions are enough to demote a true finding from `certain` to `likely`.
+    ".hive", ".swarm", ".agent-sessions",
+}
+
+# Machinery that can reach a module with NO static import edge.
+#
+# Deliberately NARROW. v1 also listed getattr/pkgutil/entry_points, which
+# downgraded every unreached module to `suspect` and left `certain` empty --
+# i.e. the tool said nothing. Inspecting the actual call sites showed every
+# getattr hit was ordinary attribute access (`getattr(obj, key, None)`), not
+# module loading. A false signal that silences the whole report is worse than
+# no signal, so only true module-loading calls count here.
+#
+# And a dynamic import with a LITERAL argument is statically resolvable -- it
+# becomes a real edge in parse_imports(), not an unknown. Only NON-literal
+# targets (f-strings, variables) actually defeat static analysis.
+# Sentinel for `f"{__name__}..."` -- build() swaps in the importing module's
+# own dotted name, which is the only place that is known.
+SELF_PREFIX = "<self> "
+
+DYNAMIC_PATTERNS = [
+    (re.compile(r"\bimportlib\.import_module\s*\("), "importlib.import_module"),
+    (re.compile(r"(?<!\.)\bimport_module\s*\("), "import_module"),
+    (re.compile(r"\b__import__\s*\("), "__import__"),
+    (re.compile(r"\bpkgutil\.(walk_packages|iter_modules)\s*\("), "pkgutil-scan"),
+]
+
+
+# --------------------------------------------------------------------------
+# discovery
+# --------------------------------------------------------------------------
+def walk_py(root: Path):
+    """Yield every .py file under root, skipping vendored/build dirs."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.endswith(".py"):
+                yield Path(dirpath) / fn
+
+
+def module_name_for(path: Path, root: Path) -> str:
+    """Dotted module name, package-aware.
+
+    A directory counts as a package only if it has __init__.py; otherwise the
+    directory is treated as a source root (common for `app/` layouts without a
+    top-level package). Getting this wrong is the #1 cause of unresolvable
+    imports, which in turn manufactures fake orphans.
+    """
+    rel = path.relative_to(root)
+    parts = list(rel.parts)
+    if parts[-1] == "__init__.py":
+        parts = parts[:-1]
+    else:
+        parts[-1] = parts[-1][:-3]
+    return ".".join(parts)
+
+
+# --------------------------------------------------------------------------
+# parsing
+# --------------------------------------------------------------------------
+def parse_imports(path: Path):
+    """Return (imports, syntax_error).
+
+    imports: list of (module_str, level) where level>0 means relative.
+    Never raises -- a file we cannot parse is recorded, not skipped silently.
+    """
+    try:
+        src = path.read_bytes().decode("utf-8", errors="replace")
+        tree = ast.parse(src, filename=str(path))
+    except SyntaxError as exc:
+        return [], f"SyntaxError: {exc}", []
+    except Exception as exc:  # noqa: BLE001 - report, never crash the run
+        return [], f"{type(exc).__name__}: {exc}", []
+
+    out = []
+    dynamic_unresolvable = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                out.append((alias.name, 0))
+        elif isinstance(node, ast.ImportFrom):
+            # `from . import x` has module=None
+            base = node.module or ""
+            lvl = node.level or 0
+            out.append((base, lvl))
+            # `from app.routes import auth, users` imports SUBMODULES, not
+            # symbols. Recording only the package `app.routes` was manufacturing
+            # a fake orphan for every route and crud module in the repo -- the
+            # single largest false-positive source found in phase 1. Emit each
+            # alias as its own candidate; resolve() falls back to the package
+            # when the alias is really just a symbol, so this is safe either way.
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                out.append((f"{base}.{alias.name}" if base else alias.name, lvl))
+        elif isinstance(node, ast.Call):
+            # importlib.import_module("x.y") / import_module("x.y") / __import__("x")
+            fn = node.func
+            name = (fn.attr if isinstance(fn, ast.Attribute)
+                    else fn.id if isinstance(fn, ast.Name) else None)
+            if name in {"import_module", "__import__"} and node.args:
+                arg = node.args[0]
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    # LITERAL target -> a real, resolvable edge
+                    out.append((arg.value, 0))
+                else:
+                    # non-literal (f-string, variable) -> genuinely opaque.
+                    # Recover the constant lead of an f-string when there is
+                    # one: import_module(f"plugins.{x}") can only ever reach
+                    # `plugins.*`, so it must not cast doubt on the whole repo.
+                    prefix = ""
+                    if isinstance(arg, ast.JoinedStr):
+                        lead = arg.values[0] if arg.values else None
+                        if isinstance(lead, ast.Constant) and isinstance(lead.value, str):
+                            prefix = lead.value
+                        elif (isinstance(lead, ast.FormattedValue)
+                              and isinstance(lead.value, ast.Name)
+                              and lead.value.id == "__name__"):
+                            # import_module(f"{__name__}.{name}") -- the plugin
+                            # loader idiom. `__name__` is the importing package
+                            # itself, so the reach IS bounded; build() swaps in
+                            # the real dotted name. Left unresolved, this one
+                            # call capped an entire repo at `suspect`.
+                            prefix = SELF_PREFIX
+                    dynamic_unresolvable.append((prefix, node.lineno))
+            elif name in {"iter_modules", "walk_packages"} and node.args:
+                # pkgutil.iter_modules(pkg.__path__) imports everything under
+                # `pkg`. The argument names the package outright, so this reach
+                # is bounded and recoverable -- treat it like an f-string lead.
+                arg = node.args[0]
+                prefix = ""
+                if isinstance(arg, ast.Name) and arg.id == "__path__":
+                    # bare `__path__` inside a package __init__ -- the package
+                    # scanning ITSELF, the commonest plugin-registry shape.
+                    # Only the attribute form `pkg.__path__` was handled, so
+                    # this one call left a whole repo capped at `suspect`.
+                    prefix = SELF_PREFIX
+                elif isinstance(arg, ast.Attribute) and arg.attr == "__path__":
+                    parts, cur = [], arg.value
+                    while isinstance(cur, ast.Attribute):
+                        parts.append(cur.attr)
+                        cur = cur.value
+                    if isinstance(cur, ast.Name):
+                        parts.append(cur.id)
+                        prefix = ".".join(reversed(parts)) + "."
+                dynamic_unresolvable.append((prefix, node.lineno))
+    return out, None, dynamic_unresolvable
+
+
+def resolve(mod: str, level: int, importer_module: str, index: dict,
+            importer_is_pkg: bool = False) -> str | None:
+    """Resolve an import to an internal module name, or None if external.
+
+    index maps dotted-module -> relpath. We try the full dotted name first,
+    then progressively shorter prefixes, because `from app.models.user import
+    User` may name a symbol inside app/models/user.py OR a submodule.
+    """
+    if level:
+        # Relative import. `.` means the containing package -- which for a
+        # module a/b/c.py is `a.b`, but for a package a/b/__init__.py is `a.b`
+        # ITSELF. Treating both the same drops every `from . import x` edge
+        # inside an __init__, which is exactly where those imports live.
+        base_parts = importer_module.split(".")
+        drop = level - 1 if importer_is_pkg else level
+        base = base_parts[: len(base_parts) - drop] if drop >= 0 else base_parts
+        cand = ".".join([p for p in base if p] + ([mod] if mod else []))
+    else:
+        cand = mod
+
+    if not cand:
+        return None
+
+    parts = cand.split(".")
+    # longest-prefix match: the import may name a symbol inside a module
+    for i in range(len(parts), 0, -1):
+        probe = ".".join(parts[:i])
+        if probe in index:
+            return probe
+    return None
+
+
+# --------------------------------------------------------------------------
+# entrypoints
+# --------------------------------------------------------------------------
+def base_name(rel: str) -> str:
+    return rel.rsplit("/", 1)[-1]
+
+
+def tracked_files(root: Path):
+    """Paths git actually tracks, or None if this is not a git repo.
+
+    An UNTRACKED file is a categorically different finding from a committed
+    one: it is local scratch that vanishes on a fresh clone, not code the team
+    is carrying. Reporting the two together conflates "someone left debris on
+    their machine" with "the repo ships code nothing uses" -- on the first repo
+    checked the split was exactly 12/12, and only the committed half was worth
+    anyone's attention.
+    """
+    try:
+        import subprocess
+        r = subprocess.run(["git", "-C", str(root), "ls-files"],
+                           capture_output=True, text=True, timeout=30)
+        if r.returncode != 0:
+            return None
+        return {p.replace("/", os.sep) for p in r.stdout.splitlines() if p}
+    except Exception:  # noqa: BLE001 - git absent or not a repo: no information
+        return None
+
+
+def manifest_entrypoints(root: Path):
+    """What the repo's PROCESS MANIFESTS actually invoke.
+
+    The TS phase learned this from package.json: convention locates candidate
+    scripts, but only the project's own config says which are live -- 11 of 41
+    scripts in one repo were wired, the other 30 were debris. Python has no
+    single manifest, so consult all the usual ones.
+
+    Returns (relpaths, dotted_modules, manifests_found). An empty
+    manifests_found means "this repo declares nothing", which must be treated
+    as no-information rather than as evidence of deadness.
+    """
+    names = ["Procfile", "Makefile", "makefile", "Dockerfile", "pyproject.toml",
+             "setup.py", "setup.cfg", "railway.json", "railway.toml",
+             "render.yaml", "fly.toml", "docker-compose.yml",
+             "docker-compose.yaml", "package.json", "nixpacks.toml"]
+    blobs, found = [], []
+    for nm in names:
+        p = root / nm
+        if p.is_file():
+            try:
+                blobs.append(p.read_text("utf-8", errors="replace"))
+                found.append(nm)
+            except OSError:
+                pass
+    for wf in list((root / ".github" / "workflows").glob("*.y*ml")):
+        try:
+            blobs.append(wf.read_text("utf-8", errors="replace"))
+            found.append(f".github/workflows/{wf.name}")
+        except OSError:
+            pass
+
+    blob = "\n".join(blobs)
+    paths, dotted = set(), set()
+
+    # explicit file invocations: `python scripts/backfill.py`, or a bare path
+    for m in re.finditer(r"[\w./\\-]+\.py\b", blob):
+        paths.add(m.group(0).replace("\\", "/").lstrip("./"))
+    # `python -m pkg.mod`
+    for m in re.finditer(r"-m\s+([A-Za-z_][\w.]*)", blob):
+        dotted.add(m.group(1))
+    # ASGI/WSGI/celery targets and console_scripts: `app.main:app`
+    for m in re.finditer(r"\b([A-Za-z_][\w.]*)\s*:\s*[A-Za-z_]\w*", blob):
+        if "." in m.group(1):
+            dotted.add(m.group(1))
+    # `celery -A app.worker`, `alembic -c ...`
+    for m in re.finditer(r"-A\s+([A-Za-z_][\w.]*)", blob):
+        dotted.add(m.group(1))
+
+    return paths, dotted, found
+
+
+def alembic_version_dirs(root: Path):
+    """Directories Alembic actually scans, read from alembic.ini.
+
+    Content alone cannot decide this. A file with `revision = "..."` and an
+    `upgrade()` IS a migration -- but an ARCHIVED one Alembic never loads is
+    dead weight, and that is a finding, not an entrypoint. Only the config says
+    which directories are live: `version_locations`, else the default
+    `<script_location>/versions`.
+
+    Returns None when there is no alembic.ini, meaning "fall back to content
+    alone" -- the right call for a repo that wires Alembic programmatically.
+    """
+    inis = [p for p in (root / "alembic.ini", root / "setup.cfg") if p.is_file()]
+    inis += [p for p in root.glob("*/alembic.ini") if p.is_file()]
+    if not inis:
+        return None
+
+    dirs = set()
+    for ini in inis:
+        try:
+            text = ini.read_text("utf-8", errors="replace")
+        except OSError:
+            continue
+        base = ini.parent
+        locs = re.search(r"^\s*version_locations\s*=\s*(.+)$", text, re.M)
+        if locs:
+            for part in re.split(r"[,\s]+", locs.group(1).strip()):
+                if part:
+                    dirs.add((base / part.replace("%(here)s", str(base))).resolve())
+            continue
+        script = re.search(r"^\s*script_location\s*=\s*(.+)$", text, re.M)
+        if script:
+            dirs.add((base / script.group(1).strip() / "versions").resolve())
+    return dirs or None
+
+
+
+def classify_entrypoints(nodes: dict, root: Path):
+    """Mark modules reachable by something other than a static import.
+
+    This is the step that decides whether `dead` is meaningful. Every class
+    here is a real invocation path that produces NO import edge, so omitting
+    one manufactures false orphans in bulk.
+    """
+    live_version_dirs = alembic_version_dirs(root)
+    manifest_paths, manifest_dotted, manifests_found = manifest_entrypoints(root)
+
+    for mod, n in nodes.items():
+        rel = n["path"].replace("\\", "/")
+        reasons = []
+        n["runnable"] = False
+
+        # Alembic migrations -- invoked by alembic, never imported.
+        #
+        # Needs BOTH signals. Path alone fitted one repo's layout and reported
+        # every migration in another (`mcp_server/db/versions/`) as an orphan.
+        # Content alone then swung the other way and blessed a repo's ARCHIVED
+        # migrations as live entrypoints, hiding 7 true findings. So: content
+        # says "this is a migration", the alembic config says "and this one is
+        # actually loaded".
+        src = n.get("_src", "")
+        is_migration = (
+            re.search(r"^revision(?::\s*str)?\s*=\s*['\"]", src, re.M)
+            and re.search(r"^def (upgrade|downgrade)\s*\(", src, re.M)
+        )
+        if is_migration:
+            if live_version_dirs is None:
+                reasons.append("alembic-migration")     # no config to consult
+            elif any(d in (root / n["path"]).resolve().parents
+                     for d in live_version_dirs):
+                reasons.append("alembic-migration")
+            # else: a migration outside version_locations -- Alembic never
+            # loads it, so it stays a dead-code candidate.
+        if base_name(rel) == "env.py" and re.search(
+                r"\bfrom alembic import\b|\balembic\.context\b|\bcontext\.configure\s*\(",
+                src):
+            reasons.append("alembic-env")
+
+        # pytest -- collected by the runner, not imported
+        base = os.path.basename(rel)
+        if base == "conftest.py":
+            reasons.append("pytest-conftest")
+        elif base.startswith("test_") or base.endswith("_test.py"):
+            reasons.append("pytest-test")
+        elif "/tests/" in f"/{rel}":
+            reasons.append("in-tests-tree")
+
+        # package initializers -- imported implicitly by the package machinery
+        if base == "__init__.py":
+            reasons.append("package-init")
+
+        # module-level app construction -- the ASGI target itself
+        if "FastAPI(" in src:
+            reasons.append("fastapi-app")
+
+        # Declared in a process manifest: Procfile, Makefile, pyproject
+        # [project.scripts], CI workflow, Dockerfile CMD. This is the only
+        # evidence that a script is actually WIRED into something.
+        if rel in manifest_paths or mod in manifest_dotted or \
+                any(mod.startswith(d + ".") for d in manifest_dotted):
+            reasons.append("manifest-declared")
+
+        # Runnable but NOT wired. `if __name__ == "__main__"` and living under
+        # scripts/ used to confer reachability outright, which is the same
+        # blanket blessing that hid 30 unwired scripts on the TS side. A script
+        # someone can run by hand is not dead -- but it is not referenced
+        # either, and conflating those two hides both. Record it as a distinct
+        # state so `dead` can report it as its own category.
+        runnable = (
+            ("__main__" in src and "if __name__" in src)
+            or rel.startswith("scripts/") or "/scripts/" in f"/{rel}"
+        )
+        n["runnable"] = bool(runnable)
+        # With no manifest at all, the repo declares nothing and we have no
+        # information -- fall back to the old permissive behaviour rather than
+        # inventing findings out of an absence of config.
+        if runnable and not manifests_found:
+            reasons.append("script-no-manifest")
+
+        if reasons:
+            n["entrypoint"] = reasons
+
+
+# --------------------------------------------------------------------------
+# graph build
+# --------------------------------------------------------------------------
+def build(root: Path) -> dict:
+    root = root.resolve()
+    files = sorted(walk_py(root))
+
+    nodes: dict[str, dict] = {}
+    for f in files:
+        try:
+            mod = module_name_for(f, root)
+        except ValueError:
+            continue
+        src = f.read_bytes().decode("utf-8", errors="replace")
+        nodes[mod] = {
+            "module": mod,
+            "path": str(f.relative_to(root)),
+            "is_pkg": f.name == "__init__.py",
+            "loc": src.count("\n") + 1,
+            "entrypoint": [],
+            "_src": src,
+        }
+
+    index = {m: n["path"] for m, n in nodes.items()}
+
+    edges = set()                    # (importer, imported) -- deduped
+    unresolved = defaultdict(list)   # importer -> [raw import]
+    parse_errors = {}
+
+    opaque_prefixes = []
+    opaque_sites = []      # (path:line, bounded-prefix or "")
+    for mod, n in nodes.items():
+        imports, err, opaque = parse_imports(root / n["path"])
+        for pref, lineno in opaque:
+            if pref == SELF_PREFIX:
+                pref = mod + "."      # `__name__` is this module's own name
+            opaque_prefixes.append(pref)
+            opaque_sites.append([f"{n['path']}:{lineno}", pref])
+        if err:
+            parse_errors[mod] = err
+            continue
+        for raw, level in imports:
+            target = resolve(raw, level, mod, index, n["is_pkg"])
+            if target and target != mod:
+                edges.add((mod, target))
+            elif level or raw.split(".")[0] in {p.split(".")[0] for p in index}:
+                # looked internal but did not resolve -- RECORD it, never drop
+                unresolved[mod].append(f"{'.' * level}{raw}")
+
+    classify_entrypoints(nodes, root)
+
+    # Dynamic machinery that we could NOT resolve to a literal target.
+    # A literal import_module("a.b") already became a real edge above, so it
+    # must not also count as an unknown -- that double-counting is what made
+    # every tier collapse to `suspect` in v1.
+    dynamic_hits = defaultdict(list)
+    for mod, n in nodes.items():
+        for rx, label in DYNAMIC_PATTERNS:
+            if not rx.search(n["_src"]):
+                continue
+            _, _, opaque = parse_imports(root / n["path"])
+            if opaque:
+                dynamic_hits[label].append(mod)
+
+    # reachability BFS from entrypoints
+    fwd = defaultdict(set)
+    rev = defaultdict(set)
+    for a, b in edges:
+        fwd[a].add(b)
+        rev[b].add(a)
+
+    roots = [m for m, n in nodes.items() if n["entrypoint"]]
+    seen = set(roots)
+    q = deque(roots)
+    while q:
+        cur = q.popleft()
+        for nxt in fwd.get(cur, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                q.append(nxt)
+
+    for m, n in nodes.items():
+        n["reachable"] = m in seen
+        n["importers"] = sorted(rev.get(m, ()))
+        n["imports"] = sorted(fwd.get(m, ()))
+        n.pop("_src", None)
+
+    return {
+        "root": str(root),
+        "language": "python",
+        "counts": {
+            "modules": len(nodes),
+            "edges": len(edges),
+            "entrypoints": len(roots),
+            "reachable": len(seen),
+            "unreached": len(nodes) - len(seen),
+            "unresolved_imports": sum(len(v) for v in unresolved.values()),
+            "parse_errors": len(parse_errors),
+        },
+        "nodes": nodes,
+        "edges": [list(e) for e in sorted(set(edges))],
+        "unresolved": {k: v for k, v in sorted(unresolved.items())},
+        "parse_errors": parse_errors,
+        "dynamic_patterns": {k: sorted(v) for k, v in sorted(dynamic_hits.items())},
+        "opaque_prefixes": sorted({p for p in opaque_prefixes if p}),
+        # True only when some dynamic call's reach could NOT be bounded (a bare
+        # variable target). That one really can hit anything, so it is the only
+        # case that justifies casting doubt on the entire repo.
+        "opaque_unbounded": any(p == "" for p in opaque_prefixes),
+        # Every opaque call site, so an unbounded one names itself instead of
+        # silently capping the whole repo at `suspect`.
+        "opaque_sites": sorted(opaque_sites),
+        "manifests_found": sorted(manifest_entrypoints(root)[2]),
+    }
+
+
+# --------------------------------------------------------------------------
+# dead-code tiering
+# --------------------------------------------------------------------------
+def dead(graph: dict, root: Path):
+    """Tier every unreached module by how confident we are it is truly dead.
+
+    certain : unreached, zero importers, and its bare module name appears
+              NOWHERE else in the repo's text (not in code, config, or docs)
+    likely  : unreached, zero importers, name appears somewhere but not as an
+              import we could resolve
+    suspect : unreached but the repo uses dynamic-import machinery, so static
+              analysis cannot prove anything
+    """
+    nodes = graph["nodes"]
+
+    # Downgrading for dynamic imports must be SCOPED to what those imports can
+    # actually reach. A single `iter_modules(mcp_server.tools.__path__)` used to
+    # push every module in the repo to `suspect` -- the tool then said nothing
+    # at all, which is the same silence as reporting no findings but disguised
+    # as caution. A bounded prefix casts doubt on that subtree only.
+    opaque_prefixes = graph.get("opaque_prefixes", [])
+    opaque_unbounded = graph.get("opaque_unbounded", False)
+
+    def dyn_shadowed(mod: str) -> str | None:
+        if opaque_unbounded:
+            return "repo has a dynamic import whose target could not be bounded"
+        for p in opaque_prefixes:
+            if mod.startswith(p):
+                return f"reachable via dynamic import under `{p}*`"
+        return None
+
+    tracked = tracked_files(root)
+    unreached = [m for m, n in nodes.items() if not n["reachable"]]
+
+    # Build one text corpus scan for name occurrences (cheap, one pass).
+    corpus = {}
+    for m, n in nodes.items():
+        p = root / n["path"]
+        try:
+            corpus[m] = p.read_bytes().decode("utf-8", errors="replace")
+        except Exception:
+            corpus[m] = ""
+
+    # also scan non-python text files -- configs reference modules by string
+    extra_text = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.endswith((".toml", ".ini", ".cfg", ".yaml", ".yml", ".json",
+                            ".txt", ".md", ".env", ".sh", "Dockerfile")):
+                try:
+                    extra_text.append((root / dirpath / fn).read_bytes()
+                                      .decode("utf-8", errors="replace"))
+                except Exception:
+                    pass
+    extra_blob = "\n".join(extra_text)
+
+    results = []
+    for m in sorted(unreached):
+        n = nodes[m]
+        leaf = m.split(".")[-1]
+        # occurrences of the leaf name outside its own file
+        hits = 0
+        for other, text in corpus.items():
+            if other == m:
+                continue
+            if re.search(rf"\b{re.escape(leaf)}\b", text):
+                hits += 1
+        cfg_hit = bool(re.search(rf"\b{re.escape(leaf)}\b", extra_blob))
+
+        shadow = dyn_shadowed(m)
+        if shadow:
+            tier = "suspect"
+            why = shadow
+        elif n.get("runnable"):
+            tier = "unwired"
+            why = ("runnable by hand, but declared in no process manifest "
+                   f"({', '.join(graph.get('manifests_found') or ['none found'])})")
+        elif n["importers"]:
+            tier = "suspect"
+            why = "has importers but is not reachable from any entrypoint"
+        elif hits == 0 and not cfg_hit:
+            tier = "certain"
+            why = "no importers, no entrypoint, zero textual references repo-wide"
+        else:
+            tier = "likely"
+            why = f"no import edge, but name appears in {hits} module(s)" + \
+                  (" and in config/docs" if cfg_hit else "")
+
+        results.append({
+            "module": m, "path": n["path"], "loc": n["loc"],
+            "tier": tier, "why": why, "text_refs": hits, "config_ref": cfg_hit,
+            "tracked": (None if tracked is None else n["path"] in tracked),
+        })
+    return results
+
+
+# --------------------------------------------------------------------------
+# cli
+# --------------------------------------------------------------------------
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("command", choices=["build", "dead", "touch", "stats"])
+    ap.add_argument("target", nargs="?")
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--out")
+    ap.add_argument("--tier",
+                    choices=["certain", "unwired", "likely", "suspect"])
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--lang", choices=["py", "ts", "rs", "auto"], default="auto",
+                    help="parser to use; `auto` picks by what the repo contains")
+    ap.add_argument("--ignore-dynamic", action="append", default=[],
+                    metavar="PATH",
+                    help="path substring of an opaque dynamic import a human "
+                         "has already adjudicated; stops it capping tiers. "
+                         "Repeatable.")
+    args = ap.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        return 2
+
+    # Pick the parser. A repo with several languages gets ONE of them and is
+    # told plainly which trees went un-analysed; a repo with none gets an
+    # explicit refusal, never a silent clean bill of health.
+    import codegraph_ts
+    import codegraph_rs
+
+    LANGS = {
+        "py": ("Python", walk_py, build, dead),
+        "ts": ("TS/JS", codegraph_ts.walk_src, codegraph_ts.build,
+               codegraph_ts.dead),
+        "rs": ("Rust", codegraph_rs.walk_src, codegraph_rs.build,
+               codegraph_rs.dead),
+    }
+
+    lang = args.lang
+    if lang == "auto":
+        # Declared priority, not a heuristic: a repo's answer must not change
+        # because someone added a file. Whatever is picked, every other
+        # language present is named below with the command that graphs it.
+        present = [k for k in ("py", "ts", "rs")
+                   if next(LANGS[k][1](root), None) is not None]
+        lang = present[0] if present else "py"
+        for other in present[1:]:
+            print(f"NOTE: repo also contains {LANGS[other][0]} source, NOT "
+                  f"analysed by this run.", file=sys.stderr)
+            print(f"      re-run with --lang {other} to graph it.",
+                  file=sys.stderr)
+
+    lang_label, _walk, build_fn, dead_fn = LANGS[lang]
+    g = build_fn(root)
+
+    # Drop adjudicated call sites BEFORE tiering, so a human ruling actually
+    # buys back real answers instead of just annotating the same silence.
+    if args.ignore_dynamic:
+        keep = [[s, pref] for s, pref in g.get("opaque_sites", [])
+                if not any(ig.replace("\\", "/") in s.replace("\\", "/")
+                           for ig in args.ignore_dynamic)]
+        dropped = len(g.get("opaque_sites", [])) - len(keep)
+        g["opaque_sites"] = keep
+        g["opaque_unbounded"] = any(not pref for _s, pref in keep)
+        g["opaque_prefixes"] = sorted({pref for _s, pref in keep if pref})
+        print(f"(ignoring {dropped} adjudicated dynamic call site(s))")
+
+    # An empty graph must never read as a clean bill of health. Pointing the
+    # Python parser at a Rust repo yields "0 UNREACHED" -- which looks like
+    # "nothing is dead" and is the single most misleading thing this tool could
+    # say. Name the reason instead.
+    if not g["nodes"]:
+        print(f"NO {lang_label.upper()} MODULES FOUND under {root}",
+              file=sys.stderr)
+        print(f"This is NOT a finding of 'no dead code' -- this run parsed "
+              f"{lang_label} only.", file=sys.stderr)
+        others = [f"--lang {k}" for k in LANGS if k != lang]
+        print(f"If this repo is another language, try: {', '.join(others)}",
+              file=sys.stderr)
+        return 3
+
+    # Stamp the tier onto every node so the emitted JSON is self-describing and
+    # validate_dead.py can consume it as data without importing this module.
+    for d in dead_fn(g, root):
+        g["nodes"][d["module"]]["dead_tier"] = d["tier"]
+
+    if args.command in ("build", "stats"):
+        c = g["counts"]
+        print(f"root:               {g['root']}")
+        print(f"modules:            {c['modules']}")
+        print(f"import edges:       {c['edges']}")
+        print(f"entrypoints:        {c['entrypoints']}")
+        print(f"reachable:          {c['reachable']}")
+        print(f"UNREACHED:          {c['unreached']}")
+        print(f"unresolved imports: {c['unresolved_imports']}  "
+              f"(recorded, not dropped)")
+        print(f"parse errors:       {c['parse_errors']}")
+        if g.get("dynamic_patterns"):
+            print("\ndynamic-import machinery (downgrades only the subtrees it can reach):")
+            for k, v in g["dynamic_patterns"].items():
+                print(f"  {k:<18} {len(v)} module(s)")
+        if args.command == "build" and args.out:
+            Path(args.out).write_text(json.dumps(g, indent=2), encoding="utf-8")
+            print(f"\nwrote {args.out}")
+        return 0
+
+    if args.command == "dead":
+        rows = dead_fn(g, root)
+        if args.tier:
+            rows = [r for r in rows if r["tier"] == args.tier]
+        if args.json:
+            print(json.dumps(rows, indent=2))
+            return 0
+        by = defaultdict(list)
+        for r in rows:
+            by[r["tier"]].append(r)
+        for tier in ("certain", "unwired", "likely", "suspect"):
+            if tier not in by:
+                continue
+            print(f"\n=== {tier.upper()}  ({len(by[tier])}) ===")
+            if by[tier]:
+                print(f"    {by[tier][0]['why']}")
+            # Untracked files are local scratch that vanishes on a fresh
+            # clone -- a different problem from code the repo actually ships.
+            # Listing them together makes a tidy repo look messy.
+            shown = by[tier][:60]
+            committed = [r for r in shown if r.get("tracked") is not False]
+            scratch = [r for r in shown if r.get("tracked") is False]
+            for r in committed:
+                print(f"  {r['loc']:>5} loc  {r['path']}")
+            if scratch:
+                print(f"  -- not in git ({len(scratch)}): local scratch, "
+                      f"vanishes on a fresh clone --")
+                for r in scratch:
+                    print(f"  {r['loc']:>5} loc  {r['path']}")
+            if len(by[tier]) > 60:
+                print(f"  ... and {len(by[tier]) - 60} more")
+
+        # A capped report must name what capped it. One unbounded call can push
+        # an entire repo to `suspect`, and a reader with no call site to look at
+        # can only conclude the tool is useless. Point at the line; bounding or
+        # allowlisting it is then a two-minute job.
+        if g.get("opaque_unbounded"):
+            blind = [s for s, pref in g.get("opaque_sites", []) if not pref]
+            print("\n--- why tiers are capped at `suspect` ---")
+            print("    These dynamic imports have targets that cannot be")
+            print("    resolved statically, so any module might be reached:")
+            for site in blind[:10]:
+                print(f"      {site}")
+            if len(blind) > 10:
+                print(f"      ... and {len(blind) - 10} more")
+            print("    Bound them (literal or f-string prefix), or re-run with")
+            print("    --ignore-dynamic <path> once you have ruled on each.")
+        return 0
+
+    if args.command == "touch":
+        if not args.target:
+            print("ERROR: touch needs a path", file=sys.stderr)
+            return 2
+        t = args.target.replace("\\", "/")
+        hit = [m for m, n in g["nodes"].items()
+               if n["path"].replace("\\", "/").endswith(t)]
+        if not hit:
+            print(f"no module matching {t}")
+            return 1
+        for m in hit:
+            n = g["nodes"][m]
+            print(f"\n=== {n['path']} ===")
+            print(f"  reachable:  {n['reachable']}  entrypoint: {n['entrypoint'] or '-'}")
+            print(f"  imported by ({len(n['importers'])}):")
+            for i in n["importers"][:25]:
+                print(f"    {g['nodes'][i]['path']}")
+            print(f"  imports ({len(n['imports'])}):")
+            for i in n["imports"][:25]:
+                print(f"    {g['nodes'][i]['path']}")
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/codegraph/codegraph_rs.py
+++ b/tools/codegraph/codegraph_rs.py
@@ -1,0 +1,814 @@
+#!/usr/bin/env python3
+# Vendored from C:/Users/RDuff/.claude/tools/codegraph/codegraph_rs.py on 2026-08-14; source SHA-256 7D6F6ED1D8171EF382313AE284CEF692AA2AE5EB654833173E3A11064B942460; upstream commit unavailable (local source is not a Git worktree).
+"""codegraph Rust parser -- phase 3. READ-ONLY, zero dependencies.
+
+Same contract as the Python and TS phases: deterministic, never silently drop
+an edge, report-never-delete, and only `certain` is ever suggested for
+deletion.
+
+WHY RUST IS DIFFERENT FROM BOTH PREVIOUS PHASES
+A .rs file is compiled ONLY if a `mod` declaration mounts it into a crate,
+transitively from a crate root (src/main.rs, src/lib.rs, src/bin/*, tests/*,
+benches/*, examples/*, build.rs, or an explicit `path =` target in
+Cargo.toml). `use` statements never bring a file in -- they only reference
+modules that are already mounted. So the load-bearing edges here are MOUNT
+edges, and an unmounted file is not "probably dead", it is provably never
+compiled. rustc emits no warning for orphaned files, which is exactly why this
+finding class is worth having.
+
+SCANNER, NOT A PARSER -- same reasoning as the TS phase: no Rust AST in the
+stdlib, no dependencies taken. `mod`/`use` items are highly regular, but ONLY
+after comments and strings are stripped. Rust adds three stripping hazards the
+TS scanner never faced: block comments NEST (/* /* */ */), raw strings carry
+arbitrary hash fences (r#"..."#), and a bare apostrophe is usually a LIFETIME
+('a) rather than a char literal -- treating 'a as an open quote would swallow
+the rest of the file.
+
+RESOLUTION RULES THE LANGUAGE DEMANDS
+  * `mod x;` in a file that OWNS its directory (crate roots and mod.rs) looks
+    for x.rs / x/mod.rs beside it; in an ordinary name.rs it looks under
+    name/x.rs / name/x/mod.rs. Conflating the two manufactures orphans in
+    whichever style the repo uses.
+  * `#[path = "..."]` overrides resolution outright, and a cfg_attr can carry
+    TWO alternative paths for one mod -- emit every candidate; a candidate
+    that resolves is an edge, and unresolved ones are only recorded when NONE
+    resolved (they are cfg branches, not failures).
+  * A workspace is several crates. `use crate::...` resolves inside the
+    referencing file's own tree; `use other_member::...` is a cross-crate edge
+    into that member's lib tree (crate names use `-`, module paths use `_`).
+  * `[lib] name = "..."` renames the lib target -- main.rs importing the lib
+    uses THAT name, not the package name.
+  * `include!("literal.rs")` is a real edge. `include!(concat!(env!("OUT_DIR"),
+    ...))` targets GENERATED code outside the repo and must not cast doubt on
+    repo files; only a non-literal include of repo-shaped paths is opaque.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+SKIP_DIRS = {
+    ".git", "target", "node_modules", "dist", "build", "vendor",
+    ".venv", "venv", ".idea", ".vscode", "logs", "coverage", "out",
+    # Agent worktrees are near-complete repo COPIES whose clones import each
+    # other -- they mask true findings, they do not merely inflate counts.
+    "worktrees", ".claude", ".hive-manager", ".worktrees",
+    # Agent session artifacts: prose that names modules, demoting true
+    # findings from `certain` to `likely`.
+    ".hive", ".swarm", ".agent-sessions",
+}
+
+CRATE_ROOT_STEMS = {"main", "lib", "mod"}
+
+
+# --------------------------------------------------------------------------
+# stripping
+# --------------------------------------------------------------------------
+def _strip(src: str, keep_strings: bool) -> str:
+    """Blank comments (and optionally strings), preserving line structure.
+
+    Rust-specific hazards handled here, each of which broke a naive port of
+    the TS stripper on real code:
+      * block comments NEST -- `/* outer /* inner */ still comment */`
+      * raw strings: r"..." and r#"..."# with any number of hashes
+      * lifetimes: 'a is NOT the start of a char literal; only '<char>' or
+        '\\...' is. Opening a "string" at a lifetime swallows the file.
+    """
+    out = []
+    i, n = 0, len(src)
+    depth = 0            # block-comment nesting depth
+    line_comment = False
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+        if line_comment:
+            if c == "\n":
+                line_comment = False
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+            continue
+        if depth:
+            if c == "/" and nxt == "*":
+                depth += 1
+                out.append("  ")
+                i += 2
+                continue
+            if c == "*" and nxt == "/":
+                depth -= 1
+                out.append("  ")
+                i += 2
+                continue
+            out.append("\n" if c == "\n" else " ")
+            i += 1
+            continue
+        if c == "/" and nxt == "/":
+            line_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        if c == "/" and nxt == "*":
+            depth = 1
+            out.append("  ")
+            i += 2
+            continue
+        if c == "r" and (nxt == '"' or nxt == "#"):
+            # raw string candidate: r"..." or r#"..."# (any hash count)
+            j = i + 1
+            hashes = 0
+            while j < n and src[j] == "#":
+                hashes += 1
+                j += 1
+            if j < n and src[j] == '"':
+                close = '"' + "#" * hashes
+                end = src.find(close, j + 1)
+                end = n if end == -1 else end + len(close)
+                seg = src[i:end]
+                if keep_strings:
+                    out.append(seg)
+                else:
+                    out.append("".join("\n" if ch == "\n" else " " for ch in seg))
+                i = end
+                continue
+        if c == '"':
+            j = i + 1
+            while j < n:
+                if src[j] == "\\":
+                    j += 2
+                    continue
+                if src[j] == '"':
+                    j += 1
+                    break
+                j += 1
+            seg = src[i:j]
+            if keep_strings:
+                out.append(seg)
+            else:
+                # Blank the CONTENT but keep the quotes and the exact length:
+                # scan_file re-reads attribute regions from the strings-kept
+                # copy using offsets taken from this one, so the two must stay
+                # byte-for-byte aligned.
+                inner = "".join("\n" if ch == "\n" else " " for ch in seg[1:-1])
+                out.append(seg[:1] + inner + seg[-1:] if len(seg) > 1 else seg)
+            i = j
+            continue
+        if c == "'":
+            # char literal ('x', '\n', '\u{1F600}') vs lifetime ('a). A char
+            # literal always closes within a few chars; a lifetime never has a
+            # closing quote adjacent. Decide by looking for the close.
+            if nxt == "\\":
+                j = i + 2
+                while j < n and src[j] != "'":
+                    j += 1
+                i = j + 1
+                out.append("''")
+                continue
+            if i + 2 < n and src[i + 2] == "'" and nxt != "'":
+                out.append("'" + (" " if not keep_strings else nxt) + "'")
+                i += 3
+                continue
+            # lifetime -- emit as-is, it is code
+            out.append(c)
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def strip_code(src: str) -> str:
+    """Comments AND string contents blanked -- for scanning mod/use items."""
+    return _strip(src, keep_strings=False)
+
+
+def strip_comments_only(src: str) -> str:
+    """Comments blanked, strings kept -- #[path]/include! targets live in
+    strings, exactly as import specifiers did in the TS phase."""
+    return _strip(src, keep_strings=True)
+
+
+# --------------------------------------------------------------------------
+# item scanners, run on stripped source
+# --------------------------------------------------------------------------
+# attribute blob (possibly several, possibly multiline) + `mod name;`
+RX_MOD = re.compile(
+    r"((?:#\[[^\]]*\]\s*)*)"
+    r"(?:pub(?:\s*\([^)]*\))?\s+)?\bmod\s+([A-Za-z_]\w*)\s*;")
+RX_ATTR_PATH = re.compile(r'path\s*=\s*"([^"]+)"')
+RX_USE = re.compile(
+    r"(?:pub(?:\s*\([^)]*\))?\s+)?\buse\s+([^;]+);")
+RX_EXTERN_CRATE = re.compile(r"\bextern\s+crate\s+([A-Za-z_]\w*)")
+RX_INCLUDE = re.compile(r'\binclude!\s*\(\s*"([^"]+)"\s*\)')
+RX_INCLUDE_NONLIT = re.compile(r"\binclude!\s*\(\s*(?!\s*\")")
+RX_AUTOMOD = re.compile(r'\bautomod::dir!\s*\(\s*"([^"]+)"\s*\)')
+RX_FN_MAIN = re.compile(r"\bfn\s+main\s*\(")
+
+
+def scan_file(src: str):
+    """(mods, uses, includes, automods, opaque_sites) from one file.
+
+    mods: list of (name, [explicit #[path] targets])  -- paths may be empty
+    uses: list of path-segment tuples (already brace-expanded)
+    includes: list of literal include! targets
+    automods: literal directory arguments to automod::dir!, which mounts EVERY
+              .rs file in that directory. The argument is a literal, so this is
+              statically resolvable and must become real edges -- the same rule
+              the Python phase applies to import_module("a.b").
+    opaque: list of (bounded_prefix_or_None, kind) for mounts static analysis
+            cannot resolve; None prefix means unbounded
+    """
+    code = strip_code(src)
+    strings_kept = strip_comments_only(src)
+
+    mods = []
+    for m in RX_MOD.finditer(code):
+        # #[path] values are string literals: re-read the attribute region
+        # from the strings-kept copy at the same offsets (stripping preserves
+        # length line-by-line closely enough only for the blob re-scan, so
+        # instead just re-scan the strings-kept text around the same mod name)
+        attr_blob = strings_kept[m.start(1):m.end(1)]
+        paths = RX_ATTR_PATH.findall(attr_blob)
+        mods.append((m.group(2), paths))
+
+    uses = []
+    for m in RX_USE.finditer(code):
+        uses.extend(expand_use_tree(m.group(1)))
+    for m in RX_EXTERN_CRATE.finditer(code):
+        uses.append((m.group(1),))
+
+    includes = RX_INCLUDE.findall(strings_kept)
+    automods = RX_AUTOMOD.findall(strings_kept)
+
+    opaque = []
+    for m in RX_INCLUDE_NONLIT.finditer(strings_kept):
+        tail = strings_kept[m.end():m.end() + 120]
+        if "OUT_DIR" in tail:
+            continue          # generated code outside the repo: bounded away
+        opaque.append((None, "include!(<non-literal>)"))
+
+    return mods, uses, includes, automods, opaque
+
+
+def expand_use_tree(spec: str):
+    """`a::b::{c, d::{e, f}, self}` -> [(a,b,c), (a,b,d,e), (a,b,d,f), (a,b)].
+
+    Handles `as` renames (path before `as` is what resolves) and `*` globs
+    (the glob's parent is the referenced module).
+    """
+    spec = spec.strip()
+    results = []
+
+    def walk(prefix: tuple, s: str):
+        s = s.strip()
+        if not s:
+            if prefix:
+                results.append(prefix)
+            return
+        brace = s.find("{")
+        if brace == -1:
+            # plain path, maybe `as rename`
+            path = s.split(" as ")[0].strip()
+            segs = [p.strip() for p in path.split("::") if p.strip()]
+            segs = [p for p in segs if p != "*"]
+            full = prefix + tuple(segs)
+            full = _fold_self(full)
+            if full:
+                results.append(full)
+            return
+        head = [p.strip() for p in s[:brace].split("::") if p.strip()]
+        inner = s[brace + 1:_match_brace(s, brace)]
+        for part in _split_top(inner):
+            walk(prefix + tuple(head), part)
+
+    def _match_brace(s: str, start: int) -> int:
+        depth = 0
+        for i in range(start, len(s)):
+            if s[i] == "{":
+                depth += 1
+            elif s[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return i
+        return len(s)
+
+    def _split_top(s: str):
+        parts, depth, cur = [], 0, []
+        for ch in s:
+            if ch == "{":
+                depth += 1
+            elif ch == "}":
+                depth -= 1
+            if ch == "," and depth == 0:
+                parts.append("".join(cur))
+                cur = []
+            else:
+                cur.append(ch)
+        if cur:
+            parts.append("".join(cur))
+        return parts
+
+    def _fold_self(segs: tuple) -> tuple:
+        # `a::b::self` means a::b; interior `self` never occurs
+        return segs[:-1] if segs and segs[-1] == "self" else segs
+
+    walk((), spec)
+    return results
+
+
+# --------------------------------------------------------------------------
+# discovery
+# --------------------------------------------------------------------------
+def walk_src(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.endswith(".rs"):
+                yield Path(dirpath) / fn
+
+
+def find_crates(root: Path):
+    """Every directory holding a Cargo.toml, deepest first so files attach to
+    their NEAREST crate (workspace members before the workspace root)."""
+    crates = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        if "Cargo.toml" in filenames:
+            crates.append(Path(dirpath))
+    return sorted(crates, key=lambda p: len(p.parts), reverse=True)
+
+
+def cargo_meta(crate_dir: Path):
+    """{lib_name, pkg_name, explicit_target_paths, path_deps} from Cargo.toml.
+
+    Uses stdlib tomllib when available (3.11+); otherwise a section-aware
+    line scan that extracts only the handful of keys needed. Either way a
+    malformed manifest degrades to defaults, never to a crash.
+    """
+    p = crate_dir / "Cargo.toml"
+    meta = {"pkg_name": crate_dir.name, "lib_name": None,
+            "target_paths": [], "path_deps": {}}
+    try:
+        raw = p.read_text("utf-8", errors="replace")
+    except OSError:
+        return meta
+
+    data = None
+    try:
+        import tomllib
+        data = tomllib.loads(raw)
+    except Exception:
+        pass
+
+    if data is not None:
+        pkg = data.get("package") or {}
+        if isinstance(pkg.get("name"), str):
+            meta["pkg_name"] = pkg["name"]
+        lib = data.get("lib") or {}
+        meta["lib_name"] = lib.get("name") or meta["pkg_name"]
+        if isinstance(lib.get("path"), str):
+            meta["target_paths"].append(lib["path"])
+        for key in ("bin", "test", "bench", "example"):
+            for t in data.get(key) or []:
+                if isinstance(t, dict) and isinstance(t.get("path"), str):
+                    meta["target_paths"].append(t["path"])
+        for depkey in ("dependencies", "dev-dependencies", "build-dependencies"):
+            for name, v in (data.get(depkey) or {}).items():
+                if isinstance(v, dict) and isinstance(v.get("path"), str):
+                    meta["path_deps"][name] = v["path"]
+        return meta
+
+    # fallback: section-aware line scan
+    section = ""
+    for line in raw.splitlines():
+        s = line.strip()
+        mh = re.match(r"^\[+([^\]]+)\]+", s)
+        if mh:
+            section = mh.group(1).strip()
+            continue
+        mk = re.match(r'^name\s*=\s*"([^"]+)"', s)
+        if mk and section == "package":
+            meta["pkg_name"] = mk.group(1)
+        if mk and section == "lib":
+            meta["lib_name"] = mk.group(1)
+        mp = re.match(r'^path\s*=\s*"([^"]+)"', s)
+        if mp and section in ("lib", "bin", "test", "bench", "example"):
+            meta["target_paths"].append(mp.group(1))
+        md = re.match(r'^([\w-]+)\s*=\s*\{[^}]*path\s*=\s*"([^"]+)"', s)
+        if md and section.endswith("dependencies"):
+            meta["path_deps"][md.group(1)] = md.group(2)
+    if meta["lib_name"] is None:
+        meta["lib_name"] = meta["pkg_name"]
+    return meta
+
+
+def crate_roots(crate_dir: Path, meta: dict, index: set):
+    """[(root_file, reason)] -- every file cargo treats as a compilation
+    root for this crate, via auto-discovery plus explicit manifest targets."""
+    roots = []
+
+    def add(p: Path, why: str):
+        if str(p) in index:
+            roots.append((p, why))
+
+    add(crate_dir / "src" / "lib.rs", "lib-root")
+    add(crate_dir / "src" / "main.rs", "bin-root")
+    add(crate_dir / "build.rs", "build-script")
+    for sub, why in (("bin", "bin-root"), ("examples", "example"),
+                     ("tests", "integration-test"), ("benches", "bench")):
+        base = crate_dir / ("src/bin" if sub == "bin" else sub)
+        if not base.is_dir():
+            continue
+        try:
+            for child in sorted(base.iterdir()):
+                if child.is_file() and child.suffix == ".rs":
+                    add(child, why)
+                elif child.is_dir():
+                    add(child / "main.rs", why)
+        except OSError:
+            pass
+    for t in meta["target_paths"]:
+        add((crate_dir / t).resolve(), "cargo-manifest-target")
+    return roots
+
+
+# --------------------------------------------------------------------------
+# graph build
+# --------------------------------------------------------------------------
+def _owns_parent(f: Path, is_root: bool) -> bool:
+    """Does `mod x;` in this file look in f.parent (roots, mod.rs) or in
+    f.parent/<stem> (ordinary name.rs)? The single most consequential rule in
+    Rust resolution -- see module docstring."""
+    return is_root or f.name == "mod.rs"
+
+
+def _automod_dir(spec: str, f: Path, crate_dir: Path | None, root: Path):
+    """Resolve an automod::dir! argument to a real directory, or None.
+
+    The argument is documented as relative to the crate root, but repos in the
+    wild also write it relative to the workspace root or the declaring file.
+    Try each; the first that EXISTS wins. Returning None matters as much as
+    returning a hit: an unresolvable directory mount is genuinely opaque, and
+    the caller must cap tiers rather than quietly drop the mount -- dropping it
+    would let a file this macro actually compiles be reported `certain`.
+    """
+    bases = [b for b in (crate_dir, root, f.parent) if b is not None]
+    for b in bases:
+        cand = (b / spec).resolve()
+        if cand.is_dir():
+            return cand
+    return None
+
+
+def _mod_candidates(f: Path, name: str, paths: list, is_root: bool):
+    """Filesystem candidates for `mod name;` declared in f."""
+    if paths:
+        # #[path] overrides everything; cfg_attr may supply several
+        return [(f.parent / p).resolve() for p in paths]
+    base = f.parent if _owns_parent(f, is_root) else f.parent / f.stem
+    return [(base / f"{name}.rs").resolve(),
+            (base / name / "mod.rs").resolve()]
+
+
+def build(root: Path) -> dict:
+    root = root.resolve()
+    files = sorted(walk_src(root))
+    index = {str(f) for f in files}
+    crates = find_crates(root)
+
+    nodes = {}
+    scans = {}
+    for f in files:
+        try:
+            src = f.read_text("utf-8", errors="replace")
+        except OSError:
+            continue
+        key = str(f)
+        nodes[key] = {
+            "path": str(f.relative_to(root)),
+            "loc": src.count("\n") + 1,
+            "entrypoint": [],
+            "_src": src,
+        }
+        scans[key] = scan_file(src)
+
+    # nearest crate for each file (crates sorted deepest-first)
+    def crate_of(f: Path):
+        for c in crates:
+            if str(f).startswith(str(c) + os.sep):
+                return c
+        return None
+
+    metas = {str(c): cargo_meta(c) for c in crates}
+    # crate module-name -> (crate_dir, lib root file), for cross-crate `use`
+    lib_by_name = {}
+    for c in crates:
+        m = metas[str(c)]
+        lib_file = c / "src" / "lib.rs"
+        for nm in {m["pkg_name"], m["lib_name"]}:
+            if nm:
+                lib_by_name[nm.replace("-", "_")] = (c, lib_file)
+
+    edges = set()
+    unresolved = {}
+    opaque_prefixes, opaque_sites = [], []
+    automod_blind = []       # (declaring file, unresolvable dir spec)
+    root_files = {}          # file key -> [reasons]
+
+    for c in crates:
+        for rf, why in crate_roots(c, metas[str(c)], index):
+            root_files.setdefault(str(rf), []).append(why)
+
+    # No Cargo.toml anywhere: a bare tree of .rs scripts. Fall back to
+    # blessing fn-main files as roots rather than inventing findings out of
+    # an absent manifest -- the same rule the Python phase applies.
+    no_manifest = not crates
+    if no_manifest:
+        for key, n in nodes.items():
+            if RX_FN_MAIN.search(strip_code(n["_src"])):
+                root_files.setdefault(key, []).append("script-no-manifest")
+
+    # ---- mount expansion: BFS from each root, assigning module paths -------
+    # modpaths: file key -> {(crate_key, modpath_tuple), ...}
+    modpaths = {}
+    mounted = set()
+    for rkey in root_files:
+        rf = Path(rkey)
+        c = crate_of(rf)
+        ckey = str(c) if c else ""
+        queue = [(rf, (), True)]
+        seen_local = set()
+        while queue:
+            f, mpath, is_root = queue.pop()
+            fkey = str(f)
+            if fkey in seen_local:
+                continue
+            seen_local.add(fkey)
+            mounted.add(fkey)
+            modpaths.setdefault(fkey, set()).add((ckey, mpath))
+            if fkey not in scans:
+                continue
+            mods, _uses, includes, automods, _opaque = scans[fkey]
+            for name, paths in mods:
+                cands = [p for p in _mod_candidates(f, name, paths, is_root)]
+                hit = [p for p in cands if str(p) in index]
+                for h in hit:
+                    edges.add((fkey, str(h)))
+                    queue.append((h, mpath + (name,), False))
+                if not hit:
+                    nrel = nodes[fkey]["path"]
+                    unresolved.setdefault(nrel, []).append(f"mod {name};")
+            for inc in includes:
+                t = (f.parent / inc).resolve()
+                if str(t) in index:
+                    edges.add((fkey, str(t)))
+                    queue.append((t, mpath, is_root))
+            # automod::dir!("d") mounts EVERY .rs in d. Literal argument ->
+            # statically resolvable -> real edges, not a tier downgrade.
+            for spec in automods:
+                d = _automod_dir(spec, f, c, root)
+                if d is None:
+                    automod_blind.append((nodes[fkey]["path"], spec))
+                    continue
+                for child in sorted(d.glob("*.rs")):
+                    if str(child) in index and str(child) != fkey:
+                        edges.add((fkey, str(child)))
+                        queue.append((child, mpath + (child.stem,), False))
+
+    # ---- mod edges from UNMOUNTED files too --------------------------------
+    # If the parent of an orphan subtree is dead, its children are dead with
+    # it -- but the edges still exist and dropping them silently would hide
+    # the subtree's structure. Recording them makes the children `suspect`
+    # ("has importers but unreachable"), which is the honest tier: delete the
+    # parent and they resolve together.
+    for fkey, n in nodes.items():
+        if fkey in mounted:
+            continue
+        f = Path(fkey)
+        mods, _uses, includes, _automods, _opaque = scans.get(
+            fkey, ([], [], [], [], []))
+        for name, paths in mods:
+            is_rootish = f.stem in CRATE_ROOT_STEMS
+            hit = [p for p in _mod_candidates(f, name, paths, is_rootish)
+                   if str(p) in index]
+            for h in hit:
+                edges.add((fkey, str(h)))
+        for inc in includes:
+            t = (f.parent / inc).resolve()
+            if str(t) in index:
+                edges.add((fkey, str(t)))
+
+    # ---- use / extern crate edges -----------------------------------------
+    # Build per-crate module index: (crate_key, modpath) -> file key
+    tree = {}
+    for fkey, mps in modpaths.items():
+        for ck, mp in mps:
+            tree.setdefault((ck, mp), fkey)
+
+    def resolve_use(fkey: str, segs: tuple):
+        """Resolve a use path to an internal file key, or None if external.
+        Returns (target|None, looked_internal)."""
+        f = Path(fkey)
+        c = crate_of(f)
+        ckey = str(c) if c else ""
+        own = sorted(mp for ck, mp in modpaths.get(fkey, ()) if ck == ckey)
+
+        if not segs:
+            return None, False
+        head = segs[0]
+        if head in ("crate", "self", "super"):
+            if not own:
+                return None, True     # unmounted file using crate:: paths
+            base = own[0]
+            rest = list(segs)
+            if head == "crate":
+                base = ()
+                rest = rest[1:]
+            elif head == "self":
+                rest = rest[1:]
+            else:
+                while rest and rest[0] == "super":
+                    base = base[:-1] if base else base
+                    rest = rest[1:]
+            return _longest(ckey, tuple(base) + tuple(rest)), True
+        if head == "":
+            return None, False
+        # bare first segment: a workspace member (or this crate's own lib,
+        # e.g. main.rs doing `use my_lib_name::...`) -- else external
+        target = lib_by_name.get(head)
+        if target is None:
+            return None, False
+        tc, tlib = target
+        hit = _longest(str(tc), tuple(segs[1:]))
+        if hit:
+            return hit, True
+        return (str(tlib) if str(tlib) in index else None), True
+
+    def _longest(ckey: str, segs: tuple):
+        for i in range(len(segs), -1, -1):
+            hit = tree.get((ckey, segs[:i]))
+            if hit:
+                return hit
+        return None
+
+    for fkey, n in nodes.items():
+        _mods, uses, _includes, _automods, opaq = scans.get(
+            fkey, ([], [], [], [], []))
+        for _pref, _kind in opaq:
+            # A non-literal include! can pull in anything, so it is the only
+            # case that justifies casting doubt on the whole crate.
+            opaque_prefixes.append("")
+            opaque_sites.append([f"{n['path']}", ""])
+        for segs in uses:
+            target, internal = resolve_use(fkey, segs)
+            if target and target != fkey:
+                edges.add((fkey, target))
+            elif internal and target is None:
+                unresolved.setdefault(n["path"], []).append("::".join(segs))
+
+    # An automod::dir! whose directory we could not locate is a mount we know
+    # exists but cannot follow. Recording it as unbounded is the honest call:
+    # dropping it would let a file that macro really does compile be reported
+    # `certain`, which is the one error this tool must never make.
+    for decl_path, spec in automod_blind:
+        opaque_prefixes.append("")
+        opaque_sites.append([f"{decl_path} (automod::dir!(\"{spec}\"))", ""])
+
+    # ---- entrypoints and runnability --------------------------------------
+    for fkey, reasons in root_files.items():
+        if fkey in nodes:
+            nodes[fkey]["entrypoint"] = sorted(set(reasons))
+    for fkey, n in nodes.items():
+        code = strip_code(n["_src"])
+        # Runnable by hand (`rustc file.rs` / copied into a bin target) but
+        # wired to no cargo target -- the Rust shape of `unwired`.
+        n["runnable"] = bool(
+            RX_FN_MAIN.search(code) and not n["entrypoint"] and not no_manifest
+        )
+
+    # ---- reachability BFS --------------------------------------------------
+    fwd, rev = {}, {}
+    for a, b in edges:
+        fwd.setdefault(a, set()).add(b)
+        rev.setdefault(b, set()).add(a)
+    roots_ = [k for k, n in nodes.items() if n["entrypoint"]]
+    seen, queue = set(roots_), list(roots_)
+    while queue:
+        cur = queue.pop()
+        for nxt in fwd.get(cur, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                queue.append(nxt)
+
+    out_nodes = {}
+    for k, n in nodes.items():
+        n["reachable"] = k in seen
+        n["mounted"] = k in mounted
+        n["importers"] = sorted(nodes[i]["path"] for i in rev.get(k, ())
+                                if i in nodes)
+        n["imports"] = sorted(nodes[i]["path"] for i in fwd.get(k, ())
+                              if i in nodes)
+        n.pop("_src", None)
+        out_nodes[n["path"]] = n
+
+    return {
+        "root": str(root),
+        "language": "rust",
+        "counts": {
+            "modules": len(nodes),
+            "edges": len(edges),
+            "entrypoints": len(roots_),
+            "reachable": len(seen),
+            "unreached": len(nodes) - len(seen),
+            "unresolved_imports": sum(len(v) for v in unresolved.values()),
+            "parse_errors": 0,
+        },
+        "crates": sorted(str(Path(c).relative_to(root)) if c != root else "."
+                         for c in (str(x) for x in crates)),
+        "nodes": out_nodes,
+        "edges": sorted([nodes[a]["path"], nodes[b]["path"]]
+                        for a, b in edges if a in nodes and b in nodes),
+        "unresolved": unresolved,
+        "parse_errors": {},
+        "opaque_prefixes": sorted({p for p in opaque_prefixes if p}),
+        "opaque_unbounded": any(p == "" for p in opaque_prefixes),
+        "opaque_sites": sorted(opaque_sites),
+    }
+
+
+# --------------------------------------------------------------------------
+# dead-code tiering (mirrors the TS phase; only leaf-name derivation and the
+# corpus extensions differ)
+# --------------------------------------------------------------------------
+TEXT_SCAN_EXT = (".rs", ".toml", ".md", ".yml", ".yaml", ".json", ".sh",
+                 ".txt", "dockerfile", "makefile")
+
+
+def leaf_name(rel: str) -> str:
+    """The name other code would reference this file by. mod.rs, and the
+    main.rs of a bin dir, are referenced by their DIRECTORY's name."""
+    parts = rel.replace("\\", "/").split("/")
+    stem = parts[-1][:-3] if parts[-1].endswith(".rs") else parts[-1]
+    if stem in CRATE_ROOT_STEMS and len(parts) > 1:
+        return parts[-2]
+    return stem
+
+
+def dead(graph: dict, root: Path):
+    from codegraph import tracked_files
+    tracked = tracked_files(root)
+    nodes = graph["nodes"]
+    opaque_prefixes = graph.get("opaque_prefixes", [])
+    opaque_unbounded = graph.get("opaque_unbounded", False)
+
+    corpus = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.lower().endswith(TEXT_SCAN_EXT):
+                p = Path(dirpath) / fn
+                try:
+                    corpus.append((str(p.relative_to(root)),
+                                   p.read_text("utf-8", errors="replace")))
+                except OSError:
+                    pass
+
+    results = []
+    for rel in sorted(m for m, n in nodes.items() if not n["reachable"]):
+        n = nodes[rel]
+        stem = leaf_name(rel)
+        rx = re.compile(rf"\b{re.escape(stem)}\b")
+        hits = sum(1 for other, text in corpus
+                   if other != rel and rx.search(text))
+
+        abs_mod = str((root / rel).resolve())
+        shadow = None
+        if opaque_unbounded:
+            shadow = "repo has an include!/mount whose target could not be bounded"
+        else:
+            for p in opaque_prefixes:
+                if abs_mod.startswith(p):
+                    shadow = f"reachable via directory mount under `{p}*`"
+                    break
+
+        if shadow:
+            tier, why = "suspect", shadow
+        elif n.get("runnable"):
+            tier, why = "unwired", ("has fn main(), but is no cargo target "
+                                    "and sits in no auto-discovered location")
+        elif n["importers"]:
+            tier, why = "suspect", ("has importers but is not reachable from "
+                                    "any crate root")
+        elif hits == 0:
+            tier, why = "certain", ("never mounted by any `mod`, no crate "
+                                    "root, zero textual references repo-wide")
+        else:
+            tier, why = "likely", (f"never mounted, but name appears in "
+                                   f"{hits} file(s)")
+
+        results.append({"module": rel, "path": rel, "loc": n["loc"],
+                        "tier": tier, "why": why, "text_refs": hits,
+                        "tracked": (None if tracked is None else rel in tracked)})
+    return results

--- a/tools/codegraph/codegraph_ts.py
+++ b/tools/codegraph/codegraph_ts.py
@@ -1,0 +1,509 @@
+#!/usr/bin/env python3
+# Vendored from C:/Users/RDuff/.claude/tools/codegraph/codegraph_ts.py on 2026-08-14; source SHA-256 474860D54F1DB3B5DE2054B0889842A0580102CABD5559C926863C397F9DA7A1; upstream commit unavailable (local source is not a Git worktree).
+"""codegraph TS/TSX parser -- phase 2. READ-ONLY, zero dependencies.
+
+Same contract as the Python phase: deterministic, never silently drop an edge,
+report-never-delete, and only `certain` is ever suggested for deletion.
+
+WHY REGEX AND NOT A REAL PARSER
+There is no TypeScript AST in the stdlib and the tool takes no dependencies.
+Import and export statements are highly regular, so a scanner is workable --
+but ONLY after comments, strings and template literals are stripped, because
+otherwise `// import './old'` and `"import x from 'y'"` inside a test fixture
+both register as edges. That is the same lesson the Python oracle learned when
+`alembic upgrade head` in a docstring matched every migration's upgrade().
+Stripping is therefore not a nicety here, it is the correctness step.
+
+RESOLUTION RULES THIS REPO SHAPE DEMANDS
+  * Extensionless specifiers: './x' may be x.ts, x.tsx, x.js, x.jsx, x/index.ts
+    ... Trying only one order manufactures orphans in bulk.
+  * `lazy(() => import('./Home'))` -- a dynamic import with a LITERAL argument
+    is statically resolvable and must become a real edge. React route-level
+    code splitting means most page components are reached ONLY this way; miss
+    it and every page in the app reads as dead.
+  * `export * from './x'` and `export { a } from './x'` are edges too. Barrel
+    files are pure re-export, so treating them as leaves strands whole trees.
+  * tsconfig `paths` aliases, when present.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from pathlib import Path
+
+SKIP_DIRS = {
+    ".git", "node_modules", "dist", "build", ".next", ".turbo", "coverage",
+    ".venv", "venv", "out", ".cache", ".parcel-cache", ".vite", "storybook-static",
+    ".idea", ".vscode", "logs", "test-results", "playwright-report",
+    # Agent worktrees are near-complete repo COPIES whose clones import each
+    # other -- they mask true findings, they do not merely inflate counts.
+    "worktrees", ".claude", ".hive-manager", ".worktrees",
+    # Agent session artifacts: transcripts, plans and task files that name
+    # modules in PROSE. They are not code and not source of truth, but their
+    # mentions are enough to demote a true finding from `certain` to `likely`.
+    ".hive", ".swarm", ".agent-sessions",
+}
+
+EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"]
+
+# Imported, but never a module edge: stylesheets and static assets carry no
+# dependency meaning for reachability. Recording them as "unresolved internal"
+# would bury the specifiers that genuinely failed to resolve.
+ASSET_EXTS = (".css", ".scss", ".sass", ".less", ".styl", ".svg", ".png",
+              ".jpg", ".jpeg", ".gif", ".webp", ".avif", ".ico", ".json",
+              ".graphql", ".gql", ".md", ".txt", ".wasm", ".woff", ".woff2")
+# Order matters: a specifier './x' prefers x.ts over x/index.ts, and .ts over
+# .js, matching TypeScript's own resolution.
+RESOLVE_SUFFIXES = (
+    [e for e in EXTS]
+    + [f"/index{e}" for e in EXTS]
+)
+
+# --- statement scanners, run on COMMENT/STRING-STRIPPED source -------------
+RX_IMPORT_FROM = re.compile(r"""\bimport\b[^;'"]*?\bfrom\s*['"]([^'"]+)['"]""")
+RX_IMPORT_BARE = re.compile(r"""\bimport\s*['"]([^'"]+)['"]""")     # side-effect
+RX_EXPORT_FROM = re.compile(r"""\bexport\b[^;'"]*?\bfrom\s*['"]([^'"]+)['"]""")
+RX_DYNAMIC = re.compile(r"""\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)""")
+RX_REQUIRE = re.compile(r"""\brequire\s*\(\s*['"]([^'"]+)['"]\s*\)""")
+# A dynamic import whose target is a template literal: import(`./pages/${n}`).
+# The constant lead bounds its reach the same way an f-string lead does.
+RX_DYNAMIC_TPL = re.compile(r"""\bimport\s*\(\s*`([^`$]*)\$\{""")
+RX_DYNAMIC_OPAQUE = re.compile(r"""\bimport\s*\(\s*(?!['"`])[A-Za-z_$]""")
+
+
+def strip_code(src: str) -> str:
+    """Remove comments, string and template literals, keeping line structure.
+
+    Replaces content with spaces rather than deleting it so that line numbers
+    survive for call-site reporting. Import specifiers are re-extracted from
+    the ORIGINAL source; this stripped copy exists only to decide WHERE a
+    statement legitimately occurs.
+    """
+    out = []
+    i, n = 0, len(src)
+    state = None   # None | "line" | "block" | "'" | '"' | "`"
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+        if state is None:
+            if c == "/" and nxt == "/":
+                state, i = "line", i + 2
+                out.append("  ")
+                continue
+            if c == "/" and nxt == "*":
+                state, i = "block", i + 2
+                out.append("  ")
+                continue
+            if c in "'\"`":
+                state = c
+                out.append(c)
+                i += 1
+                continue
+            out.append(c)
+            i += 1
+        elif state == "line":
+            if c == "\n":
+                state = None
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+        elif state == "block":
+            if c == "*" and nxt == "/":
+                state, i = None, i + 2
+                out.append("  ")
+                continue
+            out.append("\n" if c == "\n" else " ")
+            i += 1
+        else:  # inside a string/template literal
+            if c == "\\":
+                out.append("  ")
+                i += 2
+                continue
+            if c == state:
+                state = None
+                out.append(c)
+            else:
+                out.append("\n" if c == "\n" else " ")
+            i += 1
+    return "".join(out)
+
+
+def specifiers(src: str):
+    """(specifiers, template_prefixes, opaque_count) from one file.
+
+    Runs the scanners on a copy whose comments are blanked but whose string
+    CONTENT is preserved, so specifiers stay readable while `// import 'x'`
+    does not register.
+    """
+    scan = strip_comments_only(src)
+    specs = []
+    for rx in (RX_IMPORT_FROM, RX_EXPORT_FROM, RX_DYNAMIC, RX_REQUIRE,
+               RX_IMPORT_BARE):
+        specs.extend(rx.findall(scan))
+    tpl = [m for m in RX_DYNAMIC_TPL.findall(scan) if m]
+    opaque = len(RX_DYNAMIC_OPAQUE.findall(scan))
+    return specs, tpl, opaque
+
+
+def strip_comments_only(src: str) -> str:
+    """Blank comments but keep string contents (specifiers live in strings)."""
+    out = []
+    i, n = 0, len(src)
+    state = None
+    while i < n:
+        c = src[i]
+        nxt = src[i + 1] if i + 1 < n else ""
+        if state is None:
+            if c == "/" and nxt == "/":
+                state, i = "line", i + 2
+                out.append("  ")
+                continue
+            if c == "/" and nxt == "*":
+                state, i = "block", i + 2
+                out.append("  ")
+                continue
+            if c in "'\"`":
+                state = c
+            out.append(c)
+            i += 1
+        elif state == "line":
+            if c == "\n":
+                state = None
+            out.append(c if c == "\n" else " ")
+            i += 1
+        elif state == "block":
+            if c == "*" and nxt == "/":
+                state, i = None, i + 2
+                out.append("  ")
+                continue
+            out.append(c if c == "\n" else " ")
+            i += 1
+        else:
+            if c == "\\":
+                out.append(src[i:i + 2])
+                i += 2
+                continue
+            if c == state:
+                state = None
+            out.append(c)
+            i += 1
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------
+def walk_src(root: Path):
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if any(fn.endswith(e) for e in EXTS):
+                yield Path(dirpath) / fn
+
+
+def tsconfig_paths(root: Path):
+    """{alias-prefix: [target-prefix, ...]} from tsconfig `paths`, if any."""
+    aliases = {}
+    for name in ("tsconfig.json", "tsconfig.app.json", "jsconfig.json"):
+        p = root / name
+        if not p.is_file():
+            continue
+        try:
+            # tsconfig allows comments and trailing commas; JSON does not.
+            raw = strip_comments_only(p.read_text("utf-8", errors="replace"))
+            raw = re.sub(r",(\s*[}\]])", r"\1", raw)
+            cfg = json.loads(raw)
+        except (OSError, ValueError):
+            continue
+        co = cfg.get("compilerOptions", {})
+        base = co.get("baseUrl", ".")
+        for alias, targets in (co.get("paths") or {}).items():
+            aliases[alias.rstrip("*")] = [
+                str((root / base / t.rstrip("*")).resolve()) for t in targets
+            ]
+    return aliases
+
+
+def resolve_spec(spec: str, importer: Path, root: Path, index: set,
+                 aliases: dict):
+    """Resolve a specifier to an internal file, or None if external/unknown.
+
+    Returns (resolved_relpath | None, looked_internal: bool). The second value
+    is what keeps an unresolvable-but-internal specifier from being silently
+    dropped -- it gets RECORDED instead.
+    """
+    if spec.lower().endswith(ASSET_EXTS):
+        return None, False        # asset, not a module -- external by nature
+
+    cands = []
+    if spec.startswith("."):
+        base = (importer.parent / spec).resolve()
+        cands.append(base)
+        internal = True
+    else:
+        internal = False
+        for prefix, targets in aliases.items():
+            if prefix and spec.startswith(prefix):
+                rest = spec[len(prefix):]
+                for t in targets:
+                    cands.append(Path(t) / rest)
+                internal = True
+                break
+        if not cands:
+            # bare specifier -> node_modules package, genuinely external
+            return None, False
+
+    for base in cands:
+        # exact file first, then extension and index resolution
+        if str(base) in index and base.is_file():
+            return base, internal
+        for suf in RESOLVE_SUFFIXES:
+            probe = Path(str(base) + suf)
+            if str(probe) in index:
+                return probe, internal
+        # TypeScript ESM: the SPECIFIER carries the emitted `.js` extension
+        # while the file on disk is `.ts`/`.tsx`. Not rewriting this stranded
+        # 2270 real edges on the first repo it was tried against -- imports
+        # like '../../types/user.js' pointing at user.ts.
+        m = re.search(r"\.(js|jsx|mjs|cjs)$", str(base))
+        if m:
+            stem = str(base)[: m.start()]
+            for suf in RESOLVE_SUFFIXES:
+                probe = Path(stem + suf)
+                if str(probe) in index:
+                    return probe, internal
+    return None, internal
+
+
+def build(root: Path) -> dict:
+    root = root.resolve()
+    files = sorted(walk_src(root))
+    index = {str(f) for f in files}
+    aliases = tsconfig_paths(root)
+
+    nodes = {}
+    for f in files:
+        try:
+            src = f.read_text("utf-8", errors="replace")
+        except OSError:
+            continue
+        nodes[str(f)] = {
+            "path": str(f.relative_to(root)),
+            "loc": src.count("\n") + 1,
+            "entrypoint": [],
+            "_src": src,
+        }
+
+    edges = set()
+    unresolved = {}
+    tpl_prefixes, opaque_total, opaque_sites = [], 0, []
+
+    for key, n in nodes.items():
+        f = Path(key)
+        specs, tpls, opaque = specifiers(n["_src"])
+        for pref in tpls:
+            base = (f.parent / pref).resolve()
+            tpl_prefixes.append(str(base))
+        if opaque:
+            opaque_total += opaque
+            opaque_sites.append(n["path"])
+        for spec in specs:
+            target, looked_internal = resolve_spec(spec, f, root, index, aliases)
+            if target is not None and str(target) != key:
+                edges.add((key, str(target)))
+            elif looked_internal:
+                unresolved.setdefault(n["path"], []).append(spec)
+
+    classify_entrypoints(nodes, root)
+
+    fwd, rev = {}, {}
+    for a, b in edges:
+        fwd.setdefault(a, set()).add(b)
+        rev.setdefault(b, set()).add(a)
+
+    roots = [k for k, n in nodes.items() if n["entrypoint"]]
+    seen, queue = set(roots), list(roots)
+    while queue:
+        cur = queue.pop()
+        for nxt in fwd.get(cur, ()):
+            if nxt not in seen:
+                seen.add(nxt)
+                queue.append(nxt)
+
+    out_nodes = {}
+    for k, n in nodes.items():
+        n["reachable"] = k in seen
+        n["importers"] = sorted(nodes[i]["path"] for i in rev.get(k, ()))
+        n["imports"] = sorted(nodes[i]["path"] for i in fwd.get(k, ()))
+        n.pop("_src", None)
+        out_nodes[n["path"]] = n
+
+    return {
+        "root": str(root),
+        "language": "typescript",
+        "counts": {
+            "modules": len(nodes),
+            "edges": len(edges),
+            "entrypoints": len(roots),
+            "reachable": len(seen),
+            "unreached": len(nodes) - len(seen),
+            "unresolved_imports": sum(len(v) for v in unresolved.values()),
+            "parse_errors": 0,
+        },
+        "nodes": out_nodes,
+        "edges": sorted([nodes[a]["path"], nodes[b]["path"]] for a, b in edges),
+        "unresolved": unresolved,
+        "parse_errors": {},
+        "aliases": {k: v for k, v in aliases.items()},
+        "opaque_prefixes": sorted({p for p in tpl_prefixes}),
+        "opaque_unbounded": opaque_total > 0,
+        "opaque_sites": sorted([[s, ""] for s in set(opaque_sites)]),
+    }
+
+
+def classify_entrypoints(nodes: dict, root: Path):
+    """Mark files reached by something other than an import.
+
+    Omitting a class here manufactures false orphans in bulk, so each entry is
+    a real invocation path that produces no import edge.
+    """
+    html_entries = set()
+    for html in list(root.glob("*.html")) + list(root.glob("*/*.html")):
+        try:
+            text = html.read_text("utf-8", errors="replace")
+        except OSError:
+            continue
+        for m in re.finditer(r"""<script[^>]*\bsrc\s*=\s*['"]([^'"]+)['"]""", text):
+            src = m.group(1).lstrip("/")
+            html_entries.add(str((html.parent / src).resolve()))
+
+    # package.json `scripts` is the authority on which one-off scripts are
+    # actually wired. Blanket-blessing everything under scripts/ (as the Python
+    # phase does) hides the unreferenced ones, and on the first repo tried only
+    # 11 of 41 were wired -- the other 30 are exactly the finding worth having.
+    # Same shape as the Alembic rule: convention locates candidates, the
+    # project's own config decides which are live.
+    npm_referenced = set()
+    pkg = root / "package.json"
+    if pkg.is_file():
+        try:
+            data = json.loads(pkg.read_text("utf-8", errors="replace"))
+            blob = " ".join(str(v) for v in (data.get("scripts") or {}).values())
+            blob += " " + str(data.get("main", "")) + " " + str(data.get("bin", ""))
+            for m in re.finditer(r"[\w./\\-]+\.(?:ts|tsx|js|jsx|mjs|cjs)\b", blob):
+                npm_referenced.add(str((root / m.group(0)).resolve()))
+            # ts-node/tsx invocations sometimes omit the extension
+            for m in re.finditer(r"(?:tsx|ts-node[\w/]*)\s+([\w./\\-]+)", blob):
+                cand = (root / m.group(1)).resolve()
+                npm_referenced.add(str(cand))
+                for e in EXTS:
+                    npm_referenced.add(str(cand) + e)
+        except (OSError, ValueError):
+            pass
+
+    for key, n in nodes.items():
+        rel = n["path"].replace("\\", "/")
+        base = rel.rsplit("/", 1)[-1]
+        reasons = []
+
+        if key in html_entries:
+            reasons.append("html-script-entry")
+        if key in npm_referenced:
+            reasons.append("npm-script")
+        # Runnable by hand (`npx tsx src/scripts/x.ts`) but wired to nothing.
+        # Not dead -- it executes -- but not referenced either. Conflating the
+        # two hides both, so record it as its own state.
+        n["runnable"] = bool(
+            re.search(r"(^|/)scripts?/", rel) and key not in npm_referenced
+        )
+        # Vite/Vitest/Tailwind/PostCSS/ESLint configs are loaded by their tools
+        if re.match(r"^[\w.-]*\.?(config|rc)\.(ts|js|mjs|cjs|tsx|jsx)$", base):
+            reasons.append("tooling-config")
+        if re.search(r"\.(test|spec)\.(ts|tsx|js|jsx)$", base):
+            reasons.append("test")
+        elif "/__tests__/" in f"/{rel}" or "/tests/" in f"/{rel}" or \
+                "/e2e/" in f"/{rel}":
+            reasons.append("in-tests-tree")
+        if base.endswith(".d.ts"):
+            reasons.append("ambient-types")     # referenced by the compiler
+        if re.search(r"(^|/)(setupTests|setup|vitest\.setup|jest\.setup)\.",
+                     rel):
+            reasons.append("test-setup")
+        # Firebase / serverless function roots are invoked by the platform
+        if re.search(r"(^|/)functions/(src/)?index\.(ts|js)$", rel):
+            reasons.append("cloud-function")
+        if re.search(r"(^|/)(service-worker|sw|firebase-messaging-sw)\.",
+                     rel):
+            reasons.append("service-worker")
+        # Vite treats src/main.* as the app root when index.html points at it
+        if re.match(r"^(src/)?(main|index)\.(ts|tsx|js|jsx)$", rel):
+            reasons.append("app-root")
+
+        n["entrypoint"] = reasons
+
+
+# --------------------------------------------------------------------------
+# dead-code tiering  (mirrors the Python phase; only leaf-name derivation and
+# the corpus extensions differ)
+# --------------------------------------------------------------------------
+TEXT_SCAN_EXT = (".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".json",
+                 ".html", ".md", ".yml", ".yaml", ".toml", ".css", ".scss")
+
+
+def dead(graph: dict, root: Path):
+    from codegraph import tracked_files
+    tracked = tracked_files(root)
+    nodes = graph["nodes"]
+    opaque_prefixes = graph.get("opaque_prefixes", [])
+    opaque_unbounded = graph.get("opaque_unbounded", False)
+
+    corpus = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in SKIP_DIRS]
+        for fn in filenames:
+            if fn.lower().endswith(TEXT_SCAN_EXT):
+                p = Path(dirpath) / fn
+                try:
+                    corpus.append((str(p.relative_to(root)),
+                                   p.read_text("utf-8", errors="replace")))
+                except OSError:
+                    pass
+
+    results = []
+    for rel in sorted(m for m, n in nodes.items() if not n["reachable"]):
+        n = nodes[rel]
+        stem = Path(rel).name
+        for e in EXTS:
+            if stem.endswith(e):
+                stem = stem[: -len(e)]
+                break
+
+        rx = re.compile(rf"\b{re.escape(stem)}\b")
+        hits = sum(1 for other, text in corpus
+                   if other != rel and rx.search(text))
+
+        abs_mod = str((root / rel).resolve())
+        shadow = None
+        if opaque_unbounded:
+            shadow = "repo has a dynamic import whose target could not be bounded"
+        else:
+            for p in opaque_prefixes:
+                if abs_mod.startswith(p):
+                    shadow = f"reachable via dynamic import under `{p}*`"
+                    break
+
+        if shadow:
+            tier, why = "suspect", shadow
+        elif n.get("runnable"):
+            tier, why = "unwired", "runnable by hand, but wired to no package.json script"
+        elif n["importers"]:
+            tier, why = "suspect", "has importers but is not reachable from any entrypoint"
+        elif hits == 0:
+            tier, why = "certain", "no importers, no entrypoint, zero textual references repo-wide"
+        else:
+            tier, why = "likely", f"no import edge, but name appears in {hits} file(s)"
+
+        results.append({"module": rel, "path": rel, "loc": n["loc"],
+                        "tier": tier, "why": why, "text_refs": hits,
+                        "tracked": (None if tracked is None else rel in tracked)})
+    return results

--- a/tools/codegraph/vendor-manifest.json
+++ b/tools/codegraph/vendor-manifest.json
@@ -1,17 +1,17 @@
 {
-  "version": 1,
+  "version": 2,
   "files": {
     "codegraph.py": {
       "upstream_sha256": "8b5ae7cd70bd4ac2a5af11d2a05aee9cd608af8e00a545c9b65d52ef53e77a0c",
-      "vendored_sha256": "6d0e6a01955d421bdc2780f986999841bf64b4c571f189abd445fa0a4bd67536"
+      "normalized_sha256": "6d0e6a01955d421bdc2780f986999841bf64b4c571f189abd445fa0a4bd67536"
     },
     "codegraph_rs.py": {
       "upstream_sha256": "7d6f6ed1d8171ef382313ae284cef692aa2ae5eb654833173e3a11064b942460",
-      "vendored_sha256": "54107c4a98615fe8e9a680a09fe068347c916d3075b85d6332f70ace9c38bbf2"
+      "normalized_sha256": "54107c4a98615fe8e9a680a09fe068347c916d3075b85d6332f70ace9c38bbf2"
     },
     "codegraph_ts.py": {
       "upstream_sha256": "474860d54f1db3b5de2054b0889842a0580102cabd5559c926863c397f9da7a1",
-      "vendored_sha256": "78002e38b40f99abc24d69ebe8fda16c79397b24e53a6fa7de510f025f0dda97"
+      "normalized_sha256": "78002e38b40f99abc24d69ebe8fda16c79397b24e53a6fa7de510f025f0dda97"
     }
   }
 }

--- a/tools/codegraph/vendor-manifest.json
+++ b/tools/codegraph/vendor-manifest.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "files": {
+    "codegraph.py": {
+      "upstream_sha256": "8b5ae7cd70bd4ac2a5af11d2a05aee9cd608af8e00a545c9b65d52ef53e77a0c",
+      "vendored_sha256": "6d0e6a01955d421bdc2780f986999841bf64b4c571f189abd445fa0a4bd67536"
+    },
+    "codegraph_rs.py": {
+      "upstream_sha256": "7d6f6ed1d8171ef382313ae284cef692aa2ae5eb654833173e3a11064b942460",
+      "vendored_sha256": "54107c4a98615fe8e9a680a09fe068347c916d3075b85d6332f70ace9c38bbf2"
+    },
+    "codegraph_ts.py": {
+      "upstream_sha256": "474860d54f1db3b5de2054b0889842a0580102cabd5559c926863c397f9da7a1",
+      "vendored_sha256": "78002e38b40f99abc24d69ebe8fda16c79397b24e53a6fa7de510f025f0dda97"
+    }
+  }
+}

--- a/tools/codegraph/verify_vendor.py
+++ b/tools/codegraph/verify_vendor.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Verify vendored codegraph bytes and their upstream provenance metadata."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MANIFEST = ROOT / "vendor-manifest.json"
+HEADER_HASH = re.compile(rb"source SHA-256 ([0-9a-fA-F]{64})")
+EXPECTED_FILES = {"codegraph.py", "codegraph_rs.py", "codegraph_ts.py"}
+
+
+def main() -> int:
+    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+    files = manifest.get("files")
+    if (
+        manifest.get("version") != 1
+        or not isinstance(files, dict)
+        or set(files) != EXPECTED_FILES
+        or any(not isinstance(hashes, dict) for hashes in files.values())
+    ):
+        print("vendor-manifest.json: invalid schema", file=sys.stderr)
+        return 1
+
+    failures: list[str] = []
+    for name, hashes in files.items():
+        path = ROOT / name
+        if not path.is_file():
+            failures.append(f"{name}: missing")
+            continue
+
+        content = path.read_bytes()
+        vendored_hash = hashlib.sha256(content).hexdigest()
+        expected_vendored = hashes.get("vendored_sha256", "").lower()
+        expected_upstream = hashes.get("upstream_sha256", "").lower()
+        header_match = HEADER_HASH.search(content[:512])
+        header_upstream = header_match.group(1).decode("ascii").lower() if header_match else ""
+
+        file_failures = []
+        if vendored_hash != expected_vendored:
+            file_failures.append("vendored bytes differ")
+        if header_upstream != expected_upstream:
+            file_failures.append("header upstream hash differs from manifest")
+
+        if file_failures:
+            failures.append(f"{name}: {', '.join(file_failures)}")
+            print(
+                f"{name}: FAIL vendored={vendored_hash} upstream={header_upstream or 'missing'}"
+            )
+        else:
+            print(f"{name}: OK vendored={vendored_hash} upstream={header_upstream}")
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    print(f"Verified {len(files)} vendored files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/codegraph/verify_vendor.py
+++ b/tools/codegraph/verify_vendor.py
@@ -13,19 +13,86 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent
 MANIFEST = ROOT / "vendor-manifest.json"
 HEADER_HASH = re.compile(rb"source SHA-256 ([0-9a-fA-F]{64})")
-EXPECTED_FILES = {"codegraph.py", "codegraph_rs.py", "codegraph_ts.py"}
+SHA256 = re.compile(r"[0-9a-fA-F]{64}")
+HASH_FIELDS = {"upstream_sha256", "vendored_sha256"}
+
+
+def load_manifest(path: Path) -> dict[str, dict[str, str]] | None:
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        print(f"{path.name}: cannot read manifest: {error}", file=sys.stderr)
+        return None
+    except json.JSONDecodeError as error:
+        print(
+            f"{path.name}: invalid JSON at line {error.lineno}, column {error.colno}: "
+            f"{error.msg}",
+            file=sys.stderr,
+        )
+        return None
+
+    if not isinstance(manifest, dict):
+        print(f"{path.name}: invalid schema", file=sys.stderr)
+        return None
+
+    files = manifest.get("files")
+    if manifest.get("version") != 1 or not isinstance(files, dict) or not files:
+        print(f"{path.name}: invalid schema", file=sys.stderr)
+        return None
+
+    for name, hashes in files.items():
+        relative = Path(name) if isinstance(name, str) else None
+        if (
+            relative is None
+            or relative.is_absolute()
+            or relative.name != name
+            or name in (".", "..")
+            or "/" in name
+            or "\\" in name
+        ):
+            print(f"{path.name}: unsafe vendored path: {name!r}", file=sys.stderr)
+            return None
+        if not isinstance(hashes, dict) or set(hashes) != HASH_FIELDS:
+            print(f"{path.name}: invalid hash fields for {name}", file=sys.stderr)
+            return None
+        if any(
+            not isinstance(value, str) or SHA256.fullmatch(value) is None
+            for value in hashes.values()
+        ):
+            print(f"{path.name}: invalid SHA-256 for {name}", file=sys.stderr)
+            return None
+
+    return files
+
+
+def discover_vendored_files() -> set[str]:
+    return {
+        path.name
+        for path in ROOT.glob("*.py")
+        if HEADER_HASH.search(path.read_bytes()[:512])
+    }
 
 
 def main() -> int:
-    manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
-    files = manifest.get("files")
-    if (
-        manifest.get("version") != 1
-        or not isinstance(files, dict)
-        or set(files) != EXPECTED_FILES
-        or any(not isinstance(hashes, dict) for hashes in files.values())
-    ):
-        print("vendor-manifest.json: invalid schema", file=sys.stderr)
+    files = load_manifest(MANIFEST)
+    if files is None:
+        return 1
+
+    discovered = discover_vendored_files()
+    declared = set(files)
+    if discovered != declared:
+        omitted = sorted(discovered - declared)
+        stale = sorted(declared - discovered)
+        if omitted:
+            print(
+                "vendor-manifest.json: unmanifested vendored files: " + ", ".join(omitted),
+                file=sys.stderr,
+            )
+        if stale:
+            print(
+                "vendor-manifest.json: entries without vendored files: " + ", ".join(stale),
+                file=sys.stderr,
+            )
         return 1
 
     failures: list[str] = []

--- a/tools/codegraph/verify_vendor.py
+++ b/tools/codegraph/verify_vendor.py
@@ -14,7 +14,12 @@ ROOT = Path(__file__).resolve().parent
 MANIFEST = ROOT / "vendor-manifest.json"
 HEADER_HASH = re.compile(rb"source SHA-256 ([0-9a-fA-F]{64})")
 SHA256 = re.compile(r"[0-9a-fA-F]{64}")
-HASH_FIELDS = {"upstream_sha256", "vendored_sha256"}
+HASH_FIELDS = {"upstream_sha256", "normalized_sha256"}
+
+
+def normalize_line_endings(content: bytes) -> bytes:
+    """Return content with CRLF and lone CR line endings normalized to LF."""
+    return content.replace(b"\r\n", b"\n").replace(b"\r", b"\n")
 
 
 def load_manifest(path: Path) -> dict[str, dict[str, str]] | None:
@@ -36,7 +41,7 @@ def load_manifest(path: Path) -> dict[str, dict[str, str]] | None:
         return None
 
     files = manifest.get("files")
-    if manifest.get("version") != 1 or not isinstance(files, dict) or not files:
+    if manifest.get("version") != 2 or not isinstance(files, dict) or not files:
         print(f"{path.name}: invalid schema", file=sys.stderr)
         return None
 
@@ -103,25 +108,26 @@ def main() -> int:
             continue
 
         content = path.read_bytes()
-        vendored_hash = hashlib.sha256(content).hexdigest()
-        expected_vendored = hashes.get("vendored_sha256", "").lower()
+        normalized_hash = hashlib.sha256(normalize_line_endings(content)).hexdigest()
+        expected_normalized = hashes.get("normalized_sha256", "").lower()
         expected_upstream = hashes.get("upstream_sha256", "").lower()
         header_match = HEADER_HASH.search(content[:512])
         header_upstream = header_match.group(1).decode("ascii").lower() if header_match else ""
 
         file_failures = []
-        if vendored_hash != expected_vendored:
-            file_failures.append("vendored bytes differ")
+        if normalized_hash != expected_normalized:
+            file_failures.append("normalized content differs")
         if header_upstream != expected_upstream:
             file_failures.append("header upstream hash differs from manifest")
 
         if file_failures:
             failures.append(f"{name}: {', '.join(file_failures)}")
             print(
-                f"{name}: FAIL vendored={vendored_hash} upstream={header_upstream or 'missing'}"
+                f"{name}: FAIL normalized={normalized_hash} "
+                f"upstream={header_upstream or 'missing'}"
             )
         else:
-            print(f"{name}: OK vendored={vendored_hash} upstream={header_upstream}")
+            print(f"{name}: OK normalized={normalized_hash} upstream={header_upstream}")
 
     if failures:
         for failure in failures:


### PR DESCRIPTION
Closes #223. Closes #224. Closes #225. **Advances #221 — does NOT close it.**

Four defects reported out of the epic #209 hive session. Three are orchestration-reliability bugs that made #209 require manual operator intervention; the fourth is the CI gate that would have caught #209's five-unreachable-modules failure in the first place.

---

## The four decisions the plan required be stated, not silently resolved

**1. Where the discrete-submit gap lives (T6).** The plan flagged "a gap inside the lock delays every other PTY consumer" as a design risk. Reading the code, that risk is overstated: `PtySession::write` acquires and releases its writer mutex *per call*, and `write_to_agent` holds `pty_manager.read()` — an RwLock **read** guard, so concurrent PTY consumers are unaffected; only session add/remove would wait. **Decision: keep the manager read guard across the gap.** The binding rule is narrower than the plan's: the gap must never be held across an *exclusive* lock.

**2. Liveness on a terminal row vs. a new row per assignment (T12).** **Decision: refresh liveness columns on the terminal row.** Reopening a finalized row is ruled out on evidence — dependency readiness is a correlated `NOT EXISTS` on `prerequisite.status = 'finalized'`, so un-finalizing would retroactively un-satisfy the dependencies of already-claimed downstream tasks. A new row per assignment is schema-legal and is probably the eventual right answer, but it requires the Queen's reassignment path to *enqueue* — today reassignment goes through `inject`, not the queue — which is a protocol change beyond these four issues. Noted as follow-up, not implemented.

**3. The inject opt-out flag (T7).** **Decision: `submit: bool`, defaulting true, wire-compatible via `#[serde(default = "default_submit")]` on all three request structs.** Existing callers that post `{target, message}` keep working unchanged.

**4. TypeScript reachability — advisory, not blocking (T4).** **Decision: advisory.** Measured: 72 modules, 15 findings, all `suspect` (capped by one unbounded dynamic import). Adjudicated with `--ignore-dynamic`, it yields 3 `certain` findings and **all three are false positives** — two are imported by `.svelte` components, and `+layout.ts` is a SvelteKit convention entrypoint. Root cause is structural: the analyzer does not parse `.svelte`, and the repo has 65 `.svelte` vs 69 `.ts`, so roughly half the frontend import graph is invisible to it. A blocking TS gate would red-CI on day one for demonstrably live code. `docs/reachability-gate.md` records the named condition for promoting it to blocking.

## Deviation from the approved plan

The plan lists **"no changes to the Queen prompt protocol itself"** as a non-goal. The operator explicitly authorized one during the session: the queen prompt template now documents the inject defect and its two-step workaround. Recorded here rather than slipped in.

---

## #221 is deliberately left open

The structural fix is in — one discrete-submit primitive, both submitting paths routed through it — but the **gap constant is provisional and unmeasured**, and the plan's own stop condition says not to close #221 on automated byte-sequence tests. Those prove the writes are discrete; they do not prove a TUI submits.

A live experiment during this session did establish the mechanism (see #226):

| Step | Bytes written | Result |
|---|---|---|
| 1 | `payload` + `\r\n` in **one** write | **No submit** — sat in the composer 60 s |
| 2 | `\r\n` **alone, its own write** | **Submitted** |

That confirms #221's core diagnosis empirically. It also **refuted** an intermediate hypothesis of mine that the `\n` was an independent second cause: a discrete `\r\n` submits fine. Discreteness is the load-bearing property. No test in this PR encodes the refuted hypothesis. The per-CLI matrix and the `claude` half remain unmeasured and are tracked in **#226**.

### A second inject path, not in issue #221

`pty.inject` placed `\r` **inside** the `\x1b[200~ … \x1b[201~` bracketed-paste envelope, where a carriage return is literal content *by protocol*, not by heuristic. That path could never submit. A fix confined to `injection.rs` would have left the UI's inject button broken. `pty.paste` correctly submits nothing and is unchanged.

---

## Corrections to the plan's own evidence, found during execution

- **The `heartbeat_at` consumer audit was wrong in both directions.** It listed 3 consumers; there are 4 (`rows_for_session` and `get_row` were missing), and `finalize_no_progress` — which it listed — never reads the column at all. Adjudicated: the two new ones are *observational projections*, not lifecycle gates. No production code anywhere branches on `heartbeat_at`; the frontend has only a type declaration. The governing invariant was narrowed to "no unfiltered read **gates lifecycle behavior**."
- **Three assumptions in issue #225 were wrong** and are corrected in the implementation: `dead` always exits 0 (so the raw command was never a gate — hence `ci_gate.py`), the empty-parse sentinel is `NO RUST MODULES FOUND` and also exits 0, and worktree exclusion already works via `SKIP_DIRS` and needs no CI flag.

## Vendoring integrity

The three analyzer files are copied **unmodified**. Because they were CRLF→LF normalized on copy, hashing a vendored file cannot reproduce an upstream hash — so `vendor-manifest.json` records **both** identities and `verify_vendor.py` checks them in one command. Verified to detect drift: one planted byte produces a non-zero exit.

## Gates

| Gate | Result |
|---|---|
| `cargo check --tests` | clean |
| `cargo test --lib` | **738 passed, 0 failed**, 1 ignored |
| `npm run check` | 0 errors, 0 warnings |
| `npm test` | 155 passed (30 files) |
| Reachability, Rust | 133 modules, **0 certain**, exit 0 |
| Reachability, negative | uncalled fixture → 1 certain, **exit 1**; removed → exit 0 |
| Vendor integrity | 3 files verified; drift → exit 1 |
| `cargo clippy` | **not installed on this toolchain — verified in CI** |

### Mutation proofs (mandatory for T11 and T15)

Every one re-run independently at integration, not accepted from a pasted transcript.

- **#223 drift test** — moving `QaPassed` into the work-acceptance predicate fails it; removing it from the display predicate fails it. Both reverted.
- **#224 regression test** — reverting T12's SQL alone fails at `tests_wg_queue.rs:1367` (stale liveness); reverting T14 alone fails at `:1342` (stall eligibility). *Different assertion lines*, so the two mechanisms are independently covered.
- **Reachability gate** — a planted orphan module produces 1 `certain` and exit 1.

## Integration note

One lane left **mutation debris in the working tree**: `get_stalled_agents` still had its T14 fix reverted from that lane's own mandatory mutation run. Caught at integration by re-running the gates rather than trusting reported status; committing on status alone would have shipped #224 half-fixed behind a green narrative. Related: a `cp`-based mutation restore does **not** reliably invalidate cargo's fingerprint, which produced both a false failure and a false pass before being caught — `touch` after restoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Injection requests can submit text immediately or leave it unsent for further editing.
  - Multiline input preserves formatting with consistent submission behavior across platforms.
  - Added automated reachability and dead-code checks for supported project languages.

- **Bug Fixes**
  - Improved worker heartbeat and queue liveness tracking after task reassignment.
  - Preserved distinct closing, completed, and failed session statuses.
  - Improved error reporting for injection and terminal operations.

- **Documentation**
  - Added guidance for reachability checks and injection workflows.
  - Updated the application version to 0.43.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->