### PR TITLE
feat(org-graph): semantic agent identity, work-graph read API, queue/PTY correctness (v0.44.0)

### DIFF
--- a/docs/pty-submit-sweep.md
+++ b/docs/pty-submit-sweep.md
@@ -1,0 +1,156 @@
+# PTY submit-gap sweep
+
+This procedure measures whether a discrete bare carriage return submits input to each
+supported agent composer after a configurable delay. It deliberately does not infer success
+from a marker file, an agent reply, or any other downstream action: those signals are
+confounded when an operator is present and can press Enter.
+
+The read-only instrument is:
+
+```http
+GET /api/sessions/{session_id}/agents/{agent_id}/pty-buffer
+```
+
+A successful read returns HTTP 200 with the existing bounded PTY tail:
+
+```json
+{
+  "session_id": "{session_id}",
+  "agent_id": "{agent_id}",
+  "output": "recent PTY bytes decoded as text",
+  "byte_count": 31
+}
+```
+
+Malformed session or agent IDs return HTTP 400. A missing session, an agent not registered in
+that session, or a registered agent without a PTY returns HTTP 404. The endpoint only observes
+the existing 8 KB ring buffer; it never writes bytes or submits input. The ASCII fixtures below
+keep `byte_count` directly comparable to the fixture byte length.
+
+## Shipped behavior under test
+
+- The payload and Enter are two discrete PTY writes.
+- Enter is a bare `\r`; no `\n` is appended and Enter is outside any bracketed-paste envelope.
+- A multi-line payload retains its internal newlines and receives one Enter after the whole
+  payload, not one Enter per line.
+- `pty.paste` remains bracketed input with no automatic submit.
+- The compiled fallback is 50 ms for every adapter until measurements justify a change.
+- `HIVE_PTY_SUBMIT_GAP_MS` overrides the adapter policy for the sweep.
+
+The 50 ms value is intentionally unchanged. Existing uncontrolled observations report two
+failures around 1.2-2.7 seconds, two successes around 4-5 seconds, and one success around
+65 seconds. Agent busy state was uncontrolled, so those observations suggest 50 ms is likely
+too short but do not support replacing it with another guessed constant.
+
+## Evidence status before this sweep
+
+No cell has been measured against the current per-adapter policy and T6 instrument. Each cell
+below must be measured in two controlled states: **idle at the prompt** and **mid-generation**.
+
+| Adapter | About 100 bytes | About 2.5 KB | Multi-line |
+|---|---|---|---|
+| `codex` | **UNMEASURED** for the current build. Historical v0.43.0 behavior: FAIL, operator-confirmed twice. | **UNMEASURED** | **UNMEASURED** |
+| `claude` | **UNMEASURED** | **UNMEASURED** | **UNMEASURED** |
+
+The historical Codex failures are useful baseline evidence, but they do not count as a
+measured current-build cell. The uncontrolled gap observations above also do not count as
+matrix cells because their adapter, payload class, and busy state were not all controlled.
+
+## Prerequisites
+
+1. Use a build containing the per-adapter policy, the deterministic PTY tests, and T6's
+   read-only buffer endpoint.
+2. Start a fresh backend for each gap candidate with
+   `HIVE_PTY_SUBMIT_GAP_MS=<milliseconds>` set before launch.
+3. Start a fresh real session for the selected adapter and record its session and agent IDs.
+4. The operator must not focus the target terminal or touch the keyboard from immediately
+   before injection until after the buffer observation is recorded.
+5. Record the build SHA, OS/ConPTY version, adapter CLI version, model, session/agent IDs,
+   candidate gap, payload class, attempt number, and whether the agent was visibly busy.
+
+Do not run Codex and Claude trials concurrently. Background output can evict relevant bytes
+from the bounded 8 KB PTY tail and makes busy-state control harder.
+
+## Payload fixtures
+
+Use ASCII fixtures so byte counts do not depend on encoding:
+
+```powershell
+$shortPayload = ('s' * 96) + ' END'       # 100 bytes
+$longPayload = ('l' * 2556) + ' END'      # 2560 bytes (2.5 KiB)
+$multiPayload = "line-01`nline-02`nline-03 END"
+```
+
+Give each attempt a short unique prefix such as `C-S-050-A1` (adapter, payload class, gap,
+attempt). Keep the total payload in the same size class by shortening the repeated body by
+the prefix length.
+
+## Trial procedure
+
+For each adapter (`codex`, then `claude`), payload class, controlled agent state, and candidate
+gap:
+
+1. Launch the backend with that candidate gap and create a fresh target session. Put the agent
+   into the declared state before the injection:
+
+   - **idle at prompt**: wait for the composer to be idle and record the buffer evidence;
+   - **mid-generation**: submit a bounded setup prompt, confirm from the buffer that output is
+     actively streaming, then inject the sweep payload without touching the keyboard.
+2. Send `GET /api/sessions/{session_id}/agents/{agent_id}/pty-buffer` and save the complete
+   HTTP status and JSON response as the baseline.
+3. Submit one payload through the existing injection endpoint:
+
+   ```http
+   POST /api/sessions/{session_id}/inject
+   Content-Type: application/json
+
+   {
+     "target_agent_id": "{agent_id}",
+     "message": "{payload}",
+     "submit": true
+   }
+   ```
+
+4. Without touching the target terminal, repeat the PTY-buffer `GET` at 250 ms, 1 second,
+   5 seconds, and 10 seconds after the configured gap. Save every raw status and response;
+   do not rely on a transient UI repaint.
+5. Score the current terminal state reconstructed from the PTY output:
+
+   - **PASS**: the unique payload is no longer sitting in the composer and the buffer shows
+     the composer accepted the discrete Enter.
+   - **FAIL**: the unique payload remains in the composer, including the literal-newline or
+     shift-Enter shape documented by issue #226.
+   - **INVALID**: the operator touched the keyboard, the 8 KB tail evicted the observation,
+     the process exited, or output is insufficient to distinguish submitted from staged.
+
+   A marker file, response text, or other downstream agent action is supporting context only;
+   it never upgrades an ambiguous buffer observation to PASS.
+6. Repeat until there are three valid attempts for that adapter/payload/state/gap cell. Record
+   every invalid attempt
+   and its cause, but exclude it from the pass denominator.
+7. After the submit trial, create a fresh session and send the same payload with
+   `"submit": false`. Confirm the buffer shows staged, unsubmitted content. This validates
+   the instrument for that adapter/build before accepting a PASS.
+8. Run the `pty.paste` regression once per adapter/build and confirm the content remains
+   staged with no automatic Enter.
+
+## Gap search
+
+Run a coarse sweep at `0, 50, 100, 250, 500, 1000, 2500, 5000` ms in **both controlled agent
+states**. If a candidate produces three valid passes, bisect between it and the greatest lower
+failing candidate until the resolution is 50 ms. Do not promote a measured threshold directly
+into the compiled policy: retain trial records, compare both adapters, both states, and all
+payload classes, and choose a safety margin explicitly in a follow-up review.
+
+## Results ledger
+
+Append one row per attempt. A cell becomes **MEASURED PASS** only after three valid passes at
+the stated gap; any valid failure makes it **MEASURED FAIL** at that gap.
+
+| Build | Adapter/version | Payload class | Bytes/lines | Gap ms | Attempt | Busy state | Buffer artifact | Result | Notes |
+|---|---|---:|---:|---:|---:|---|---|---|---|
+| _unmeasured_ | | | | | | | | | |
+
+After the operator sweep, replace the evidence-status table's `UNMEASURED` labels with the
+measured result and link each cell to its retained buffer artifacts. Cells not actually run
+must remain explicitly `UNMEASURED`.

--- a/docs/pty-submit-sweep.md
+++ b/docs/pty-submit-sweep.md
@@ -18,7 +18,7 @@ A successful read returns HTTP 200 with the existing bounded PTY tail:
   "session_id": "{session_id}",
   "agent_id": "{agent_id}",
   "output": "recent PTY bytes decoded as text",
-  "byte_count": 31
+  "byte_count": 32
 }
 ```
 
@@ -35,7 +35,9 @@ keep `byte_count` directly comparable to the fixture byte length.
   payload, not one Enter per line.
 - `pty.paste` remains bracketed input with no automatic submit.
 - The compiled fallback is 50 ms for every adapter until measurements justify a change.
-- `HIVE_PTY_SUBMIT_GAP_MS` overrides the adapter policy for the sweep.
+- `HIVE_PTY_SUBMIT_GAP_MS` values from 0 through 300,000 ms override the adapter policy for the
+  sweep. Invalid, overflowed, and larger values are rejected with one warning and fall back to the
+  adapter default; they are never silently clamped. The 300,000 ms safety ceiling is not a default.
 
 The 50 ms value is intentionally unchanged. Existing uncontrolled observations report two
 failures around 1.2-2.7 seconds, two successes around 4-5 seconds, and one success around

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/roles/backend.md
+++ b/roles/backend.md
@@ -1,0 +1,6 @@
+---
+{"id":"backend","version":1,"domain":"Server-side systems, APIs, persistence, and service reliability","knowledge_scope":[{"source":"institutional","pointer":"engineering/backend-contracts.md","summary":"Backend boundaries, persistence conventions, and service reliability checks.","priority":80}],"lens":{"id":"backend-correctness","question":"Are data, failure, and compatibility contracts explicit and preserved?"},"authority":{"may_commit":true},"prompt_template":"roles/backend","non_goals":["Do not redesign frontend interaction without an assigned cross-lane contract."]}
+---
+# Backend
+
+Bring the backend-correctness lens to the assigned task and follow referenced guidance only.

--- a/roles/code-quality.md
+++ b/roles/code-quality.md
@@ -1,0 +1,6 @@
+---
+{"id":"code-quality","version":1,"domain":"Maintainability, static analysis, and repository quality gates","knowledge_scope":[{"source":"institutional","pointer":"engineering/quality-gates.md","summary":"Static checks, maintainability criteria, and review closure conventions.","priority":85}],"lens":{"id":"quality-gate","question":"Does the change satisfy the repository's quality gates without hiding debt?"},"authority":{"may_commit":true},"prompt_template":"roles/code-quality","non_goals":["Do not suppress a valid diagnostic merely to make a gate green."]}
+---
+# Code Quality
+
+Resolve assigned quality findings and preserve the meaning of every gate.

--- a/roles/coherence.md
+++ b/roles/coherence.md
@@ -1,0 +1,6 @@
+---
+{"id":"coherence","version":1,"domain":"Cross-component contracts and integration consistency","knowledge_scope":[{"source":"institutional","pointer":"engineering/integration-contracts.md","summary":"Shared API, naming, lifecycle, and compatibility conventions.","priority":85}],"lens":{"id":"system-coherence","question":"Do the changed components still tell one consistent story?"},"authority":{"may_commit":true},"prompt_template":"roles/coherence","non_goals":["Do not expand a local integration fix into an unrelated redesign."]}
+---
+# Coherence
+
+Reconcile assigned integration contracts without taking ownership of unrelated components.

--- a/roles/evaluator.md
+++ b/roles/evaluator.md
@@ -1,0 +1,6 @@
+---
+{"id":"evaluator","version":1,"domain":"Independent milestone evaluation against declared acceptance criteria","knowledge_scope":[{"source":"institutional","pointer":"verification/evaluator-evidence.md","summary":"Independent verdict standards, contamination controls, and blocked-result reporting.","priority":100}],"lens":{"id":"independent-verdict","question":"Does the delivered artifact satisfy each criterion under adversarial scrutiny?"},"authority":{"may_adjudicate":true},"behavior":"instruction_following","context_boundary":"artifact","signal_class":"judgmental","prompt_template":"roles/evaluator","non_goals":["Do not repair the artifact being evaluated.","Do not inherit the implementer's narrative as evidence."]}
+---
+# Evaluator
+
+Issue an independent verdict from the artifact and declared acceptance evidence.

--- a/roles/frontend.md
+++ b/roles/frontend.md
@@ -1,0 +1,6 @@
+---
+{"id":"frontend","version":1,"domain":"User interfaces, state, accessibility, and interaction quality","knowledge_scope":[{"source":"institutional","pointer":"engineering/frontend-contracts.md","summary":"UI state, accessibility, and interaction conventions.","priority":80}],"lens":{"id":"user-interaction","question":"Is the interface legible, accessible, and resilient across user states?"},"authority":{"may_commit":true},"prompt_template":"roles/frontend","non_goals":["Do not change server contracts without an assigned cross-lane contract."]}
+---
+# Frontend
+
+Bring the user-interaction lens to the assigned task and follow referenced guidance only.

--- a/roles/general.md
+++ b/roles/general.md
@@ -1,0 +1,6 @@
+---
+{"id":"general","version":1,"domain":"Coherent implementation within an explicit task contract","knowledge_scope":[{"source":"project","pointer":"project-dna.md","summary":"Project-specific conventions and validated implementation constraints.","priority":80}],"lens":{"id":"task-contract","question":"What is the smallest complete change that satisfies the assigned contract?"},"authority":{"may_commit":true},"prompt_template":"roles/general","non_goals":["Do not expand beyond the assigned ownership boundary."]}
+---
+# General
+
+Execute the assigned contract using only the context explicitly composed for it.

--- a/roles/master-planner.md
+++ b/roles/master-planner.md
@@ -1,0 +1,6 @@
+---
+{"id":"master-planner","version":1,"domain":"Evidence-backed implementation planning and task decomposition","knowledge_scope":[{"source":"institutional","pointer":"planning/implementation-contracts.md","summary":"Dependency-aware decomposition, ownership, risk, and acceptance conventions.","priority":100}],"lens":{"id":"execution-readiness","question":"Is every task independently executable, owned, ordered, and mechanically verifiable?"},"authority":{"may_spawn_subordinates":true},"context_boundary":"full","prompt_template":"roles/master-planner","non_goals":["Do not implement the plan.","Do not invent unavailable APIs or dependencies."]}
+---
+# Master Planner
+
+Produce an executable plan grounded in repository evidence.

--- a/roles/prince.md
+++ b/roles/prince.md
@@ -1,0 +1,6 @@
+---
+{"id":"prince","version":1,"domain":"Coordinated remediation of failed evaluation findings","knowledge_scope":[{"source":"institutional","pointer":"orchestration/remediation-protocol.md","summary":"Finding decomposition, ownership, remediation, and re-evaluation handoff.","priority":100}],"lens":{"id":"remediation-closure","question":"Is every confirmed failure assigned, repaired, and returned with new evidence?"},"authority":{"may_commit":true,"may_push":true,"may_spawn_subordinates":true},"context_boundary":"full","prompt_template":"roles/prince","non_goals":["Do not overrule an evaluator verdict without declared adjudication authority."]}
+---
+# Prince
+
+Coordinate scoped remediation and return all findings for independent re-evaluation.

--- a/roles/queen.md
+++ b/roles/queen.md
@@ -1,0 +1,6 @@
+---
+{"id":"queen","version":1,"domain":"Session orchestration, integration, and delivery accountability","knowledge_scope":[{"source":"institutional","pointer":"orchestration/queen-protocol.md","summary":"Delegation, ownership, integration, escalation, and completion protocols.","priority":100}],"lens":{"id":"whole-session-delivery","question":"Are ownership, dependencies, evidence, and integration all sufficient for the objective?"},"authority":{"may_commit":true,"may_push":true,"may_spawn_subordinates":true},"context_boundary":"full","prompt_template":"roles/queen","non_goals":["Do not silently take over live principal-owned paths.","Do not treat self-report as verification evidence."]}
+---
+# Queen
+
+Coordinate the session and integrate only mechanically supported results.

--- a/roles/researcher.md
+++ b/roles/researcher.md
@@ -1,0 +1,6 @@
+---
+{"id":"researcher","version":1,"domain":"Read-only investigation and evidence synthesis","knowledge_scope":[{"source":"institutional","pointer":"research/evidence-provenance.md","summary":"Source quality, provenance, and fact-versus-inference conventions.","priority":90}],"lens":{"id":"evidence-first","question":"What do primary sources establish, and what remains inference?"},"authority":{},"context_boundary":"full","prompt_template":"roles/researcher","non_goals":["Do not modify project files or git state.","Do not present inference as observed fact."]}
+---
+# Researcher
+
+Investigate read-only and return concise findings with source provenance.

--- a/roles/resolver.md
+++ b/roles/resolver.md
@@ -1,0 +1,6 @@
+---
+{"id":"resolver","version":1,"domain":"Resolution of confirmed review findings","knowledge_scope":[{"source":"institutional","pointer":"engineering/finding-resolution.md","summary":"Finding reproduction, scoped remediation, and closure evidence.","priority":90}],"lens":{"id":"finding-closure","question":"Does the smallest safe change close the finding and prove it stays closed?"},"authority":{"may_commit":true},"prompt_template":"roles/resolver","non_goals":["Do not dismiss or broaden findings without recorded rationale."]}
+---
+# Resolver
+
+Close assigned findings with a scoped fix and focused regression evidence.

--- a/roles/reviewer-quick.md
+++ b/roles/reviewer-quick.md
@@ -1,0 +1,6 @@
+---
+{"id":"reviewer-quick","version":1,"domain":"Fast independent regression and maintainability review","knowledge_scope":[{"source":"institutional","pointer":"engineering/review-checklist.md","summary":"Compact correctness and regression checklist.","priority":90}],"lens":{"id":"fast-regression-scan","question":"Is there an obvious defect, regression, or maintenance hazard?"},"authority":{},"context_boundary":"artifact","signal_class":"judgmental","prompt_template":"roles/reviewer-quick","non_goals":["Do not claim exhaustive coverage."]}
+---
+# Quick Reviewer
+
+Return a concise, evidence-backed scan without claiming exhaustive review.

--- a/roles/reviewer.md
+++ b/roles/reviewer.md
@@ -1,0 +1,6 @@
+---
+{"id":"reviewer","version":1,"domain":"Independent review of correctness, security, performance, and compatibility","knowledge_scope":[{"source":"institutional","pointer":"engineering/review-evidence.md","summary":"Evidence standards, severity calibration, and regression-review practice.","priority":100}],"lens":{"id":"adversarial-review","question":"What concrete defect or unsupported claim could make this change fail?"},"authority":{},"context_boundary":"artifact","signal_class":"judgmental","prompt_template":"roles/reviewer","non_goals":["Do not implement the code being judged unless explicitly reassigned.","Do not accept narrative evidence in place of a reproducible check."]}
+---
+# Reviewer
+
+Judge the assigned artifact independently and cite reproducible evidence.

--- a/roles/simplify.md
+++ b/roles/simplify.md
@@ -1,0 +1,6 @@
+---
+{"id":"simplify","version":1,"domain":"Behavior-preserving simplification and maintainability","knowledge_scope":[{"source":"institutional","pointer":"engineering/refactoring-safety.md","summary":"Small-step refactoring, compatibility, and proof obligations.","priority":75}],"lens":{"id":"essential-complexity","question":"What can be removed or clarified without changing observable behavior?"},"authority":{"may_commit":true},"prompt_template":"roles/simplify","non_goals":["Do not combine simplification with an unrequested behavior change."]}
+---
+# Simplify
+
+Reduce accidental complexity only where the assignment authorizes it.

--- a/roles/tester.md
+++ b/roles/tester.md
@@ -1,0 +1,6 @@
+---
+{"id":"tester","version":1,"domain":"Mechanical validation and regression evidence","knowledge_scope":[{"source":"institutional","pointer":"engineering/test-evidence.md","summary":"Test selection, failure triage, and reproducible evidence standards.","priority":95}],"lens":{"id":"mechanism-proof","question":"Which executable observation proves the mechanism works and fails when broken?"},"authority":{"may_commit":true},"context_boundary":"full","signal_class":"mechanical","prompt_template":"roles/tester","non_goals":["Do not substitute green output for a mechanism-sensitive assertion."]}
+---
+# Tester
+
+Produce mechanical evidence at the changed seam and repair only assigned failures.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.43.1"
+version = "0.44.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.43.1"
+version = "0.44.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/adapters/mod.rs
+++ b/src-tauri/src/adapters/mod.rs
@@ -12,6 +12,7 @@ mod qwen;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 
@@ -31,6 +32,57 @@ pub const VALID_CLIS: &[&str] = &[
     "droid",
     "qwen",
 ];
+
+/// Unvalidated default spacing between a PTY payload and its discrete Enter write.
+///
+/// Under load, measured payload/Enter separations of 1.2-2.7 s failed twice,
+/// while roughly 4-5 s succeeded twice and 65 s succeeded once. Agent busy
+/// state was uncontrolled, so those observations do not justify replacing the
+/// compiled 50 ms default with another guess.
+pub const DEFAULT_PTY_SUBMIT_GAP: Duration = Duration::from_millis(50);
+
+/// Submit timing selected for one PTY session.
+///
+/// Adapter identity stays explicit even while all adapters retain the same
+/// unvalidated default, so later measured tuning remains adapter-local.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PtySubmitPolicy {
+    pub adapter: Option<&'static str>,
+    pub default_gap: Duration,
+}
+
+/// Resolve the policy from the executable that is actually handed to the PTY.
+/// Cursor launches through `wsl`, so that executable is normalized back to the
+/// Cursor adapter instead of silently using the unknown-command fallback.
+pub fn pty_submit_policy(command: &str) -> PtySubmitPolicy {
+    let executable = command
+        .rsplit(|character| character == '/' || character == '\\')
+        .next()
+        .unwrap_or(command)
+        .to_ascii_lowercase();
+    let executable = executable.strip_suffix(".exe").unwrap_or(&executable);
+    let adapter_name = if executable == "wsl" {
+        Some("cursor")
+    } else {
+        VALID_CLIS
+            .iter()
+            .copied()
+            .find(|candidate| *candidate == executable)
+    };
+
+    let Some(adapter_name) = adapter_name else {
+        return PtySubmitPolicy {
+            adapter: None,
+            default_gap: DEFAULT_PTY_SUBMIT_GAP,
+        };
+    };
+    let adapter = get_adapter(adapter_name)
+        .expect("every VALID_CLIS entry must have a matching adapter implementation");
+    PtySubmitPolicy {
+        adapter: Some(adapter.cli_name()),
+        default_gap: adapter.pty_submit_gap(),
+    }
+}
 
 /// Validate a CLI name against the allowlist.
 pub fn is_valid_cli(cli: &str) -> bool {
@@ -182,6 +234,11 @@ pub trait CliAdapter: Send + Sync {
     fn prompt_flag(&self) -> Option<&'static str> {
         None
     }
+
+    /// Default payload-to-Enter spacing for this adapter's interactive PTY.
+    fn pty_submit_gap(&self) -> Duration {
+        DEFAULT_PTY_SUBMIT_GAP
+    }
 }
 
 /// Get the appropriate adapter for a CLI name.
@@ -259,5 +316,37 @@ mod tests {
         // run GPT-5.6 tiers (sol/terra/luna) through the codex adapter.
         assert!(get_adapter("gemini").is_err());
         assert!(get_adapter("antigravity").is_err());
+    }
+
+    #[test]
+    fn pty_submit_policy_resolves_every_spawnable_adapter() {
+        for cli in VALID_CLIS {
+            let policy = pty_submit_policy(cli);
+            assert_eq!(policy.adapter, Some(*cli), "policy mismatch for {cli}");
+            assert_eq!(policy.default_gap, DEFAULT_PTY_SUBMIT_GAP);
+        }
+
+        assert_eq!(pty_submit_policy("wsl").adapter, Some("cursor"));
+        assert_eq!(pty_submit_policy("WSL.EXE").adapter, Some("cursor"));
+        assert_eq!(
+            pty_submit_policy(r"C:\\tools\\codex.exe").adapter,
+            Some("codex")
+        );
+    }
+
+    #[test]
+    fn codex_and_claude_submit_policies_resolve_independently() {
+        let codex = pty_submit_policy("codex");
+        let claude = pty_submit_policy("claude");
+
+        assert_eq!(codex.adapter, Some("codex"));
+        assert_eq!(claude.adapter, Some("claude"));
+        assert_ne!(codex.adapter, claude.adapter);
+        assert_eq!(codex.default_gap, Duration::from_millis(50));
+        assert_eq!(claude.default_gap, Duration::from_millis(50));
+
+        let fallback = pty_submit_policy("test-shell");
+        assert_eq!(fallback.adapter, None);
+        assert_eq!(fallback.default_gap, DEFAULT_PTY_SUBMIT_GAP);
     }
 }

--- a/src-tauri/src/cli/registry.rs
+++ b/src-tauri/src/cli/registry.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 
+use serde::{Deserialize, Serialize};
+
 use crate::domain::{CapabilityCard, CapabilitySupport, DelegationPolicy, NativeDelegationMode};
+use crate::orchestrator::org_graph::RoleDefinition;
 use crate::pty::AgentConfig;
 use crate::storage::{AppConfig, CliConfig};
 
 /// CLI behavioral profiles for characterizing how different CLI tools behave
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CliBehavior {
     /// Highly proactive - will "help" by taking action. Needs strong constraints.
     ActionProne,
@@ -250,13 +254,15 @@ impl CliRegistry {
         matches!(Self::get_behavior(cli), CliBehavior::ActionProne)
     }
 
-    /// Evaluators should default to a skeptical, instruction-following profile
-    /// even when the underlying CLI is more action-prone in other roles.
-    pub fn get_behavior_for_role(cli: &str, role_type: Option<&str>) -> CliBehavior {
-        match role_type.map(str::to_ascii_lowercase).as_deref() {
-            Some("evaluator") => CliBehavior::InstructionFollowing,
-            _ => Self::get_behavior(cli),
-        }
+    /// A role may declare a behavior override; otherwise capability inheritance
+    /// preserves the CLI's existing behavior exactly.
+    pub fn get_behavior_for_role(
+        cli: &str,
+        definition: Option<&RoleDefinition>,
+    ) -> CliBehavior {
+        definition
+            .and_then(|definition| definition.behavior)
+            .unwrap_or_else(|| Self::get_behavior(cli))
     }
 }
 
@@ -558,12 +564,14 @@ mod tests {
 
     #[test]
     fn test_get_behavior_for_evaluator_role() {
+        let evaluator = crate::orchestrator::org_graph::evaluator_role_definition();
         assert!(matches!(
-            CliRegistry::get_behavior_for_role("claude", Some("evaluator")),
+            CliRegistry::get_behavior_for_role("claude", Some(&evaluator)),
             CliBehavior::InstructionFollowing
         ));
+        let backend = crate::orchestrator::org_graph::RoleDefinition::empty("backend");
         assert!(matches!(
-            CliRegistry::get_behavior_for_role("claude", Some("backend")),
+            CliRegistry::get_behavior_for_role("claude", Some(&backend)),
             CliBehavior::ActionProne
         ));
     }

--- a/src-tauri/src/coordination/queue_manager.rs
+++ b/src-tauri/src/coordination/queue_manager.rs
@@ -307,6 +307,7 @@ impl QueueManager {
             no_progress_count: 0,
             last_status: None,
             heartbeat_at: None,
+            assignment_id: 0,
             blocked_reason: None,
             created_at: now,
             updated_at: now,
@@ -356,6 +357,7 @@ impl QueueManager {
             no_progress_count: 0,
             last_status: None,
             heartbeat_at: None,
+            assignment_id: 0,
             blocked_reason: None,
             created_at: now,
             updated_at: now,
@@ -796,22 +798,36 @@ impl QueueManager {
         worker_id: &str,
         status: &str,
     ) -> Result<bool, StorageError> {
+        self.record_heartbeat_for_assignment(session_id, worker_id, None, status)
+            .await
+    }
+
+    /// Record a heartbeat for one durable assignment, falling back deterministically only
+    /// when an older caller omits `assignment_id`.
+    pub async fn record_heartbeat_for_assignment(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        assignment_id: Option<i64>,
+        status: &str,
+    ) -> Result<bool, StorageError> {
         let now = Self::now_ms();
-        let updated = self
+        let updated_row_id = self
             .repo
-            .record_heartbeat(session_id, worker_id, status, now)?;
-        if updated && status == "completed" {
-            if let Some(row) = self
-                .repo
-                .rows_for_session(session_id)?
-                .into_iter()
-                .find(|row| row.worker_id == worker_id)
-            {
-                self.emit_for_row(&row.id, EventType::WorkerFinalized, Severity::Info)
+            .record_heartbeat_for_assignment(
+                session_id,
+                worker_id,
+                assignment_id,
+                status,
+                now,
+            )?;
+        if status == "completed" {
+            if let Some(row_id) = updated_row_id.as_deref() {
+                self.emit_for_row(row_id, EventType::WorkerFinalized, Severity::Info)
                     .await;
             }
         }
-        Ok(updated)
+        Ok(updated_row_id.is_some())
     }
 
     /// Maintenance: flip stale `running` rows back to `queued`. Emits `WorkerReclaimed`

--- a/src-tauri/src/coordination/state.rs
+++ b/src-tauri/src/coordination/state.rs
@@ -7,9 +7,15 @@ use serde::{Deserialize, Serialize};
 use tempfile::NamedTempFile;
 use thiserror::Error;
 
-use crate::orchestrator::work_graph::WorkGraph;
+use crate::orchestrator::org_graph::definitions::role_prompt_template;
+use crate::orchestrator::org_graph::ownership::{
+    derive_path_ownership, LivePrincipal, OrchestratorWriteAttempt, OrchestratorWriteOutcome,
+    OwnershipSessionState,
+};
+use crate::orchestrator::work_graph::divergence::DivergenceSummary;
 use crate::orchestrator::work_graph::review::ReviewExpansionSidecar;
 use crate::orchestrator::work_graph::runtime::GraphCompositionState;
+use crate::orchestrator::work_graph::WorkGraph;
 use crate::pty::WorkerRole;
 
 use super::{parse_sprint_contract, SprintContract};
@@ -84,6 +90,16 @@ pub enum AssignmentStatus {
 /// Manages state files for a session
 pub struct StateManager {
     session_path: PathBuf,
+}
+
+/// Durable evidence that a lifecycle transition refreshed the graph artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WorkGraphLifecycleSnapshot {
+    pub lifecycle_stage: String,
+    pub emitted_at: DateTime<Utc>,
+    pub node_count: usize,
+    pub edge_count: usize,
+    pub artifact: String,
 }
 
 impl StateManager {
@@ -218,9 +234,10 @@ impl StateManager {
                     id: n.id,
                     role: WorkerRole {
                         role_type: n.role.clone(),
-                        label: n.role,
+                        label: n.role.clone(),
                         default_cli: "claude".to_string(),
-                        prompt_template: None,
+                        prompt_template: Some(role_prompt_template(&n.role)),
+                        resolved_definition: None,
                     },
                     cli: "claude".to_string(),
                     status: "Running".to_string(),
@@ -416,6 +433,107 @@ impl StateManager {
         Ok(Some(serde_json::from_str(&json)?))
     }
 
+    /// Refresh transition evidence and the standalone graph view from the current
+    /// authoritative graph. This never writes `state/work-graph.json`; the scheduler
+    /// remains its sole writer.
+    pub fn emit_work_graph_snapshot(
+        &self,
+        lifecycle_stage: &str,
+    ) -> Result<Option<PathBuf>, StateError> {
+        let Some(graph) = self.read_work_graph()? else {
+            return Ok(None);
+        };
+        let artifact = self.write_portable_work_graph_artifact(
+            lifecycle_stage,
+            &graph,
+            None,
+        )?;
+        let snapshot = WorkGraphLifecycleSnapshot {
+            lifecycle_stage: lifecycle_stage.to_string(),
+            emitted_at: Utc::now(),
+            node_count: graph.nodes.len(),
+            edge_count: graph.edges.len(),
+            artifact: "work-graph.html".to_string(),
+        };
+        self.ensure_state_dir()?;
+        let json = serde_json::to_string_pretty(&snapshot)?;
+        self.write_atomic_text(
+            self.state_dir().join("work-graph-lifecycle.json"),
+            &json,
+        )?;
+        Ok(Some(artifact))
+    }
+
+    pub fn read_work_graph_snapshot(
+        &self,
+    ) -> Result<Option<WorkGraphLifecycleSnapshot>, StateError> {
+        let path = self.state_dir().join("work-graph-lifecycle.json");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let json = fs::read_to_string(path)?;
+        Ok(Some(serde_json::from_str(&json)?))
+    }
+
+    /// Write a browser-renderable, dependency-free graph artifact at the stable
+    /// session-root path used by headless and post-crash operators.
+    pub fn write_portable_work_graph_artifact(
+        &self,
+        lifecycle_stage: &str,
+        graph: &WorkGraph,
+        divergence: Option<&DivergenceSummary>,
+    ) -> Result<PathBuf, StateError> {
+        let nodes = graph
+            .nodes
+            .iter()
+            .map(|node| {
+                serde_json::json!({
+                    "id": node.id,
+                    "status": node.status,
+                    "lane": node.binding,
+                    "contract_summary": {
+                        "input_count": node.contract.inputs.len(),
+                        "output_count": node.contract.outputs.len(),
+                        "acceptance_count": node.contract.acceptance.len(),
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        let edges = graph
+            .edges
+            .iter()
+            .map(|edge| {
+                serde_json::json!({
+                    "source": edge.source,
+                    "target": edge.target,
+                    "kind": edge.kind,
+                    "provenance": edge.provenance,
+                })
+            })
+            .collect::<Vec<_>>();
+        let session_id = self
+            .session_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unknown-session");
+        let payload = serde_json::json!({
+            "session_id": session_id,
+            "lifecycle_stage": lifecycle_stage,
+            "generated_at": Utc::now(),
+            "nodes": nodes,
+            "edges": edges,
+            "divergence": divergence,
+        });
+        let payload_json = serde_json::to_string(&payload)?
+            .replace('&', "\\u0026")
+            .replace('<', "\\u003c")
+            .replace('>', "\\u003e");
+        let html = PORTABLE_WORK_GRAPH_HTML.replace("__GRAPH_DATA__", &payload_json);
+        let path = self.session_path.join("work-graph.html");
+        self.write_atomic_text(path.clone(), &html)?;
+        Ok(path)
+    }
+
     /// Persist evaluator-addressable template plus expansion state beside the
     /// authoritative graph. This sidecar is optional for legacy sessions.
     pub fn write_review_expansion_sidecar(
@@ -458,6 +576,49 @@ impl StateManager {
         }
         let json = fs::read_to_string(path)?;
         Ok(Some(serde_json::from_str(&json)?))
+    }
+
+    /// Persist the visible orchestrator footprints, authority scopes, live
+    /// principal ownership and surfaced write collisions for this session.
+    pub fn write_ownership_session_state(
+        &self,
+        state: &OwnershipSessionState,
+    ) -> Result<(), StateError> {
+        self.ensure_state_dir()?;
+        let json = serde_json::to_string_pretty(state)?;
+        self.write_atomic_text(self.state_dir().join("orchestrator-ownership.json"), &json)
+    }
+
+    pub fn read_ownership_session_state(
+        &self,
+    ) -> Result<Option<OwnershipSessionState>, StateError> {
+        let path = self.state_dir().join("orchestrator-ownership.json");
+        if !path.exists() {
+            return Ok(None);
+        }
+        let json = fs::read_to_string(path)?;
+        Ok(Some(serde_json::from_str(&json)?))
+    }
+
+    /// Check and durably surface a collision before the caller mutates a path.
+    /// Process write-capability is supplied explicitly; a task-status mirror is
+    /// not accepted as a substitute for liveness (the d1e86179 failure mode).
+    pub fn record_orchestrator_write_attempt(
+        &self,
+        graph: &WorkGraph,
+        live_principals: &[LivePrincipal],
+        attempt: OrchestratorWriteAttempt,
+    ) -> Result<OrchestratorWriteOutcome, StateError> {
+        let mut state = self.read_ownership_session_state()?.ok_or_else(|| {
+            StateError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "orchestrator ownership state is unavailable",
+            ))
+        })?;
+        state.live_principal_ownership = derive_path_ownership(graph, live_principals);
+        let outcome = state.record_write_attempt(attempt);
+        self.write_ownership_session_state(&state)?;
+        Ok(outcome)
     }
 
     /// Record a task assignment
@@ -578,6 +739,99 @@ impl StateManager {
     }
 
 }
+
+const PORTABLE_WORK_GRAPH_HTML: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Hive work graph</title>
+  <style>
+    :root { color-scheme: dark; font-family: ui-monospace, SFMono-Regular, Consolas, monospace; }
+    body { margin: 0; padding: 24px; background: #090b10; color: #e7eaf0; }
+    header { margin-bottom: 24px; }
+    h1, h2, h3 { margin: 0 0 10px; }
+    #meta { color: #9ca5b5; }
+    #waves { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }
+    .wave { padding: 14px; border: 1px solid #303747; border-radius: 10px; background: #121620; }
+    .node { margin-top: 10px; padding: 10px; border-left: 4px solid #6aa9ff; background: #191f2c; }
+    .node[data-status="blocked"], .node[data-status="failed"] { border-left-color: #ff6b6b; }
+    .node small { display: block; margin-top: 6px; color: #aeb7c7; }
+    table { width: 100%; margin-top: 12px; border-collapse: collapse; }
+    th, td { padding: 8px; border-bottom: 1px solid #303747; text-align: left; }
+    section { margin-top: 28px; }
+    pre { overflow: auto; padding: 12px; background: #121620; border-radius: 8px; }
+  </style>
+</head>
+<body>
+  <header><h1>Work graph</h1><div id="meta"></div></header>
+  <main>
+    <div id="waves"></div>
+    <section><h2>Edges</h2><table><thead><tr><th>Source</th><th>Target</th><th>Kind</th><th>Provenance</th></tr></thead><tbody id="edges"></tbody></table></section>
+    <section><h2>Divergence</h2><pre id="divergence"></pre></section>
+  </main>
+  <script id="graph-data" type="application/json">__GRAPH_DATA__</script>
+  <script>
+    const data = JSON.parse(document.getElementById('graph-data').textContent);
+    document.getElementById('meta').textContent = `${data.session_id} · ${data.lifecycle_stage} · ${data.generated_at}`;
+    const nodeById = new Map(data.nodes.map(node => [node.id, node]));
+    const indegree = new Map(data.nodes.map(node => [node.id, 0]));
+    const dependents = new Map(data.nodes.map(node => [node.id, []]));
+    for (const edge of data.edges.filter(edge => edge.kind === 'depends_on')) {
+      if (!nodeById.has(edge.source) || !nodeById.has(edge.target)) continue;
+      indegree.set(edge.target, indegree.get(edge.target) + 1);
+      dependents.get(edge.source).push(edge.target);
+    }
+    let ready = [...indegree].filter(([, degree]) => degree === 0).map(([id]) => id).sort();
+    const waves = [];
+    while (ready.length) {
+      const wave = ready;
+      waves.push(wave);
+      const next = new Set();
+      for (const id of wave) {
+        for (const target of dependents.get(id).sort()) {
+          indegree.set(target, indegree.get(target) - 1);
+          if (indegree.get(target) === 0) next.add(target);
+        }
+      }
+      ready = [...next].sort();
+    }
+    const wavesRoot = document.getElementById('waves');
+    waves.forEach((wave, index) => {
+      const column = document.createElement('section');
+      column.className = 'wave';
+      const heading = document.createElement('h2');
+      heading.textContent = `Wave ${index + 1}`;
+      column.appendChild(heading);
+      wave.forEach(id => {
+        const node = nodeById.get(id);
+        const card = document.createElement('article');
+        card.className = 'node';
+        card.dataset.status = node.status;
+        const title = document.createElement('strong');
+        title.textContent = `${node.id} · ${node.status}`;
+        const detail = document.createElement('small');
+        detail.textContent = `${node.lane.kind}:${node.lane.value} · ${node.contract_summary.input_count} in / ${node.contract_summary.output_count} out / ${node.contract_summary.acceptance_count} acceptance`;
+        card.append(title, detail);
+        column.appendChild(card);
+      });
+      wavesRoot.appendChild(column);
+    });
+    const edgeRoot = document.getElementById('edges');
+    data.edges.forEach(edge => {
+      const row = document.createElement('tr');
+      [edge.source, edge.target, edge.kind, edge.provenance].forEach(value => {
+        const cell = document.createElement('td');
+        cell.textContent = value;
+        row.appendChild(cell);
+      });
+      edgeRoot.appendChild(row);
+    });
+    document.getElementById('divergence').textContent = JSON.stringify(data.divergence || {}, null, 2);
+  </script>
+</body>
+</html>
+"##;
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -18,6 +18,10 @@ pub struct PostHeartbeatRequest {
     pub status: String,
     #[serde(default)]
     pub summary: Option<String>,
+    /// Durable queue assignment identity. Older prompts omit this and use the server-side
+    /// deterministic fallback; a supplied identity is always treated as an exact fence.
+    #[serde(default)]
+    pub assignment_id: Option<i64>,
 }
 
 /// Response for POST heartbeat
@@ -65,6 +69,11 @@ pub async fn post_heartbeat(
     if !VALID_HEARTBEAT_STATUSES.contains(&req.status.as_str()) {
         return Err(ApiError::bad_request(
             "Status must be one of: working, idle, completed",
+        ));
+    }
+    if req.assignment_id.is_some_and(|assignment_id| assignment_id <= 0) {
+        return Err(ApiError::bad_request(
+            "assignment_id must be a positive server-issued identity",
         ));
     }
 
@@ -143,7 +152,12 @@ pub async fn post_heartbeat(
     // Queen) is simply a no-op here.
     state
         .queue_manager
-        .record_heartbeat(&session_id, &agent_id, &req.status)
+        .record_heartbeat_for_assignment(
+            &session_id,
+            &agent_id,
+            req.assignment_id,
+            &req.status,
+        )
         .await
         .map_err(|e| ApiError::internal(e.to_string()))?;
 

--- a/src-tauri/src/http/handlers/heartbeats.rs
+++ b/src-tauri/src/http/handlers/heartbeats.rs
@@ -139,7 +139,33 @@ pub async fn post_heartbeat(
         }
     };
 
-    // Scope the (non-Send) parking_lot guard so it is dropped before the await below.
+    // A supplied assignment identity is an exact durable fence. Check it before
+    // mutating controller liveness so a stale worker cannot report a completion
+    // that the queue rejected. Assignment-free callers remain fail-open below:
+    // the Queen has no queue row, and legacy worker prompts omit this field.
+    if let Some(assignment_id) = req.assignment_id {
+        let recorded = state
+            .queue_manager
+            .record_heartbeat_for_assignment(
+                &session_id,
+                &agent_id,
+                Some(assignment_id),
+                &req.status,
+            )
+            .await
+            .map_err(|e| ApiError::internal(e.to_string()))?;
+        if !recorded {
+            return Err(ApiError::new(
+                StatusCode::CONFLICT,
+                format!(
+                    "Assignment {} is stale or does not belong to agent {}",
+                    assignment_id, agent_id
+                ),
+            ));
+        }
+    }
+
+    // Scope the (non-Send) parking_lot guard so it is dropped before the no-ID await below.
     {
         let controller = state.session_controller.read();
         controller
@@ -147,19 +173,15 @@ pub async fn post_heartbeat(
             .map_err(|e| ApiError::internal(e))?;
     }
 
-    // #126: record the heartbeat into the durable queue row, advancing the
-    // continuation / no-progress counters. A worker with no matching queue row (e.g. the
-    // Queen) is simply a no-op here.
-    state
-        .queue_manager
-        .record_heartbeat_for_assignment(
-            &session_id,
-            &agent_id,
-            req.assignment_id,
-            &req.status,
-        )
-        .await
-        .map_err(|e| ApiError::internal(e.to_string()))?;
+    // #126: without an explicit fence, retain the legacy deterministic fallback.
+    // A caller with no matching queue row (notably the Queen) is intentionally a no-op.
+    if req.assignment_id.is_none() {
+        state
+            .queue_manager
+            .record_heartbeat_for_assignment(&session_id, &agent_id, None, &req.status)
+            .await
+            .map_err(|e| ApiError::internal(e.to_string()))?;
+    }
 
     Ok((
         StatusCode::OK,
@@ -216,4 +238,295 @@ pub async fn get_active_sessions(
         .collect();
 
     Ok(Json(ActiveSessionsResponse { sessions }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use parking_lot::RwLock;
+    use tempfile::TempDir;
+
+    use crate::coordination::{InjectionManager, QueueManager};
+    use crate::domain::HiveExecutionPolicy;
+    use crate::events::EventBus;
+    use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager};
+    use crate::session::{
+        AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
+    };
+    use crate::storage::queue::{QueueRow, QueueStatus};
+    use crate::storage::{ApplicationStateDb, QueueRepo, SessionStorage};
+
+    const SESSION_ID: &str = "heartbeat-assignment-fence";
+    const WORKER_ID: &str = "heartbeat-assignment-fence-worker-1";
+    const QUEEN_ID: &str = "heartbeat-assignment-fence-queen";
+    const ROW_ID: &str = "heartbeat-assignment-row";
+    const ASSIGNMENT_ID: i64 = 41;
+
+    struct HeartbeatFixture {
+        _temp: TempDir,
+        state: Arc<AppState>,
+    }
+
+    fn agent(id: &str, role: AgentRole, parent_id: Option<&str>) -> AgentInfo {
+        AgentInfo {
+            id: id.to_string(),
+            role,
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: parent_id.map(str::to_string),
+            role_definition_id: None,
+            role_definition_version: None,
+            commit_sha: None,
+            base_commit_sha: None,
+        }
+    }
+
+    fn fixture() -> HeartbeatFixture {
+        let temp = TempDir::new().expect("heartbeat fixture directory");
+        let storage = Arc::new(
+            SessionStorage::new_with_base(temp.path().to_path_buf())
+                .expect("session storage"),
+        );
+        storage
+            .create_session_dir(SESSION_ID)
+            .expect("session directory");
+        let config = Arc::new(tokio::sync::RwLock::new(
+            storage.load_config().expect("test config"),
+        ));
+        let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+        let session_controller = Arc::new(RwLock::new(SessionController::new(
+            Arc::clone(&pty_manager),
+        )));
+        session_controller.write().set_storage(Arc::clone(&storage));
+        let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+            Arc::clone(&pty_manager),
+            SessionStorage::new_with_base(temp.path().to_path_buf())
+                .expect("injection storage"),
+        )));
+        let event_bus = EventBus::new(storage.base_dir().clone());
+        let app_state_db = Arc::new(
+            ApplicationStateDb::open_in_memory().expect("application state database"),
+        );
+        let queue_repo = Arc::new(QueueRepo::new(Arc::clone(&app_state_db)));
+        queue_repo.ensure_schema().expect("queue schema");
+        let queue_manager = Arc::new(QueueManager::new(queue_repo, Arc::clone(&event_bus)));
+        let state = Arc::new(AppState::new(
+            config,
+            pty_manager,
+            Arc::clone(&session_controller),
+            injection_manager,
+            Arc::clone(&storage),
+            event_bus,
+            app_state_db,
+            queue_manager,
+            None,
+        ));
+
+        let now = Utc::now();
+        session_controller.read().insert_test_session(Session {
+            id: SESSION_ID.to_string(),
+            name: None,
+            color: None,
+            session_type: SessionType::Hive { worker_count: 1 },
+            project_path: temp.path().to_path_buf(),
+            state: SessionState::Running,
+            created_at: now,
+            last_activity_at: now,
+            agents: vec![
+                agent(QUEEN_ID, AgentRole::Queen, None),
+                agent(
+                    WORKER_ID,
+                    AgentRole::Worker {
+                        index: 1,
+                        parent: Some(QUEEN_ID.to_string()),
+                    },
+                    Some(QUEEN_ID),
+                ),
+            ],
+            default_cli: "codex".to_string(),
+            default_model: None,
+            default_principal_cli: None,
+            default_principal_model: None,
+            default_principal_flags: Vec::new(),
+            execution_policy: HiveExecutionPolicy::default(),
+            qa_workers: Vec::new(),
+            max_qa_iterations: 3,
+            qa_timeout_secs: 300,
+            auth_strategy: AuthStrategy::default(),
+            worktree_path: None,
+            worktree_branch: None,
+            no_git: true,
+            resume_report: None,
+        });
+
+        HeartbeatFixture { _temp: temp, state }
+    }
+
+    fn running_row() -> QueueRow {
+        QueueRow {
+            id: ROW_ID.to_string(),
+            task_id: Some("T-review-3".to_string()),
+            session_id: SESSION_ID.to_string(),
+            worker_id: WORKER_ID.to_string(),
+            role_type: "backend".to_string(),
+            cli: "codex".to_string(),
+            status: QueueStatus::Running,
+            payload: serde_json::json!({}),
+            attempts: 1,
+            continuation_count: 0,
+            no_progress_count: 0,
+            last_status: None,
+            heartbeat_at: None,
+            assignment_id: ASSIGNMENT_ID,
+            blocked_reason: None,
+            created_at: 1,
+            updated_at: 1,
+        }
+    }
+
+    async fn heartbeat(
+        state: Arc<AppState>,
+        agent_id: &str,
+        status: &str,
+        assignment_id: Option<i64>,
+    ) -> Result<(StatusCode, Json<PostHeartbeatResponse>), ApiError> {
+        post_heartbeat(
+            State(state),
+            Path(SESSION_ID.to_string()),
+            Json(PostHeartbeatRequest {
+                agent_id: agent_id.to_string(),
+                status: status.to_string(),
+                summary: Some(format!("{status} from handler test")),
+                assignment_id,
+            }),
+        )
+        .await
+    }
+
+    fn expect_success(
+        response: Result<(StatusCode, Json<PostHeartbeatResponse>), ApiError>,
+        context: &str,
+    ) -> (StatusCode, Json<PostHeartbeatResponse>) {
+        match response {
+            Ok(response) => response,
+            Err(error) => panic!("{context}: {} ({})", error.message, error.status),
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_assignment_mismatch_is_conflict_without_mutating_queue_or_controller() {
+        let fixture = fixture();
+        let original_row = running_row();
+        fixture
+            .state
+            .queue_manager
+            .repo()
+            .enqueue(&original_row)
+            .expect("running queue row");
+
+        let response = heartbeat(
+            Arc::clone(&fixture.state),
+            WORKER_ID,
+            "completed",
+            Some(ASSIGNMENT_ID + 1),
+        )
+        .await;
+        let status = match response {
+            Ok((status, _)) => status,
+            Err(error) => error.status,
+        };
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(
+            fixture
+                .state
+                .queue_manager
+                .repo()
+                .get_row(ROW_ID)
+                .expect("queue lookup")
+                .expect("queue row"),
+            original_row,
+            "a stale explicit assignment must not mutate the durable row",
+        );
+        assert!(
+            fixture
+                .state
+                .session_controller
+                .read()
+                .get_heartbeat_info(SESSION_ID)
+                .is_empty(),
+            "a stale explicit assignment must not update controller liveness",
+        );
+    }
+
+    #[tokio::test]
+    async fn explicit_assignment_match_records_durable_and_controller_heartbeat() {
+        let fixture = fixture();
+        fixture
+            .state
+            .queue_manager
+            .repo()
+            .enqueue(&running_row())
+            .expect("running queue row");
+
+        let response = expect_success(
+            heartbeat(
+                Arc::clone(&fixture.state),
+                WORKER_ID,
+                "completed",
+                Some(ASSIGNMENT_ID),
+            )
+            .await,
+            "matching assignment heartbeat",
+        );
+
+        assert_eq!(response.0, StatusCode::OK);
+        let updated_row = fixture
+            .state
+            .queue_manager
+            .repo()
+            .get_row(ROW_ID)
+            .expect("queue lookup")
+            .expect("queue row");
+        assert_eq!(updated_row.status, QueueStatus::Finalized);
+        assert_eq!(updated_row.last_status.as_deref(), Some("completed"));
+        assert!(updated_row.heartbeat_at.is_some());
+        let heartbeats = fixture
+            .state
+            .session_controller
+            .read()
+            .get_heartbeat_info(SESSION_ID);
+        assert_eq!(heartbeats[WORKER_ID].status, "completed");
+        assert_eq!(
+            heartbeats[WORKER_ID].summary.as_deref(),
+            Some("completed from handler test"),
+        );
+    }
+
+    #[tokio::test]
+    async fn queen_heartbeat_without_assignment_remains_fail_open() {
+        let fixture = fixture();
+
+        let response = expect_success(
+            heartbeat(Arc::clone(&fixture.state), "queen", "working", None).await,
+            "assignment-free Queen heartbeat",
+        );
+
+        assert_eq!(response.0, StatusCode::OK);
+        assert!(fixture
+            .state
+            .queue_manager
+            .repo()
+            .rows_for_session(SESSION_ID)
+            .expect("queue lookup")
+            .is_empty());
+        let heartbeats = fixture
+            .state
+            .session_controller
+            .read()
+            .get_heartbeat_info(SESSION_ID);
+        assert!(!heartbeats.contains_key("queen"));
+        assert_eq!(heartbeats[QUEEN_ID].status, "working");
+    }
 }

--- a/src-tauri/src/http/handlers/mod.rs
+++ b/src-tauri/src/http/handlers/mod.rs
@@ -12,11 +12,13 @@ pub mod inject;
 pub mod knowledge;
 pub mod learnings;
 pub mod planners;
+pub mod pty_buffer;
 pub mod queue;
 pub mod resolver;
 pub mod session_files;
 pub mod sessions;
 pub mod templates;
+pub mod work_graph;
 pub mod workers;
 
 use crate::http::error::ApiError;

--- a/src-tauri/src/http/handlers/planners.rs
+++ b/src-tauri/src/http/handlers/planners.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
+use crate::orchestrator::org_graph::definitions::role_prompt_template;
 use crate::pty::{AgentConfig, AgentRole};
 use super::{validate_session_id, validate_cli};
 
@@ -99,7 +100,8 @@ pub async fn add_planner(
                     role_type: w.role_type.clone(),
                     label: w.label.clone().unwrap_or_else(|| w.role_type.clone()),
                     default_cli: w.cli.clone().unwrap_or(cli.clone()),
-                    prompt_template: None,
+                    prompt_template: Some(role_prompt_template(&w.role_type)),
+                    resolved_definition: None,
                 }),
                 initial_prompt: None,
             }
@@ -119,7 +121,8 @@ pub async fn add_planner(
                     role_type: "general".to_string(),
                     label: format!("Worker {}", i + 1),
                     default_cli: cli.clone(),
-                    prompt_template: None,
+                    prompt_template: Some(role_prompt_template("general")),
+                    resolved_definition: None,
                 }),
                 initial_prompt: None,
             }

--- a/src-tauri/src/http/handlers/pty_buffer.rs
+++ b/src-tauri/src/http/handlers/pty_buffer.rs
@@ -1,0 +1,53 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use serde::Serialize;
+
+use crate::http::error::ApiError;
+use crate::http::state::AppState;
+
+use super::{validate_agent_id, validate_session_id};
+
+#[derive(Debug, Serialize)]
+pub struct PtyBufferResponse {
+    pub session_id: String,
+    pub agent_id: String,
+    pub output: String,
+    pub byte_count: usize,
+}
+
+/// GET /api/sessions/{id}/agents/{agent_id}/pty-buffer
+///
+/// The route observes the existing 8 KB ring buffer only. It never writes bytes or submits input.
+pub async fn get_pty_buffer(
+    State(state): State<Arc<AppState>>,
+    Path((session_id, agent_id)): Path<(String, String)>,
+) -> Result<Json<PtyBufferResponse>, ApiError> {
+    validate_session_id(&session_id)?;
+    validate_agent_id(&agent_id)?;
+
+    let session = state
+        .session_controller
+        .read()
+        .get_session(&session_id)
+        .ok_or_else(|| ApiError::not_found(format!("Session not found: {session_id}")))?;
+    if !session.agents.iter().any(|agent| agent.id == agent_id) {
+        return Err(ApiError::not_found(format!(
+            "Agent {agent_id} not found in session {session_id}"
+        )));
+    }
+
+    let output = state
+        .pty_manager
+        .read()
+        .recent_output(&agent_id)
+        .ok_or_else(|| ApiError::not_found(format!("PTY not found for agent: {agent_id}")))?;
+    let byte_count = output.len();
+    Ok(Json(PtyBufferResponse {
+        session_id,
+        agent_id,
+        output,
+        byte_count,
+    }))
+}

--- a/src-tauri/src/http/handlers/work_graph.rs
+++ b/src-tauri/src/http/handlers/work_graph.rs
@@ -1,0 +1,354 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+use std::sync::Arc;
+
+use axum::extract::{Path as AxumPath, Query, State};
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::coordination::StateManager;
+use crate::http::error::ApiError;
+use crate::http::state::AppState;
+use crate::orchestrator::work_graph::archive::{
+    list_archives, read_archive, WorkGraphArchive,
+};
+use crate::orchestrator::work_graph::divergence::{
+    compute_divergence, DivergenceSummary,
+};
+use crate::orchestrator::work_graph::{
+    topological_sort, BindingRef, EdgeKind, EdgeProvenance, NodeStatus, TaskGraph, TaskId,
+};
+
+use super::validate_session_id;
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkGraphView {
+    Plan,
+    #[default]
+    Runtime,
+    Divergence,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WorkGraphQuery {
+    #[serde(default)]
+    view: WorkGraphView,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkGraphSource {
+    Live,
+    Archive,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ContractSummary {
+    pub input_count: usize,
+    pub output_count: usize,
+    pub acceptance_count: usize,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkGraphNodeResponse {
+    pub id: TaskId,
+    pub status: NodeStatus,
+    pub lane: BindingRef,
+    pub contract_summary: ContractSummary,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkGraphEdgeResponse {
+    pub source: TaskId,
+    pub target: TaskId,
+    pub kind: EdgeKind,
+    pub provenance: EdgeProvenance,
+}
+
+#[derive(Debug, Serialize)]
+pub struct EdgeProvenanceResponse {
+    pub source: TaskId,
+    pub target: TaskId,
+    pub kind: EdgeKind,
+    pub provenance: EdgeProvenance,
+}
+
+#[derive(Debug, Serialize)]
+pub struct WorkGraphResponse {
+    pub view: WorkGraphView,
+    pub source: WorkGraphSource,
+    pub nodes: Vec<WorkGraphNodeResponse>,
+    pub edges: Vec<WorkGraphEdgeResponse>,
+    pub waves: Vec<Vec<TaskId>>,
+    pub status_by_node: BTreeMap<TaskId, NodeStatus>,
+    pub lane_assignment: BTreeMap<TaskId, BindingRef>,
+    pub critical_path: Vec<TaskId>,
+    pub provenance_by_edge: Vec<EdgeProvenanceResponse>,
+    pub divergence: Option<DivergenceSummary>,
+}
+
+/// GET /api/sessions/{id}/work-graph?view=plan|runtime|divergence
+///
+/// This handler only projects existing state. It never creates, archives, or mutates a graph.
+pub async fn get_work_graph(
+    State(state): State<Arc<AppState>>,
+    AxumPath(session_id): AxumPath<String>,
+    Query(query): Query<WorkGraphQuery>,
+) -> Result<Json<WorkGraphResponse>, ApiError> {
+    validate_session_id(&session_id)?;
+    let session_dir = state.storage.session_dir(&session_id);
+    if !session_dir.is_dir() {
+        return Err(ApiError::not_found(format!(
+            "Session not found: {session_id}"
+        )));
+    }
+
+    let (source, graph, divergence) =
+        if let Some(archive) = latest_archive(&session_dir, &session_id)? {
+            graph_from_archive(&archive, query.view)
+        } else {
+            graph_from_live_state(&state, &session_dir, &session_id, query.view)?
+        };
+
+    let response = project_graph(query.view, source, graph, divergence)?;
+    Ok(Json(response))
+}
+
+fn latest_archive(
+    session_dir: &Path,
+    session_id: &str,
+) -> Result<Option<WorkGraphArchive>, ApiError> {
+    let paths = list_archives(session_dir)
+        .map_err(|error| ApiError::internal(format!("Failed to list work-graph archives: {error}")))?;
+    let mut latest: Option<WorkGraphArchive> = None;
+
+    for path in paths {
+        let archive = read_archive(&path).map_err(|error| {
+            ApiError::internal(format!(
+                "Failed to read work-graph archive {}: {error}",
+                path.display()
+            ))
+        })?;
+        if archive.session_id != session_id {
+            continue;
+        }
+        if latest
+            .as_ref()
+            .is_none_or(|current| archive.archived_at > current.archived_at)
+        {
+            latest = Some(archive);
+        }
+    }
+
+    Ok(latest)
+}
+
+fn graph_from_archive(
+    archive: &WorkGraphArchive,
+    view: WorkGraphView,
+) -> (WorkGraphSource, TaskGraph, Option<DivergenceSummary>) {
+    match view {
+        WorkGraphView::Plan => (
+            WorkGraphSource::Archive,
+            archive
+                .plan_graph
+                .clone()
+                .unwrap_or_else(|| archive.runtime_graph.clone()),
+            None,
+        ),
+        WorkGraphView::Runtime => (
+            WorkGraphSource::Archive,
+            archive.runtime_graph.clone(),
+            None,
+        ),
+        WorkGraphView::Divergence => (
+            WorkGraphSource::Archive,
+            archive.runtime_graph.clone(),
+            Some(archive.divergence.clone()),
+        ),
+    }
+}
+
+fn graph_from_live_state(
+    state: &AppState,
+    session_dir: &Path,
+    session_id: &str,
+    view: WorkGraphView,
+) -> Result<(WorkGraphSource, TaskGraph, Option<DivergenceSummary>), ApiError> {
+    let plan = StateManager::new(session_dir.to_path_buf())
+        .read_work_graph()
+        .map_err(|error| ApiError::internal(format!("Failed to read live work graph: {error}")))?
+        .ok_or_else(|| ApiError::not_found(format!("Work graph not found: {session_id}")))?;
+
+    if matches!(view, WorkGraphView::Plan) {
+        return Ok((WorkGraphSource::Live, plan, None));
+    }
+
+    let runtime = state
+        .queue_manager
+        .project_queue_statuses(session_id, &plan)
+        .map_err(|error| {
+            ApiError::internal(format!("Failed to project live work-graph status: {error}"))
+        })?;
+    let divergence = matches!(view, WorkGraphView::Divergence)
+        .then(|| compute_divergence(Some(&plan), &runtime, &[]));
+    Ok((WorkGraphSource::Live, runtime, divergence))
+}
+
+fn project_graph(
+    view: WorkGraphView,
+    source: WorkGraphSource,
+    graph: TaskGraph,
+    divergence: Option<DivergenceSummary>,
+) -> Result<WorkGraphResponse, ApiError> {
+    let order = topological_sort(&graph).map_err(|error| {
+        ApiError::internal(format!("Persisted work graph is not schedulable: {error}"))
+    })?;
+    let waves = topological_waves(&graph, &order);
+    let critical_path = critical_path(&graph, &order);
+
+    let nodes = graph
+        .nodes
+        .iter()
+        .map(|node| WorkGraphNodeResponse {
+            id: node.id.clone(),
+            status: node.status,
+            lane: node.binding.clone(),
+            contract_summary: ContractSummary {
+                input_count: node.contract.inputs.len(),
+                output_count: node.contract.outputs.len(),
+                acceptance_count: node.contract.acceptance.len(),
+            },
+        })
+        .collect();
+    let edges = graph
+        .edges
+        .iter()
+        .map(|edge| WorkGraphEdgeResponse {
+            source: edge.source.clone(),
+            target: edge.target.clone(),
+            kind: edge.kind,
+            provenance: edge.provenance,
+        })
+        .collect();
+    let status_by_node = graph
+        .nodes
+        .iter()
+        .map(|node| (node.id.clone(), node.status))
+        .collect();
+    let lane_assignment = graph
+        .nodes
+        .iter()
+        .map(|node| (node.id.clone(), node.binding.clone()))
+        .collect();
+    let provenance_by_edge = graph
+        .edges
+        .iter()
+        .map(|edge| EdgeProvenanceResponse {
+            source: edge.source.clone(),
+            target: edge.target.clone(),
+            kind: edge.kind,
+            provenance: edge.provenance,
+        })
+        .collect();
+
+    Ok(WorkGraphResponse {
+        view,
+        source,
+        nodes,
+        edges,
+        waves,
+        status_by_node,
+        lane_assignment,
+        critical_path,
+        provenance_by_edge,
+        divergence,
+    })
+}
+
+fn topological_waves(graph: &TaskGraph, order: &[TaskId]) -> Vec<Vec<TaskId>> {
+    let known: BTreeSet<&str> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+    let mut dependents: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for edge in graph
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::DependsOn)
+    {
+        if known.contains(edge.source.as_str()) && known.contains(edge.target.as_str()) {
+            dependents
+                .entry(edge.source.as_str())
+                .or_default()
+                .push(edge.target.as_str());
+        }
+    }
+    for targets in dependents.values_mut() {
+        targets.sort_unstable();
+        targets.dedup();
+    }
+
+    let mut levels: BTreeMap<&str, usize> =
+        known.iter().copied().map(|id| (id, 0)).collect();
+    for id in order {
+        let level = levels.get(id.as_str()).copied().unwrap_or(0);
+        for target in dependents.get(id.as_str()).into_iter().flatten() {
+            let target_level = levels.entry(target).or_insert(0);
+            *target_level = (*target_level).max(level.saturating_add(1));
+        }
+    }
+
+    let wave_count = levels.values().copied().max().map_or(0, |level| level + 1);
+    let mut waves = vec![Vec::new(); wave_count];
+    for (id, level) in levels {
+        waves[level].push(id.to_string());
+    }
+    for wave in &mut waves {
+        wave.sort();
+    }
+    waves
+}
+
+/// Deterministic longest path over dependency edges. Non-dependency edges never affect it.
+fn critical_path(graph: &TaskGraph, order: &[TaskId]) -> Vec<TaskId> {
+    let known: BTreeSet<&str> = graph.nodes.iter().map(|node| node.id.as_str()).collect();
+    let mut predecessors: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for edge in graph
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::DependsOn)
+    {
+        if known.contains(edge.source.as_str()) && known.contains(edge.target.as_str()) {
+            predecessors
+                .entry(edge.target.as_str())
+                .or_default()
+                .push(edge.source.as_str());
+        }
+    }
+    for sources in predecessors.values_mut() {
+        sources.sort_unstable();
+        sources.dedup();
+    }
+
+    let mut paths: BTreeMap<&str, Vec<TaskId>> = BTreeMap::new();
+    let mut longest = Vec::new();
+    for id in order {
+        let mut best = vec![id.clone()];
+        for predecessor in predecessors.get(id.as_str()).into_iter().flatten() {
+            let Some(prefix) = paths.get(predecessor) else {
+                continue;
+            };
+            let mut candidate = prefix.clone();
+            candidate.push(id.clone());
+            if candidate.len() > best.len()
+                || (candidate.len() == best.len() && candidate < best)
+            {
+                best = candidate;
+            }
+        }
+        if best.len() > longest.len() || (best.len() == longest.len() && best < longest) {
+            longest = best.clone();
+        }
+        paths.insert(id.as_str(), best);
+    }
+    longest
+}

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -16,6 +16,7 @@ use crate::coordination::{ReleaseAfterFailure, ReleaseOutcome, StateManager, Wor
 use crate::domain::WorkspaceStrategy;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
+use crate::orchestrator::org_graph::definitions::role_prompt_template;
 use crate::pty::{AgentConfig, AgentRole, WorkerRole};
 use crate::session::{AddWorkerError, AddWorkerRejectionReason, SessionController};
 use crate::storage::queue::{
@@ -342,7 +343,8 @@ pub async fn add_worker(
         role_type: role_type.clone(),
         label: role_label.clone(),
         default_cli: cli.clone(),
-        prompt_template: None,
+        prompt_template: Some(role_prompt_template(&role_type)),
+        resolved_definition: None,
     };
 
     // Build config

--- a/src-tauri/src/http/mod.rs
+++ b/src-tauri/src/http/mod.rs
@@ -24,6 +24,14 @@ mod tests_wg_schema;
 mod tests_wg_state;
 #[cfg(test)]
 mod tests_wg_templates;
+#[cfg(test)]
+mod tests_wg_api;
+#[cfg(test)]
+mod tests_wg_roles;
+#[cfg(test)]
+mod tests_wg_authority;
+#[cfg(test)]
+mod tests_wg_verifier;
 
 use crate::http::routes::create_router;
 use crate::http::state::AppState;

--- a/src-tauri/src/http/routes.rs
+++ b/src-tauri/src/http/routes.rs
@@ -1,7 +1,7 @@
 use crate::http::handlers::{
     actions, agents, application_state, artifacts, cells, conversations, evaluator, events, health,
-    heartbeats, inject, knowledge, learnings, planners, queue, resolver, session_files, sessions,
-    templates, workers,
+    heartbeats, inject, knowledge, learnings, planners, pty_buffer, queue, resolver, session_files,
+    sessions, templates, work_graph, workers,
 };
 use crate::http::state::AppState;
 use crate::cli::health as cli_health;
@@ -131,6 +131,11 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/files/content",
             get(session_files::read_session_file),
         )
+        // Read-only work-graph projection (#227). The scheduler remains the sole writer.
+        .route(
+            "/api/sessions/{id}/work-graph",
+            get(work_graph::get_work_graph),
+        )
         // Durable run-queue snapshot (#126)
         .route("/api/sessions/{id}/queue", get(queue::get_queue))
         // Evaluator routes
@@ -195,6 +200,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         .route(
             "/api/sessions/{id}/agents/{aid}/input",
             post(agents::send_agent_input),
+        )
+        .route(
+            "/api/sessions/{id}/agents/{aid}/pty-buffer",
+            get(pty_buffer::get_pty_buffer),
         )
         .route(
             "/api/sessions/{id}/cells/{cid}/artifacts",

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -350,6 +350,8 @@ fn make_test_session_with_agents(id: &str, project_path: &str, agent_ids: &[&str
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         })
@@ -389,6 +391,8 @@ fn make_test_agent(id: &str, role: AgentRole) -> AgentInfo {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     }
@@ -421,6 +425,8 @@ fn make_test_session_for_completion(
             status: AgentStatus::Completed,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         });
@@ -4238,6 +4244,8 @@ async fn test_add_qa_worker_valid_request_reaches_controller() {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });
@@ -5022,6 +5030,8 @@ async fn milestone_ready_respawn_branch_arms_qa_and_preserves_iteration() {
             ..AgentConfig::default()
         },
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });
@@ -5105,6 +5115,8 @@ async fn force_pass_is_allowed_before_the_milestone_handoff() {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });
@@ -6186,6 +6198,8 @@ async fn test_post_verdict_persists_commit_sha_and_rationale() {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });
@@ -6301,6 +6315,8 @@ async fn test_post_verdict_fail_persists_commit_sha_and_failure_state() {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });
@@ -9528,6 +9544,8 @@ async fn heartbeat_accepts_the_bare_queen_alias_and_canonicalizes_it() {
         status: AgentStatus::Running,
         config: AgentConfig::default(),
         parent_id: None,
+        role_definition_id: None,
+        role_definition_version: None,
         commit_sha: None,
         base_commit_sha: None,
     });

--- a/src-tauri/src/http/tests_wg_api.rs
+++ b/src-tauri/src/http/tests_wg_api.rs
@@ -1,0 +1,817 @@
+//! Full-stack read-surface tests for work-graph observability (#227) and PTY evidence (#226).
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use chrono::{Duration, Utc};
+use parking_lot::RwLock;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+use crate::coordination::{InjectionManager, QueueManager, StateManager};
+use crate::domain::HiveExecutionPolicy;
+use crate::events::EventBus;
+use crate::http::routes::create_router;
+use crate::http::state::AppState;
+use crate::orchestrator::work_graph::archive::archive_completed_session;
+use crate::orchestrator::work_graph::runtime::{
+    record_graph_change, GraphMutationType,
+};
+use crate::orchestrator::work_graph::{
+    BindingRef, EdgeKind, EdgeProvenance, NodeContract, NodeKind, NodeStatus, TaskGraph,
+    WorkEdge, WorkNode,
+};
+use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager};
+use crate::session::{
+    AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
+};
+use crate::storage::queue::{QueueRow, QueueStatus};
+use crate::storage::{ApplicationStateDb, QueueRepo, SessionStorage};
+
+struct TestApp {
+    _storage_dir: TempDir,
+    router: axum::Router,
+    state: Arc<AppState>,
+}
+
+impl TestApp {
+    fn storage(&self) -> &SessionStorage {
+        &self.state.storage
+    }
+}
+
+async fn test_app() -> TestApp {
+    let storage_dir = TempDir::new().expect("temporary storage");
+    let storage = Arc::new(
+        SessionStorage::new_with_base(storage_dir.path().to_path_buf())
+            .expect("session storage"),
+    );
+    let config = Arc::new(tokio::sync::RwLock::new(
+        storage.load_config().expect("test config"),
+    ));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    session_controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new_with_base(storage_dir.path().to_path_buf())
+            .expect("injection storage"),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    let app_state_db = Arc::new(
+        ApplicationStateDb::open(storage.base_dir()).expect("application state database"),
+    );
+    let queue_repo = Arc::new(QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().expect("queue schema");
+    let queue_manager = Arc::new(QueueManager::new(queue_repo, event_bus.clone()));
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        session_controller,
+        injection_manager,
+        storage,
+        event_bus,
+        app_state_db,
+        queue_manager,
+        None,
+    ));
+    state.set_registry(Arc::new(crate::actions::build_registry()));
+
+    TestApp {
+        _storage_dir: storage_dir,
+        router: create_router(state.clone()),
+        state,
+    }
+}
+
+async fn get(app: &axum::Router, uri: &str) -> (StatusCode, String, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("router response");
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response bytes");
+    let body = String::from_utf8(bytes.to_vec()).expect("UTF-8 response");
+    let json = serde_json::from_str(&body).unwrap_or(Value::Null);
+    (status, body, json)
+}
+
+fn portable_graph_payload(html: &str) -> Value {
+    const OPEN: &str = "<script id=\"graph-data\" type=\"application/json\">";
+    const CLOSE: &str = "</script>";
+    let start = html.find(OPEN).expect("embedded graph payload") + OPEN.len();
+    let end = html[start..]
+        .find(CLOSE)
+        .map(|offset| start + offset)
+        .expect("embedded graph payload terminator");
+    serde_json::from_str(&html[start..end]).expect("valid embedded graph JSON")
+}
+
+fn node(
+    id: &str,
+    lane: BindingRef,
+    status: NodeStatus,
+    contract_marker: &str,
+) -> WorkNode {
+    WorkNode::new(
+        id,
+        NodeKind::Task,
+        format!("task-body-title-{contract_marker}"),
+        NodeContract {
+            inputs: vec![format!("task-body-input-{contract_marker}")],
+            outputs: vec![format!("task-body-output-{contract_marker}")],
+            acceptance: vec![format!("task-body-acceptance-{contract_marker}")],
+        },
+        lane,
+        status,
+    )
+}
+
+fn queue_row(
+    session_id: &str,
+    id: &str,
+    task_id: &str,
+    status: QueueStatus,
+    created_at: i64,
+) -> QueueRow {
+    QueueRow {
+        id: id.to_string(),
+        task_id: Some(task_id.to_string()),
+        session_id: session_id.to_string(),
+        worker_id: format!("worker-{task_id}"),
+        role_type: "backend".to_string(),
+        cli: "codex".to_string(),
+        status,
+        payload: json!({"task_id": task_id}),
+        attempts: 1,
+        continuation_count: 0,
+        no_progress_count: 0,
+        last_status: None,
+        heartbeat_at: Some(created_at),
+        assignment_id: created_at,
+        blocked_reason: (status == QueueStatus::Blocked)
+            .then(|| format!("blocked subtree at {task_id}")),
+        created_at,
+        updated_at: created_at,
+    }
+}
+
+fn running_session_with_agent(session_id: &str, agent_id: &str) -> Session {
+    let now = Utc::now();
+    Session {
+        id: session_id.to_string(),
+        name: None,
+        color: None,
+        session_type: SessionType::Hive { worker_count: 0 },
+        project_path: std::path::PathBuf::from("test-project"),
+        state: SessionState::Running,
+        created_at: now,
+        last_activity_at: now,
+        agents: vec![AgentInfo {
+            id: agent_id.to_string(),
+            role: AgentRole::Queen,
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+            commit_sha: None,
+            base_commit_sha: None,
+            role_definition_id: None,
+            role_definition_version: None,
+        }],
+        default_cli: "codex".to_string(),
+        default_model: None,
+        default_principal_cli: None,
+        default_principal_model: None,
+        default_principal_flags: Vec::new(),
+        execution_policy: HiveExecutionPolicy::default(),
+        qa_workers: Vec::new(),
+        max_qa_iterations: 3,
+        qa_timeout_secs: 300,
+        auth_strategy: AuthStrategy::default(),
+        worktree_path: None,
+        worktree_branch: None,
+        no_git: true,
+        resume_report: None,
+    }
+}
+
+#[tokio::test]
+async fn plan_ready_graph_is_bounded_and_preserves_all_provenance_classes() {
+    const SESSION_ID: &str = "wg-api-plan-ready";
+    const SECRET: &str = "SECRET-FULL-TASK-BODY-MUST-NOT-CROSS-THE-WIRE";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    let graph = TaskGraph::new(
+        vec![
+            node(
+                "a",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Ready,
+                SECRET,
+            ),
+            node(
+                "b",
+                BindingRef::Role("frontend".to_string()),
+                NodeStatus::Pending,
+                SECRET,
+            ),
+            node(
+                "c",
+                BindingRef::Zone("integration".to_string()),
+                NodeStatus::Pending,
+                SECRET,
+            ),
+            node(
+                "d",
+                BindingRef::Zone("docs".to_string()),
+                NodeStatus::Ready,
+                SECRET,
+            ),
+            node(
+                "e",
+                BindingRef::Role("reviewer".to_string()),
+                NodeStatus::Pending,
+                SECRET,
+            ),
+        ],
+        vec![
+            WorkEdge::new("a", "b", EdgeKind::DependsOn, EdgeProvenance::Planner),
+            WorkEdge::new("b", "c", EdgeKind::DependsOn, EdgeProvenance::Codegraph),
+            WorkEdge::new("a", "d", EdgeKind::Informs, EdgeProvenance::Knowledge),
+            WorkEdge::new("d", "e", EdgeKind::DependsOn, EdgeProvenance::Runtime),
+        ],
+    );
+    StateManager::new(session_dir)
+        .write_work_graph(&graph)
+        .expect("persisted plan graph");
+
+    let (status, body, response) = get(
+        &app.router,
+        &format!("/api/sessions/{SESSION_ID}/work-graph?view=plan"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(response["source"], "live");
+    assert_eq!(response["view"], "plan");
+    assert_eq!(response["waves"], json!([["a", "d"], ["b", "e"], ["c"]]));
+    assert_eq!(response["critical_path"], json!(["a", "b", "c"]));
+    assert_eq!(
+        response["lane_assignment"]["a"],
+        json!({"kind": "role", "value": "backend"})
+    );
+
+    let provenance: BTreeSet<&str> = response["provenance_by_edge"]
+        .as_array()
+        .expect("provenance list")
+        .iter()
+        .filter_map(|edge| edge["provenance"].as_str())
+        .collect();
+    assert_eq!(
+        provenance,
+        BTreeSet::from(["planner", "codegraph", "knowledge", "runtime"]),
+        "the four trust classes must remain distinct over HTTP"
+    );
+
+    let first_node = &response["nodes"][0];
+    assert!(first_node.get("title").is_none());
+    assert!(first_node.get("contract").is_none());
+    assert_eq!(
+        first_node["contract_summary"],
+        json!({"input_count": 1, "output_count": 1, "acceptance_count": 1})
+    );
+    assert!(
+        !body.contains(SECRET) && !body.contains("task-body-"),
+        "bounded node projection leaked a full task body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn runtime_graph_projects_a_blocked_subtree_from_the_durable_queue() {
+    const SESSION_ID: &str = "wg-api-mid-flight";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    let graph = TaskGraph::new(
+        vec![
+            node(
+                "root",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Ready,
+                "root",
+            ),
+            node(
+                "blocked-child",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Pending,
+                "child",
+            ),
+            node(
+                "blocked-leaf",
+                BindingRef::Role("reviewer".to_string()),
+                NodeStatus::Pending,
+                "leaf",
+            ),
+        ],
+        vec![
+            WorkEdge::new(
+                "root",
+                "blocked-child",
+                EdgeKind::DependsOn,
+                EdgeProvenance::Planner,
+            ),
+            WorkEdge::new(
+                "blocked-child",
+                "blocked-leaf",
+                EdgeKind::DependsOn,
+                EdgeProvenance::Runtime,
+            ),
+        ],
+    );
+    StateManager::new(session_dir)
+        .write_work_graph(&graph)
+        .expect("persisted live graph");
+    let repo = app.state.queue_manager.repo();
+    repo.enqueue(&queue_row(
+        SESSION_ID,
+        "run-root",
+        "root",
+        QueueStatus::Running,
+        1,
+    ))
+    .expect("running queue row");
+    repo.enqueue(&queue_row(
+        SESSION_ID,
+        "run-child",
+        "blocked-child",
+        QueueStatus::Blocked,
+        2,
+    ))
+    .expect("blocked child queue row");
+    repo.enqueue(&queue_row(
+        SESSION_ID,
+        "run-leaf",
+        "blocked-leaf",
+        QueueStatus::Blocked,
+        3,
+    ))
+    .expect("blocked leaf queue row");
+
+    let (status, body, response) = get(
+        &app.router,
+        &format!("/api/sessions/{SESSION_ID}/work-graph?view=runtime"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(response["source"], "live");
+    assert_eq!(response["status_by_node"]["root"], "running");
+    assert_eq!(response["status_by_node"]["blocked-child"], "blocked");
+    assert_eq!(response["status_by_node"]["blocked-leaf"], "blocked");
+    assert_eq!(response["critical_path"], json!(["root", "blocked-child", "blocked-leaf"]));
+    assert_eq!(
+        response["nodes"]
+            .as_array()
+            .expect("nodes")
+            .iter()
+            .filter(|node| node["status"] == "blocked")
+            .count(),
+        2,
+        "the dependent branch must remain visibly blocked"
+    );
+}
+
+#[tokio::test]
+async fn completed_session_falls_back_to_archive_with_divergence() {
+    const SESSION_ID: &str = "wg-api-archived";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    let plan = TaskGraph::new(
+        vec![node(
+            "planned",
+            BindingRef::Role("backend".to_string()),
+            NodeStatus::Ready,
+            "planned",
+        )],
+        vec![],
+    );
+    let mut runtime = plan.clone();
+    runtime.nodes.push(node(
+        "runtime-review",
+        BindingRef::Role("reviewer".to_string()),
+        NodeStatus::Completed,
+        "runtime",
+    ));
+    runtime.edges.push(WorkEdge::new(
+        "planned",
+        "runtime-review",
+        EdgeKind::Reviews,
+        EdgeProvenance::Runtime,
+    ));
+    StateManager::new(session_dir)
+        .write_work_graph(&plan)
+        .expect("persisted plan graph");
+    record_graph_change(
+        SESSION_ID,
+        GraphMutationType::Other,
+        &plan,
+        &runtime,
+        vec!["integration-test".to_string()],
+    )
+    .expect("recorded runtime mutation")
+    .expect("non-empty runtime mutation");
+    let completion = archive_completed_session(app.storage().base_dir(), None, SESSION_ID)
+        .expect("completed archive");
+    assert!(completion.created);
+
+    let (status, body, response) = get(
+        &app.router,
+        &format!("/api/sessions/{SESSION_ID}/work-graph?view=divergence"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(response["source"], "archive");
+    assert_eq!(response["view"], "divergence");
+    assert_eq!(
+        response["divergence"]["counts_by_mutation_type"]["node_added"],
+        1
+    );
+    assert_eq!(
+        response["divergence"]["recorded_runtime_mutations"]["other"],
+        1
+    );
+    assert!(response["nodes"]
+        .as_array()
+        .expect("nodes")
+        .iter()
+        .any(|node| node["id"] == "runtime-review"));
+}
+
+#[tokio::test]
+async fn pty_buffer_exposes_unsubmitted_stub_content_and_rejects_traversal_ids() {
+    const SESSION_ID: &str = "wg-api-pty";
+    const AGENT_ID: &str = "wg-api-pty-queen";
+    const PAYLOAD: &str = "UNSUBMITTED_SENTINEL_WITHOUT_ENTER";
+    let app = test_app().await;
+    app.storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    app.state
+        .session_controller
+        .read()
+        .insert_test_session(running_session_with_agent(SESSION_ID, AGENT_ID));
+    app.state
+        .pty_manager
+        .write()
+        .create_session(
+            AGENT_ID.to_string(),
+            AgentRole::Queen,
+            "cmd",
+            &[],
+            None,
+            80,
+            24,
+        )
+        .expect("stub PTY");
+    app.state
+        .pty_manager
+        .read()
+        .write(AGENT_ID, PAYLOAD.as_bytes())
+        .expect("unsubmitted PTY write");
+
+    let (status, body, response) = get(
+        &app.router,
+        &format!("/api/sessions/{SESSION_ID}/agents/{AGENT_ID}/pty-buffer"),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(response["session_id"], SESSION_ID);
+    assert_eq!(response["agent_id"], AGENT_ID);
+    assert_eq!(response["output"], PAYLOAD);
+    assert_eq!(response["byte_count"], PAYLOAD.len());
+    assert!(
+        !response["output"].as_str().unwrap().contains('\r'),
+        "the fixture must observe composer content before Enter is submitted"
+    );
+
+    let (bad_session_status, _, _) = get(
+        &app.router,
+        &format!("/api/sessions/bad..session/agents/{AGENT_ID}/pty-buffer"),
+    )
+    .await;
+    assert_eq!(bad_session_status, StatusCode::BAD_REQUEST);
+
+    let (bad_agent_status, _, _) = get(
+        &app.router,
+        &format!("/api/sessions/{SESSION_ID}/agents/bad..agent/pty-buffer"),
+    )
+    .await;
+    assert_eq!(bad_agent_status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn every_session_lifecycle_stage_emits_a_retrievable_graph() {
+    const SESSION_ID: &str = "wg-api-all-lifecycle-stages";
+    const AGENT_ID: &str = "wg-api-lifecycle-queen";
+    const SECRET: &str = "LIFECYCLE-TASK-BODY-MUST-STAY-BOUNDED";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    StateManager::new(session_dir.clone())
+        .write_work_graph(&TaskGraph::new(
+            vec![node(
+                "lifecycle-task",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Running,
+                SECRET,
+            )],
+            vec![],
+        ))
+        .expect("persisted lifecycle graph");
+    app.state
+        .session_controller
+        .read()
+        .insert_test_session(running_session_with_agent(SESSION_ID, AGENT_ID));
+
+    let lifecycle_states = [
+        SessionState::Planning,
+        SessionState::PlanReady,
+        SessionState::Starting,
+        SessionState::SpawningWorker(3),
+        SessionState::WaitingForWorker(3),
+        SessionState::SpawningPlanner(2),
+        SessionState::WaitingForPlanner(2),
+        SessionState::SpawningFusionVariant(1),
+        SessionState::WaitingForFusionVariants,
+        SessionState::SpawningDebateRound(1),
+        SessionState::WaitingForDebateRound(1),
+        SessionState::SpawningJudge,
+        SessionState::Judging,
+        SessionState::AwaitingVerdictSelection,
+        SessionState::MergingWinner,
+        SessionState::SpawningEvaluator,
+        SessionState::QaInProgress { iteration: None },
+        SessionState::QaPassed,
+        SessionState::QaFailed { iteration: 1 },
+        SessionState::QaMaxRetriesExceeded,
+        SessionState::PrinceRemediation,
+        SessionState::QaInconclusive,
+        SessionState::Running,
+        SessionState::Paused,
+        SessionState::Completed,
+        SessionState::Closing,
+        SessionState::Closed,
+        SessionState::Failed("simulated crash".to_string()),
+    ];
+    assert_eq!(lifecycle_states.len(), 28);
+
+    for lifecycle_state in lifecycle_states {
+        let expected_stage = format!("{:?}", lifecycle_state.kind());
+        app.state
+            .session_controller
+            .read()
+            .transition_test_session(SESSION_ID, lifecycle_state)
+            .expect("transition through production lifecycle seam");
+
+        let snapshot = StateManager::new(session_dir.clone())
+            .read_work_graph_snapshot()
+            .expect("snapshot read")
+            .expect("transition emitted snapshot");
+        assert_eq!(snapshot.lifecycle_stage, expected_stage);
+        assert_eq!(snapshot.node_count, 1);
+
+        let (status, body, response) = get(
+            &app.router,
+            &format!("/api/sessions/{SESSION_ID}/work-graph?view=runtime"),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "stage {expected_stage}: {body}");
+        assert_eq!(response["source"], "live");
+        assert_eq!(response["nodes"][0]["id"], "lifecycle-task");
+        assert!(
+            !body.contains(SECRET),
+            "stage {expected_stage} leaked the task body"
+        );
+    }
+
+    let artifact = session_dir.join("work-graph.html");
+    let html = std::fs::read_to_string(artifact).expect("crash-stage portable artifact");
+    assert!(html.contains("\"lifecycle_stage\":\"Failed\""));
+    assert!(html.contains("lifecycle-task"));
+    assert!(!html.contains(SECRET));
+}
+
+#[tokio::test]
+async fn completion_persistence_rollback_refreshes_the_graph_artifact() {
+    const SESSION_ID: &str = "wg-api-completion-rollback";
+    const AGENT_ID: &str = "wg-api-rollback-queen";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    StateManager::new(session_dir.clone())
+        .write_work_graph(&TaskGraph::new(
+            vec![node(
+                "rollback-task",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Running,
+                "rollback",
+            )],
+            vec![],
+        ))
+        .expect("persisted rollback graph");
+    let mut session = running_session_with_agent(SESSION_ID, AGENT_ID);
+    session.last_activity_at = Utc::now() - Duration::minutes(11);
+    app.state
+        .session_controller
+        .read()
+        .insert_test_session(session);
+    app.state
+        .session_controller
+        .read()
+        .transition_test_session(SESSION_ID, SessionState::Running)
+        .expect("baseline lifecycle snapshot");
+
+    // A directory at the metadata file path deterministically rejects the atomic
+    // session.json replace while leaving state/work-graph.json writable.
+    std::fs::create_dir(session_dir.join("session.json"))
+        .expect("session metadata failure fixture");
+    app.state
+        .session_controller
+        .read()
+        .mark_session_completed(SESSION_ID)
+        .expect_err("completion persistence must fail and roll back");
+
+    let restored = app
+        .state
+        .session_controller
+        .read()
+        .get_session(SESSION_ID)
+        .expect("restored session");
+    assert_eq!(restored.state, SessionState::Running);
+    let snapshot = StateManager::new(session_dir.clone())
+        .read_work_graph_snapshot()
+        .expect("snapshot read")
+        .expect("rollback refreshed snapshot");
+    assert_eq!(snapshot.lifecycle_stage, "Running");
+    let html = std::fs::read_to_string(session_dir.join("work-graph.html"))
+        .expect("rollback artifact");
+    assert_eq!(portable_graph_payload(&html)["lifecycle_stage"], "Running");
+}
+
+#[test]
+fn every_production_state_rollback_refreshes_lifecycle_evidence() {
+    let source = include_str!("../session/controller.rs").replace("\r\n", "\n");
+    let production = source
+        .split("\n#[cfg(test)]\nmod tests {")
+        .next()
+        .expect("production controller source");
+    let forbidden_direct_mutations = [
+        ("completion rollback", "session.state = previous_session_state;"),
+        ("QA-timeout forward", "session.state = SessionState::QaInconclusive;"),
+        ("QA-timeout rollback", "session.state = previous_state;"),
+    ];
+    for (label, needle) in forbidden_direct_mutations {
+        assert!(
+            !production.contains(needle),
+            "{label} bypasses the snapshot-emitting transition helper"
+        );
+    }
+
+    let whole_session_rollbacks = production
+        .match_indices("*session = previous_session;")
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    assert_eq!(
+        whole_session_rollbacks.len(),
+        4,
+        "whole-session rollback audit changed; inspect every restore before updating this gate"
+    );
+    for index in whole_session_rollbacks {
+        let end = production.len().min(index + 900);
+        assert!(
+            production[index..end].contains("emit_work_graph_snapshot"),
+            "whole-session rollback at byte {index} restores state without refreshing graph evidence"
+        );
+    }
+}
+
+#[tokio::test]
+async fn simulated_crash_after_plan_ready_leaves_a_bounded_standalone_graph() {
+    const SESSION_ID: &str = "wg-api-crash-artifact";
+    const AGENT_ID: &str = "wg-api-crash-queen";
+    const SECRET: &str = "CRASH-TASK-BODY-MUST-STAY-IN-AUTHORITATIVE-STATE";
+    let app = test_app().await;
+    let session_dir = app
+        .storage()
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    let manager = StateManager::new(session_dir.clone());
+    manager
+        .write_work_graph(&TaskGraph::new(
+            vec![node(
+                "crashed-task",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Running,
+                SECRET,
+            )],
+            vec![],
+        ))
+        .expect("persisted graph");
+    app.state
+        .session_controller
+        .read()
+        .insert_test_session(running_session_with_agent(SESSION_ID, AGENT_ID));
+
+    // The process is considered to disappear immediately after this ordinary
+    // lifecycle transition: no archival or read endpoint is invoked to create evidence.
+    app.state
+        .session_controller
+        .read()
+        .transition_test_session(SESSION_ID, SessionState::PlanReady)
+        .expect("production PlanReady transition");
+    let artifact = session_dir.join("work-graph.html");
+    let snapshot = manager
+        .read_work_graph_snapshot()
+        .expect("snapshot read")
+        .expect("snapshot exists");
+    let html = std::fs::read_to_string(&artifact).expect("portable graph HTML");
+    let payload = portable_graph_payload(&html);
+
+    assert_eq!(artifact, session_dir.join("work-graph.html"));
+    assert_eq!(snapshot.lifecycle_stage, "PlanReady");
+    assert_eq!(snapshot.node_count, 1);
+    assert_eq!(snapshot.artifact, "work-graph.html");
+    assert!(html.starts_with("<!doctype html>"));
+    assert_eq!(payload["lifecycle_stage"], "PlanReady");
+    assert_eq!(payload["nodes"][0]["id"], "crashed-task");
+    assert!(payload["nodes"][0].get("title").is_none());
+    assert!(!html.contains(SECRET));
+    assert!(!html.contains("http://") && !html.contains("https://"));
+}
+
+#[test]
+fn clean_archival_writes_and_backfills_the_portable_graph() {
+    const SESSION_ID: &str = "wg-api-clean-artifact";
+    let temp = TempDir::new().expect("temporary storage");
+    let storage = SessionStorage::new_with_base(temp.path().to_path_buf()).expect("storage");
+    let session_dir = storage
+        .create_session_dir(SESSION_ID)
+        .expect("session directory");
+    StateManager::new(session_dir.clone())
+        .write_work_graph(&TaskGraph::new(
+            vec![node(
+                "completed-task",
+                BindingRef::Role("backend".to_string()),
+                NodeStatus::Completed,
+                "clean-archive",
+            )],
+            vec![],
+        ))
+        .expect("persisted graph");
+
+    let completion = archive_completed_session(temp.path(), None, SESSION_ID)
+        .expect("clean archival");
+    let artifact = session_dir.join("work-graph.html");
+    assert!(completion.created);
+    assert!(artifact.is_file());
+    let html = std::fs::read_to_string(&artifact).expect("portable graph HTML");
+    let payload = portable_graph_payload(&html);
+    assert_eq!(payload["lifecycle_stage"], "archived");
+    assert_eq!(payload["nodes"][0]["id"], "completed-task");
+    assert!(payload["divergence"].is_object());
+
+    std::fs::remove_file(&artifact).expect("remove artifact to exercise upgrade backfill");
+    let repeated = archive_completed_session(temp.path(), None, SESSION_ID)
+        .expect("idempotent archival backfills HTML");
+    assert!(!repeated.created);
+    assert_eq!(repeated.path, completion.path);
+    assert!(
+        artifact.is_file(),
+        "an existing JSON archive must not skip the portable artifact"
+    );
+}

--- a/src-tauri/src/http/tests_wg_authority.rs
+++ b/src-tauri/src/http/tests_wg_authority.rs
@@ -280,6 +280,171 @@ fn ownership_sidecar_round_trips_and_prewrite_collision_is_durable() {
 }
 
 #[test]
+fn undeclared_or_role_mismatched_actor_cannot_bypass_a_live_owner() {
+    let graph = incident_graph();
+    for (actor_id, role) in [
+        ("unregistered-orchestrator", OrchestratorRole::Queen),
+        ("queen", OrchestratorRole::Evaluator),
+    ] {
+        let mut state = OwnershipSessionState::from_plan(
+            &graph,
+            declared_orchestrators(),
+            &[LivePrincipal {
+                principal_id: W4_ID.to_string(),
+                task_id: "T14/T15".to_string(),
+                write_capable: true,
+            }],
+        )
+        .expect("live ownership state");
+
+        let outcome = state.record_write_attempt(OrchestratorWriteAttempt {
+            actor_id: actor_id.to_string(),
+            role,
+            path: INCIDENT_PATH.to_string(),
+            operation: OrchestratorOperation::Restore,
+            attempted_at: incident_time(),
+        });
+        let OrchestratorWriteOutcome::Collision { collision } = outcome else {
+            panic!("{actor_id:?} with role {role:?} bypassed a write-capable owner");
+        };
+        assert_eq!(collision.actor_id, actor_id);
+        assert_eq!(collision.actor_role, role);
+        assert_eq!(collision.owner_principal_id, W4_ID);
+        assert!(!collision.within_declared_footprint);
+        assert!(!collision.override_authorized);
+        assert_eq!(
+            collision.disposition,
+            CollisionDisposition::RequiresSerialization
+        );
+        assert_eq!(state.collisions, vec![collision]);
+    }
+}
+
+#[test]
+fn ownership_sidecar_persists_an_undeclared_actor_collision() {
+    let temp = TempDir::new().expect("ownership sidecar root");
+    let manager = StateManager::new(temp.path().join("ownership-session"));
+    let graph = incident_graph();
+    let initial = OwnershipSessionState::from_plan(&graph, declared_orchestrators(), &[])
+        .expect("initial ownership state");
+    manager
+        .write_ownership_session_state(&initial)
+        .expect("persist visible ownership state");
+
+    let outcome = manager
+        .record_orchestrator_write_attempt(
+            &graph,
+            &[LivePrincipal {
+                principal_id: W4_ID.to_string(),
+                task_id: "T14/T15".to_string(),
+                write_capable: true,
+            }],
+            OrchestratorWriteAttempt {
+                actor_id: "unregistered-orchestrator".to_string(),
+                role: OrchestratorRole::Queen,
+                path: INCIDENT_PATH.to_string(),
+                operation: OrchestratorOperation::Restore,
+                attempted_at: incident_time(),
+            },
+        )
+        .expect("pre-write check persists its result");
+    assert!(matches!(outcome, OrchestratorWriteOutcome::Collision { .. }));
+
+    let persisted = manager
+        .read_ownership_session_state()
+        .expect("read surfaced collision")
+        .expect("ownership sidecar exists");
+    assert_eq!(persisted.collisions.len(), 1);
+    assert_eq!(persisted.collisions[0].actor_id, "unregistered-orchestrator");
+    assert_eq!(
+        persisted.collisions[0].disposition,
+        CollisionDisposition::RequiresSerialization
+    );
+    assert!(!persisted.collisions[0].override_authorized);
+}
+
+#[test]
+fn undeclared_actor_without_a_live_owner_proceeds_without_collision_evidence() {
+    let mut state = OwnershipSessionState::from_plan(
+        &incident_graph(),
+        declared_orchestrators(),
+        &[],
+    )
+    .expect("ownership state without live principals");
+    assert_eq!(
+        state.record_write_attempt(OrchestratorWriteAttempt {
+            actor_id: "unregistered-orchestrator".to_string(),
+            role: OrchestratorRole::Queen,
+            path: INCIDENT_PATH.to_string(),
+            operation: OrchestratorOperation::Restore,
+            attempted_at: incident_time(),
+        }),
+        OrchestratorWriteOutcome::Proceed
+    );
+    assert!(state.collisions.is_empty());
+}
+
+#[test]
+fn lexically_equivalent_path_spellings_surface_the_same_live_owner_collision() {
+    let graph = incident_graph();
+    for equivalent_path in [
+        "src-tauri/src/session/./controller.rs",
+        "src-tauri//src//session//controller.rs",
+        "src-tauri/src/session/controller.rs///",
+    ] {
+        let mut state = OwnershipSessionState::from_plan(
+            &graph,
+            declared_orchestrators(),
+            &[LivePrincipal {
+                principal_id: W4_ID.to_string(),
+                task_id: "T14/T15".to_string(),
+                write_capable: true,
+            }],
+        )
+        .expect("live ownership state");
+        let outcome = state.record_write_attempt(OrchestratorWriteAttempt {
+            actor_id: "queen".to_string(),
+            role: OrchestratorRole::Queen,
+            path: equivalent_path.to_string(),
+            operation: OrchestratorOperation::Restore,
+            attempted_at: incident_time(),
+        });
+        let OrchestratorWriteOutcome::Collision { collision } = outcome else {
+            panic!("equivalent spelling {equivalent_path:?} bypassed live ownership");
+        };
+        assert_eq!(collision.path, INCIDENT_PATH);
+        assert!(collision.within_declared_footprint);
+        assert_eq!(state.collisions, vec![collision]);
+    }
+}
+
+#[test]
+fn parent_segments_are_not_resolved_without_a_containment_policy() {
+    let graph = incident_graph();
+    let mut state = OwnershipSessionState::from_plan(
+        &graph,
+        declared_orchestrators(),
+        &[LivePrincipal {
+            principal_id: W4_ID.to_string(),
+            task_id: "T14/T15".to_string(),
+            write_capable: true,
+        }],
+    )
+    .expect("live ownership state");
+    assert_eq!(
+        state.record_write_attempt(OrchestratorWriteAttempt {
+            actor_id: "queen".to_string(),
+            role: OrchestratorRole::Queen,
+            path: "src-tauri/src/session/../session/controller.rs".to_string(),
+            operation: OrchestratorOperation::Restore,
+            attempted_at: incident_time(),
+        }),
+        OrchestratorWriteOutcome::Proceed
+    );
+    assert!(state.collisions.is_empty());
+}
+
+#[test]
 fn inactive_owner_and_unowned_path_do_not_create_false_collisions() {
     let mut inactive = OwnershipSessionState::from_plan(
         &incident_graph(),

--- a/src-tauri/src/http/tests_wg_authority.rs
+++ b/src-tauri/src/http/tests_wg_authority.rs
@@ -1,0 +1,639 @@
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use tempfile::TempDir;
+
+use crate::coordination::StateManager;
+use crate::orchestrator::org_graph::adjudication::{
+    adjudicate_contradiction, AdjudicationDeclaration, AdjudicationPolicy,
+    AdjudicationResolution, DeclaredAdjudicator, SourceVerdict, SourceVerdictValue,
+};
+use crate::orchestrator::org_graph::ownership::{
+    orchestrator_nodes_for_plan, CollisionDisposition, LivePrincipal, OrchestratorOperation,
+    OrchestratorOwnershipNode, OrchestratorRole, OrchestratorWriteAttempt,
+    OrchestratorWriteOutcome, OwnershipSessionState,
+};
+use crate::orchestrator::org_graph::{ContextBoundary, SignalClass};
+use crate::orchestrator::work_graph::archive::{archive_completed_session, read_archive};
+use crate::orchestrator::work_graph::review::{
+    instantiate_review_templates, ReviewTemplate, JUDGE_PRINCE_REMEDIATION_TEMPLATE,
+};
+use crate::orchestrator::work_graph::runtime::{
+    route_contradictory_verdicts_and_record, route_failed_verdict_and_record,
+    GraphMutationType,
+};
+use crate::orchestrator::work_graph::schema::{
+    BindingRef, CompositeExpansion, EdgeKind, EdgeProvenance, NodeContract, NodeKind, NodeStatus,
+    TaskGraph, WorkEdge, WorkNode,
+};
+use crate::orchestrator::work_graph::validate::{
+    validate_plan_ready, PlanReadyError, PlanReadyWarning,
+};
+use crate::storage::SessionStorage;
+
+const INCIDENT_PATH: &str = "src-tauri/src/session/controller.rs";
+const W4_ID: &str = "d1e86179-de61-4b3a-8744-7c62a14ce4b2-worker-4";
+
+fn incident_graph() -> TaskGraph {
+    let owner = WorkNode::new(
+        "T14/T15",
+        NodeKind::Task,
+        "W4 get_stalled_agents fix and mutation proof",
+        NodeContract {
+            inputs: Vec::new(),
+            outputs: vec!["code".to_string()],
+            acceptance: vec!["preserve the reassignment guard".to_string()],
+        },
+        BindingRef::Role("worker".to_string()),
+        // The historical mirror said completed even while W4 remained write-capable.
+        NodeStatus::Completed,
+    );
+    let mut parameters = BTreeMap::new();
+    parameters.insert("module".to_string(), INCIDENT_PATH.to_string());
+    let mut module = WorkNode::new(
+        "codegraph::controller",
+        NodeKind::Context,
+        "Module controller.rs",
+        NodeContract::default(),
+        BindingRef::Zone("codegraph".to_string()),
+        NodeStatus::Completed,
+    );
+    module.expansion = Some(CompositeExpansion {
+        template: "codegraph-module".to_string(),
+        parameters,
+    });
+    TaskGraph::new(
+        vec![owner, module],
+        vec![WorkEdge::new(
+            "T14/T15",
+            "codegraph::controller",
+            EdgeKind::Touches,
+            EdgeProvenance::Codegraph,
+        )],
+    )
+}
+
+fn declared_orchestrators() -> Vec<OrchestratorOwnershipNode> {
+    orchestrator_nodes_for_plan(&incident_graph())
+}
+
+fn incident_time() -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339("2026-08-14T14:23:37Z")
+        .expect("historical incident timestamp")
+        .with_timezone(&Utc)
+}
+
+fn review_fixture(
+    template: &ReviewTemplate,
+) -> (
+    TaskGraph,
+    crate::orchestrator::work_graph::review::ReviewExpansion,
+) {
+    let task = WorkNode::new(
+        "implementation",
+        NodeKind::Task,
+        "Implementation",
+        NodeContract {
+            inputs: Vec::new(),
+            outputs: vec!["code".to_string()],
+            acceptance: vec!["implementation works".to_string()],
+        },
+        BindingRef::Role("worker".to_string()),
+        NodeStatus::Pending,
+    );
+    let mut graph = TaskGraph::new(vec![task], Vec::new());
+    let expansion = instantiate_review_templates(&mut graph, std::slice::from_ref(template))
+        .expect("review expansion")
+        .remove(0);
+    (graph, expansion)
+}
+
+fn adjudication(policy: AdjudicationPolicy) -> AdjudicationDeclaration {
+    AdjudicationDeclaration {
+        policy,
+        adjudicator: Some(DeclaredAdjudicator::new("prince")),
+    }
+}
+
+fn contradictory_verdicts() -> Vec<SourceVerdict> {
+    vec![
+        SourceVerdict {
+            source_id: "correctness".to_string(),
+            verdict: SourceVerdictValue::Pass,
+            rationale: "mechanism satisfies its contract".to_string(),
+        },
+        SourceVerdict {
+            source_id: "security".to_string(),
+            verdict: SourceVerdictValue::Fail,
+            rationale: "authorization finding remains".to_string(),
+        },
+    ]
+}
+
+#[test]
+fn orchestrator_nodes_serialize_footprint_separately_from_authority() {
+    let state = OwnershipSessionState::from_plan(
+        &incident_graph(),
+        declared_orchestrators(),
+        &[LivePrincipal {
+            principal_id: W4_ID.to_string(),
+            task_id: "T14/T15".to_string(),
+            write_capable: true,
+        }],
+    )
+    .expect("all orchestrators declare a footprint");
+    let serialized = serde_json::to_value(&state).expect("ownership state serializes");
+    let orchestrators = serialized["orchestrators"]
+        .as_array()
+        .expect("orchestrators are visible session state");
+
+    assert_eq!(orchestrators.len(), 3);
+    for role in ["queen", "prince", "evaluator"] {
+        let node = orchestrators
+            .iter()
+            .find(|node| node["role"] == role)
+            .unwrap_or_else(|| panic!("missing serialized {role} node"));
+        assert!(
+            !node["footprint"].as_array().expect("footprint array").is_empty(),
+            "{role} footprint was erased"
+        );
+        assert!(node.get("authority").is_some(), "{role} authority missing");
+        assert!(
+            node.get("ownership_authority").is_some(),
+            "{role} ownership authority missing"
+        );
+    }
+
+    let queen = orchestrators
+        .iter()
+        .find(|node| node["role"] == "queen")
+        .expect("queen node");
+    assert!(queen["footprint"].as_array().expect("Queen footprint").iter().any(
+        |entry| entry["path"] == INCIDENT_PATH && entry["operation"] == "restore"
+    ));
+    assert_eq!(queen["authority"]["may_commit"], true);
+    assert_eq!(queen["ownership_authority"]["may_mutate_mid_flight"], true);
+}
+
+#[test]
+fn d1e86179_queen_restore_to_live_principal_path_is_detected_and_surfaced() {
+    let graph = incident_graph();
+    let mut state = OwnershipSessionState::from_plan(
+        &graph,
+        declared_orchestrators(),
+        &[LivePrincipal {
+            principal_id: W4_ID.to_string(),
+            task_id: "T14/T15".to_string(),
+            // This is the liveness fact that the premature COMPLETED mirror lost.
+            write_capable: true,
+        }],
+    )
+    .expect("incident ownership state");
+
+    // Historical interleaving: W4 wrote the correct guard, Queen mutated it for
+    // proof and restored it, then still-live W4 wrote its stale mutant again.
+    let correct_guard = "info.status != \"completed\" || reassigned_after_completion";
+    let stale_mutant = "info.status != \"completed\"";
+    let mut working_guard = correct_guard;
+    assert_eq!(working_guard, correct_guard); // W4's correct T14 write.
+    working_guard = stale_mutant; // Queen mutation proof.
+    assert_eq!(working_guard, stale_mutant);
+    working_guard = correct_guard; // Queen restore attempt must check ownership now.
+    assert_eq!(working_guard, correct_guard);
+
+    let outcome = state.record_write_attempt(OrchestratorWriteAttempt {
+        actor_id: "queen".to_string(),
+        role: OrchestratorRole::Queen,
+        path: INCIDENT_PATH.to_string(),
+        operation: OrchestratorOperation::Restore,
+        attempted_at: incident_time(),
+    });
+    let OrchestratorWriteOutcome::Collision { collision } = outcome else {
+        panic!("Queen restore raced a write-capable W4 but was allowed silently");
+    };
+    assert_eq!(collision.actor_id, "queen");
+    assert_eq!(collision.actor_role, OrchestratorRole::Queen);
+    assert_eq!(collision.owner_principal_id, W4_ID);
+    assert_eq!(collision.owner_task_id, "T14/T15");
+    assert!(collision.owner_write_capable);
+    assert_eq!(collision.path, INCIDENT_PATH);
+    assert_eq!(collision.operation, OrchestratorOperation::Restore);
+    assert!(collision.within_declared_footprint);
+    assert!(collision.override_authorized);
+    assert_eq!(
+        collision.disposition,
+        CollisionDisposition::SurfacedAuthorizedOverride
+    );
+    assert_eq!(collision.detected_at, incident_time());
+    assert_eq!(state.collisions, vec![collision.clone()]);
+
+    working_guard = stale_mutant; // W4's post-restore write proves it was still live.
+    assert_eq!(working_guard, stale_mutant);
+    assert_eq!(
+        serde_json::to_value(&state).expect("surfaced state")["collisions"][0]["path"],
+        INCIDENT_PATH
+    );
+}
+
+#[test]
+fn ownership_sidecar_round_trips_and_prewrite_collision_is_durable() {
+    let temp = TempDir::new().expect("ownership sidecar root");
+    let manager = StateManager::new(temp.path().join("ownership-session"));
+    let graph = incident_graph();
+    let initial = OwnershipSessionState::from_plan(&graph, declared_orchestrators(), &[])
+        .expect("initial ownership state");
+    manager
+        .write_ownership_session_state(&initial)
+        .expect("persist visible ownership state");
+    assert_eq!(
+        manager
+            .read_ownership_session_state()
+            .expect("read sidecar"),
+        Some(initial)
+    );
+
+    let outcome = manager
+        .record_orchestrator_write_attempt(
+            &graph,
+            &[LivePrincipal {
+                principal_id: W4_ID.to_string(),
+                task_id: "T14/T15".to_string(),
+                write_capable: true,
+            }],
+            OrchestratorWriteAttempt {
+                actor_id: "queen".to_string(),
+                role: OrchestratorRole::Queen,
+                path: INCIDENT_PATH.to_string(),
+                operation: OrchestratorOperation::Restore,
+                attempted_at: incident_time(),
+            },
+        )
+        .expect("pre-write check persists its result");
+    assert!(matches!(outcome, OrchestratorWriteOutcome::Collision { .. }));
+    let persisted = manager
+        .read_ownership_session_state()
+        .expect("read surfaced collision")
+        .expect("ownership sidecar exists");
+    assert_eq!(persisted.collisions.len(), 1);
+    assert_eq!(persisted.collisions[0].path, INCIDENT_PATH);
+    assert_eq!(persisted.collisions[0].owner_principal_id, W4_ID);
+}
+
+#[test]
+fn inactive_owner_and_unowned_path_do_not_create_false_collisions() {
+    let mut inactive = OwnershipSessionState::from_plan(
+        &incident_graph(),
+        declared_orchestrators(),
+        &[LivePrincipal {
+            principal_id: W4_ID.to_string(),
+            task_id: "T14/T15".to_string(),
+            write_capable: false,
+        }],
+    )
+    .expect("inactive ownership state");
+    let attempt = |path: &str| OrchestratorWriteAttempt {
+        actor_id: "queen".to_string(),
+        role: OrchestratorRole::Queen,
+        path: path.to_string(),
+        operation: OrchestratorOperation::Restore,
+        attempted_at: incident_time(),
+    };
+    assert_eq!(
+        inactive.record_write_attempt(attempt(INCIDENT_PATH)),
+        OrchestratorWriteOutcome::Proceed
+    );
+    assert_eq!(
+        inactive.record_write_attempt(attempt("src-tauri/src/lib.rs")),
+        OrchestratorWriteOutcome::Proceed
+    );
+    assert!(inactive.collisions.is_empty());
+}
+
+#[test]
+fn unassigned_task_class_verification_duty_is_reported_at_plan_ready() {
+    let task = WorkNode::new(
+        "implement-auth",
+        NodeKind::Task,
+        "Implement auth",
+        NodeContract {
+            inputs: Vec::new(),
+            outputs: vec!["security_critical_code".to_string()],
+            acceptance: Vec::new(),
+        },
+        BindingRef::Role("worker".to_string()),
+        NodeStatus::Pending,
+    );
+    let mut graph = TaskGraph::new(vec![task], Vec::new());
+    let validation = validate_plan_ready(&graph).expect("gap is a plan-time report");
+    assert!(validation.warnings.contains(
+        &PlanReadyWarning::UnassignedVerificationDuty {
+            task_class: "output:security_critical_code".to_string(),
+            task_ids: vec!["implement-auth".to_string()],
+        }
+    ));
+
+    graph.nodes.push(WorkNode::new(
+        "review-auth",
+        NodeKind::Review,
+        "Review auth",
+        NodeContract::default(),
+        BindingRef::Role("evaluator".to_string()),
+        NodeStatus::Pending,
+    ));
+    graph.edges.push(WorkEdge::new(
+        "implement-auth",
+        "review-auth",
+        EdgeKind::Reviews,
+        EdgeProvenance::Planner,
+    ));
+    let assigned = validate_plan_ready(&graph).expect("assigned duty remains plan-ready");
+    assert!(
+        !assigned
+            .warnings
+            .iter()
+            .any(|warning| matches!(warning, PlanReadyWarning::UnassignedVerificationDuty { .. })),
+        "a real Reviews edge must satisfy the task class duty"
+    );
+}
+
+#[test]
+fn plan_ready_enforces_named_signal_class_and_judgmental_isolation_separately() {
+    let mut missing_signal = ReviewTemplate::code_tasks("missing-signal");
+    missing_signal.verification_duty.signal_name = Some("   ".to_string());
+    let (graph, _) = review_fixture(&missing_signal);
+    assert!(matches!(
+        validate_plan_ready(&graph),
+        Err(PlanReadyError::MissingVerificationSignal { .. })
+    ));
+
+    let mut missing_class = ReviewTemplate::code_tasks("missing-class");
+    missing_class.verification_duty.signal_class = None;
+    let (graph, _) = review_fixture(&missing_class);
+    assert!(matches!(
+        validate_plan_ready(&graph),
+        Err(PlanReadyError::MissingVerificationSignalClass { .. })
+    ));
+
+    let mut contaminated_judgment = ReviewTemplate::code_tasks("contaminated-judgment");
+    contaminated_judgment.verification_duty.context_boundary = ContextBoundary::Full;
+    let (graph, _) = review_fixture(&contaminated_judgment);
+    assert!(matches!(
+        validate_plan_ready(&graph),
+        Err(PlanReadyError::InsufficientVerificationIsolation {
+            signal_class: SignalClass::Judgmental,
+            actual: ContextBoundary::Full,
+            required: ContextBoundary::Artifact,
+            ..
+        })
+    ));
+
+    let mut contaminated_mechanism = ReviewTemplate::code_tasks("contaminated-mechanism");
+    contaminated_mechanism.verification_duty.signal_class = Some(SignalClass::Mechanical);
+    contaminated_mechanism.verification_duty.context_boundary = ContextBoundary::Full;
+    let (graph, _) = review_fixture(&contaminated_mechanism);
+    validate_plan_ready(&graph).expect("mechanical signal may receive full spawner context");
+}
+
+#[test]
+fn plan_ready_rejects_missing_or_unauthorized_adjudicator_without_queen_fallback() {
+    let mut missing = ReviewTemplate::code_tasks("missing-adjudicator");
+    missing.adjudication = None;
+    let (graph, _) = review_fixture(&missing);
+    assert!(matches!(
+        validate_plan_ready(&graph),
+        Err(PlanReadyError::MissingAdjudicator { .. })
+    ));
+
+    let mut unauthorized = ReviewTemplate::code_tasks("unauthorized-adjudicator");
+    unauthorized
+        .adjudication
+        .as_mut()
+        .expect("default declaration")
+        .adjudicator
+        .as_mut()
+        .expect("default adjudicator")
+        .authority
+        .may_adjudicate = false;
+    let (graph, _) = review_fixture(&unauthorized);
+    assert!(matches!(
+        validate_plan_ready(&graph),
+        Err(PlanReadyError::AdjudicatorLacksAuthority { ref role_id, .. })
+            if role_id == "prince"
+    ));
+}
+
+#[test]
+fn every_disagreement_policy_is_order_independent() {
+    let two = contradictory_verdicts();
+    let three = vec![
+        two[0].clone(),
+        two[1].clone(),
+        SourceVerdict {
+            source_id: "regression".to_string(),
+            verdict: SourceVerdictValue::Pass,
+            rationale: "compatibility remains intact".to_string(),
+        },
+    ];
+    let cases = vec![
+        (
+            adjudication(AdjudicationPolicy::Consensus { required: 2 }),
+            three,
+            AdjudicationResolution::ConsensusPass,
+        ),
+        (
+            adjudication(AdjudicationPolicy::Escalate),
+            two.clone(),
+            AdjudicationResolution::Escalated {
+                role_id: "prince".to_string(),
+            },
+        ),
+        (
+            adjudication(AdjudicationPolicy::HumanGate),
+            two.clone(),
+            AdjudicationResolution::HumanGate,
+        ),
+        (
+            adjudication(AdjudicationPolicy::BothAreFindings),
+            two,
+            AdjudicationResolution::Findings {
+                source_ids: vec!["correctness".to_string(), "security".to_string()],
+            },
+        ),
+    ];
+    for (declaration, verdicts, expected) in cases {
+        let forward = adjudicate_contradiction(&declaration, &verdicts).expect("policy routes");
+        let mut reversed = verdicts.clone();
+        reversed.reverse();
+        let reverse =
+            adjudicate_contradiction(&declaration, &reversed).expect("reverse policy routes");
+        assert_eq!(forward, reverse, "arrival order changed adjudication");
+        assert_eq!(forward.resolution, expected);
+        assert_eq!(forward.source_verdicts.len(), verdicts.len());
+    }
+}
+
+#[test]
+fn contradictory_arrival_order_produces_the_same_runtime_graph() {
+    let template = ReviewTemplate::code_tasks("order-independent");
+    let (mut forward_graph, expansion) = review_fixture(&template);
+    let mut reverse_graph = forward_graph.clone();
+    let verdict_id = &expansion.rounds[0].verdict_id;
+    let declaration = adjudication(AdjudicationPolicy::Escalate);
+    let verdicts = contradictory_verdicts();
+    let (forward, forward_delta) = route_contradictory_verdicts_and_record(
+        "authority-order-forward",
+        &mut forward_graph,
+        verdict_id,
+        &declaration,
+        &verdicts,
+    )
+    .expect("forward contradiction");
+    let mut reversed = verdicts.clone();
+    reversed.reverse();
+    let (reverse, reverse_delta) = route_contradictory_verdicts_and_record(
+        "authority-order-reverse",
+        &mut reverse_graph,
+        verdict_id,
+        &declaration,
+        &reversed,
+    )
+    .expect("reverse contradiction");
+
+    assert_eq!(forward, reverse);
+    assert_eq!(forward_graph, reverse_graph);
+    assert_eq!(
+        forward_delta.expect("forward delta").mutation_type,
+        GraphMutationType::ContradictionAdjudicated
+    );
+    assert_eq!(
+        reverse_delta.expect("reverse delta").mutation_type,
+        GraphMutationType::ContradictionAdjudicated
+    );
+}
+
+#[test]
+fn ordinary_failure_and_contradiction_take_distinct_graph_paths() {
+    let template = ReviewTemplate::code_tasks("distinct-paths");
+    let (mut failure_graph, mut failure_expansion) = review_fixture(&template);
+    let (_, failure_delta) = route_failed_verdict_and_record(
+        "authority-ordinary-failure",
+        &mut failure_graph,
+        &template,
+        &mut failure_expansion,
+    )
+    .expect("ordinary failure routes to remediation");
+    let failure_delta = failure_delta.expect("remediation changes graph");
+    assert_eq!(
+        failure_delta.mutation_type,
+        GraphMutationType::RemediationDetour
+    );
+    assert!(failure_graph.nodes.iter().any(|node| {
+        node.expansion.as_ref().is_some_and(|expansion| {
+            expansion.template == JUDGE_PRINCE_REMEDIATION_TEMPLATE
+        })
+    }));
+
+    let (mut contradiction_graph, contradiction_expansion) = review_fixture(&template);
+    let verdict_id = &contradiction_expansion.rounds[0].verdict_id;
+    let (_, contradiction_delta) = route_contradictory_verdicts_and_record(
+        "authority-contradiction",
+        &mut contradiction_graph,
+        verdict_id,
+        &adjudication(AdjudicationPolicy::HumanGate),
+        &contradictory_verdicts(),
+    )
+    .expect("contradiction routes to adjudication");
+    let contradiction_delta = contradiction_delta.expect("adjudication changes graph");
+    assert_eq!(
+        contradiction_delta.mutation_type,
+        GraphMutationType::ContradictionAdjudicated
+    );
+    assert_ne!(
+        contradiction_delta.mutation_type,
+        failure_delta.mutation_type
+    );
+    assert!(contradiction_graph.nodes.iter().any(|node| {
+        node.expansion
+            .as_ref()
+            .is_some_and(|expansion| expansion.template == "review-adjudication")
+    }));
+    assert!(!contradiction_graph.nodes.iter().any(|node| {
+        node.expansion.as_ref().is_some_and(|expansion| {
+            expansion.template == JUDGE_PRINCE_REMEDIATION_TEMPLATE
+        })
+    }));
+    assert_eq!(
+        contradiction_graph
+            .nodes
+            .iter()
+            .find(|node| node.id == verdict_id.as_str())
+            .expect("aggregate verdict retained")
+            .status,
+        NodeStatus::Blocked
+    );
+}
+
+#[test]
+fn source_verdicts_and_separate_adjudication_survive_real_archive_round_trip() {
+    let temp = TempDir::new().expect("temporary archive root");
+    let session_id = "authority-contradiction-archive";
+    let storage = SessionStorage::new_with_base(temp.path().to_path_buf()).expect("storage");
+    let session_dir = storage.create_session_dir(session_id).expect("session dir");
+    let manager = StateManager::new(session_dir);
+    let template = ReviewTemplate::code_tasks("archive-policy");
+    let (mut graph, expansion) = review_fixture(&template);
+    manager
+        .write_work_graph(&graph)
+        .expect("persist pre-adjudication plan graph");
+    let verdict_id = &expansion.rounds[0].verdict_id;
+    route_contradictory_verdicts_and_record(
+        session_id,
+        &mut graph,
+        verdict_id,
+        &adjudication(AdjudicationPolicy::BothAreFindings),
+        &contradictory_verdicts(),
+    )
+    .expect("record contradiction");
+
+    let completion =
+        archive_completed_session(temp.path(), None, session_id).expect("archive session");
+    let reread = read_archive(&completion.path).expect("read persisted archive");
+    assert_eq!(reread, completion.archive);
+    assert_eq!(
+        reread.deltas[0].mutation_type,
+        GraphMutationType::ContradictionAdjudicated
+    );
+    let source_nodes = reread
+        .runtime_graph
+        .nodes
+        .iter()
+        .filter(|node| {
+            node.expansion
+                .as_ref()
+                .is_some_and(|expansion| expansion.template == "source-review-verdict")
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(source_nodes.len(), 2, "archive collapsed a source verdict");
+    assert!(source_nodes.iter().any(|node| node.status == NodeStatus::Completed));
+    assert!(source_nodes.iter().any(|node| node.status == NodeStatus::Failed));
+    let adjudication_node = reread
+        .runtime_graph
+        .nodes
+        .iter()
+        .find(|node| {
+            node.expansion
+                .as_ref()
+                .is_some_and(|expansion| expansion.template == "review-adjudication")
+        })
+        .expect("archive retains separate adjudication");
+    let metadata = &adjudication_node
+        .expansion
+        .as_ref()
+        .expect("adjudication metadata")
+        .parameters;
+    assert!(metadata["policy"].contains("both_are_findings"));
+    assert!(metadata["adjudicator"].contains("prince"));
+    assert!(metadata["resolution"].contains("findings"));
+    assert!(metadata["source_verdicts"].contains("correctness"));
+    assert!(metadata["source_verdicts"].contains("security"));
+}

--- a/src-tauri/src/http/tests_wg_queue.rs
+++ b/src-tauri/src/http/tests_wg_queue.rs
@@ -17,6 +17,7 @@ use crate::coordination::{InjectionManager, StateManager};
 use crate::domain::event::{EventType, Severity};
 use crate::domain::HiveExecutionPolicy;
 use crate::events::EventBus;
+use crate::http::handlers::heartbeats::PostHeartbeatRequest;
 use crate::http::handlers::workers::AddWorkerRequest;
 use crate::http::routes::create_router;
 use crate::http::state::AppState;
@@ -75,6 +76,7 @@ fn queue_row(
         no_progress_count: 0,
         last_status: None,
         heartbeat_at: None,
+        assignment_id: 0,
         blocked_reason: None,
         created_at,
         updated_at: created_at,
@@ -899,6 +901,202 @@ fn distinct_tasks_cannot_concurrently_claim_the_same_worker_slot() {
     );
 }
 
+#[test]
+fn assignment_ids_advance_across_claim_rebind_and_release_paths() {
+    let repo = queue_repo();
+    repo.enqueue(&queued_row("run-a", "pending:run-a", Some("A"), 1))
+        .unwrap();
+
+    let epoch_1 = repo
+        .try_claim_for_worker("run-a", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    let claim_1 = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(claim_1 > 0, "a won claim must mint an assignment identity");
+
+    assert!(repo.requeue_claimed("run-a", epoch_1, 10).unwrap());
+    let released = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(
+        released > claim_1,
+        "a fenced release must invalidate the prior assignment even in the same millisecond"
+    );
+
+    let epoch_2 = repo
+        .try_claim_for_worker("run-a", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    let claim_2 = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(
+        claim_2 > released,
+        "a rebind must mint a new identity without relying on wall-clock ordering"
+    );
+
+    assert!(repo.fail_claimed("run-a", epoch_2, 10).unwrap());
+    let failed = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(failed > claim_2, "terminal claim failure invalidates its identity");
+    assert!(repo.release_claim_manual("run-a", 10).unwrap());
+    let manual_release = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(manual_release > failed, "manual recovery mints a new identity");
+
+    repo.try_claim_for_worker("run-a", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    let before_reclaim = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert_eq!(
+        repo.reclaim_stuck(11, 10).unwrap(),
+        vec!["run-a".to_string()]
+    );
+    let reclaimed = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(reclaimed > before_reclaim, "stale reclaim invalidates the assignment");
+
+    let epoch_4 = repo
+        .try_claim_for_worker("run-a", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    let before_spawn_release = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(matches!(
+        repo.release_failed_spawn("run-a", epoch_4, "worker-1", 3, 10)
+            .unwrap(),
+        crate::storage::queue::SpawnFailureRelease::Requeued { .. }
+    ));
+    assert!(
+        repo.get_row("run-a").unwrap().unwrap().assignment_id > before_spawn_release,
+        "failed-spawn release must fence the abandoned assignment"
+    );
+
+    repo.try_claim_for_worker("run-a", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    let before_resume_requeue = repo.get_row("run-a").unwrap().unwrap().assignment_id;
+    assert!(repo.requeue_running("run-a", 10).unwrap());
+    assert!(
+        repo.get_row("run-a").unwrap().unwrap().assignment_id > before_resume_requeue,
+        "resume reconciliation must invalidate the orphaned assignment"
+    );
+}
+
+#[test]
+fn heartbeat_updates_only_the_current_finalized_assignment_for_a_reused_slot() {
+    let repo = queue_repo();
+    repo.enqueue(&queued_row("zz-old", "pending:zz-old", Some("OLD"), 1))
+        .unwrap();
+    repo.try_claim_for_worker("zz-old", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    repo.record_heartbeat(SESSION_ID, "worker-1", "completed", 20)
+        .unwrap();
+
+    repo.enqueue(&queued_row("aa-current", "pending:aa-current", Some("CURRENT"), 2))
+        .unwrap();
+    repo.try_claim_for_worker("aa-current", Some("worker-1"), -90_000, 30)
+        .unwrap()
+        .unwrap();
+    repo.record_heartbeat(SESSION_ID, "worker-1", "completed", 40)
+        .unwrap();
+
+    let old_before = repo.get_row("zz-old").unwrap().unwrap();
+    let current_before = repo.get_row("aa-current").unwrap().unwrap();
+    assert!(current_before.assignment_id > old_before.assignment_id);
+    assert_eq!(
+        repo.record_heartbeat_for_assignment(SESSION_ID, "worker-1", None, "working", 999)
+            .unwrap(),
+        Some("aa-current".to_string()),
+        "the legacy fallback must resolve the greatest durable assignment, not row order"
+    );
+
+    let old_after = repo.get_row("zz-old").unwrap().unwrap();
+    let current_after = repo.get_row("aa-current").unwrap().unwrap();
+    assert_eq!(
+        (old_after.heartbeat_at, old_after.updated_at),
+        (old_before.heartbeat_at, old_before.updated_at),
+        "the sibling's historical liveness bytes must remain unchanged"
+    );
+    assert_eq!((current_after.heartbeat_at, current_after.updated_at), (Some(999), 999));
+
+    let impossible_assignment = current_after.assignment_id + 100;
+    assert_eq!(
+        repo.record_heartbeat_for_assignment(
+            SESSION_ID,
+            "worker-1",
+            Some(impossible_assignment),
+            "working",
+            1_111,
+        )
+        .unwrap(),
+        None,
+        "an explicit stale identity must not cascade into the fallback"
+    );
+    assert_eq!(repo.get_row("zz-old").unwrap().unwrap(), old_after);
+    assert_eq!(repo.get_row("aa-current").unwrap().unwrap(), current_after);
+}
+
+#[test]
+fn heartbeat_body_keeps_assignment_identity_optional_for_legacy_prompts() {
+    let legacy: PostHeartbeatRequest = serde_json::from_value(json!({
+        "agent_id": "worker-1",
+        "status": "working"
+    }))
+    .unwrap();
+    assert_eq!(legacy.assignment_id, None);
+
+    let scoped: PostHeartbeatRequest = serde_json::from_value(json!({
+        "agent_id": "worker-1",
+        "status": "working",
+        "assignment_id": 42
+    }))
+    .unwrap();
+    assert_eq!(scoped.assignment_id, Some(42));
+}
+
+#[tokio::test]
+async fn worker_finalized_event_uses_the_current_assignment_row_under_slot_reuse() {
+    let temp = tempfile::tempdir().unwrap();
+    let repo = Arc::new(queue_repo());
+    repo.enqueue(&queued_row("old-run", "pending:old-run", Some("old-task"), 1))
+        .unwrap();
+    repo.try_claim_for_worker("old-run", Some("worker-1"), -90_000, 10)
+        .unwrap()
+        .unwrap();
+    repo.record_heartbeat(SESSION_ID, "worker-1", "completed", 20)
+        .unwrap();
+    let old_assignment = repo.get_row("old-run").unwrap().unwrap().assignment_id;
+
+    repo.enqueue(&queued_row("current-run", "pending:current-run", Some("current-task"), 2))
+        .unwrap();
+    repo.try_claim_for_worker("current-run", Some("worker-1"), -90_000, 30)
+        .unwrap()
+        .unwrap();
+    let current_assignment = repo
+        .get_row("current-run")
+        .unwrap()
+        .unwrap()
+        .assignment_id;
+    assert!(current_assignment > old_assignment);
+
+    let event_bus = EventBus::new(temp.path().to_path_buf());
+    let mut events = event_bus.subscribe();
+    let manager = QueueManager::new(Arc::clone(&repo), event_bus);
+    assert!(manager
+        .record_heartbeat(SESSION_ID, "worker-1", "completed")
+        .await
+        .unwrap());
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), events.recv())
+        .await
+        .expect("completion heartbeat must emit WorkerFinalized promptly")
+        .unwrap();
+    assert_eq!(event.event_type, EventType::WorkerFinalized);
+    assert_eq!(event.payload["task_id"], "current-task");
+    assert_eq!(
+        repo.get_row("current-run").unwrap().unwrap().status,
+        QueueStatus::Finalized
+    );
+    assert_eq!(
+        repo.get_row("old-run").unwrap().unwrap().status,
+        QueueStatus::Finalized
+    );
+}
+
 #[tokio::test]
 async fn recovery_prioritizes_live_claim_over_older_terminal_slot_history() {
     let temp = tempfile::tempdir().unwrap();
@@ -1182,20 +1380,31 @@ async fn post_heartbeat(
     agent_id: &str,
     status: &str,
 ) -> axum::response::Response {
+    post_heartbeat_with_assignment(app, session_id, agent_id, status, None).await
+}
+
+async fn post_heartbeat_with_assignment(
+    app: &axum::Router,
+    session_id: &str,
+    agent_id: &str,
+    status: &str,
+    assignment_id: Option<i64>,
+) -> axum::response::Response {
+    let mut payload = json!({
+        "agent_id": agent_id,
+        "status": status,
+        "summary": format!("HTTP {status} heartbeat")
+    });
+    if let Some(assignment_id) = assignment_id {
+        payload["assignment_id"] = json!(assignment_id);
+    }
     app.clone()
         .oneshot(
             Request::builder()
                 .method("POST")
                 .uri(format!("/api/sessions/{session_id}/heartbeat"))
                 .header("content-type", "application/json")
-                .body(Body::from(
-                    serde_json::to_vec(&json!({
-                        "agent_id": agent_id,
-                        "status": status,
-                        "summary": format!("HTTP {status} heartbeat")
-                    }))
-                    .unwrap(),
-                ))
+                .body(Body::from(serde_json::to_vec(&payload).unwrap()))
                 .unwrap(),
         )
         .await
@@ -1260,6 +1469,8 @@ async fn http_reassignment_refreshes_finalized_liveness_and_restores_stall_cover
         parent_id: Some(queen_id.clone()),
         commit_sha: None,
         base_commit_sha: None,
+        role_definition_id: None,
+        role_definition_version: None,
     });
     controller.read().insert_test_session(session);
     state
@@ -1351,9 +1562,15 @@ async fn http_reassignment_refreshes_finalized_liveness_and_restores_stall_cover
     );
 
     assert_eq!(
-        post_heartbeat(&app, session_id, "worker-1", "working")
-            .await
-            .status(),
+        post_heartbeat_with_assignment(
+            &app,
+            session_id,
+            "worker-1",
+            "working",
+            Some(completed_row.assignment_id),
+        )
+        .await
+        .status(),
         StatusCode::OK
     );
     let refreshed_row = state

--- a/src-tauri/src/http/tests_wg_roles.rs
+++ b/src-tauri/src/http/tests_wg_roles.rs
@@ -1,0 +1,547 @@
+//! Org-graph role schema and resolution tests for issues #229-#231.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use chrono::Utc;
+use parking_lot::RwLock;
+
+use crate::cli::{CliBehavior, CliRegistry};
+use crate::domain::{HiveExecutionPolicy, WorkspaceStrategy};
+use crate::orchestrator::org_graph::composition::{
+    compose_context, lint_role_knowledge_hubs, render_composed_context, ContextBudget,
+    spawn_context_from_work_graph_task, ContextOrigin, SpawnContext,
+};
+use crate::orchestrator::org_graph::definitions::{
+    resolve_role_definition, ResolvedRoleDefinition, RoleDefinitionSource,
+    RoleResolutionIssueKind,
+};
+use crate::orchestrator::org_graph::{
+    evaluator_role_definition, AuthorityScope, KnowledgeRef, KnowledgeSource, RoleDefinition,
+};
+use crate::orchestrator::work_graph::{
+    BindingRef, CompositeExpansion, EdgeKind, EdgeProvenance, NodeContract, NodeKind,
+    NodeStatus, TaskGraph, WorkEdge, WorkNode,
+};
+use crate::pty::{AgentConfig, PtyManager, WorkerRole};
+use crate::session::{
+    AuthStrategy, Session, SessionController, SessionState, SessionType,
+    DEFAULT_MAX_QA_ITERATIONS,
+};
+use crate::templates::CellTemplate;
+
+#[test]
+fn a11_cell_template_semantics_serde_round_trip() {
+    let template = CellTemplate {
+        role: "reviewer".to_string(),
+        cli: "claude".to_string(),
+        model: Some("opus".to_string()),
+        prompt_template: "roles/reviewer".to_string(),
+        knowledge_scope: vec![KnowledgeRef {
+            source: KnowledgeSource::Project,
+            pointer: "patterns/testing-strategy.md".to_string(),
+            summary: Some("Mutation proofs must fail at the production seam.".to_string()),
+            priority: 100,
+        }],
+        lens: Some("test-quality".to_string()),
+        authority: AuthorityScope {
+            may_spawn_subordinates: true,
+            may_adjudicate: true,
+            ..AuthorityScope::default()
+        },
+        behavior: Some(CliBehavior::InstructionFollowing),
+    };
+
+    let encoded = serde_json::to_string(&template).expect("serialize CellTemplate");
+    let decoded: CellTemplate =
+        serde_json::from_str(&encoded).expect("deserialize CellTemplate");
+
+    assert_eq!(decoded, template);
+    assert_eq!(decoded.knowledge_scope[0].priority, 100);
+    assert!(decoded.authority.may_adjudicate);
+    assert_eq!(decoded.behavior, Some(CliBehavior::InstructionFollowing));
+    assert!(encoded.contains(r#""knowledge_scope""#));
+    assert!(encoded.contains(r#""lens":"test-quality""#));
+    assert!(encoded.contains(r#""authority""#));
+    assert!(encoded.contains(r#""behavior":"instruction_following""#));
+
+    let legacy: CellTemplate = serde_json::from_str(
+        r#"{"role":"backend","cli":"codex","model":null,"prompt_template":"roles/backend"}"#,
+    )
+    .expect("deserialize pre-T1 CellTemplate");
+    assert!(legacy.knowledge_scope.is_empty());
+    assert!(legacy.lens.is_none());
+    assert_eq!(legacy.authority, AuthorityScope::default());
+    assert!(legacy.behavior.is_none());
+}
+
+#[test]
+fn a12_evaluator_behavior_comes_from_declared_definition() {
+    let evaluator = evaluator_role_definition();
+
+    assert_eq!(
+        CliRegistry::get_behavior_for_role("claude", Some(&evaluator)),
+        CliBehavior::InstructionFollowing
+    );
+    assert_eq!(evaluator.behavior, Some(CliBehavior::InstructionFollowing));
+
+    let project = tempfile::tempdir().expect("temp project");
+    let resolved = resolve_role_definition(project.path(), None, "evaluator");
+    let prompt = SessionController::build_worker_prompt(
+        1,
+        &AgentConfig {
+            cli: "claude".to_string(),
+            role: Some(WorkerRole::new("evaluator", "Evaluator", "claude")),
+            ..AgentConfig::default()
+        },
+        &resolved,
+        &crate::orchestrator::org_graph::composition::SpawnContext::default(),
+        "session-role-queen",
+        "session-role",
+        project.path(),
+        project.path(),
+        &HiveExecutionPolicy::default(),
+    );
+    assert!(
+        prompt.contains("Read and follow the complete task file."),
+        "the declared evaluator profile must reach emitted spawn instructions"
+    );
+
+    let registry_source = include_str!("../cli/registry.rs");
+    assert!(
+        !registry_source.contains(r#"Some("evaluator") =>"#),
+        "the evaluator must not reappear as a CLI registry match arm"
+    );
+}
+
+#[test]
+fn a13_empty_definition_preserves_spawn_prompt_bytes() {
+    let empty = RoleDefinition::empty("backend");
+    let empty_report = resolved_for_test(empty.clone());
+    let absent_report = ResolvedRoleDefinition {
+        requested_id: "backend".to_string(),
+        definition: None,
+        base_source: None,
+        applied_override: None,
+        issues: Vec::new(),
+    };
+    let project = tempfile::tempdir().expect("temp project");
+
+    assert!(empty.knowledge_scope.is_empty());
+    assert!(empty.lens.is_none());
+    assert!(empty.behavior.is_none());
+
+    for cli in ["claude", "qwen", "codex", "droid", "unknown-cli"] {
+        assert_eq!(
+            CliRegistry::get_behavior_for_role(cli, Some(&empty)),
+            CliRegistry::get_behavior(cli),
+            "an empty definition must inherit {cli}'s existing capability behavior"
+        );
+        assert_eq!(
+            SessionController::polling_instructions_for_definition(
+                cli,
+                "worker-1-task.md",
+                Some(&empty),
+            ),
+            SessionController::polling_instructions_for_definition(
+                cli,
+                "worker-1-task.md",
+                None,
+            ),
+            "an empty definition changed the emitted spawn prompt for {cli}"
+        );
+        let config = AgentConfig {
+            cli: cli.to_string(),
+            role: Some(WorkerRole::new("backend", "Backend", cli)),
+            ..AgentConfig::default()
+        };
+        let build = |resolved| {
+            SessionController::build_worker_prompt(
+                1,
+                &config,
+                resolved,
+                &SpawnContext::default(),
+                "byte-parity-queen",
+                "byte-parity",
+                project.path(),
+                project.path(),
+                &HiveExecutionPolicy::default(),
+            )
+        };
+        assert_eq!(
+            build(&empty_report),
+            build(&absent_report),
+            "an empty definition changed the full emitted spawn prompt for {cli}"
+        );
+    }
+}
+
+fn role_test_session(id: &str, project_path: PathBuf) -> Session {
+    let shared_workspace = project_path.to_string_lossy().to_string();
+    Session {
+        id: id.to_string(),
+        name: None,
+        color: None,
+        session_type: SessionType::Hive { worker_count: 0 },
+        project_path,
+        state: SessionState::Running,
+        created_at: Utc::now(),
+        last_activity_at: Utc::now(),
+        agents: Vec::new(),
+        default_cli: "claude".to_string(),
+        default_model: None,
+        default_principal_cli: None,
+        default_principal_model: None,
+        default_principal_flags: Vec::new(),
+        execution_policy: HiveExecutionPolicy {
+            workspace_strategy: WorkspaceStrategy::SharedCell,
+            ..HiveExecutionPolicy::default()
+        },
+        qa_workers: Vec::new(),
+        max_qa_iterations: DEFAULT_MAX_QA_ITERATIONS,
+        qa_timeout_secs: 300,
+        auth_strategy: AuthStrategy::default(),
+        worktree_path: Some(shared_workspace),
+        worktree_branch: Some(format!("hive/{id}/primary")),
+        no_git: false,
+        resume_report: None,
+    }
+}
+
+#[test]
+fn a14_reviewer_spawn_records_resolved_definition_and_version() {
+    let project = tempfile::tempdir().expect("temp project");
+    let session_id = "role-reviewer-spawn";
+    let controller = SessionController::new(Arc::new(RwLock::new(PtyManager::new())));
+    controller.insert_test_session(role_test_session(
+        session_id,
+        project.path().to_path_buf(),
+    ));
+
+    let agent = controller
+        .add_worker(
+            session_id,
+            AgentConfig::default(),
+            WorkerRole::new("reviewer", "Reviewer", "claude"),
+            None,
+            None,
+        )
+        .expect("spawn reviewer from embedded definition");
+
+    assert_eq!(agent.role_definition_id.as_deref(), Some("reviewer"));
+    assert_eq!(agent.role_definition_version, Some(1));
+    let role_identity = agent
+        .config
+        .role
+        .as_ref()
+        .and_then(|role| role.resolved_definition.as_ref())
+        .expect("worker position must carry its separate semantic identity");
+    assert_eq!(role_identity.id, "reviewer");
+    assert_eq!(role_identity.version, 1);
+
+    let stored = controller
+        .get_session(session_id)
+        .expect("stored session")
+        .agents
+        .into_iter()
+        .find(|candidate| candidate.id == agent.id)
+        .expect("stored reviewer agent");
+    assert_eq!(stored.role_definition_id, agent.role_definition_id);
+    assert_eq!(stored.role_definition_version, agent.role_definition_version);
+    let persisted = SessionController::persisted_snapshot_for_test(
+        &controller.get_session(session_id).expect("session to archive"),
+    );
+    let archived_agent = persisted
+        .agents
+        .iter()
+        .find(|candidate| candidate.id == agent.id)
+        .expect("persisted reviewer agent");
+    assert_eq!(archived_agent.role_definition_id.as_deref(), Some("reviewer"));
+    assert_eq!(archived_agent.role_definition_version, Some(1));
+}
+
+#[test]
+fn a15_project_path_override_wins_without_mutating_institutional_definition() {
+    let project = tempfile::tempdir().expect("temp project");
+    let institutional = tempfile::tempdir().expect("temp institutional wiki");
+    std::fs::create_dir_all(project.path().join(".ai-docs/roles"))
+        .expect("create project role directory");
+    std::fs::create_dir_all(institutional.path().join("roles"))
+        .expect("create institutional role directory");
+
+    let institutional_definition = r#"---
+{"id":"reviewer","version":3,"domain":"Institutional review","knowledge_scope":[{"source":"institutional","pointer":"review/base.md","summary":"Institutional base guidance.","priority":50}],"lens":{"id":"base","question":"What does the shared standard require?"},"authority":{},"context_boundary":"artifact","signal_class":"judgmental","prompt_template":"roles/reviewer","non_goals":[]}
+---
+# Institutional reviewer
+"#;
+    let institutional_path = institutional.path().join("roles/reviewer.md");
+    std::fs::write(&institutional_path, institutional_definition)
+        .expect("write institutional definition");
+    let institutional_before = std::fs::read(&institutional_path).expect("read base bytes");
+
+    let override_path = project.path().join(".ai-docs/roles/reviewer.md");
+    std::fs::write(
+        &override_path,
+        r#"---
+{"id":"reviewer","version":7,"knowledge_scope":[{"source":"project","pointer":"repo-only/review-contract.md","summary":"This repository's independent review contract.","priority":100}]}
+---
+# Project reviewer override
+"#,
+    )
+    .expect("write project override");
+
+    assert_ne!(
+        std::env::current_dir().expect("current directory"),
+        project.path(),
+        "fixture must fail if the resolver consults CWD"
+    );
+    let resolved = resolve_role_definition(
+        project.path(),
+        Some(institutional.path()),
+        "reviewer",
+    );
+    let definition = resolved.definition.expect("resolved reviewer");
+
+    assert_eq!(resolved.base_source, Some(RoleDefinitionSource::Institutional));
+    assert_eq!(
+        resolved.applied_override.as_deref().map(PathBuf::from),
+        Some(override_path.clone())
+    );
+    assert_eq!(definition.version, 7);
+    assert_eq!(definition.domain.as_deref(), Some("Institutional review"));
+    assert_eq!(definition.knowledge_scope.len(), 1);
+    assert_eq!(
+        definition.knowledge_scope[0].pointer,
+        "repo-only/review-contract.md"
+    );
+    assert_eq!(
+        std::fs::read(&institutional_path).expect("re-read base bytes"),
+        institutional_before,
+        "Tier 1 resolution must never rewrite the institutional definition"
+    );
+}
+
+#[test]
+fn a16_prompt_templates_are_explicit_and_absence_is_reported() {
+    for (site, source) in [
+        ("workers", include_str!("handlers/workers.rs")),
+        ("planners", include_str!("handlers/planners.rs")),
+        ("coordination state", include_str!("../coordination/state.rs")),
+    ] {
+        assert!(
+            !source.contains("prompt_template: None"),
+            "{site} still passes an implicit missing role definition"
+        );
+        assert!(
+            source.contains("role_prompt_template"),
+            "{site} does not declare which role template it intends to resolve"
+        );
+    }
+
+    let project = tempfile::tempdir().expect("temp project");
+    std::fs::create_dir_all(project.path().join(".ai-docs/roles"))
+        .expect("create known-empty project role directory");
+    let missing = resolve_role_definition(project.path(), None, "not-a-declared-role");
+    assert!(
+        missing.definition.is_none(),
+        "an unknown role must not resolve to RoleDefinition::empty"
+    );
+    assert!(missing.issues.iter().any(|issue| {
+        issue.kind == RoleResolutionIssueKind::DefinitionNotFound
+            && issue.source_ref == "not-a-declared-role"
+    }));
+}
+
+#[test]
+fn a17_overlapping_role_and_task_source_is_loaded_once_in_spawn_prompt() {
+    let reference = KnowledgeRef {
+        source: KnowledgeSource::Project,
+        pointer: "shared/review-contract.md".to_string(),
+        summary: Some("Apply the repository review contract.".to_string()),
+        priority: 90,
+    };
+    let mut role = RoleDefinition::empty("reviewer");
+    role.version = 1;
+    role.knowledge_scope.push(reference.clone());
+    let resolved = resolved_for_test(role);
+    let task = WorkNode::new(
+        "T17",
+        NodeKind::Task,
+        "Review the implementation",
+        NodeContract::default(),
+        BindingRef::Role("reviewer".to_string()),
+        NodeStatus::Ready,
+    );
+    let mut context_node = WorkNode::new(
+        "context:T17",
+        NodeKind::Context,
+        "Apply the repository review contract.",
+        NodeContract::default(),
+        BindingRef::Zone("knowledge".to_string()),
+        NodeStatus::Completed,
+    );
+    context_node.expansion = Some(CompositeExpansion {
+        template: "derived-project-context".to_string(),
+        parameters: BTreeMap::from([
+            (
+                "source_ref".to_string(),
+                reference.pointer.clone(),
+            ),
+            (
+                "summary".to_string(),
+                reference.summary.clone().expect("reference summary"),
+            ),
+            ("priority".to_string(), "90".to_string()),
+        ]),
+    });
+    let graph = TaskGraph::new(
+        vec![task, context_node],
+        vec![WorkEdge::new(
+            "context:T17",
+            "T17",
+            EdgeKind::Informs,
+            EdgeProvenance::Knowledge,
+        )],
+    );
+    let spawn = spawn_context_from_work_graph_task(&graph, "T17");
+    assert_eq!(spawn.task_scope, vec![reference]);
+    let project = tempfile::tempdir().expect("temp project");
+    let prompt = SessionController::build_worker_prompt(
+        1,
+        &AgentConfig {
+            cli: "claude".to_string(),
+            role: Some(WorkerRole::new("reviewer", "Reviewer", "claude")),
+            ..AgentConfig::default()
+        },
+        &resolved,
+        &spawn,
+        "composition-queen",
+        "composition-session",
+        project.path(),
+        project.path(),
+        &HiveExecutionPolicy::default(),
+    );
+
+    assert_eq!(
+        prompt.matches("project:shared/review-contract.md").count(),
+        1,
+        "the composed spawn prompt must emit an overlapping reference once"
+    );
+    assert!(prompt.contains("[role+task]"));
+}
+
+#[test]
+fn a18_conflicting_role_and_task_guidance_is_rendered() {
+    let mut role = RoleDefinition::empty("reviewer");
+    role.version = 1;
+    role.knowledge_scope.push(KnowledgeRef {
+        source: KnowledgeSource::Project,
+        pointer: "shared/review-contract.md".to_string(),
+        summary: Some("Require independent evidence before approval.".to_string()),
+        priority: 90,
+    });
+    let spawn = SpawnContext {
+        task_scope: vec![KnowledgeRef {
+            source: KnowledgeSource::Project,
+            pointer: "shared/review-contract.md".to_string(),
+            summary: Some("Approve once the implementation compiles.".to_string()),
+            priority: 80,
+        }],
+        ..SpawnContext::default()
+    };
+    let composed = compose_context(Some(&role), &spawn);
+    assert_eq!(composed.conflicts.len(), 1);
+    let rendered = render_composed_context(&composed);
+
+    assert!(rendered.contains("Context Conflicts"));
+    assert!(rendered.contains("shared/review-contract.md"));
+    assert!(rendered.contains("Require independent evidence before approval."));
+    assert!(rendered.contains("Approve once the implementation compiles."));
+}
+
+#[test]
+fn a19_budget_overflow_drops_by_priority_and_names_every_drop() {
+    let mut role = RoleDefinition::empty("reviewer");
+    role.knowledge_scope = vec![
+        KnowledgeRef {
+            source: KnowledgeSource::Project,
+            pointer: "high.md".to_string(),
+            summary: Some("highest".to_string()),
+            priority: 100,
+        },
+        KnowledgeRef {
+            source: KnowledgeSource::Project,
+            pointer: "low.md".to_string(),
+            summary: Some("low".to_string()),
+            priority: 1,
+        },
+    ];
+    let spawn = SpawnContext {
+        budget: ContextBudget {
+            role_chars: 60,
+            ..ContextBudget::default()
+        },
+        ..SpawnContext::default()
+    };
+    let composed = compose_context(Some(&role), &spawn);
+
+    assert_eq!(composed.knowledge.len(), 1);
+    assert_eq!(composed.knowledge[0].reference.pointer, "high.md");
+    assert_eq!(composed.knowledge[0].origin, ContextOrigin::Role);
+    assert!(composed
+        .dropped
+        .iter()
+        .any(|dropped| dropped.pointer == "low.md"));
+    let rendered = render_composed_context(&composed);
+    let knowledge_section = rendered
+        .split("### Dropped Context")
+        .next()
+        .expect("knowledge section");
+    assert!(!knowledge_section.contains("low.md"));
+    assert!(rendered.contains("`low.md` [role]: role context budget exceeded"));
+}
+
+#[test]
+fn a20_anti_hub_lint_flags_whole_tree_scope() {
+    let mut reviewer = RoleDefinition::empty("reviewer");
+    reviewer.knowledge_scope.push(KnowledgeRef {
+        source: KnowledgeSource::Project,
+        pointer: "*".to_string(),
+        summary: None,
+        priority: 0,
+    });
+    let tester = RoleDefinition::empty("tester");
+
+    let lints = lint_role_knowledge_hubs(&[reviewer, tester]);
+    assert_eq!(lints.len(), 1);
+    assert_eq!(lints[0].role_id, "reviewer");
+    assert_eq!(lints[0].affected_role_ids, vec!["reviewer", "tester"]);
+    assert_eq!(lints[0].role_fraction, 1.0);
+}
+
+#[test]
+fn a20_anti_hub_lint_allows_one_shared_page() {
+    let shared_reference = KnowledgeRef {
+        source: KnowledgeSource::Institutional,
+        pointer: "standards/review.md".to_string(),
+        summary: None,
+        priority: 0,
+    };
+    let mut reviewer = RoleDefinition::empty("reviewer");
+    reviewer.knowledge_scope.push(shared_reference.clone());
+    let mut tester = RoleDefinition::empty("tester");
+    tester.knowledge_scope.push(shared_reference);
+
+    assert!(lint_role_knowledge_hubs(&[reviewer, tester]).is_empty());
+}
+
+fn resolved_for_test(definition: RoleDefinition) -> ResolvedRoleDefinition {
+    ResolvedRoleDefinition {
+        requested_id: definition.id.clone(),
+        definition: Some(definition),
+        base_source: Some(RoleDefinitionSource::EmbeddedDefault),
+        applied_override: None,
+        issues: Vec::new(),
+    }
+}

--- a/src-tauri/src/http/tests_wg_roles.rs
+++ b/src-tauri/src/http/tests_wg_roles.rs
@@ -6,9 +6,19 @@ use std::sync::Arc;
 
 use chrono::Utc;
 use parking_lot::RwLock;
+use tower::ServiceExt;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
 
 use crate::cli::{CliBehavior, CliRegistry};
+use crate::coordination::{HierarchyNode, InjectionManager, QueueManager, StateManager};
 use crate::domain::{HiveExecutionPolicy, WorkspaceStrategy};
+use crate::events::EventBus;
+use crate::http::routes::create_router;
+use crate::http::state::AppState;
 use crate::orchestrator::org_graph::composition::{
     compose_context, lint_role_knowledge_hubs, render_composed_context, ContextBudget,
     spawn_context_from_work_graph_task, ContextOrigin, SpawnContext,
@@ -29,6 +39,7 @@ use crate::session::{
     AuthStrategy, Session, SessionController, SessionState, SessionType,
     DEFAULT_MAX_QA_ITERATIONS,
 };
+use crate::storage::{ApplicationStateDb, QueueRepo, SessionStorage};
 use crate::templates::CellTemplate;
 
 #[test]
@@ -209,6 +220,47 @@ fn role_test_session(id: &str, project_path: PathBuf) -> Session {
     }
 }
 
+fn role_test_app(
+    base_dir: PathBuf,
+) -> (
+    axum::Router,
+    Arc<RwLock<SessionController>>,
+    Arc<SessionStorage>,
+) {
+    let storage = Arc::new(
+        SessionStorage::new_with_base(base_dir.clone()).expect("create isolated session storage"),
+    );
+    let config = Arc::new(tokio::sync::RwLock::new(
+        storage.load_config().expect("load isolated config"),
+    ));
+    let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
+    let controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
+    controller.write().set_storage(storage.clone());
+    let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
+        pty_manager.clone(),
+        SessionStorage::new_with_base(base_dir).expect("create injection storage"),
+    )));
+    let event_bus = EventBus::new(storage.base_dir().clone());
+    let app_state_db =
+        Arc::new(ApplicationStateDb::open(storage.base_dir()).expect("open queue database"));
+    let queue_repo = Arc::new(QueueRepo::new(app_state_db.clone()));
+    queue_repo.ensure_schema().expect("create queue schema");
+    let queue_manager = Arc::new(QueueManager::new(queue_repo, event_bus.clone()));
+    let state = Arc::new(AppState::new(
+        config,
+        pty_manager,
+        controller.clone(),
+        injection_manager,
+        storage.clone(),
+        event_bus,
+        app_state_db,
+        queue_manager,
+        None,
+    ));
+
+    (create_router(state), controller, storage)
+}
+
 #[test]
 fn a14_reviewer_spawn_records_resolved_definition_and_version() {
     let project = tempfile::tempdir().expect("temp project");
@@ -323,7 +375,214 @@ fn a15_project_path_override_wins_without_mutating_institutional_definition() {
 }
 
 #[test]
-fn a16_prompt_templates_are_explicit_and_absence_is_reported() {
+fn a33_semantically_invalid_project_override_retains_valid_base() {
+    let project = tempfile::tempdir().expect("temp project");
+    let institutional = tempfile::tempdir().expect("temp institutional wiki");
+    std::fs::create_dir_all(project.path().join(".ai-docs/roles"))
+        .expect("create project role directory");
+    std::fs::create_dir_all(institutional.path().join("roles"))
+        .expect("create institutional role directory");
+
+    std::fs::write(
+        institutional.path().join("roles/reviewer.md"),
+        r#"---
+{"id":"reviewer","version":3,"domain":"Institutional review","knowledge_scope":[{"source":"institutional","pointer":"review/base.md","summary":"Institutional base guidance.","priority":50}],"lens":{"id":"base","question":"What does the shared standard require?"},"authority":{},"context_boundary":"artifact","signal_class":"judgmental","prompt_template":"roles/reviewer","non_goals":[]}
+---
+# Institutional reviewer
+"#,
+    )
+    .expect("write institutional definition");
+    let override_path = project.path().join(".ai-docs/roles/reviewer.md");
+    std::fs::write(
+        &override_path,
+        r#"---
+{"id":"tester","version":9,"knowledge_scope":[{"source":"project","pointer":"wrong/review.md","summary":"Must not replace the reviewer base.","priority":100}]}
+---
+# Invalid reviewer override
+"#,
+    )
+    .expect("write semantically invalid project override");
+
+    let resolved = resolve_role_definition(
+        project.path(),
+        Some(institutional.path()),
+        "reviewer",
+    );
+    let definition = resolved
+        .definition
+        .as_ref()
+        .expect("a rejected override must retain the valid base definition");
+
+    assert_eq!(resolved.base_source, Some(RoleDefinitionSource::Institutional));
+    assert_eq!(definition.id, "reviewer");
+    assert_eq!(definition.version, 3);
+    assert_eq!(definition.knowledge_scope[0].pointer, "review/base.md");
+    assert!(
+        resolved.applied_override.is_none(),
+        "a rejected override must not be recorded as applied"
+    );
+    assert!(resolved.issues.iter().any(|issue| {
+        issue.kind == RoleResolutionIssueKind::SourceUnreadable
+            && PathBuf::from(&issue.source_ref) == override_path
+            && issue.detail.contains("declares role tester, expected reviewer")
+    }));
+    assert!(
+        !resolved
+            .issues
+            .iter()
+            .any(|issue| issue.kind == RoleResolutionIssueKind::DefinitionNotFound),
+        "rejecting a project override must not manufacture base-definition absence"
+    );
+}
+
+#[tokio::test]
+async fn a16_role_construction_paths_produce_explicit_template_keys() {
+    let fixture = tempfile::tempdir().expect("temp role-construction fixture");
+    let (app, controller, storage) = role_test_app(fixture.path().join("storage"));
+
+    let worker_session_id = "role-template-worker";
+    let worker_session =
+        role_test_session(worker_session_id, fixture.path().join("worker-project"));
+    std::fs::create_dir_all(&worker_session.project_path).expect("create worker project");
+    controller.write().insert_test_session(worker_session);
+
+    let worker_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{worker_session_id}/workers"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"role_type":"reviewer","cli":"claude"}"#))
+                .expect("worker request"),
+        )
+        .await
+        .expect("worker response");
+    let worker_status = worker_response.status();
+    let worker_body = axum::body::to_bytes(worker_response.into_body(), usize::MAX)
+        .await
+        .expect("read worker response body");
+    assert_eq!(
+        worker_status,
+        StatusCode::CREATED,
+        "unexpected worker response: {}",
+        String::from_utf8_lossy(&worker_body)
+    );
+    let worker = controller
+        .read()
+        .get_session(worker_session_id)
+        .expect("worker session")
+        .agents
+        .into_iter()
+        .find(|agent| matches!(agent.role, crate::pty::AgentRole::Worker { .. }))
+        .expect("spawned worker");
+    assert_eq!(
+        worker
+            .config
+            .role
+            .as_ref()
+            .and_then(|role| role.prompt_template.as_deref()),
+        Some("roles/reviewer"),
+        "the worker HTTP construction path must carry its explicit template key"
+    );
+
+    let planner_session_id = "role-template-planner";
+    let mut planner_session =
+        role_test_session(planner_session_id, fixture.path().join("planner-project"));
+    planner_session.session_type = SessionType::Swarm { planner_count: 1 };
+    planner_session.no_git = true;
+    std::fs::create_dir_all(&planner_session.project_path).expect("create planner project");
+    let planner_project = planner_session.project_path.clone();
+    controller.write().insert_test_session(planner_session);
+
+    let planner_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/sessions/{planner_session_id}/planners"))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"domain":"backend","cli":"claude","workers":[{"role_type":"backend","label":"Backend","cli":"claude"}]}"#,
+                ))
+                .expect("planner request"),
+        )
+        .await
+        .expect("planner response");
+    let planner_status = planner_response.status();
+    let planner_body = axum::body::to_bytes(planner_response.into_body(), usize::MAX)
+        .await
+        .expect("read planner response body");
+    assert_eq!(
+        planner_status,
+        StatusCode::CREATED,
+        "unexpected planner response: {}",
+        String::from_utf8_lossy(&planner_body)
+    );
+    let planner_workers: Vec<AgentConfig> = serde_json::from_slice(
+        &std::fs::read(
+            planner_project
+                .join(".hive-manager")
+                .join(planner_session_id)
+                .join("planner-1-workers.json"),
+        )
+        .expect("read planner worker roster"),
+    )
+    .expect("decode planner worker roster");
+    assert_eq!(
+        planner_workers[0]
+            .role
+            .as_ref()
+            .and_then(|role| role.prompt_template.as_deref()),
+        Some("roles/backend"),
+        "the planner HTTP construction path must carry its explicit worker template key"
+    );
+
+    let state_manager = StateManager::new(storage.session_dir("role-template-coordination"));
+    state_manager
+        .update_workers_file(&[])
+        .expect("create coordination worker roster marker");
+    state_manager
+        .update_hierarchy(&[HierarchyNode {
+            id: "coordination-reviewer".to_string(),
+            role: "Reviewer".to_string(),
+            parent_id: Some("coordination-queen".to_string()),
+            children: Vec::new(),
+        }])
+        .expect("write hierarchy fixture");
+    let coordination_workers = state_manager
+        .read_workers_file()
+        .expect("read coordination roster");
+    assert_eq!(
+        coordination_workers
+            .first()
+            .expect("constructed coordination worker")
+            .role
+            .prompt_template
+            .as_deref(),
+        Some("roles/reviewer"),
+        "the coordination roster construction path must carry its explicit template key"
+    );
+}
+
+#[test]
+fn a16_absent_definition_is_reported() {
+    let project = tempfile::tempdir().expect("temp project");
+    std::fs::create_dir_all(project.path().join(".ai-docs/roles"))
+        .expect("create known-empty project role directory");
+    let missing = resolve_role_definition(project.path(), None, "not-a-declared-role");
+    assert!(
+        missing.definition.is_none(),
+        "an unknown role must not resolve to RoleDefinition::empty"
+    );
+    assert!(missing.issues.iter().any(|issue| {
+        issue.kind == RoleResolutionIssueKind::DefinitionNotFound
+            && issue.source_ref == "not-a-declared-role"
+    }));
+}
+
+#[test]
+fn a16_secondary_source_guards_reject_implicit_template_literals() {
     for (site, source) in [
         ("workers", include_str!("handlers/workers.rs")),
         ("planners", include_str!("handlers/planners.rs")),
@@ -338,19 +597,6 @@ fn a16_prompt_templates_are_explicit_and_absence_is_reported() {
             "{site} does not declare which role template it intends to resolve"
         );
     }
-
-    let project = tempfile::tempdir().expect("temp project");
-    std::fs::create_dir_all(project.path().join(".ai-docs/roles"))
-        .expect("create known-empty project role directory");
-    let missing = resolve_role_definition(project.path(), None, "not-a-declared-role");
-    assert!(
-        missing.definition.is_none(),
-        "an unknown role must not resolve to RoleDefinition::empty"
-    );
-    assert!(missing.issues.iter().any(|issue| {
-        issue.kind == RoleResolutionIssueKind::DefinitionNotFound
-            && issue.source_ref == "not-a-declared-role"
-    }));
 }
 
 #[test]

--- a/src-tauri/src/http/tests_wg_verifier.rs
+++ b/src-tauri/src/http/tests_wg_verifier.rs
@@ -1,0 +1,591 @@
+//! Verifier-property HTTP integration tests are owned by P6.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use chrono::{TimeZone, Utc};
+use tempfile::TempDir;
+
+use crate::domain::run_journal::Confidence;
+use crate::domain::HiveExecutionPolicy;
+use crate::orchestrator::org_graph::{
+    adjudication::{
+        AdjudicationDeclaration, AdjudicationPolicy, DeclaredAdjudicator,
+        VerificationDuty,
+    },
+    boundary::{
+        context_boundary_satisfies, includes_artifact_context,
+        includes_spawner_conversation, required_context_boundary,
+        verification_duty_declares_signal_class, verification_duty_has_named_signal,
+    },
+    composition::{ConversationContext, SpawnContext},
+    definitions::resolve_role_definition,
+    ContextBoundary, SignalClass,
+};
+use crate::orchestrator::work_graph::archive::{
+    ArchiveSourceKind, ArchiveSourceReport, WorkGraphArchive,
+    WORK_GRAPH_ARCHIVE_SCHEMA_VERSION,
+};
+use crate::orchestrator::work_graph::divergence::DivergenceSummary;
+use crate::orchestrator::work_graph::retro::{
+    evaluate_archives_with_role_attributions, propose_role_definition_refinements,
+    AgentRoleDefinitionAttribution, IndependentEvaluator, RetroRunInput,
+    RoleDefinitionKey, RoleDefinitionRefinementObservation, RoleRefinementSignal,
+    ScopeImpact, UNREVIEWED_OUTCOME,
+};
+use crate::orchestrator::work_graph::runtime::{
+    RuntimeEffect, RuntimeOutcome, RuntimeOutcomeStatus,
+};
+use crate::orchestrator::work_graph::review::{
+    ADJUDICATION_DECLARATION_PARAMETER, MULTI_LENS_REVIEW_TEMPLATE,
+    VERIFICATION_DUTY_PARAMETER,
+};
+use crate::orchestrator::work_graph::validate::{
+    validate_plan_ready, PlanReadyError,
+};
+use crate::orchestrator::work_graph::{
+    BindingRef, CompositeExpansion, NodeContract, NodeKind, NodeStatus,
+    TaskGraph, WorkNode,
+};
+use crate::pty::{AgentConfig, WorkerRole};
+use crate::session::SessionController;
+
+const TASK_SENTINEL: &str = "TASK_SENTINEL_VERIFIER_OBJECTIVE";
+const COMPOSER_SENTINEL: &str = "COMPOSER_SENTINEL_RENDERED_TASK_CONTEXT";
+const ARTIFACT_SENTINEL: &str = "ARTIFACT_SENTINEL_INHERITED_CONTEXT";
+const SPAWNER_CONVERSATION_POISON: &str =
+    "SPAWNER_CONVERSATION_POISON_EXPECT_PRIOR_VERDICT";
+
+#[test]
+fn signal_class_derives_the_least_isolated_permitted_boundary() {
+    assert_eq!(
+        required_context_boundary(SignalClass::Mechanical),
+        ContextBoundary::Full
+    );
+    assert_eq!(
+        required_context_boundary(SignalClass::Judgmental),
+        ContextBoundary::Artifact
+    );
+}
+
+#[test]
+fn judgmental_signals_reject_full_context_while_mechanical_signals_allow_it() {
+    assert!(context_boundary_satisfies(
+        SignalClass::Judgmental,
+        ContextBoundary::None
+    ));
+    assert!(context_boundary_satisfies(
+        SignalClass::Judgmental,
+        ContextBoundary::Artifact
+    ));
+    assert!(!context_boundary_satisfies(
+        SignalClass::Judgmental,
+        ContextBoundary::Full
+    ));
+
+    for boundary in [
+        ContextBoundary::None,
+        ContextBoundary::Artifact,
+        ContextBoundary::Full,
+    ] {
+        assert!(context_boundary_satisfies(
+            SignalClass::Mechanical,
+            boundary
+        ));
+    }
+}
+
+#[test]
+fn verification_duties_require_a_named_signal_and_declared_class() {
+    assert!(!verification_duty_has_named_signal(None));
+    assert!(!verification_duty_has_named_signal(Some("")));
+    assert!(!verification_duty_has_named_signal(Some(" \t\r\n")));
+    assert!(verification_duty_has_named_signal(Some("cargo-test")));
+
+    assert!(!verification_duty_declares_signal_class(None));
+    assert!(verification_duty_declares_signal_class(Some(
+        SignalClass::Mechanical
+    )));
+    assert!(verification_duty_declares_signal_class(Some(
+        SignalClass::Judgmental
+    )));
+}
+
+#[test]
+fn context_inclusion_matches_each_declared_boundary() {
+    assert!(!includes_artifact_context(ContextBoundary::None));
+    assert!(!includes_spawner_conversation(ContextBoundary::None));
+
+    assert!(includes_artifact_context(ContextBoundary::Artifact));
+    assert!(!includes_spawner_conversation(ContextBoundary::Artifact));
+
+    assert!(includes_artifact_context(ContextBoundary::Full));
+    assert!(includes_spawner_conversation(ContextBoundary::Full));
+}
+
+fn verification_plan(duty: VerificationDuty) -> TaskGraph {
+    let mut review = WorkNode::new(
+        "review-verdict",
+        NodeKind::Join,
+        "Review verdict",
+        NodeContract::default(),
+        BindingRef::Role("evaluator".to_string()),
+        NodeStatus::Pending,
+    );
+    review.expansion = Some(CompositeExpansion {
+        template: MULTI_LENS_REVIEW_TEMPLATE.to_string(),
+        parameters: BTreeMap::from([
+            (
+                VERIFICATION_DUTY_PARAMETER.to_string(),
+                serde_json::to_string(&duty).expect("verification duty fixture"),
+            ),
+            (
+                ADJUDICATION_DECLARATION_PARAMETER.to_string(),
+                serde_json::to_string(&AdjudicationDeclaration {
+                    policy: AdjudicationPolicy::HumanGate,
+                    adjudicator: Some(DeclaredAdjudicator::new("evaluator")),
+                })
+                .expect("adjudication fixture"),
+            ),
+        ]),
+    });
+    TaskGraph::new(vec![review], Vec::new())
+}
+
+fn composed_verifier_prompt(boundary: ContextBoundary) -> String {
+    let project = TempDir::new().expect("verifier prompt project");
+    let mut resolved = resolve_role_definition(project.path(), None, "evaluator");
+    resolved
+        .definition
+        .as_mut()
+        .expect("embedded evaluator definition")
+        .context_boundary = boundary;
+    let config = AgentConfig {
+        initial_prompt: Some(TASK_SENTINEL.to_string()),
+        role: Some(WorkerRole::new("evaluator", "Evaluator", "claude")),
+        ..AgentConfig::default()
+    };
+    let spawn_context = SpawnContext {
+        task_summary: Some(COMPOSER_SENTINEL.to_string()),
+        conversation: ConversationContext {
+            artifact_summary: Some(ARTIFACT_SENTINEL.to_string()),
+            spawner_conversation: Some(SPAWNER_CONVERSATION_POISON.to_string()),
+        },
+        ..SpawnContext::default()
+    };
+
+    SessionController::build_worker_prompt(
+        1,
+        &config,
+        &resolved,
+        &spawn_context,
+        "verifier-queen",
+        "verifier-session",
+        project.path(),
+        project.path(),
+        &HiveExecutionPolicy::default(),
+    )
+}
+
+#[test]
+fn a24_none_boundary_removes_inherited_context_from_the_composed_prompt() {
+    let prompt = composed_verifier_prompt(ContextBoundary::None);
+
+    assert!(prompt.contains(TASK_SENTINEL));
+    assert!(prompt.contains("## Composed Role and Task Context"));
+    assert!(prompt.contains(COMPOSER_SENTINEL));
+    assert!(!prompt.contains(ARTIFACT_SENTINEL));
+    assert!(!prompt.contains(SPAWNER_CONVERSATION_POISON));
+    assert!(!prompt.contains("### Artifact Context"));
+    assert!(!prompt.contains("### Spawner Conversation"));
+}
+
+#[test]
+fn a25_judgmental_full_context_fails_with_required_artifact() {
+    let error = validate_plan_ready(&verification_plan(VerificationDuty {
+        signal_name: Some("architecture-review".to_string()),
+        signal_class: Some(SignalClass::Judgmental),
+        context_boundary: ContextBoundary::Full,
+    }))
+    .expect_err("judgmental verification must reject full inherited context");
+
+    assert_eq!(
+        error,
+        PlanReadyError::InsufficientVerificationIsolation {
+            review_id: "review-verdict".to_string(),
+            signal_class: SignalClass::Judgmental,
+            actual: ContextBoundary::Full,
+            required: ContextBoundary::Artifact,
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        "PlanReady rejected: review review-verdict uses Full context for Judgmental signal; requires Artifact or stronger isolation"
+    );
+}
+
+#[test]
+fn a25_blank_verification_signal_fails_separately() {
+    let error = validate_plan_ready(&verification_plan(VerificationDuty {
+        signal_name: Some(" \t\r\n".to_string()),
+        signal_class: Some(SignalClass::Judgmental),
+        context_boundary: ContextBoundary::None,
+    }))
+    .expect_err("verification duties require a real named signal");
+
+    assert_eq!(
+        error,
+        PlanReadyError::MissingVerificationSignal {
+            review_id: "review-verdict".to_string(),
+        }
+    );
+    assert_eq!(
+        error.to_string(),
+        "PlanReady rejected: review review-verdict has no named verification signal"
+    );
+}
+
+#[test]
+fn a26_mechanical_full_context_validates_and_keeps_spawner_conversation() {
+    let validation = validate_plan_ready(&verification_plan(VerificationDuty {
+        signal_name: Some("cargo-test".to_string()),
+        signal_class: Some(SignalClass::Mechanical),
+        context_boundary: ContextBoundary::Full,
+    }))
+    .expect("mechanical verification deliberately permits full inherited context");
+    assert!(validation.warnings.is_empty());
+
+    let prompt = composed_verifier_prompt(ContextBoundary::Full);
+    assert!(prompt.contains(TASK_SENTINEL));
+    assert!(prompt.contains(COMPOSER_SENTINEL));
+    assert!(prompt.contains(ARTIFACT_SENTINEL));
+    assert!(prompt.contains(SPAWNER_CONVERSATION_POISON));
+    assert!(prompt.contains("### Spawner Conversation"));
+}
+
+fn verifier_evaluator() -> IndependentEvaluator {
+    IndependentEvaluator::new(
+        "independent-role-retro",
+        vec!["planner".to_string()],
+        vec!["supervisor".to_string()],
+    )
+    .expect("the evaluator is independent")
+}
+
+fn verifier_sources() -> Vec<ArchiveSourceReport> {
+    [
+        ArchiveSourceKind::PlanGraph,
+        ArchiveSourceKind::EventLog,
+        ArchiveSourceKind::RunJournal,
+        ArchiveSourceKind::RunLedger,
+        ArchiveSourceKind::MutationLog,
+    ]
+    .into_iter()
+    .map(|kind| ArchiveSourceReport {
+        kind,
+        location: format!("fixture/{kind:?}"),
+        available: true,
+        record_count: 1,
+        omissions: Vec::new(),
+    })
+    .collect()
+}
+
+fn role_archive(
+    archive_id: &str,
+    session_id: &str,
+    agent_id: &str,
+    attempts: usize,
+    scope_gap: bool,
+) -> WorkGraphArchive {
+    let graph = TaskGraph::new(
+        vec![WorkNode::new(
+            "verification-task",
+            NodeKind::Task,
+            "Verification task",
+            NodeContract::default(),
+            BindingRef::Role("evaluator".to_string()),
+            NodeStatus::Completed,
+        )],
+        Vec::new(),
+    );
+    let timestamp = Utc
+        .timestamp_opt(1_900_000_000 + attempts as i64, 0)
+        .single()
+        .expect("fixture timestamp");
+    let effects = scope_gap
+        .then(|| RuntimeEffect {
+            kind: "role_scope_gap".to_string(),
+            reference: Some("verification-task".to_string()),
+            confirmed: true,
+            confidence: Confidence::High,
+            source_ref: format!("ledger:{archive_id}:scope-gap"),
+        })
+        .into_iter()
+        .collect();
+    WorkGraphArchive {
+        schema_version: WORK_GRAPH_ARCHIVE_SCHEMA_VERSION,
+        archive_id: archive_id.to_string(),
+        session_id: session_id.to_string(),
+        archived_at: timestamp,
+        plan_graph: Some(graph.clone()),
+        runtime_graph: graph,
+        deltas: Vec::new(),
+        outcomes: vec![RuntimeOutcome {
+            subject_id: "verification-task".to_string(),
+            task_id: Some("verification-task".to_string()),
+            agent_ids: vec![agent_id.to_string()],
+            status: RuntimeOutcomeStatus::Completed,
+            started_at: Some(timestamp),
+            finished_at: Some(timestamp),
+            attempt_count: attempts,
+            effects,
+            source_refs: vec![format!("event:{archive_id}")],
+        }],
+        divergence: DivergenceSummary::default(),
+        sources: verifier_sources(),
+    }
+}
+
+fn role_input(
+    repo_id: &str,
+    archive_id: &str,
+    session_id: &str,
+    agent_id: &str,
+    attempts: usize,
+    scope_gap: bool,
+) -> RetroRunInput {
+    RetroRunInput {
+        repo_id: repo_id.to_string(),
+        archive: role_archive(
+            archive_id,
+            session_id,
+            agent_id,
+            attempts,
+            scope_gap,
+        ),
+    }
+}
+
+fn role_attribution(
+    session_id: &str,
+    agent_id: &str,
+    definition_version: u32,
+) -> AgentRoleDefinitionAttribution {
+    AgentRoleDefinitionAttribution {
+        session_id: session_id.to_string(),
+        agent_id: agent_id.to_string(),
+        definition: RoleDefinitionKey {
+            definition_id: "evaluator".to_string(),
+            definition_version,
+        },
+    }
+}
+
+fn git_output(repo: &Path, args: &[&str]) -> String {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .output()
+        .expect("git is available to the repository test suite");
+    assert!(
+        output.status.success(),
+        "git {:?} failed: {}",
+        args,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn a30_retro_attribution_separates_versions_of_the_same_role_definition() {
+    let inputs = [
+        role_input("repo-a", "archive-v1", "session-v1", "agent-v1", 2, false),
+        role_input("repo-a", "archive-v2", "session-v2", "agent-v2", 2, false),
+    ];
+    let attributions = [
+        role_attribution("session-v1", "agent-v1", 1),
+        role_attribution("session-v2", "agent-v2", 2),
+    ];
+
+    let report = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &inputs,
+        &attributions,
+    )
+    .expect("role-attributed retro");
+
+    assert_eq!(report.role_definition_aggregates.len(), 2);
+    assert_eq!(
+        report
+            .role_definition_aggregates
+            .iter()
+            .map(|aggregate| aggregate.definition.definition_version)
+            .collect::<Vec<_>>(),
+        vec![1, 2]
+    );
+    assert!(report
+        .role_definition_aggregates
+        .iter()
+        .all(|aggregate| aggregate.run_count == 1));
+    assert!(report.role_refinement_proposals.is_empty());
+}
+
+#[test]
+fn a31_role_refinement_is_unreviewed_and_does_not_apply_or_commit() {
+    let temp = TempDir::new().expect("definition canary root");
+    let definition_path = temp.path().join("roles").join("evaluator.md");
+    fs::create_dir_all(definition_path.parent().unwrap()).expect("roles directory");
+    fs::write(&definition_path, "definition-canary").expect("definition canary");
+    git_output(temp.path(), &["init"]);
+    git_output(temp.path(), &["config", "user.email", "retro@example.invalid"]);
+    git_output(temp.path(), &["config", "user.name", "Retro Fixture"]);
+    git_output(temp.path(), &["add", "."]);
+    git_output(temp.path(), &["commit", "-m", "definition canary"]);
+    let head_before = git_output(temp.path(), &["rev-parse", "HEAD"]);
+    let inputs = [
+        role_input("repo-a", "archive-a", "session-a", "agent-a", 2, false),
+        role_input("repo-a", "archive-b", "session-b", "agent-b", 2, false),
+    ];
+    let attributions = [
+        role_attribution("session-a", "agent-a", 7),
+        role_attribution("session-b", "agent-b", 7),
+    ];
+
+    let report = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &inputs,
+        &attributions,
+    )
+    .expect("role refinement retro");
+
+    assert_eq!(report.role_refinement_proposals.len(), 1);
+    let proposal = &report.role_refinement_proposals[0];
+    assert_eq!(proposal.definition.definition_id, "evaluator");
+    assert_eq!(proposal.definition.definition_version, 7);
+    assert_eq!(proposal.observation_count, 2);
+    assert_eq!(proposal.repo_ids, vec!["repo-a"]);
+    let learning = report
+        .learning_submissions
+        .iter()
+        .find(|learning| learning.keywords.iter().any(|item| item == "evaluator@7"))
+        .expect("role proposal uses the existing learning submission channel");
+    assert_eq!(learning.outcome, UNREVIEWED_OUTCOME);
+    assert!(learning.files_touched.is_empty());
+
+    let guard_observations = ["guard-a", "guard-b"].map(|id| {
+        RoleDefinitionRefinementObservation {
+            repo_id: temp.path().display().to_string(),
+            session_id: format!("session-{id}"),
+            archive_id: format!("archive-{id}"),
+            definition: RoleDefinitionKey {
+                definition_id: "evaluator".to_string(),
+                definition_version: 7,
+            },
+            signal: RoleRefinementSignal::AdditionalAttempts,
+            evidence_refs: vec![definition_path.display().to_string()],
+        }
+    });
+    assert_eq!(
+        propose_role_definition_refinements(&guard_observations).len(),
+        1
+    );
+    assert_eq!(
+        fs::read_to_string(&definition_path).unwrap(),
+        "definition-canary"
+    );
+    assert_eq!(git_output(temp.path(), &["rev-parse", "HEAD"]), head_before);
+    assert!(git_output(temp.path(), &["status", "--porcelain"]).is_empty());
+}
+
+#[test]
+fn a32_institutional_promotion_uses_distinct_repos_not_observation_count() {
+    let same_repo_inputs = [
+        role_input("repo-a", "archive-1", "session-1", "agent-1", 2, false),
+        role_input("repo-a", "archive-2", "session-2", "agent-2", 2, false),
+        role_input("repo-a", "archive-3", "session-3", "agent-3", 2, false),
+    ];
+    let same_repo_attributions = [
+        role_attribution("session-1", "agent-1", 3),
+        role_attribution("session-2", "agent-2", 3),
+        role_attribution("session-3", "agent-3", 3),
+    ];
+    let same_repo = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &same_repo_inputs,
+        &same_repo_attributions,
+    )
+    .expect("same-repo retro");
+    assert_eq!(
+        same_repo.role_refinement_proposals[0].tier,
+        crate::orchestrator::work_graph::archetypes::PromotionTier::ProjectOverride
+    );
+
+    let multi_repo_inputs = [
+        role_input("repo-a", "archive-x", "session-x", "agent-x", 2, false),
+        role_input("repo-b", "archive-y", "session-y", "agent-y", 2, false),
+    ];
+    let multi_repo_attributions = [
+        role_attribution("session-x", "agent-x", 3),
+        role_attribution("session-y", "agent-y", 3),
+    ];
+    let multi_repo = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &multi_repo_inputs,
+        &multi_repo_attributions,
+    )
+    .expect("multi-repo retro");
+    assert_eq!(
+        multi_repo.role_refinement_proposals[0].tier,
+        crate::orchestrator::work_graph::archetypes::PromotionTier::InstitutionalRevision
+    );
+    assert_eq!(multi_repo.role_refinement_proposals[0].repo_ids.len(), 2);
+}
+
+#[test]
+fn widening_and_narrowing_role_refinements_are_flagged_distinctly() {
+    let definition = RoleDefinitionKey {
+        definition_id: "evaluator".to_string(),
+        definition_version: 9,
+    };
+    let widening_inputs = [
+        role_input("repo-a", "scope-a", "scope-session-a", "scope-agent-a", 1, true),
+        role_input("repo-a", "scope-b", "scope-session-b", "scope-agent-b", 1, true),
+    ];
+    let widening_attributions = [
+        role_attribution("scope-session-a", "scope-agent-a", 9),
+        role_attribution("scope-session-b", "scope-agent-b", 9),
+    ];
+    let widening = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &widening_inputs,
+        &widening_attributions,
+    )
+    .expect("scope-gap retro");
+    assert!(widening.role_refinement_proposals.iter().any(|proposal| {
+        proposal.change_key == "declared_scope_gap"
+            && proposal.scope_impact == ScopeImpact::Widening
+            && proposal.rationale.contains("suspect by default")
+    }));
+
+    let observations = ["review-a", "review-b"]
+    .into_iter()
+    .map(|id| RoleDefinitionRefinementObservation {
+        repo_id: "repo-a".to_string(),
+        session_id: format!("session-{id}"),
+        archive_id: format!("archive-{id}"),
+        definition: definition.clone(),
+        signal: RoleRefinementSignal::ReviewEscapes,
+        evidence_refs: vec![format!("evidence:{id}")],
+    })
+    .collect::<Vec<_>>();
+
+    let proposals = propose_role_definition_refinements(&observations);
+    assert_eq!(proposals.len(), 1);
+    assert!(proposals.iter().any(|proposal| {
+        proposal.change_key == "review_escapes"
+            && proposal.scope_impact == ScopeImpact::Narrowing
+    }));
+}

--- a/src-tauri/src/http/tests_wg_verifier.rs
+++ b/src-tauri/src/http/tests_wg_verifier.rs
@@ -385,7 +385,13 @@ fn role_attribution(
 }
 
 fn git_output(repo: &Path, args: &[&str]) -> String {
+    let empty_hooks = repo.join(".hive-manager-test-empty-hooks");
+    fs::create_dir_all(&empty_hooks).expect("empty repository-local hooks directory");
     let output = Command::new("git")
+        .arg("-c")
+        .arg("commit.gpgSign=false")
+        .arg("-c")
+        .arg(format!("core.hooksPath={}", empty_hooks.to_string_lossy()))
         .args(args)
         .current_dir(repo)
         .output()
@@ -397,6 +403,38 @@ fn git_output(repo: &Path, args: &[&str]) -> String {
         String::from_utf8_lossy(&output.stderr)
     );
     String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+#[test]
+fn review_6_git_fixture_ignores_hostile_signing_and_hooks() {
+    let temp = TempDir::new().expect("hostile git fixture root");
+    git_output(temp.path(), &["init"]);
+    git_output(temp.path(), &["config", "user.email", "retro@example.invalid"]);
+    git_output(temp.path(), &["config", "user.name", "Retro Fixture"]);
+
+    let hostile_hooks = temp.path().join("hostile-hooks");
+    fs::create_dir_all(&hostile_hooks).expect("hostile hooks directory");
+    fs::write(
+        hostile_hooks.join("pre-commit"),
+        "#!/bin/sh\necho hostile-hook >&2\nexit 73\n",
+    )
+    .expect("hostile pre-commit hook");
+    let hostile_hooks = hostile_hooks.to_string_lossy().to_string();
+    git_output(temp.path(), &["config", "commit.gpgSign", "true"]);
+    git_output(
+        temp.path(),
+        &["config", "core.hooksPath", &hostile_hooks],
+    );
+
+    fs::write(temp.path().join("fixture.txt"), "hermetic fixture")
+        .expect("fixture content");
+    git_output(temp.path(), &["add", "fixture.txt"]);
+    git_output(temp.path(), &["commit", "-m", "hermetic fixture"]);
+
+    assert_eq!(
+        git_output(temp.path(), &["log", "-1", "--pretty=%s"]),
+        "hermetic fixture"
+    );
 }
 
 #[test]
@@ -431,6 +469,128 @@ fn a30_retro_attribution_separates_versions_of_the_same_role_definition() {
         .iter()
         .all(|aggregate| aggregate.run_count == 1));
     assert!(report.role_refinement_proposals.is_empty());
+}
+
+#[test]
+fn review_6_scope_gaps_count_once_per_definition_and_preserve_contributors() {
+    let mut shared = role_input(
+        "repo-a",
+        "archive-shared",
+        "session-shared",
+        "agent-a",
+        1,
+        true,
+    );
+    shared.archive.outcomes[0]
+        .agent_ids
+        .push("agent-b".to_string());
+    let shared_report = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &[shared],
+        &[
+            role_attribution("session-shared", "agent-a", 11),
+            role_attribution("session-shared", "agent-b", 11),
+        ],
+    )
+    .expect("shared-definition scope-gap retro");
+
+    let shared_metric = &shared_report.runs[0].role_definitions[0];
+    assert_eq!(shared_metric.confirmed_scope_gaps, 1);
+    assert_eq!(shared_metric.agent_ids, vec!["agent-a", "agent-b"]);
+    assert!(shared_metric
+        .evidence_refs
+        .iter()
+        .any(|reference| reference == "event:archive-shared"));
+    assert!(shared_metric
+        .evidence_refs
+        .iter()
+        .any(|reference| reference == "ledger:archive-shared:scope-gap"));
+    assert!(shared_report.role_refinement_proposals.is_empty());
+
+    let mut distinct = role_input(
+        "repo-a",
+        "archive-distinct",
+        "session-distinct",
+        "agent-c",
+        1,
+        true,
+    );
+    distinct.archive.outcomes[0]
+        .agent_ids
+        .push("agent-d".to_string());
+    let distinct_report = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &[distinct],
+        &[
+            role_attribution("session-distinct", "agent-c", 21),
+            role_attribution("session-distinct", "agent-d", 22),
+        ],
+    )
+    .expect("distinct-definition scope-gap retro");
+    assert_eq!(
+        distinct_report.runs[0]
+            .role_definitions
+            .iter()
+            .map(|metric| (
+                metric.definition.definition_version,
+                metric.confirmed_scope_gaps,
+            ))
+            .collect::<Vec<_>>(),
+        vec![(21, 1), (22, 1)]
+    );
+}
+
+#[test]
+fn review_6_optional_totals_serialize_their_contributing_run_counts() {
+    let complete = role_input(
+        "repo-a",
+        "archive-complete",
+        "session-complete",
+        "agent-complete",
+        2,
+        false,
+    );
+    let mut unavailable = role_input(
+        "repo-a",
+        "archive-unavailable",
+        "session-unavailable",
+        "agent-unavailable",
+        2,
+        false,
+    );
+    unavailable.archive.plan_graph = None;
+    for source in &mut unavailable.archive.sources {
+        if matches!(
+            source.kind,
+            ArchiveSourceKind::EventLog | ArchiveSourceKind::MutationLog
+        ) {
+            source.available = false;
+            source.record_count = 0;
+        }
+    }
+    let report = evaluate_archives_with_role_attributions(
+        &verifier_evaluator(),
+        &[complete, unavailable],
+        &[
+            role_attribution("session-complete", "agent-complete", 31),
+            role_attribution("session-unavailable", "agent-unavailable", 31),
+        ],
+    )
+    .expect("partially available role aggregates");
+
+    let aggregate = &report.role_definition_aggregates[0];
+    assert_eq!(aggregate.run_count, 2);
+    let serialized = serde_json::to_value(aggregate).expect("serialized role aggregate");
+    for field in [
+        "additional_attempts_contributing_runs",
+        "remediation_detours_contributing_runs",
+        "caught_defects_contributing_runs",
+        "escaped_defects_contributing_runs",
+        "gotcha_edges_eligible_contributing_runs",
+        "gotcha_targets_attempted_contributing_runs",
+    ] {
+        assert_eq!(serialized[field], serde_json::json!(1), "{field}");
+    }
 }
 
 #[test]

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -4,6 +4,7 @@
 //! specialized submodules for better maintainability and testability.
 
 pub mod fusion;
+pub mod org_graph;
 pub mod planner;
 pub mod resolver;
 pub mod session_orchestrator;

--- a/src-tauri/src/orchestrator/org_graph/adjudication.rs
+++ b/src-tauri/src/orchestrator/org_graph/adjudication.rs
@@ -1,0 +1,225 @@
+//! Order-independent disagreement policies for review subgraphs.
+
+use std::collections::BTreeSet;
+use std::error::Error;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use super::{AuthorityScope, ContextBoundary, SignalClass};
+
+/// Verification is a named signal with an explicit judgment class and context
+/// boundary. Role defaults must not silently fill any of these plan-time facts.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationDuty {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_class: Option<SignalClass>,
+    pub context_boundary: ContextBoundary,
+}
+
+impl Default for VerificationDuty {
+    fn default() -> Self {
+        Self {
+            signal_name: None,
+            signal_class: None,
+            context_boundary: ContextBoundary::Full,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AdjudicationPolicy {
+    Consensus { required: usize },
+    Escalate,
+    HumanGate,
+    BothAreFindings,
+}
+
+/// The role named by a review subgraph, including the authority declaration
+/// that permits it to adjudicate. An absent role is never replaced by Queen.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeclaredAdjudicator {
+    pub role_id: String,
+    pub authority: AuthorityScope,
+}
+
+impl DeclaredAdjudicator {
+    pub fn new(role_id: impl Into<String>) -> Self {
+        Self {
+            role_id: role_id.into(),
+            authority: AuthorityScope {
+                may_adjudicate: true,
+                ..AuthorityScope::default()
+            },
+        }
+    }
+}
+
+/// Policy plus the role that holds the decision authority for one review
+/// subgraph. `adjudicator` remains optional so PlanReady can report absence.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdjudicationDeclaration {
+    pub policy: AdjudicationPolicy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adjudicator: Option<DeclaredAdjudicator>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceVerdictValue {
+    Pass,
+    Fail,
+}
+
+/// An immutable source verdict. Every one is retained alongside, not replaced
+/// by, the separate adjudication record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceVerdict {
+    pub source_id: String,
+    pub verdict: SourceVerdictValue,
+    pub rationale: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AdjudicationResolution {
+    ConsensusPass,
+    ConsensusFail,
+    ConsensusUnresolved {
+        required: usize,
+        pass_count: usize,
+        fail_count: usize,
+    },
+    Escalated { role_id: String },
+    HumanGate,
+    Findings { source_ids: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdjudicationRecord {
+    pub policy: AdjudicationPolicy,
+    pub adjudicator: DeclaredAdjudicator,
+    pub source_verdicts: Vec<SourceVerdict>,
+    pub resolution: AdjudicationResolution,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdjudicationError {
+    MissingAdjudicator,
+    AdjudicatorLacksAuthority { role_id: String },
+    TooFewVerdicts,
+    DuplicateSourceVerdict { source_id: String },
+    NoContradiction,
+    InvalidConsensusThreshold { required: usize, verdicts: usize },
+}
+
+impl fmt::Display for AdjudicationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingAdjudicator => write!(formatter, "review disagreement has no adjudicator"),
+            Self::AdjudicatorLacksAuthority { role_id } => write!(
+                formatter,
+                "declared adjudicator role {role_id} lacks adjudication authority"
+            ),
+            Self::TooFewVerdicts => write!(formatter, "disagreement needs at least two verdicts"),
+            Self::DuplicateSourceVerdict { source_id } => {
+                write!(formatter, "duplicate source verdict {source_id}")
+            }
+            Self::NoContradiction => write!(formatter, "verdict set does not contradict"),
+            Self::InvalidConsensusThreshold { required, verdicts } => write!(
+                formatter,
+                "consensus threshold {required} is invalid for {verdicts} verdicts"
+            ),
+        }
+    }
+}
+
+impl Error for AdjudicationError {}
+
+/// Resolve a contradictory verdict set without consulting arrival order.
+pub fn adjudicate_contradiction(
+    declaration: &AdjudicationDeclaration,
+    verdicts: &[SourceVerdict],
+) -> Result<AdjudicationRecord, AdjudicationError> {
+    let adjudicator = declaration
+        .adjudicator
+        .as_ref()
+        .ok_or(AdjudicationError::MissingAdjudicator)?;
+    if adjudicator.role_id.trim().is_empty() || !adjudicator.authority.may_adjudicate {
+        return Err(AdjudicationError::AdjudicatorLacksAuthority {
+            role_id: adjudicator.role_id.clone(),
+        });
+    }
+    if verdicts.len() < 2 {
+        return Err(AdjudicationError::TooFewVerdicts);
+    }
+
+    let mut source_ids = BTreeSet::new();
+    for verdict in verdicts {
+        if !source_ids.insert(verdict.source_id.as_str()) {
+            return Err(AdjudicationError::DuplicateSourceVerdict {
+                source_id: verdict.source_id.clone(),
+            });
+        }
+    }
+    let pass_count = verdicts
+        .iter()
+        .filter(|verdict| verdict.verdict == SourceVerdictValue::Pass)
+        .count();
+    let fail_count = verdicts.len() - pass_count;
+    if pass_count == 0 || fail_count == 0 {
+        return Err(AdjudicationError::NoContradiction);
+    }
+
+    let resolution = match &declaration.policy {
+        AdjudicationPolicy::Consensus { required } => {
+            if *required == 0 || *required > verdicts.len() {
+                return Err(AdjudicationError::InvalidConsensusThreshold {
+                    required: *required,
+                    verdicts: verdicts.len(),
+                });
+            }
+            match (pass_count >= *required, fail_count >= *required) {
+                (true, false) => AdjudicationResolution::ConsensusPass,
+                (false, true) => AdjudicationResolution::ConsensusFail,
+                // If both sides meet a permissive threshold, contradiction is
+                // not resolved by privileging whichever branch was checked first.
+                (true, true) | (false, false) => AdjudicationResolution::ConsensusUnresolved {
+                    required: *required,
+                    pass_count,
+                    fail_count,
+                },
+            }
+        }
+        AdjudicationPolicy::Escalate => AdjudicationResolution::Escalated {
+            role_id: adjudicator.role_id.clone(),
+        },
+        AdjudicationPolicy::HumanGate => AdjudicationResolution::HumanGate,
+        AdjudicationPolicy::BothAreFindings => AdjudicationResolution::Findings {
+            source_ids: verdicts
+                .iter()
+                .map(|verdict| verdict.source_id.clone())
+                .collect(),
+        },
+    };
+    let mut source_verdicts = verdicts.to_vec();
+    source_verdicts.sort_by(|left, right| left.source_id.cmp(&right.source_id));
+    let resolution = match resolution {
+        AdjudicationResolution::Findings { .. } => AdjudicationResolution::Findings {
+            source_ids: source_verdicts
+                .iter()
+                .map(|verdict| verdict.source_id.clone())
+                .collect(),
+        },
+        other => other,
+    };
+    Ok(AdjudicationRecord {
+        policy: declaration.policy.clone(),
+        adjudicator: adjudicator.clone(),
+        source_verdicts,
+        resolution,
+    })
+}

--- a/src-tauri/src/orchestrator/org_graph/boundary.rs
+++ b/src-tauri/src/orchestrator/org_graph/boundary.rs
@@ -1,0 +1,57 @@
+//! Verification-boundary semantics.
+//!
+//! A [`ContextBoundary`] is the maximum inherited context a verifier may receive.
+//! `None` is therefore the strongest isolation, while `Full` is the weakest.
+
+use super::{ContextBoundary, SignalClass};
+
+/// Return the least-isolated boundary permitted for a signal class.
+pub const fn required_context_boundary(signal_class: SignalClass) -> ContextBoundary {
+    match signal_class {
+        SignalClass::Mechanical => ContextBoundary::Full,
+        SignalClass::Judgmental => ContextBoundary::Artifact,
+    }
+}
+
+/// Whether the declared boundary provides enough isolation for the signal class.
+pub const fn context_boundary_satisfies(
+    signal_class: SignalClass,
+    actual: ContextBoundary,
+) -> bool {
+    match (signal_class, actual) {
+        (SignalClass::Mechanical, _) => true,
+        (SignalClass::Judgmental, ContextBoundary::None | ContextBoundary::Artifact) => true,
+        (SignalClass::Judgmental, ContextBoundary::Full) => false,
+    }
+}
+
+/// Whether a verification duty names a real, non-whitespace signal.
+pub fn verification_duty_has_named_signal(signal_name: Option<&str>) -> bool {
+    match signal_name {
+        Some(signal_name) => !signal_name.trim().is_empty(),
+        None => false,
+    }
+}
+
+/// Whether a verification duty explicitly declares its signal class.
+pub const fn verification_duty_declares_signal_class(
+    signal_class: Option<SignalClass>,
+) -> bool {
+    signal_class.is_some()
+}
+
+/// Whether artifact context may be included in a composed prompt.
+pub const fn includes_artifact_context(boundary: ContextBoundary) -> bool {
+    match boundary {
+        ContextBoundary::None => false,
+        ContextBoundary::Artifact | ContextBoundary::Full => true,
+    }
+}
+
+/// Whether spawner conversation may be included in a composed prompt.
+pub const fn includes_spawner_conversation(boundary: ContextBoundary) -> bool {
+    match boundary {
+        ContextBoundary::None | ContextBoundary::Artifact => false,
+        ContextBoundary::Full => true,
+    }
+}

--- a/src-tauri/src/orchestrator/org_graph/composition.rs
+++ b/src-tauri/src/orchestrator/org_graph/composition.rs
@@ -1,0 +1,730 @@
+//! Deterministic role, task, and inherited-context composition.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use super::boundary::{includes_artifact_context, includes_spawner_conversation};
+use super::definitions::{MAX_KNOWLEDGE_POINTER_CHARS, MAX_KNOWLEDGE_SUMMARY_CHARS};
+use super::schema::{
+    ContextBoundary, KnowledgeRef, KnowledgeSource, RoleDefinition, RoleLens,
+};
+use crate::orchestrator::work_graph::context::{
+    ANTI_HUB_MIN_TASKS, ANTI_HUB_TASK_FRACTION,
+};
+use crate::orchestrator::work_graph::{EdgeKind, EdgeProvenance, TaskGraph};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextOrigin {
+    Role,
+    Task,
+    RoleAndTask,
+    Conversation,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextDropReason {
+    RoleBudgetExceeded,
+    TaskBudgetExceeded,
+    ConversationBudgetExceeded,
+    BoundaryExcluded,
+    SourceBoundsExceeded,
+}
+
+impl ContextDropReason {
+    fn description(self) -> &'static str {
+        match self {
+            Self::RoleBudgetExceeded => "role context budget exceeded",
+            Self::TaskBudgetExceeded => "task context budget exceeded",
+            Self::ConversationBudgetExceeded => "conversation context budget exceeded",
+            Self::BoundaryExcluded => "role context boundary excluded this source",
+            Self::SourceBoundsExceeded => "source pointer or summary exceeded declared bounds",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComposedKnowledgeRef {
+    pub reference: KnowledgeRef,
+    pub origin: ContextOrigin,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextConflict {
+    pub source: KnowledgeSource,
+    pub pointer: String,
+    pub role_guidance: String,
+    pub task_guidance: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DroppedContext {
+    pub pointer: String,
+    pub origin: ContextOrigin,
+    pub reason: ContextDropReason,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContextBudget {
+    pub role_chars: usize,
+    pub task_chars: usize,
+    pub conversation_chars: usize,
+}
+
+impl Default for ContextBudget {
+    fn default() -> Self {
+        Self {
+            role_chars: 4_096,
+            task_chars: 4_096,
+            conversation_chars: 4_096,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConversationContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawner_conversation: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SpawnContext {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub task_scope: Vec<KnowledgeRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_summary: Option<String>,
+    #[serde(default)]
+    pub conversation: ConversationContext,
+    #[serde(default)]
+    pub budget: ContextBudget,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ComposedContext {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lens: Option<RoleLens>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub non_goals: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub knowledge: Vec<ComposedKnowledgeRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_summary: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_context: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawner_conversation: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conflicts: Vec<ContextConflict>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dropped: Vec<DroppedContext>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RoleKnowledgeHubLint {
+    pub source: KnowledgeSource,
+    pub role_id: String,
+    pub pointer: String,
+    pub affected_role_ids: Vec<String>,
+    pub role_fraction: f64,
+    pub threshold: f64,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+struct PendingKnowledge {
+    reference: KnowledgeRef,
+    origin: ContextOrigin,
+    role_summary: Option<String>,
+    task_summary: Option<String>,
+}
+
+/// Merge role and task scope once, preserving the role's framing while making
+/// disagreement and every budget exclusion visible.
+pub fn compose_context(
+    role: Option<&RoleDefinition>,
+    spawn: &SpawnContext,
+) -> ComposedContext {
+    let mut composed = ComposedContext::default();
+    let mut role_remaining = spawn.budget.role_chars;
+    let mut task_remaining = spawn.budget.task_chars;
+    let mut conversation_remaining = spawn.budget.conversation_chars;
+
+    if let Some(role) = role {
+        admit_role_metadata(role, &mut role_remaining, &mut composed);
+    }
+
+    if let Some(summary) = nonempty(spawn.task_summary.as_deref()) {
+        let cost = text_record_cost("task-summary", summary);
+        if take_budget(&mut task_remaining, cost) {
+            composed.task_summary = Some(summary.to_string());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: "task-summary".to_string(),
+                origin: ContextOrigin::Task,
+                reason: ContextDropReason::TaskBudgetExceeded,
+            });
+        }
+    }
+
+    let mut pending = BTreeMap::<String, PendingKnowledge>::new();
+    if let Some(role) = role {
+        for reference in &role.knowledge_scope {
+            insert_knowledge(
+                &mut pending,
+                reference,
+                ContextOrigin::Role,
+                &mut composed.dropped,
+            );
+        }
+    }
+    for reference in &spawn.task_scope {
+        insert_knowledge(
+            &mut pending,
+            reference,
+            ContextOrigin::Task,
+            &mut composed.dropped,
+        );
+    }
+
+    let mut records: Vec<_> = pending.into_values().collect();
+    records.sort_by(|left, right| {
+        right
+            .reference
+            .priority
+            .cmp(&left.reference.priority)
+            .then(origin_rank(left.origin).cmp(&origin_rank(right.origin)))
+            .then(knowledge_key(&left.reference).cmp(&knowledge_key(&right.reference)))
+    });
+
+    for record in records {
+        if let (Some(role_guidance), Some(task_guidance)) =
+            (record.role_summary.as_deref(), record.task_summary.as_deref())
+        {
+            if role_guidance != task_guidance {
+                composed.conflicts.push(ContextConflict {
+                    source: record.reference.source,
+                    pointer: record.reference.pointer.clone(),
+                    role_guidance: role_guidance.to_string(),
+                    task_guidance: task_guidance.to_string(),
+                });
+            }
+        }
+
+        let cost = knowledge_record_cost(&record.reference);
+        let (remaining, reason) = match record.origin {
+            ContextOrigin::Role | ContextOrigin::RoleAndTask => {
+                (&mut role_remaining, ContextDropReason::RoleBudgetExceeded)
+            }
+            ContextOrigin::Task => {
+                (&mut task_remaining, ContextDropReason::TaskBudgetExceeded)
+            }
+            ContextOrigin::Conversation => unreachable!("conversation is not knowledge scope"),
+        };
+        if take_budget(remaining, cost) {
+            composed.knowledge.push(ComposedKnowledgeRef {
+                reference: record.reference,
+                origin: record.origin,
+            });
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: record.reference.pointer,
+                origin: record.origin,
+                reason,
+            });
+        }
+    }
+
+    let boundary = role
+        .map(|definition| definition.context_boundary)
+        .unwrap_or_else(ContextBoundary::default);
+    admit_conversation_context(
+        &spawn.conversation,
+        boundary,
+        &mut conversation_remaining,
+        &mut composed,
+    );
+
+    composed.conflicts.sort_by(|left, right| {
+        knowledge_source_key(left.source)
+            .cmp(knowledge_source_key(right.source))
+            .then(left.pointer.cmp(&right.pointer))
+    });
+    composed.dropped.sort_by(|left, right| {
+        origin_rank(left.origin)
+            .cmp(&origin_rank(right.origin))
+            .then(left.pointer.cmp(&right.pointer))
+            .then(drop_reason_rank(left.reason).cmp(&drop_reason_rank(right.reason)))
+    });
+    composed
+}
+
+/// Convert the authoritative knowledge edges for one explicitly identified
+/// work-graph task into spawn context. Missing nodes or IDs produce an empty
+/// context; callers must not infer a replacement task from prose.
+pub fn spawn_context_from_work_graph_task(
+    graph: &TaskGraph,
+    plan_task_id: &str,
+) -> SpawnContext {
+    let plan_task_id = plan_task_id.trim();
+    let Some(task_node) = graph.nodes.iter().find(|node| node.id == plan_task_id) else {
+        return SpawnContext::default();
+    };
+    let task_scope = graph
+        .edges
+        .iter()
+        .filter(|edge| {
+            edge.target == plan_task_id
+                && edge.kind == EdgeKind::Informs
+                && edge.provenance == EdgeProvenance::Knowledge
+        })
+        .filter_map(|edge| graph.nodes.iter().find(|node| node.id == edge.source))
+        .filter_map(|source_node| source_node.expansion.as_ref())
+        .filter_map(|expansion| {
+            let source_ref = expansion.parameters.get("source_ref")?.trim();
+            if source_ref.is_empty() {
+                return None;
+            }
+            let summary = expansion
+                .parameters
+                .get("summary")
+                .map(|summary| bound_context_text(summary, MAX_KNOWLEDGE_SUMMARY_CHARS))
+                .filter(|summary| !summary.is_empty());
+            let (source, pointer) = if let Some(pointer) = source_ref
+                .strip_prefix("institutional:")
+                .or_else(|| source_ref.strip_prefix("global:"))
+            {
+                (KnowledgeSource::Institutional, pointer.trim())
+            } else {
+                (KnowledgeSource::Project, source_ref)
+            };
+            let priority = expansion
+                .parameters
+                .get("priority")
+                .and_then(|priority| priority.parse().ok())
+                .unwrap_or_default();
+            Some(KnowledgeRef {
+                source,
+                pointer: pointer.to_string(),
+                summary,
+                priority,
+            })
+        })
+        .collect();
+
+    SpawnContext {
+        task_scope,
+        task_summary: Some(bound_context_text(
+            &task_node.title,
+            MAX_KNOWLEDGE_SUMMARY_CHARS,
+        ))
+        .filter(|summary| !summary.is_empty()),
+        ..SpawnContext::default()
+    }
+}
+
+/// Render one stable prompt section. An empty input produces zero bytes so
+/// legacy spawns retain their exact prompt.
+pub fn render_composed_context(context: &ComposedContext) -> String {
+    if context == &ComposedContext::default() {
+        return String::new();
+    }
+
+    let mut rendered = String::from("## Composed Role and Task Context\n\n");
+    if let Some(domain) = context.domain.as_deref() {
+        rendered.push_str(&format!("Domain: {domain}\n\n"));
+    }
+    if let Some(lens) = context.lens.as_ref() {
+        rendered.push_str(&format!(
+            "Lens `{}`: {}\n\n",
+            lens.id, lens.question
+        ));
+    }
+    if !context.non_goals.is_empty() {
+        rendered.push_str("### Declared Non-Goals\n\n");
+        for non_goal in &context.non_goals {
+            rendered.push_str(&format!("- {non_goal}\n"));
+        }
+        rendered.push('\n');
+    }
+    if !context.knowledge.is_empty() {
+        rendered.push_str("### Knowledge References\n\n");
+        for item in &context.knowledge {
+            let summary = item
+                .reference
+                .summary
+                .as_deref()
+                .map(|summary| format!(": {summary}"))
+                .unwrap_or_default();
+            rendered.push_str(&format!(
+                "- [{}] `{}` (priority {}){}\n",
+                origin_label(item.origin),
+                display_reference(&item.reference),
+                item.reference.priority,
+                summary
+            ));
+        }
+        rendered.push('\n');
+    }
+    if let Some(summary) = context.task_summary.as_deref() {
+        rendered.push_str(&format!("### Task Summary\n\n{summary}\n\n"));
+    }
+    if let Some(artifact) = context.artifact_context.as_deref() {
+        rendered.push_str(&format!("### Artifact Context\n\n{artifact}\n\n"));
+    }
+    if let Some(conversation) = context.spawner_conversation.as_deref() {
+        rendered.push_str(&format!(
+            "### Spawner Conversation\n\n{conversation}\n\n"
+        ));
+    }
+    if !context.conflicts.is_empty() {
+        rendered.push_str("### Context Conflicts\n\n");
+        for conflict in &context.conflicts {
+            rendered.push_str(&format!(
+                "- `{}`: role guidance = {:?}; task guidance = {:?}\n",
+                display_source_pointer(conflict.source, &conflict.pointer),
+                conflict.role_guidance,
+                conflict.task_guidance
+            ));
+        }
+        rendered.push('\n');
+    }
+    if !context.dropped.is_empty() {
+        rendered.push_str("### Dropped Context\n\n");
+        for dropped in &context.dropped {
+            rendered.push_str(&format!(
+                "- `{}` [{}]: {}\n",
+                dropped.pointer,
+                origin_label(dropped.origin),
+                dropped.reason.description()
+            ));
+        }
+        rendered.push('\n');
+    }
+    rendered
+}
+
+/// Fraction-based anti-hub lint for declarations that name an entire knowledge
+/// tree. A specific page may legitimately be shared by every role and is not a
+/// hub; a wildcard/root scope is treated as affecting the complete definition
+/// universe and checked against the existing work-graph thresholds.
+pub fn lint_role_knowledge_hubs(definitions: &[RoleDefinition]) -> Vec<RoleKnowledgeHubLint> {
+    let mut role_ids: Vec<_> = definitions
+        .iter()
+        .map(|definition| definition.id.clone())
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+    role_ids.sort();
+    if role_ids.len() < ANTI_HUB_MIN_TASKS {
+        return Vec::new();
+    }
+    // A whole-tree declaration reaches the complete definition universe, not
+    // only the role that authored the declaration.
+    let affected_role_ids = role_ids.clone();
+    let fraction = affected_role_ids.len() as f64 / role_ids.len() as f64;
+    if fraction < ANTI_HUB_TASK_FRACTION {
+        return Vec::new();
+    }
+
+    let mut lints = Vec::new();
+    for definition in definitions {
+        for reference in &definition.knowledge_scope {
+            let pointer = normalize_pointer(&reference.pointer);
+            if is_whole_tree_scope(&pointer) {
+                lints.push(RoleKnowledgeHubLint {
+                    source: reference.source,
+                    role_id: definition.id.clone(),
+                    pointer,
+                    affected_role_ids: affected_role_ids.clone(),
+                    role_fraction: fraction,
+                    threshold: ANTI_HUB_TASK_FRACTION,
+                    detail: "role knowledge scope covers a whole tree; replace it with discriminating references".to_string(),
+                });
+            }
+        }
+    }
+    lints.sort_by(|left, right| {
+        knowledge_source_key(left.source)
+            .cmp(knowledge_source_key(right.source))
+            .then(left.role_id.cmp(&right.role_id))
+            .then(left.pointer.cmp(&right.pointer))
+    });
+    lints
+}
+
+fn admit_role_metadata(
+    role: &RoleDefinition,
+    remaining: &mut usize,
+    composed: &mut ComposedContext,
+) {
+    if let Some(domain) = nonempty(role.domain.as_deref()) {
+        if take_budget(remaining, text_record_cost("role-domain", domain)) {
+            composed.domain = Some(domain.to_string());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: "role-domain".to_string(),
+                origin: ContextOrigin::Role,
+                reason: ContextDropReason::RoleBudgetExceeded,
+            });
+        }
+    }
+    if let Some(lens) = role.lens.as_ref() {
+        let cost = text_record_cost(&lens.id, &lens.question);
+        if take_budget(remaining, cost) {
+            composed.lens = Some(lens.clone());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: format!("role-lens:{}", lens.id),
+                origin: ContextOrigin::Role,
+                reason: ContextDropReason::RoleBudgetExceeded,
+            });
+        }
+    }
+    for (index, non_goal) in role.non_goals.iter().enumerate() {
+        let pointer = format!("role-non-goal-{}", index + 1);
+        if take_budget(remaining, text_record_cost(&pointer, non_goal)) {
+            composed.non_goals.push(non_goal.clone());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer,
+                origin: ContextOrigin::Role,
+                reason: ContextDropReason::RoleBudgetExceeded,
+            });
+        }
+    }
+}
+
+fn insert_knowledge(
+    pending: &mut BTreeMap<String, PendingKnowledge>,
+    reference: &KnowledgeRef,
+    origin: ContextOrigin,
+    dropped: &mut Vec<DroppedContext>,
+) {
+    if !within_source_bounds(reference) {
+        dropped.push(DroppedContext {
+            pointer: bounded_pointer_label(&reference.pointer),
+            origin,
+            reason: ContextDropReason::SourceBoundsExceeded,
+        });
+        return;
+    }
+    let mut normalized = reference.clone();
+    normalized.pointer = normalize_pointer(&reference.pointer);
+    normalized.summary = nonempty(reference.summary.as_deref()).map(ToString::to_string);
+    let key = knowledge_key(&normalized);
+    if let Some(existing) = pending.get_mut(&key) {
+        existing.reference.priority = existing.reference.priority.max(normalized.priority);
+        existing.origin = merge_origins(existing.origin, origin);
+        match origin {
+            ContextOrigin::Role => {
+                existing.role_summary = normalized.summary.clone();
+                existing.reference.summary = normalized.summary.clone().or_else(|| {
+                    existing.task_summary.clone()
+                });
+            }
+            ContextOrigin::Task => {
+                existing.task_summary = normalized.summary.clone();
+                if existing.role_summary.is_none() {
+                    existing.reference.summary = normalized.summary.clone();
+                }
+            }
+            ContextOrigin::RoleAndTask | ContextOrigin::Conversation => {}
+        }
+        return;
+    }
+
+    pending.insert(
+        key,
+        PendingKnowledge {
+            reference: normalized.clone(),
+            origin,
+            role_summary: if origin == ContextOrigin::Role {
+                normalized.summary.clone()
+            } else {
+                None
+            },
+            task_summary: if origin == ContextOrigin::Task {
+                normalized.summary.clone()
+            } else {
+                None
+            },
+        },
+    );
+}
+
+fn admit_conversation_context(
+    conversation: &ConversationContext,
+    boundary: ContextBoundary,
+    remaining: &mut usize,
+    composed: &mut ComposedContext,
+) {
+    if let Some(artifact) = nonempty(conversation.artifact_summary.as_deref()) {
+        if !includes_artifact_context(boundary) {
+            composed.dropped.push(DroppedContext {
+                pointer: "artifact-context".to_string(),
+                origin: ContextOrigin::Conversation,
+                reason: ContextDropReason::BoundaryExcluded,
+            });
+        } else if take_budget(remaining, text_record_cost("artifact-context", artifact)) {
+            composed.artifact_context = Some(artifact.to_string());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: "artifact-context".to_string(),
+                origin: ContextOrigin::Conversation,
+                reason: ContextDropReason::ConversationBudgetExceeded,
+            });
+        }
+    }
+    if let Some(spawner) = nonempty(conversation.spawner_conversation.as_deref()) {
+        if !includes_spawner_conversation(boundary) {
+            composed.dropped.push(DroppedContext {
+                pointer: "spawner-conversation".to_string(),
+                origin: ContextOrigin::Conversation,
+                reason: ContextDropReason::BoundaryExcluded,
+            });
+        } else if take_budget(
+            remaining,
+            text_record_cost("spawner-conversation", spawner),
+        ) {
+            composed.spawner_conversation = Some(spawner.to_string());
+        } else {
+            composed.dropped.push(DroppedContext {
+                pointer: "spawner-conversation".to_string(),
+                origin: ContextOrigin::Conversation,
+                reason: ContextDropReason::ConversationBudgetExceeded,
+            });
+        }
+    }
+}
+
+fn within_source_bounds(reference: &KnowledgeRef) -> bool {
+    let pointer_len = reference.pointer.trim().chars().count();
+    pointer_len > 0
+        && pointer_len <= MAX_KNOWLEDGE_POINTER_CHARS
+        && reference
+            .summary
+            .as_deref()
+            .map_or(true, |summary| {
+                summary.chars().count() <= MAX_KNOWLEDGE_SUMMARY_CHARS
+            })
+}
+
+fn knowledge_key(reference: &KnowledgeRef) -> String {
+    format!(
+        "{}:{}",
+        knowledge_source_key(reference.source),
+        normalize_pointer(&reference.pointer)
+    )
+}
+
+fn knowledge_source_key(source: KnowledgeSource) -> &'static str {
+    match source {
+        KnowledgeSource::Institutional => "institutional",
+        KnowledgeSource::Project => "project",
+    }
+}
+
+fn display_reference(reference: &KnowledgeRef) -> String {
+    display_source_pointer(reference.source, &reference.pointer)
+}
+
+fn display_source_pointer(source: KnowledgeSource, pointer: &str) -> String {
+    format!("{}:{}", knowledge_source_key(source), pointer)
+}
+
+fn normalize_pointer(pointer: &str) -> String {
+    let mut normalized = pointer.trim().replace('\\', "/");
+    while normalized.contains("//") {
+        normalized = normalized.replace("//", "/");
+    }
+    normalized.trim_start_matches("./").to_string()
+}
+
+fn is_whole_tree_scope(pointer: &str) -> bool {
+    let pointer = pointer.to_ascii_lowercase();
+    matches!(pointer.as_str(), "*" | "." | "/" | "wiki" | "global")
+        || pointer.ends_with("/*")
+        || pointer.ends_with("/**")
+}
+
+fn merge_origins(left: ContextOrigin, right: ContextOrigin) -> ContextOrigin {
+    match (left, right) {
+        (ContextOrigin::Role, ContextOrigin::Task)
+        | (ContextOrigin::Task, ContextOrigin::Role)
+        | (ContextOrigin::RoleAndTask, ContextOrigin::Role | ContextOrigin::Task)
+        | (ContextOrigin::Role | ContextOrigin::Task, ContextOrigin::RoleAndTask) => {
+            ContextOrigin::RoleAndTask
+        }
+        _ => left,
+    }
+}
+
+fn origin_rank(origin: ContextOrigin) -> u8 {
+    match origin {
+        ContextOrigin::RoleAndTask => 0,
+        ContextOrigin::Role => 1,
+        ContextOrigin::Task => 2,
+        ContextOrigin::Conversation => 3,
+    }
+}
+
+fn origin_label(origin: ContextOrigin) -> &'static str {
+    match origin {
+        ContextOrigin::Role => "role",
+        ContextOrigin::Task => "task",
+        ContextOrigin::RoleAndTask => "role+task",
+        ContextOrigin::Conversation => "conversation",
+    }
+}
+
+fn drop_reason_rank(reason: ContextDropReason) -> u8 {
+    match reason {
+        ContextDropReason::RoleBudgetExceeded => 0,
+        ContextDropReason::TaskBudgetExceeded => 1,
+        ContextDropReason::ConversationBudgetExceeded => 2,
+        ContextDropReason::BoundaryExcluded => 3,
+        ContextDropReason::SourceBoundsExceeded => 4,
+    }
+}
+
+fn knowledge_record_cost(reference: &KnowledgeRef) -> usize {
+    text_record_cost(
+        &display_reference(reference),
+        reference.summary.as_deref().unwrap_or_default(),
+    )
+}
+
+fn text_record_cost(pointer: &str, summary: &str) -> usize {
+    pointer.chars().count() + summary.chars().count() + 32
+}
+
+fn take_budget(remaining: &mut usize, cost: usize) -> bool {
+    if cost > *remaining {
+        return false;
+    }
+    *remaining -= cost;
+    true
+}
+
+fn nonempty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn bound_context_text(value: &str, max_chars: usize) -> String {
+    value.trim().chars().take(max_chars).collect()
+}
+
+fn bounded_pointer_label(pointer: &str) -> String {
+    let bounded = bound_context_text(pointer, MAX_KNOWLEDGE_POINTER_CHARS);
+    if bounded.is_empty() {
+        "<empty-pointer>".to_string()
+    } else {
+        bounded
+    }
+}

--- a/src-tauri/src/orchestrator/org_graph/definitions.rs
+++ b/src-tauri/src/orchestrator/org_graph/definitions.rs
@@ -154,7 +154,7 @@ pub fn resolve_role_definition(
                 .map_err(|error| error.to_string())
                 .and_then(|source| parse_document::<RoleDefinitionOverride>(&source))
                 .and_then(|patch| {
-                    apply_project_override(definition.take(), &normalized_id, patch)
+                    apply_project_override(definition.clone(), &normalized_id, patch)
                 }) {
                 Ok(overridden) => {
                     definition = Some(overridden);

--- a/src-tauri/src/orchestrator/org_graph/definitions.rs
+++ b/src-tauri/src/orchestrator/org_graph/definitions.rs
@@ -1,0 +1,376 @@
+//! Two-tier role-definition resolution.
+//!
+//! Institutional definitions are optional configured inputs. The checked-in
+//! files are embedded fallbacks so installed applications do not depend on a
+//! source checkout, while project overrides are always loaded relative to the
+//! session's project path.
+
+use std::fs;
+use std::path::Path;
+
+use serde::{Deserialize, Serialize};
+
+use super::schema::{
+    AuthorityScope, ContextBoundary, KnowledgeRef, RoleDefinition, RoleLens, SignalClass,
+};
+use crate::cli::CliBehavior;
+
+pub const INSTITUTIONAL_ROLE_DIR: &str = "roles";
+pub const PROJECT_ROLE_DIR: &str = ".ai-docs/roles";
+pub const MAX_KNOWLEDGE_POINTER_CHARS: usize = 256;
+pub const MAX_KNOWLEDGE_SUMMARY_CHARS: usize = 240;
+
+const EMBEDDED_ROLE_DEFINITIONS: &[(&str, &str)] = &[
+    ("backend", include_str!("../../../../roles/backend.md")),
+    ("frontend", include_str!("../../../../roles/frontend.md")),
+    ("coherence", include_str!("../../../../roles/coherence.md")),
+    ("simplify", include_str!("../../../../roles/simplify.md")),
+    ("reviewer", include_str!("../../../../roles/reviewer.md")),
+    ("reviewer-quick", include_str!("../../../../roles/reviewer-quick.md")),
+    ("resolver", include_str!("../../../../roles/resolver.md")),
+    ("tester", include_str!("../../../../roles/tester.md")),
+    ("code-quality", include_str!("../../../../roles/code-quality.md")),
+    ("researcher", include_str!("../../../../roles/researcher.md")),
+    ("general", include_str!("../../../../roles/general.md")),
+    (
+        "master-planner",
+        include_str!("../../../../roles/master-planner.md"),
+    ),
+    ("queen", include_str!("../../../../roles/queen.md")),
+    ("evaluator", include_str!("../../../../roles/evaluator.md")),
+    ("prince", include_str!("../../../../roles/prince.md")),
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoleDefinitionSource {
+    Institutional,
+    EmbeddedDefault,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoleResolutionIssueKind {
+    InstitutionalUnavailable,
+    ProjectKnowledgeUnavailable,
+    DefinitionNotFound,
+    SourceUnreadable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleResolutionIssue {
+    pub kind: RoleResolutionIssueKind,
+    pub source_ref: String,
+    pub detail: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResolvedRoleDefinition {
+    pub requested_id: String,
+    pub definition: Option<RoleDefinition>,
+    pub base_source: Option<RoleDefinitionSource>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub applied_override: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub issues: Vec<RoleResolutionIssue>,
+}
+
+impl ResolvedRoleDefinition {
+    pub fn definition_identity(&self) -> Option<(&str, u32)> {
+        self.definition
+            .as_ref()
+            .map(|definition| (definition.id.as_str(), definition.version))
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RoleDefinitionOverride {
+    id: Option<String>,
+    version: Option<u32>,
+    domain: Option<String>,
+    knowledge_scope: Option<Vec<KnowledgeRef>>,
+    lens: Option<RoleLens>,
+    authority: Option<AuthorityScope>,
+    behavior: Option<CliBehavior>,
+    context_boundary: Option<ContextBoundary>,
+    signal_class: Option<SignalClass>,
+    prompt_template: Option<String>,
+    non_goals: Option<Vec<String>>,
+}
+
+/// Return the stable template key associated with a declared role. Invalid
+/// path-shaped input is made explicit without allowing template traversal.
+pub fn role_prompt_template(role_id: &str) -> String {
+    normalize_role_id(role_id)
+        .map(|id| format!("roles/{id}"))
+        .unwrap_or_else(|| "roles/unresolved".to_string())
+}
+
+/// Resolve an institutional base plus an optional project override. The
+/// project root is an explicit argument by design; resolution never consults
+/// the process current directory.
+pub fn resolve_role_definition(
+    project_path: &Path,
+    institutional_wiki_root: Option<&Path>,
+    role_id: &str,
+) -> ResolvedRoleDefinition {
+    let requested_id = role_id.trim().to_ascii_lowercase();
+    let Some(normalized_id) = normalize_role_id(role_id) else {
+        return ResolvedRoleDefinition {
+            requested_id,
+            definition: None,
+            base_source: None,
+            applied_override: None,
+            issues: vec![RoleResolutionIssue {
+                kind: RoleResolutionIssueKind::DefinitionNotFound,
+                source_ref: role_id.to_string(),
+                detail: "role id must contain only lowercase letters, digits, and hyphens"
+                    .to_string(),
+            }],
+        };
+    };
+
+    let mut issues = Vec::new();
+    let (mut definition, base_source) = load_base_definition(
+        institutional_wiki_root,
+        &normalized_id,
+        &mut issues,
+    );
+    let mut applied_override = None;
+
+    let ai_docs = project_path.join(".ai-docs");
+    if !ai_docs.is_dir() {
+        issues.push(RoleResolutionIssue {
+            kind: RoleResolutionIssueKind::ProjectKnowledgeUnavailable,
+            source_ref: ai_docs.display().to_string(),
+            detail: "project knowledge directory is unavailable".to_string(),
+        });
+    } else {
+        let override_path = project_path
+            .join(PROJECT_ROLE_DIR)
+            .join(format!("{normalized_id}.md"));
+        if override_path.exists() {
+            match fs::read_to_string(&override_path)
+                .map_err(|error| error.to_string())
+                .and_then(|source| parse_document::<RoleDefinitionOverride>(&source))
+                .and_then(|patch| {
+                    apply_project_override(definition.take(), &normalized_id, patch)
+                }) {
+                Ok(overridden) => {
+                    definition = Some(overridden);
+                    applied_override = Some(override_path.display().to_string());
+                }
+                Err(detail) => issues.push(source_unreadable(&override_path, detail)),
+            }
+        }
+    }
+
+    if definition.is_none() {
+        issues.push(RoleResolutionIssue {
+            kind: RoleResolutionIssueKind::DefinitionNotFound,
+            source_ref: normalized_id.clone(),
+            detail: "no institutional, embedded, or project role definition resolved".to_string(),
+        });
+    }
+
+    ResolvedRoleDefinition {
+        requested_id: normalized_id,
+        definition,
+        base_source,
+        applied_override,
+        issues,
+    }
+}
+
+fn load_base_definition(
+    institutional_wiki_root: Option<&Path>,
+    role_id: &str,
+    issues: &mut Vec<RoleResolutionIssue>,
+) -> (Option<RoleDefinition>, Option<RoleDefinitionSource>) {
+    if let Some(root) = institutional_wiki_root {
+        let path = root
+            .join(INSTITUTIONAL_ROLE_DIR)
+            .join(format!("{role_id}.md"));
+        if path.exists() {
+            match fs::read_to_string(&path)
+                .map_err(|error| error.to_string())
+                .and_then(|source| parse_role_definition(&source, role_id))
+            {
+                Ok(definition) => {
+                    return (Some(definition), Some(RoleDefinitionSource::Institutional));
+                }
+                Err(detail) => issues.push(source_unreadable(&path, detail)),
+            }
+        } else {
+            issues.push(RoleResolutionIssue {
+                kind: RoleResolutionIssueKind::InstitutionalUnavailable,
+                source_ref: path.display().to_string(),
+                detail: "institutional role definition is absent".to_string(),
+            });
+        }
+    } else {
+        issues.push(RoleResolutionIssue {
+            kind: RoleResolutionIssueKind::InstitutionalUnavailable,
+            source_ref: INSTITUTIONAL_ROLE_DIR.to_string(),
+            detail: "institutional knowledge root is not configured".to_string(),
+        });
+    }
+
+    let embedded = EMBEDDED_ROLE_DEFINITIONS
+        .iter()
+        .find(|(id, _)| *id == role_id)
+        .map(|(_, source)| *source);
+    match embedded {
+        Some(source) => match parse_role_definition(source, role_id) {
+            Ok(definition) => (
+                Some(definition),
+                Some(RoleDefinitionSource::EmbeddedDefault),
+            ),
+            Err(detail) => {
+                issues.push(RoleResolutionIssue {
+                    kind: RoleResolutionIssueKind::SourceUnreadable,
+                    source_ref: format!("embedded:roles/{role_id}.md"),
+                    detail,
+                });
+                (None, None)
+            }
+        },
+        None => (None, None),
+    }
+}
+
+fn apply_project_override(
+    base: Option<RoleDefinition>,
+    role_id: &str,
+    patch: RoleDefinitionOverride,
+) -> Result<RoleDefinition, String> {
+    if let Some(id) = patch.id.as_deref() {
+        let normalized = normalize_role_id(id)
+            .ok_or_else(|| "override contains an invalid role id".to_string())?;
+        if normalized != role_id {
+            return Err(format!(
+                "override declares role {normalized}, expected {role_id}"
+            ));
+        }
+    }
+    if base.is_none() && patch.version.is_none() {
+        return Err("a project-only role definition must declare a version".to_string());
+    }
+
+    let mut definition = base.unwrap_or_else(|| RoleDefinition::empty(role_id));
+    definition.id = role_id.to_string();
+    if let Some(value) = patch.version {
+        definition.version = value;
+    }
+    if let Some(value) = patch.domain {
+        definition.domain = Some(value);
+    }
+    if let Some(value) = patch.knowledge_scope {
+        definition.knowledge_scope = value;
+    }
+    if let Some(value) = patch.lens {
+        definition.lens = Some(value);
+    }
+    if let Some(value) = patch.authority {
+        definition.authority = value;
+    }
+    if let Some(value) = patch.behavior {
+        definition.behavior = Some(value);
+    }
+    if let Some(value) = patch.context_boundary {
+        definition.context_boundary = value;
+    }
+    if let Some(value) = patch.signal_class {
+        definition.signal_class = Some(value);
+    }
+    if let Some(value) = patch.prompt_template {
+        definition.prompt_template = Some(value);
+    }
+    if let Some(value) = patch.non_goals {
+        definition.non_goals = value;
+    }
+    if definition.prompt_template.is_none() {
+        definition.prompt_template = Some(role_prompt_template(role_id));
+    }
+    validate_role_definition(&definition, role_id)?;
+    Ok(definition)
+}
+
+fn parse_role_definition(source: &str, role_id: &str) -> Result<RoleDefinition, String> {
+    let mut definition: RoleDefinition = parse_document(source)?;
+    let normalized = normalize_role_id(&definition.id)
+        .ok_or_else(|| "definition contains an invalid role id".to_string())?;
+    if normalized != role_id {
+        return Err(format!(
+            "definition declares role {normalized}, expected {role_id}"
+        ));
+    }
+    definition.id = normalized;
+    validate_role_definition(&definition, role_id)?;
+    Ok(definition)
+}
+
+fn parse_document<T: for<'de> Deserialize<'de>>(source: &str) -> Result<T, String> {
+    let trimmed = source.trim();
+    let json = if let Some(after_open) = trimmed.strip_prefix("---") {
+        let (front_matter, _) = after_open
+            .split_once("---")
+            .ok_or_else(|| "role definition front matter is missing its closing ---".to_string())?;
+        front_matter.trim()
+    } else {
+        trimmed
+    };
+    serde_json::from_str(json).map_err(|error| error.to_string())
+}
+
+fn validate_role_definition(definition: &RoleDefinition, expected_id: &str) -> Result<(), String> {
+    if definition.id != expected_id {
+        return Err(format!(
+            "definition id {} does not match {expected_id}",
+            definition.id
+        ));
+    }
+    if definition.version == 0 {
+        return Err("resolved definitions must have a non-zero version".to_string());
+    }
+    for reference in &definition.knowledge_scope {
+        let pointer_len = reference.pointer.chars().count();
+        if reference.pointer.trim().is_empty() || pointer_len > MAX_KNOWLEDGE_POINTER_CHARS {
+            return Err(format!(
+                "knowledge pointer must contain 1..={MAX_KNOWLEDGE_POINTER_CHARS} characters"
+            ));
+        }
+        if reference
+            .summary
+            .as_deref()
+            .is_some_and(|summary| summary.chars().count() > MAX_KNOWLEDGE_SUMMARY_CHARS)
+        {
+            return Err(format!(
+                "knowledge summary exceeds {MAX_KNOWLEDGE_SUMMARY_CHARS} characters"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn normalize_role_id(role_id: &str) -> Option<String> {
+    let normalized = role_id.trim().to_ascii_lowercase();
+    (!normalized.is_empty()
+        && normalized.len() <= 64
+        && normalized
+            .chars()
+            .all(|character| {
+                character.is_ascii_lowercase()
+                    || character.is_ascii_digit()
+                    || character == '-'
+            }))
+    .then_some(normalized)
+}
+
+fn source_unreadable(path: &Path, detail: String) -> RoleResolutionIssue {
+    RoleResolutionIssue {
+        kind: RoleResolutionIssueKind::SourceUnreadable,
+        source_ref: path.display().to_string(),
+        detail,
+    }
+}

--- a/src-tauri/src/orchestrator/org_graph/mod.rs
+++ b/src-tauri/src/orchestrator/org_graph/mod.rs
@@ -1,0 +1,13 @@
+//! Durable role definitions and per-session organization semantics.
+
+pub mod adjudication;
+pub mod boundary;
+pub mod composition;
+pub mod definitions;
+pub mod ownership;
+pub mod schema;
+
+pub use schema::{
+    evaluator_role_definition, AuthorityScope, ContextBoundary, KnowledgeRef, KnowledgeSource,
+    RoleDefinition, RoleLens, SignalClass,
+};

--- a/src-tauri/src/orchestrator/org_graph/ownership.rs
+++ b/src-tauri/src/orchestrator/org_graph/ownership.rs
@@ -1,0 +1,477 @@
+//! Orchestrator ownership and write-collision semantics.
+//!
+//! Orchestrators are explicit session principals. Their authority answers what
+//! they may do; their footprint answers where and why they expect to write.
+//! Keeping those declarations separate preserves collision evidence even when
+//! an orchestrator is authorized to override live ownership.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::error::Error;
+use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::AuthorityScope;
+use crate::orchestrator::work_graph::schema::{
+    BindingRef, EdgeKind, NodeKind, TaskGraph, TaskId,
+};
+
+const CODEGRAPH_ZONE: &str = "codegraph";
+const CODEGRAPH_MODULE_TEMPLATE: &str = "codegraph-module";
+
+/// A first-class orchestrator node in visible session ownership state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestratorRole {
+    Queen,
+    Prince,
+    Evaluator,
+}
+
+/// Why an orchestrator expects to touch a path outside ordinary task ownership.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrchestratorOperation {
+    IntegrationEdit,
+    Restore,
+    MutationProof,
+    Verification,
+    Remediation,
+}
+
+/// One exact path in an orchestrator's declared footprint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnershipFootprint {
+    pub path: String,
+    pub operation: OrchestratorOperation,
+}
+
+impl OwnershipFootprint {
+    pub fn new(path: impl Into<String>, operation: OrchestratorOperation) -> Self {
+        Self {
+            path: normalize_path(&path.into()),
+            operation,
+        }
+    }
+}
+
+/// Ownership-specific authority that cannot be inferred from broad role power.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnershipAuthority {
+    #[serde(default)]
+    pub may_adjudicate_blocked_tasks: bool,
+    #[serde(default)]
+    pub may_override_live_ownership: bool,
+    #[serde(default)]
+    pub may_mutate_mid_flight: bool,
+}
+
+/// The role, footprint, and authority declarations serialized for one
+/// orchestrator. `authority` deliberately does not replace `footprint`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorOwnershipNode {
+    pub principal_id: String,
+    pub role: OrchestratorRole,
+    pub footprint: Vec<OwnershipFootprint>,
+    pub authority: AuthorityScope,
+    pub ownership_authority: OwnershipAuthority,
+}
+
+impl OrchestratorOwnershipNode {
+    pub fn queen(
+        principal_id: impl Into<String>,
+        footprint: Vec<OwnershipFootprint>,
+    ) -> Self {
+        Self {
+            principal_id: principal_id.into(),
+            role: OrchestratorRole::Queen,
+            footprint,
+            authority: AuthorityScope {
+                may_commit: true,
+                may_push: true,
+                may_spawn_subordinates: true,
+                may_adjudicate: true,
+                may_mutate_unowned_paths: true,
+            },
+            ownership_authority: OwnershipAuthority {
+                may_adjudicate_blocked_tasks: true,
+                may_override_live_ownership: true,
+                may_mutate_mid_flight: true,
+            },
+        }
+    }
+
+    pub fn prince(
+        principal_id: impl Into<String>,
+        footprint: Vec<OwnershipFootprint>,
+    ) -> Self {
+        Self {
+            principal_id: principal_id.into(),
+            role: OrchestratorRole::Prince,
+            footprint,
+            authority: AuthorityScope {
+                may_commit: false,
+                may_push: false,
+                may_spawn_subordinates: true,
+                may_adjudicate: true,
+                may_mutate_unowned_paths: false,
+            },
+            ownership_authority: OwnershipAuthority {
+                may_adjudicate_blocked_tasks: true,
+                may_override_live_ownership: false,
+                may_mutate_mid_flight: false,
+            },
+        }
+    }
+
+    pub fn evaluator(
+        principal_id: impl Into<String>,
+        footprint: Vec<OwnershipFootprint>,
+    ) -> Self {
+        Self {
+            principal_id: principal_id.into(),
+            role: OrchestratorRole::Evaluator,
+            footprint,
+            authority: AuthorityScope::default(),
+            ownership_authority: OwnershipAuthority::default(),
+        }
+    }
+
+    fn declares(&self, path: &str, operation: OrchestratorOperation) -> bool {
+        let path = normalize_path(path);
+        self.footprint
+            .iter()
+            .any(|entry| entry.operation == operation && entry.path == path)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OwnershipDeclarationError {
+    MissingRole(OrchestratorRole),
+    DuplicateRole(OrchestratorRole),
+    EmptyFootprint(OrchestratorRole),
+}
+
+impl fmt::Display for OwnershipDeclarationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingRole(role) => write!(formatter, "missing {role:?} ownership node"),
+            Self::DuplicateRole(role) => write!(formatter, "duplicate {role:?} ownership node"),
+            Self::EmptyFootprint(role) => {
+                write!(formatter, "{role:?} ownership node has no declared footprint")
+            }
+        }
+    }
+}
+
+impl Error for OwnershipDeclarationError {}
+
+/// A live worker/principal assignment. `write_capable` is explicit because a
+/// task status mirror may say completed while its process can still write.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LivePrincipal {
+    pub principal_id: String,
+    pub task_id: TaskId,
+    pub write_capable: bool,
+}
+
+/// File ownership derived from a real `Touches` edge and a live principal.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PrincipalPathOwnership {
+    pub principal_id: String,
+    pub task_id: TaskId,
+    pub path: String,
+    pub write_capable: bool,
+}
+
+/// The write attempt that must be checked before mutating the filesystem.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorWriteAttempt {
+    pub actor_id: String,
+    pub role: OrchestratorRole,
+    pub path: String,
+    pub operation: OrchestratorOperation,
+    pub attempted_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CollisionDisposition {
+    /// The live owner must finish or explicitly yield before this write runs.
+    RequiresSerialization,
+    /// The override is allowed, but the collision remains surfaced and durable.
+    SurfacedAuthorizedOverride,
+}
+
+/// Durable evidence of an orchestrator/live-principal path collision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnershipCollision {
+    pub actor_id: String,
+    pub actor_role: OrchestratorRole,
+    pub owner_principal_id: String,
+    pub owner_task_id: TaskId,
+    pub owner_write_capable: bool,
+    pub path: String,
+    pub operation: OrchestratorOperation,
+    pub within_declared_footprint: bool,
+    pub override_authorized: bool,
+    pub disposition: CollisionDisposition,
+    pub detected_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum OrchestratorWriteOutcome {
+    Proceed,
+    Collision { collision: OwnershipCollision },
+}
+
+/// One output-defined task class whose members lack a review duty.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerificationDutyGap {
+    pub task_class: String,
+    pub unassigned_task_ids: Vec<TaskId>,
+}
+
+/// Visible, serializable ownership state for the running session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OwnershipSessionState {
+    pub schema_version: u32,
+    pub orchestrators: Vec<OrchestratorOwnershipNode>,
+    pub live_principal_ownership: Vec<PrincipalPathOwnership>,
+    #[serde(default)]
+    pub collisions: Vec<OwnershipCollision>,
+    #[serde(default)]
+    pub verification_duty_gaps: Vec<VerificationDutyGap>,
+}
+
+impl OwnershipSessionState {
+    pub fn from_plan(
+        graph: &TaskGraph,
+        mut orchestrators: Vec<OrchestratorOwnershipNode>,
+        live_principals: &[LivePrincipal],
+    ) -> Result<Self, OwnershipDeclarationError> {
+        validate_orchestrator_declarations(&orchestrators)?;
+        orchestrators.sort_by_key(|node| node.role);
+        Ok(Self {
+            schema_version: 1,
+            orchestrators,
+            live_principal_ownership: derive_path_ownership(graph, live_principals),
+            collisions: Vec::new(),
+            verification_duty_gaps: verification_duty_gaps(graph),
+        })
+    }
+
+    /// Detect and persist a collision before the caller performs the write.
+    pub fn record_write_attempt(
+        &mut self,
+        attempt: OrchestratorWriteAttempt,
+    ) -> OrchestratorWriteOutcome {
+        let path = normalize_path(&attempt.path);
+        let Some(actor) = self.orchestrators.iter().find(|node| {
+            node.principal_id == attempt.actor_id && node.role == attempt.role
+        }) else {
+            return OrchestratorWriteOutcome::Proceed;
+        };
+        let Some(owner) = self
+            .live_principal_ownership
+            .iter()
+            .find(|owner| owner.write_capable && owner.path == path)
+        else {
+            return OrchestratorWriteOutcome::Proceed;
+        };
+
+        let override_authorized = actor.ownership_authority.may_override_live_ownership
+            && actor.ownership_authority.may_mutate_mid_flight;
+        let collision = OwnershipCollision {
+            actor_id: actor.principal_id.clone(),
+            actor_role: actor.role,
+            owner_principal_id: owner.principal_id.clone(),
+            owner_task_id: owner.task_id.clone(),
+            owner_write_capable: owner.write_capable,
+            path,
+            operation: attempt.operation,
+            within_declared_footprint: actor.declares(&attempt.path, attempt.operation),
+            override_authorized,
+            disposition: if override_authorized {
+                CollisionDisposition::SurfacedAuthorizedOverride
+            } else {
+                CollisionDisposition::RequiresSerialization
+            },
+            detected_at: attempt.attempted_at,
+        };
+        self.collisions.push(collision.clone());
+        OrchestratorWriteOutcome::Collision { collision }
+    }
+}
+
+/// Build the three explicit orchestrator nodes for a plan. Their session-state
+/// artifacts are always in scope, while repository paths come only from the
+/// plan's real Codegraph `Touches` surface rather than an implicit Queen=all
+/// rule.
+pub fn orchestrator_nodes_for_plan(graph: &TaskGraph) -> Vec<OrchestratorOwnershipNode> {
+    let paths = module_paths(graph).into_values().collect::<BTreeSet<_>>();
+    let mut queen = vec![OwnershipFootprint::new(
+        "state/work-graph.json",
+        OrchestratorOperation::IntegrationEdit,
+    )];
+    let mut prince = vec![OwnershipFootprint::new(
+        "state/assignments.json",
+        OrchestratorOperation::Remediation,
+    )];
+    let mut evaluator = vec![OwnershipFootprint::new(
+        "state/work-graph-reviews.json",
+        OrchestratorOperation::Verification,
+    )];
+    for path in paths {
+        queen.extend([
+            OwnershipFootprint::new(&path, OrchestratorOperation::IntegrationEdit),
+            OwnershipFootprint::new(&path, OrchestratorOperation::Restore),
+            OwnershipFootprint::new(&path, OrchestratorOperation::MutationProof),
+        ]);
+        prince.push(OwnershipFootprint::new(
+            &path,
+            OrchestratorOperation::Remediation,
+        ));
+        evaluator.extend([
+            OwnershipFootprint::new(&path, OrchestratorOperation::Verification),
+            OwnershipFootprint::new(&path, OrchestratorOperation::MutationProof),
+        ]);
+    }
+    vec![
+        OrchestratorOwnershipNode::queen("queen", queen),
+        OrchestratorOwnershipNode::prince("prince", prince),
+        OrchestratorOwnershipNode::evaluator("evaluator", evaluator),
+    ]
+}
+
+fn validate_orchestrator_declarations(
+    orchestrators: &[OrchestratorOwnershipNode],
+) -> Result<(), OwnershipDeclarationError> {
+    for role in [
+        OrchestratorRole::Queen,
+        OrchestratorRole::Prince,
+        OrchestratorRole::Evaluator,
+    ] {
+        let matching = orchestrators.iter().filter(|node| node.role == role).count();
+        if matching == 0 {
+            return Err(OwnershipDeclarationError::MissingRole(role));
+        }
+        if matching > 1 {
+            return Err(OwnershipDeclarationError::DuplicateRole(role));
+        }
+        if orchestrators
+            .iter()
+            .find(|node| node.role == role)
+            .is_some_and(|node| node.footprint.is_empty())
+        {
+            return Err(OwnershipDeclarationError::EmptyFootprint(role));
+        }
+    }
+    Ok(())
+}
+
+/// Resolve live path ownership from Codegraph-produced `Touches` edges. No
+/// separate ownership matrix exists; the module node's zone and expansion
+/// parameter are the file-level source of truth.
+pub fn derive_path_ownership(
+    graph: &TaskGraph,
+    live_principals: &[LivePrincipal],
+) -> Vec<PrincipalPathOwnership> {
+    let modules = module_paths(graph);
+    let principals = live_principals
+        .iter()
+        .map(|principal| (principal.task_id.as_str(), principal))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut ownership = graph
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::Touches)
+        .filter_map(|edge| {
+            let principal = principals.get(edge.source.as_str())?;
+            let path = modules.get(edge.target.as_str())?;
+            Some(PrincipalPathOwnership {
+                principal_id: principal.principal_id.clone(),
+                task_id: principal.task_id.clone(),
+                path: path.clone(),
+                write_capable: principal.write_capable,
+            })
+        })
+        .collect::<Vec<_>>();
+    ownership.sort_by(|left, right| {
+        (&left.path, &left.principal_id, &left.task_id).cmp(&(
+            &right.path,
+            &right.principal_id,
+            &right.task_id,
+        ))
+    });
+    ownership.dedup();
+    ownership
+}
+
+fn module_paths(graph: &TaskGraph) -> BTreeMap<&str, String> {
+    graph
+        .nodes
+        .iter()
+        .filter_map(|node| {
+            let BindingRef::Zone(zone) = &node.binding else {
+                return None;
+            };
+            if zone != CODEGRAPH_ZONE {
+                return None;
+            }
+            let expansion = node.expansion.as_ref()?;
+            if expansion.template != CODEGRAPH_MODULE_TEMPLATE {
+                return None;
+            }
+            let path = expansion.parameters.get("module")?;
+            Some((node.id.as_str(), normalize_path(path)))
+        })
+        .collect()
+}
+
+/// Report task-class verification gaps while the plan is being validated.
+/// Task output names are the existing class selector used by review templates.
+pub fn verification_duty_gaps(graph: &TaskGraph) -> Vec<VerificationDutyGap> {
+    let reviewed_tasks = graph
+        .edges
+        .iter()
+        .filter(|edge| edge.kind == EdgeKind::Reviews)
+        .map(|edge| edge.source.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut classes = BTreeMap::<String, BTreeSet<TaskId>>::new();
+    for node in graph.nodes.iter().filter(|node| node.kind == NodeKind::Task) {
+        if reviewed_tasks.contains(node.id.as_str()) {
+            continue;
+        }
+        for output in node
+            .contract
+            .outputs
+            .iter()
+            .map(|output| output.trim())
+            .filter(|output| !output.is_empty())
+        {
+            classes
+                .entry(format!("output:{output}"))
+                .or_default()
+                .insert(node.id.clone());
+        }
+    }
+    classes
+        .into_iter()
+        .map(|(task_class, task_ids)| VerificationDutyGap {
+            task_class,
+            unassigned_task_ids: task_ids.into_iter().collect(),
+        })
+        .collect()
+}
+
+fn normalize_path(path: &str) -> String {
+    let mut normalized = path.trim().replace('\\', "/");
+    while let Some(stripped) = normalized.strip_prefix("./") {
+        normalized = stripped.to_string();
+    }
+    normalized
+}

--- a/src-tauri/src/orchestrator/org_graph/ownership.rs
+++ b/src-tauri/src/orchestrator/org_graph/ownership.rs
@@ -269,11 +269,6 @@ impl OwnershipSessionState {
         attempt: OrchestratorWriteAttempt,
     ) -> OrchestratorWriteOutcome {
         let path = normalize_path(&attempt.path);
-        let Some(actor) = self.orchestrators.iter().find(|node| {
-            node.principal_id == attempt.actor_id && node.role == attempt.role
-        }) else {
-            return OrchestratorWriteOutcome::Proceed;
-        };
         let Some(owner) = self
             .live_principal_ownership
             .iter()
@@ -282,17 +277,27 @@ impl OwnershipSessionState {
             return OrchestratorWriteOutcome::Proceed;
         };
 
-        let override_authorized = actor.ownership_authority.may_override_live_ownership
-            && actor.ownership_authority.may_mutate_mid_flight;
+        let actor = self.orchestrators.iter().find(|node| {
+            node.principal_id == attempt.actor_id && node.role == attempt.role
+        });
+        let (within_declared_footprint, override_authorized) = actor
+            .map(|actor| {
+                (
+                    actor.declares(&attempt.path, attempt.operation),
+                    actor.ownership_authority.may_override_live_ownership
+                        && actor.ownership_authority.may_mutate_mid_flight,
+                )
+            })
+            .unwrap_or((false, false));
         let collision = OwnershipCollision {
-            actor_id: actor.principal_id.clone(),
-            actor_role: actor.role,
+            actor_id: attempt.actor_id,
+            actor_role: attempt.role,
             owner_principal_id: owner.principal_id.clone(),
             owner_task_id: owner.task_id.clone(),
             owner_write_capable: owner.write_capable,
             path,
             operation: attempt.operation,
-            within_declared_footprint: actor.declares(&attempt.path, attempt.operation),
+            within_declared_footprint,
             override_authorized,
             disposition: if override_authorized {
                 CollisionDisposition::SurfacedAuthorizedOverride
@@ -469,9 +474,20 @@ pub fn verification_duty_gaps(graph: &TaskGraph) -> Vec<VerificationDutyGap> {
 }
 
 fn normalize_path(path: &str) -> String {
-    let mut normalized = path.trim().replace('\\', "/");
-    while let Some(stripped) = normalized.strip_prefix("./") {
-        normalized = stripped.to_string();
+    let normalized_separators = path.trim().replace('\\', "/");
+    let rooted = normalized_separators.starts_with('/');
+    let normalized = normalized_separators
+        .split('/')
+        .filter(|component| !component.is_empty() && *component != ".")
+        .collect::<Vec<_>>()
+        .join("/");
+
+    // Ownership paths are normally repository-relative. Preserve an explicit
+    // root marker when one is supplied, but deliberately retain `..` segments:
+    // resolving them would require a declared containment root and policy.
+    if rooted {
+        format!("/{normalized}")
+    } else {
+        normalized
     }
-    normalized
 }

--- a/src-tauri/src/orchestrator/org_graph/schema.rs
+++ b/src-tauri/src/orchestrator/org_graph/schema.rs
@@ -1,0 +1,117 @@
+//! Serializable org-graph types shared by definition, composition, and runtime consumers.
+
+use serde::{Deserialize, Serialize};
+
+use crate::cli::CliBehavior;
+
+/// A durable semantic role definition. Runtime agents record the definition id
+/// and version, but the definition itself remains an external, reusable artifact.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinition {
+    pub id: String,
+    pub version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub domain: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub knowledge_scope: Vec<KnowledgeRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lens: Option<RoleLens>,
+    #[serde(default)]
+    pub authority: AuthorityScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior: Option<CliBehavior>,
+    #[serde(default)]
+    pub context_boundary: ContextBoundary,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal_class: Option<SignalClass>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_template: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub non_goals: Vec<String>,
+}
+
+impl RoleDefinition {
+    /// Backward-compatible role identity: task context and CLI capability only.
+    pub fn empty(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            version: 0,
+            domain: None,
+            knowledge_scope: Vec::new(),
+            lens: None,
+            authority: AuthorityScope::default(),
+            behavior: None,
+            context_boundary: ContextBoundary::default(),
+            signal_class: None,
+            prompt_template: None,
+            non_goals: Vec::new(),
+        }
+    }
+}
+
+/// The evaluator's behavior is data on its role definition, not a CLI registry exception.
+pub fn evaluator_role_definition() -> RoleDefinition {
+    let mut definition = RoleDefinition::empty("evaluator");
+    definition.version = 1;
+    definition.behavior = Some(CliBehavior::InstructionFollowing);
+    definition
+}
+
+/// A pointer into a knowledge graph plus a bounded synopsis. It never embeds
+/// the referenced document or subtree.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KnowledgeRef {
+    pub source: KnowledgeSource,
+    pub pointer: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub priority: u16,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeSource {
+    Institutional,
+    Project,
+}
+
+/// The question a role consistently brings to otherwise task-specific context.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RoleLens {
+    pub id: String,
+    pub question: String,
+}
+
+/// Role-level authority independent of a particular task assignment.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthorityScope {
+    #[serde(default)]
+    pub may_commit: bool,
+    #[serde(default)]
+    pub may_push: bool,
+    #[serde(default)]
+    pub may_spawn_subordinates: bool,
+    #[serde(default)]
+    pub may_adjudicate: bool,
+    #[serde(default)]
+    pub may_mutate_unowned_paths: bool,
+}
+
+/// How much spawner context may cross into a role's composed prompt.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextBoundary {
+    None,
+    Artifact,
+    #[default]
+    Full,
+}
+
+/// Verification signals differ in how much contextual independence they require.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SignalClass {
+    Mechanical,
+    Judgmental,
+}

--- a/src-tauri/src/orchestrator/work_graph/archive.rs
+++ b/src-tauri/src/orchestrator/work_graph/archive.rs
@@ -292,8 +292,16 @@ pub fn archive_completed_session(
     let archive_id = archive_id_for_session(session_id);
     let target = archive_dir.join(format!("{archive_id}.json"));
     if target.exists() {
+        let archive = read_archive(&target)?;
+        StateManager::new(session_dir)
+            .write_portable_work_graph_artifact(
+                "archived",
+                &archive.runtime_graph,
+                Some(&archive.divergence),
+            )
+            .map_err(|error| ArchiveError::Storage(error.to_string()))?;
         return Ok(ArchiveCompletion {
-            archive: read_archive(&target)?,
+            archive,
             path: target,
             created: false,
         });
@@ -425,19 +433,27 @@ pub fn archive_completed_session(
 
     let mut temp = NamedTempFile::new_in(&archive_dir)?;
     serde_json::to_writer_pretty(&mut temp, &archive)?;
-    match temp.persist_noclobber(&target) {
-        Ok(_) => Ok(ArchiveCompletion {
+    let completion = match temp.persist_noclobber(&target) {
+        Ok(_) => ArchiveCompletion {
             path: target,
             archive,
             created: true,
-        }),
-        Err(_error) if target.exists() => Ok(ArchiveCompletion {
+        },
+        Err(_error) if target.exists() => ArchiveCompletion {
             archive: read_archive(&target)?,
             path: target,
             created: false,
-        }),
-        Err(error) => Err(ArchiveError::Io(error.error)),
-    }
+        },
+        Err(error) => return Err(ArchiveError::Io(error.error)),
+    };
+    StateManager::new(session_dir)
+        .write_portable_work_graph_artifact(
+            "archived",
+            &completion.archive.runtime_graph,
+            Some(&completion.archive.divergence),
+        )
+        .map_err(|error| ArchiveError::Storage(error.to_string()))?;
+    Ok(completion)
 }
 
 /// Synchronously run the ordered terminal pipeline used by the detached hook:

--- a/src-tauri/src/orchestrator/work_graph/retro.rs
+++ b/src-tauri/src/orchestrator/work_graph/retro.rs
@@ -511,11 +511,23 @@ pub struct RoleDefinitionAggregate {
     pub session_ids: Vec<String>,
     pub archive_ids: Vec<String>,
     pub additional_attempts: Option<usize>,
+    #[serde(default)]
+    pub additional_attempts_contributing_runs: usize,
     pub remediation_detours: Option<usize>,
+    #[serde(default)]
+    pub remediation_detours_contributing_runs: usize,
     pub caught_defects: Option<usize>,
+    #[serde(default)]
+    pub caught_defects_contributing_runs: usize,
     pub escaped_defects: Option<usize>,
+    #[serde(default)]
+    pub escaped_defects_contributing_runs: usize,
     pub gotcha_edges_eligible: Option<usize>,
+    #[serde(default)]
+    pub gotcha_edges_eligible_contributing_runs: usize,
     pub gotcha_targets_attempted: Option<usize>,
+    #[serde(default)]
+    pub gotcha_targets_attempted_contributing_runs: usize,
     pub confirmed_scope_gaps: usize,
 }
 
@@ -996,24 +1008,25 @@ fn role_definition_metrics(
     let mut missing_agents = BTreeSet::new();
     for outcome in &archive.outcomes {
         let mut outcome_definitions = BTreeSet::new();
+        let confirmed_scope_gaps = outcome
+            .effects
+            .iter()
+            .filter(|effect| effect.confirmed && effect.kind == ROLE_SCOPE_GAP_EFFECT_KIND)
+            .count();
         for agent_id in &outcome.agent_ids {
             let Some(definition) = by_agent.get(agent_id) else {
                 missing_agents.insert(agent_id.clone());
                 continue;
             };
-            outcome_definitions.insert(definition.clone());
+            let newly_inserted_definition = outcome_definitions.insert(definition.clone());
             let accumulator = accumulators.entry(definition.clone()).or_default();
             accumulator.agent_ids.insert(agent_id.clone());
             accumulator
                 .evidence_refs
                 .extend(outcome.source_refs.iter().cloned());
-            accumulator.confirmed_scope_gaps += outcome
-                .effects
-                .iter()
-                .filter(|effect| {
-                    effect.confirmed && effect.kind == ROLE_SCOPE_GAP_EFFECT_KIND
-                })
-                .count();
+            if newly_inserted_definition {
+                accumulator.confirmed_scope_gaps += confirmed_scope_gaps;
+            }
             accumulator.evidence_refs.extend(
                 outcome
                     .effects
@@ -2088,9 +2101,14 @@ fn role_refinement_learnings(
         .collect()
 }
 
-fn add_optional(total: &mut Option<usize>, value: Option<usize>) {
+fn add_optional(
+    total: &mut Option<usize>,
+    contributing_runs: &mut usize,
+    value: Option<usize>,
+) {
     if let Some(value) = value {
         *total.get_or_insert(0) += value;
+        *contributing_runs += 1;
     }
 }
 
@@ -2107,11 +2125,17 @@ fn aggregate_role_definitions(runs: &[PerRunRetro]) -> Vec<RoleDefinitionAggrega
                     session_ids: Vec::new(),
                     archive_ids: Vec::new(),
                     additional_attempts: None,
+                    additional_attempts_contributing_runs: 0,
                     remediation_detours: None,
+                    remediation_detours_contributing_runs: 0,
                     caught_defects: None,
+                    caught_defects_contributing_runs: 0,
                     escaped_defects: None,
+                    escaped_defects_contributing_runs: 0,
                     gotcha_edges_eligible: None,
+                    gotcha_edges_eligible_contributing_runs: 0,
                     gotcha_targets_attempted: None,
+                    gotcha_targets_attempted_contributing_runs: 0,
                     confirmed_scope_gaps: 0,
                 });
             aggregate.run_count += 1;
@@ -2120,20 +2144,32 @@ fn aggregate_role_definitions(runs: &[PerRunRetro]) -> Vec<RoleDefinitionAggrega
             aggregate.archive_ids.push(run.archive_id.clone());
             add_optional(
                 &mut aggregate.additional_attempts,
+                &mut aggregate.additional_attempts_contributing_runs,
                 metric.additional_attempts,
             );
             add_optional(
                 &mut aggregate.remediation_detours,
+                &mut aggregate.remediation_detours_contributing_runs,
                 metric.remediation_detours,
             );
-            add_optional(&mut aggregate.caught_defects, metric.caught_defects);
-            add_optional(&mut aggregate.escaped_defects, metric.escaped_defects);
+            add_optional(
+                &mut aggregate.caught_defects,
+                &mut aggregate.caught_defects_contributing_runs,
+                metric.caught_defects,
+            );
+            add_optional(
+                &mut aggregate.escaped_defects,
+                &mut aggregate.escaped_defects_contributing_runs,
+                metric.escaped_defects,
+            );
             add_optional(
                 &mut aggregate.gotcha_edges_eligible,
+                &mut aggregate.gotcha_edges_eligible_contributing_runs,
                 metric.gotcha_edges_eligible,
             );
             add_optional(
                 &mut aggregate.gotcha_targets_attempted,
+                &mut aggregate.gotcha_targets_attempted_contributing_runs,
                 metric.gotcha_targets_attempted,
             );
             aggregate.confirmed_scope_gaps += metric.confirmed_scope_gaps;

--- a/src-tauri/src/orchestrator/work_graph/retro.rs
+++ b/src-tauri/src/orchestrator/work_graph/retro.rs
@@ -13,6 +13,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::error::Error;
 use std::fmt;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::{DateTime, Utc};
@@ -37,6 +38,7 @@ use super::schema::{
 
 pub const PROMOTION_RUN_THRESHOLD: usize = 2;
 pub const REVIEW_ESCAPE_EFFECT_KIND: &str = "review_escape";
+pub const ROLE_SCOPE_GAP_EFFECT_KIND: &str = "role_scope_gap";
 pub const UNREVIEWED_OUTCOME: &str = "unreviewed";
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -57,6 +59,98 @@ impl Ord for TemplateKey {
             .cmp(&other.template_id)
             .then(self.template_version.cmp(&other.template_version))
     }
+}
+
+/// Exact role-definition lineage used for historical aggregation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinitionKey {
+    pub definition_id: String,
+    pub definition_version: u32,
+}
+
+impl PartialOrd for RoleDefinitionKey {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for RoleDefinitionKey {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.definition_id
+            .cmp(&other.definition_id)
+            .then(self.definition_version.cmp(&other.definition_version))
+    }
+}
+
+/// Immutable attribution captured when an agent resolves its role definition.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentRoleDefinitionAttribution {
+    pub session_id: String,
+    pub agent_id: String,
+    pub definition: RoleDefinitionKey,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RoleRefinementSignal {
+    AdditionalAttempts,
+    RemediationDetours,
+    ReviewEscapes,
+    UnusedKnowledgeScope,
+    DeclaredScopeGap,
+}
+
+impl RoleRefinementSignal {
+    pub const fn scope_impact(self) -> ScopeImpact {
+        match self {
+            Self::AdditionalAttempts | Self::RemediationDetours => ScopeImpact::NoScopeChange,
+            Self::ReviewEscapes | Self::UnusedKnowledgeScope => ScopeImpact::Narrowing,
+            Self::DeclaredScopeGap => ScopeImpact::Widening,
+        }
+    }
+
+    const fn change_key(self) -> &'static str {
+        match self {
+            Self::AdditionalAttempts => "additional_attempts",
+            Self::RemediationDetours => "remediation_detours",
+            Self::ReviewEscapes => "review_escapes",
+            Self::UnusedKnowledgeScope => "unused_knowledge_scope",
+            Self::DeclaredScopeGap => "declared_scope_gap",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ScopeImpact {
+    Narrowing,
+    Widening,
+    NoScopeChange,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinitionRefinementObservation {
+    pub repo_id: String,
+    pub session_id: String,
+    pub archive_id: String,
+    pub definition: RoleDefinitionKey,
+    pub signal: RoleRefinementSignal,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinitionRefinementProposal {
+    pub tier: PromotionTier,
+    pub definition: RoleDefinitionKey,
+    pub change_key: String,
+    pub scope_impact: ScopeImpact,
+    pub observation_count: usize,
+    pub repo_ids: Vec<String>,
+    pub session_ids: Vec<String>,
+    pub archive_ids: Vec<String>,
+    pub evidence_refs: Vec<String>,
+    pub rationale: String,
 }
 
 /// The archive stores the aggregation portion of `ArchetypeLineage` on each
@@ -122,6 +216,7 @@ pub enum RetroOmissionReason {
     UnsupportedSchemaVersion,
     PlanGraphUnavailable,
     TemplateLineageUnavailable,
+    RoleDefinitionLineageUnavailable,
     EvaluatorProvenanceUnavailable,
     EventEvidenceUnavailable,
     RunLedgerEvidenceUnavailable,
@@ -304,6 +399,22 @@ pub struct RetroArchivePath {
     pub path: PathBuf,
 }
 
+#[derive(Debug, Deserialize)]
+struct PersistedRoleAttributionSession {
+    id: String,
+    #[serde(default)]
+    agents: Vec<PersistedRoleAttributionAgent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PersistedRoleAttributionAgent {
+    id: String,
+    #[serde(default)]
+    role_definition_id: Option<String>,
+    #[serde(default)]
+    role_definition_version: Option<u32>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PlanActualEditDistance {
     /// Unit-cost archived structural divergences. An edge rewire is one unit.
@@ -377,6 +488,38 @@ pub struct GotchaEdgeHitRate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinitionRunMetric {
+    pub definition: RoleDefinitionKey,
+    pub agent_ids: Vec<String>,
+    pub node_ids: Vec<String>,
+    pub additional_attempts: Option<usize>,
+    pub remediation_detours: Option<usize>,
+    pub caught_defects: Option<usize>,
+    pub escaped_defects: Option<usize>,
+    pub gotcha_edges_eligible: Option<usize>,
+    pub gotcha_targets_attempted: Option<usize>,
+    pub confirmed_scope_gaps: usize,
+    #[serde(default)]
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoleDefinitionAggregate {
+    pub definition: RoleDefinitionKey,
+    pub run_count: usize,
+    pub repo_ids: Vec<String>,
+    pub session_ids: Vec<String>,
+    pub archive_ids: Vec<String>,
+    pub additional_attempts: Option<usize>,
+    pub remediation_detours: Option<usize>,
+    pub caught_defects: Option<usize>,
+    pub escaped_defects: Option<usize>,
+    pub gotcha_edges_eligible: Option<usize>,
+    pub gotcha_targets_attempted: Option<usize>,
+    pub confirmed_scope_gaps: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PerRunRetro {
     pub repo_id: String,
     pub archive_id: String,
@@ -388,6 +531,8 @@ pub struct PerRunRetro {
     pub checkpoints: EvidenceMetric<Vec<CheckpointBarrierMetric>>,
     pub reviews: EvidenceMetric<Vec<ReviewEfficacyMetric>>,
     pub gotcha_edge_hit_rate: EvidenceMetric<GotchaEdgeHitRate>,
+    #[serde(default)]
+    pub role_definitions: Vec<RoleDefinitionRunMetric>,
     #[serde(default)]
     pub omissions: Vec<RetroOmission>,
 }
@@ -433,6 +578,10 @@ pub struct RetroReport {
     pub runs: Vec<PerRunRetro>,
     pub template_aggregates: Vec<TemplateAggregate>,
     pub promotion_proposals: Vec<DeviationPromotionProposal>,
+    #[serde(default)]
+    pub role_definition_aggregates: Vec<RoleDefinitionAggregate>,
+    #[serde(default)]
+    pub role_refinement_proposals: Vec<RoleDefinitionRefinementProposal>,
     /// Request bodies exposed for the sanctioned session-learning endpoint.
     pub learning_submissions: Vec<UnreviewedLearningSubmission>,
     #[serde(default)]
@@ -449,6 +598,8 @@ impl RetroReport {
             runs: Vec::new(),
             template_aggregates: Vec::new(),
             promotion_proposals: Vec::new(),
+            role_definition_aggregates: Vec::new(),
+            role_refinement_proposals: Vec::new(),
             learning_submissions: Vec::new(),
             omissions: vec![omission],
         }
@@ -460,13 +611,20 @@ pub fn evaluate_archive_paths(
     paths: &[RetroArchivePath],
 ) -> Result<RetroReport, RetroError> {
     let mut inputs = Vec::new();
+    let mut role_attributions = Vec::new();
     let mut omissions = Vec::new();
     for input in paths {
         match read_archive(&input.path) {
-            Ok(archive) => inputs.push(RetroRunInput {
-                repo_id: input.repo_id.clone(),
-                archive,
-            }),
+            Ok(archive) => {
+                let (mut loaded_attributions, mut attribution_omissions) =
+                    load_role_attributions_for_archive(&input.path, &archive);
+                role_attributions.append(&mut loaded_attributions);
+                omissions.append(&mut attribution_omissions);
+                inputs.push(RetroRunInput {
+                    repo_id: input.repo_id.clone(),
+                    archive,
+                });
+            }
             Err(error) => {
                 let rendered = error.to_string();
                 let reason = if rendered.contains("unsupported schema version") {
@@ -483,7 +641,13 @@ pub fn evaluate_archive_paths(
             }
         }
     }
-    evaluate_inputs(evaluator, &inputs, omissions, paths.is_empty())
+    evaluate_inputs(
+        evaluator,
+        &inputs,
+        &role_attributions,
+        omissions,
+        paths.is_empty(),
+    )
 }
 
 /// Discover and evaluate immutable archives beneath a completed session.
@@ -508,6 +672,7 @@ pub fn evaluate_completed_session(
         Err(error) => evaluate_inputs(
             evaluator,
             &[],
+            &[],
             vec![RetroOmission::new(
                 RetroOmissionReason::ArchiveUnreadable,
                 "archive",
@@ -523,12 +688,30 @@ pub fn evaluate_archives(
     evaluator: &IndependentEvaluator,
     inputs: &[RetroRunInput],
 ) -> Result<RetroReport, RetroError> {
-    evaluate_inputs(evaluator, inputs, Vec::new(), inputs.is_empty())
+    evaluate_inputs(evaluator, inputs, &[], Vec::new(), inputs.is_empty())
+}
+
+/// Evaluate in-memory archives with exact historical role-definition lineage.
+/// The legacy entry point remains available and reports missing lineage rather
+/// than guessing from a role binding or the current definition on disk.
+pub fn evaluate_archives_with_role_attributions(
+    evaluator: &IndependentEvaluator,
+    inputs: &[RetroRunInput],
+    role_attributions: &[AgentRoleDefinitionAttribution],
+) -> Result<RetroReport, RetroError> {
+    evaluate_inputs(
+        evaluator,
+        inputs,
+        role_attributions,
+        Vec::new(),
+        inputs.is_empty(),
+    )
 }
 
 fn evaluate_inputs(
     evaluator: &IndependentEvaluator,
     inputs: &[RetroRunInput],
+    role_attributions: &[AgentRoleDefinitionAttribution],
     mut omissions: Vec<RetroOmission>,
     no_candidates: bool,
 ) -> Result<RetroReport, RetroError> {
@@ -591,9 +774,25 @@ fn evaluate_inputs(
 
     let mut runs: Vec<_> = valid.iter().map(evaluate_run).collect();
     apply_review_escape_revisions(&valid, &mut runs, &mut omissions);
-    let (promotion_proposals, learning_submissions) =
+    for (input, run) in valid.iter().zip(runs.iter_mut()) {
+        let role_definitions = role_definition_metrics(
+            input,
+            run,
+            role_attributions,
+            &mut omissions,
+        );
+        run.role_definitions = role_definitions;
+    }
+    let (promotion_proposals, mut learning_submissions) =
         systematic_divergence(&valid, &runs, &mut omissions);
     let template_aggregates = aggregate_templates(&runs);
+    let role_definition_aggregates = aggregate_role_definitions(&runs);
+    let role_observations = role_refinement_observations(&runs);
+    let role_refinement_proposals =
+        propose_role_definition_refinements(&role_observations);
+    learning_submissions.extend(role_refinement_learnings(
+        &role_refinement_proposals,
+    ));
     for run in &runs {
         omissions.extend(run.omissions.iter().cloned());
     }
@@ -602,6 +801,8 @@ fn evaluate_inputs(
         runs,
         template_aggregates,
         promotion_proposals,
+        role_definition_aggregates,
+        role_refinement_proposals,
         learning_submissions,
         omissions,
     })
@@ -640,8 +841,318 @@ fn evaluate_run(input: &RetroRunInput) -> PerRunRetro {
         checkpoints: checkpoint_metrics(archive),
         reviews: review_metrics(archive),
         gotcha_edge_hit_rate: gotcha_hit_rate(archive),
+        role_definitions: Vec::new(),
         omissions: run_omissions,
     }
+}
+
+fn load_role_attributions_for_archive(
+    archive_path: &Path,
+    archive: &WorkGraphArchive,
+) -> (
+    Vec<AgentRoleDefinitionAttribution>,
+    Vec<RetroOmission>,
+) {
+    let Some(session_dir) = archive_path
+        .parent()
+        .and_then(Path::parent)
+        .and_then(Path::parent)
+    else {
+        return (
+            Vec::new(),
+            vec![RetroOmission::new(
+                RetroOmissionReason::RoleDefinitionLineageUnavailable,
+                "role_definition_attribution",
+                "the archive path does not identify its session directory",
+                vec![archive_path.display().to_string()],
+            )
+            .for_archive(&archive.archive_id)],
+        );
+    };
+    let session_path = session_dir.join("session.json");
+    let persisted = match fs::read_to_string(&session_path)
+        .map_err(|error| error.to_string())
+        .and_then(|source| {
+            serde_json::from_str::<PersistedRoleAttributionSession>(&source)
+                .map_err(|error| error.to_string())
+        }) {
+        Ok(persisted) => persisted,
+        Err(detail) => {
+            return (
+                Vec::new(),
+                vec![RetroOmission::new(
+                    RetroOmissionReason::RoleDefinitionLineageUnavailable,
+                    "role_definition_attribution",
+                    format!("persisted agent role-definition lineage is unavailable: {detail}"),
+                    vec![session_path.display().to_string()],
+                )
+                .for_archive(&archive.archive_id)],
+            );
+        }
+    };
+    if persisted.id != archive.session_id {
+        return (
+            Vec::new(),
+            vec![RetroOmission::new(
+                RetroOmissionReason::RoleDefinitionLineageUnavailable,
+                "role_definition_attribution",
+                "the persisted session identity does not match the archive",
+                vec![persisted.id, archive.session_id.clone()],
+            )
+            .for_archive(&archive.archive_id)],
+        );
+    }
+
+    let mut attributions = Vec::new();
+    let mut incomplete = Vec::new();
+    let relevant_agent_ids: BTreeSet<_> = archive
+        .outcomes
+        .iter()
+        .flat_map(|outcome| outcome.agent_ids.iter().cloned())
+        .collect();
+    for agent in persisted.agents {
+        if !relevant_agent_ids.contains(&agent.id) {
+            continue;
+        }
+        match (agent.role_definition_id, agent.role_definition_version) {
+            (Some(definition_id), Some(definition_version))
+                if !definition_id.trim().is_empty() && definition_version > 0 =>
+            {
+                attributions.push(AgentRoleDefinitionAttribution {
+                    session_id: archive.session_id.clone(),
+                    agent_id: agent.id,
+                    definition: RoleDefinitionKey {
+                        definition_id,
+                        definition_version,
+                    },
+                });
+            }
+            _ => incomplete.push(agent.id),
+        }
+    }
+    let omissions = if incomplete.is_empty() {
+        Vec::new()
+    } else {
+        vec![RetroOmission::new(
+            RetroOmissionReason::RoleDefinitionLineageUnavailable,
+            "role_definition_attribution",
+            "persisted agents without both a definition id and version were excluded",
+            incomplete,
+        )
+        .for_archive(&archive.archive_id)]
+    };
+    (attributions, omissions)
+}
+
+#[derive(Default)]
+struct RoleMetricAccumulator {
+    agent_ids: BTreeSet<String>,
+    node_ids: BTreeSet<String>,
+    additional_attempts: usize,
+    remediation_detours: usize,
+    caught_defects: usize,
+    escaped_defects: usize,
+    gotcha_edges_eligible: usize,
+    gotcha_targets_attempted: usize,
+    confirmed_scope_gaps: usize,
+    evidence_refs: BTreeSet<String>,
+}
+
+fn role_definition_metrics(
+    input: &RetroRunInput,
+    run: &PerRunRetro,
+    role_attributions: &[AgentRoleDefinitionAttribution],
+    omissions: &mut Vec<RetroOmission>,
+) -> Vec<RoleDefinitionRunMetric> {
+    let archive = &input.archive;
+    let mut by_agent = BTreeMap::new();
+    let mut conflicts = BTreeSet::new();
+    for attribution in role_attributions
+        .iter()
+        .filter(|item| item.session_id == archive.session_id)
+    {
+        if attribution.agent_id.trim().is_empty()
+            || attribution.definition.definition_id.trim().is_empty()
+            || attribution.definition.definition_version == 0
+        {
+            conflicts.insert(attribution.agent_id.clone());
+            continue;
+        }
+        match by_agent.get(&attribution.agent_id) {
+            Some(existing) if existing != &attribution.definition => {
+                conflicts.insert(attribution.agent_id.clone());
+            }
+            _ => {
+                by_agent.insert(attribution.agent_id.clone(), attribution.definition.clone());
+            }
+        }
+    }
+    for agent_id in &conflicts {
+        by_agent.remove(agent_id);
+    }
+
+    let mut by_node: BTreeMap<String, BTreeSet<RoleDefinitionKey>> = BTreeMap::new();
+    let mut accumulators: BTreeMap<RoleDefinitionKey, RoleMetricAccumulator> = BTreeMap::new();
+    let mut missing_agents = BTreeSet::new();
+    for outcome in &archive.outcomes {
+        let mut outcome_definitions = BTreeSet::new();
+        for agent_id in &outcome.agent_ids {
+            let Some(definition) = by_agent.get(agent_id) else {
+                missing_agents.insert(agent_id.clone());
+                continue;
+            };
+            outcome_definitions.insert(definition.clone());
+            let accumulator = accumulators.entry(definition.clone()).or_default();
+            accumulator.agent_ids.insert(agent_id.clone());
+            accumulator
+                .evidence_refs
+                .extend(outcome.source_refs.iter().cloned());
+            accumulator.confirmed_scope_gaps += outcome
+                .effects
+                .iter()
+                .filter(|effect| {
+                    effect.confirmed && effect.kind == ROLE_SCOPE_GAP_EFFECT_KIND
+                })
+                .count();
+            accumulator.evidence_refs.extend(
+                outcome
+                    .effects
+                    .iter()
+                    .filter(|effect| effect.confirmed)
+                    .map(|effect| effect.source_ref.clone()),
+            );
+        }
+        let mut node_ids = BTreeSet::from([outcome.subject_id.clone()]);
+        if let Some(task_id) = &outcome.task_id {
+            node_ids.insert(task_id.clone());
+        }
+        for node_id in node_ids {
+            by_node
+                .entry(node_id.clone())
+                .or_default()
+                .extend(outcome_definitions.iter().cloned());
+            for definition in &outcome_definitions {
+                accumulators
+                    .entry(definition.clone())
+                    .or_default()
+                    .node_ids
+                    .insert(node_id.clone());
+            }
+        }
+    }
+
+    let mut lineage_examples = conflicts;
+    lineage_examples.extend(missing_agents);
+    let lineage_already_reported = omissions.iter().any(|omission| {
+        omission.reason == RetroOmissionReason::RoleDefinitionLineageUnavailable
+            && omission.archive_id.as_deref() == Some(archive.archive_id.as_str())
+    });
+    if (!lineage_examples.is_empty() || (by_agent.is_empty() && !archive.outcomes.is_empty()))
+        && !lineage_already_reported
+    {
+        omissions.push(
+            RetroOmission::new(
+                RetroOmissionReason::RoleDefinitionLineageUnavailable,
+                "role_definition_attribution",
+                "runtime agent ids without one exact persisted role-definition version were excluded",
+                lineage_examples.into_iter().collect(),
+            )
+            .for_archive(&archive.archive_id),
+        );
+    }
+
+    if let Some(nodes) = run.nodes.value() {
+        for node in nodes {
+            let Some(definitions) = by_node.get(&node.node_id) else {
+                continue;
+            };
+            for definition in definitions {
+                let accumulator = accumulators.entry(definition.clone()).or_default();
+                accumulator.additional_attempts += node.additional_attempts.unwrap_or(0);
+                accumulator.remediation_detours += node.remediation_detours.unwrap_or(0);
+            }
+        }
+    }
+
+    if let Some(reviews) = run.reviews.value() {
+        for review in reviews {
+            let Some(definitions) = by_node.get(&review.verdict_id) else {
+                continue;
+            };
+            for definition in definitions {
+                let accumulator = accumulators.entry(definition.clone()).or_default();
+                accumulator.caught_defects += review.caught_defects;
+                accumulator.escaped_defects += review.escaped_defects;
+                accumulator
+                    .evidence_refs
+                    .extend(review.evidence_refs.iter().cloned());
+                accumulator.evidence_refs.extend(
+                    review
+                        .revisions
+                        .iter()
+                        .map(|revision| revision.source_ref.clone()),
+                );
+            }
+        }
+    }
+
+    let knowledge_available = !archive.runtime_graph.omissions.iter().any(|omission| {
+        omission.reason == WorkGraphOmissionReason::ProjectKnowledgeUnavailable
+    });
+    let event_available = source_available(archive, ArchiveSourceKind::EventLog);
+    if knowledge_available && event_available {
+        for edge in archive.runtime_graph.edges.iter().filter(|edge| {
+            edge.kind == EdgeKind::Informs
+                && edge.provenance == EdgeProvenance::Knowledge
+        }) {
+            let Some(definitions) = by_node.get(&edge.target) else {
+                continue;
+            };
+            let attempted = archive.outcomes.iter().any(|outcome| {
+                outcome_matches_node(outcome, &edge.target)
+                    && outcome.attempt_count > 0
+                    && event_backed(outcome)
+            });
+            for definition in definitions {
+                let accumulator = accumulators.entry(definition.clone()).or_default();
+                accumulator.gotcha_edges_eligible += 1;
+                accumulator.gotcha_targets_attempted += usize::from(attempted);
+                accumulator.evidence_refs.insert(format!(
+                    "knowledge-edge:{}->{}",
+                    edge.source, edge.target
+                ));
+            }
+        }
+    }
+
+    let node_evidence_available = run.nodes.value().is_some();
+    let review_evidence_available = run.reviews.value().is_some();
+    let gotcha_evidence_available = knowledge_available && event_available;
+    accumulators
+        .into_iter()
+        .map(|(definition, mut value)| {
+            value
+                .evidence_refs
+                .insert(format!("archive:{}", archive.archive_id));
+            RoleDefinitionRunMetric {
+                definition,
+                agent_ids: value.agent_ids.into_iter().collect(),
+                node_ids: value.node_ids.into_iter().collect(),
+                additional_attempts: node_evidence_available
+                    .then_some(value.additional_attempts),
+                remediation_detours: node_evidence_available
+                    .then_some(value.remediation_detours),
+                caught_defects: review_evidence_available.then_some(value.caught_defects),
+                escaped_defects: review_evidence_available.then_some(value.escaped_defects),
+                gotcha_edges_eligible: gotcha_evidence_available
+                    .then_some(value.gotcha_edges_eligible),
+                gotcha_targets_attempted: gotcha_evidence_available
+                    .then_some(value.gotcha_targets_attempted),
+                confirmed_scope_gaps: value.confirmed_scope_gaps,
+                evidence_refs: value.evidence_refs.into_iter().collect(),
+            }
+        })
+        .collect()
 }
 
 fn edit_distance(
@@ -1415,6 +1926,231 @@ fn unique_edge_kind(graph: &TaskGraph, source: &str, target: &str) -> Option<Str
         .filter_map(|edge| serde_json::to_string(&edge.kind).ok())
         .collect();
     (kinds.len() == 1).then(|| kinds.into_iter().next()).flatten()
+}
+
+fn role_refinement_observations(
+    runs: &[PerRunRetro],
+) -> Vec<RoleDefinitionRefinementObservation> {
+    let mut observations = Vec::new();
+    for run in runs {
+        for metric in &run.role_definitions {
+            let signals = [
+                (
+                    RoleRefinementSignal::AdditionalAttempts,
+                    metric.additional_attempts.unwrap_or(0) > 0,
+                ),
+                (
+                    RoleRefinementSignal::RemediationDetours,
+                    metric.remediation_detours.unwrap_or(0) > 0,
+                ),
+                (
+                    RoleRefinementSignal::ReviewEscapes,
+                    metric.escaped_defects.unwrap_or(0) > 0,
+                ),
+                (
+                    RoleRefinementSignal::UnusedKnowledgeScope,
+                    metric.gotcha_edges_eligible.unwrap_or(0) > 0
+                        && metric.gotcha_targets_attempted == Some(0),
+                ),
+                (
+                    RoleRefinementSignal::DeclaredScopeGap,
+                    metric.confirmed_scope_gaps > 0,
+                ),
+            ];
+            for (signal, observed) in signals {
+                if !observed {
+                    continue;
+                }
+                observations.push(RoleDefinitionRefinementObservation {
+                    repo_id: run.repo_id.clone(),
+                    session_id: run.session_id.clone(),
+                    archive_id: run.archive_id.clone(),
+                    definition: metric.definition.clone(),
+                    signal,
+                    evidence_refs: metric.evidence_refs.clone(),
+                });
+            }
+        }
+    }
+    observations
+}
+
+/// Return review-gated proposals only. The function has no definition path or
+/// git handle and therefore cannot apply or commit the proposed refinement.
+pub fn propose_role_definition_refinements(
+    observations: &[RoleDefinitionRefinementObservation],
+) -> Vec<RoleDefinitionRefinementProposal> {
+    let mut groups: BTreeMap<
+        (RoleDefinitionKey, RoleRefinementSignal),
+        BTreeMap<(String, String), &RoleDefinitionRefinementObservation>,
+    > = BTreeMap::new();
+    for observation in observations {
+        groups
+            .entry((observation.definition.clone(), observation.signal))
+            .or_default()
+            .entry((
+                observation.repo_id.clone(),
+                observation.session_id.clone(),
+            ))
+            .or_insert(observation);
+    }
+
+    let mut proposals = Vec::new();
+    for ((definition, signal), instances) in groups {
+        let repo_ids: BTreeSet<_> =
+            instances.values().map(|item| item.repo_id.clone()).collect();
+        if repo_ids.len() < 2 && instances.len() < PROMOTION_RUN_THRESHOLD {
+            continue;
+        }
+        let tier = if repo_ids.len() >= 2 {
+            PromotionTier::InstitutionalRevision
+        } else {
+            PromotionTier::ProjectOverride
+        };
+        let session_ids: BTreeSet<_> = instances
+            .values()
+            .map(|item| item.session_id.clone())
+            .collect();
+        let archive_ids: BTreeSet<_> = instances
+            .values()
+            .map(|item| item.archive_id.clone())
+            .collect();
+        let evidence_refs: BTreeSet<_> = instances
+            .values()
+            .flat_map(|item| item.evidence_refs.iter().cloned())
+            .collect();
+        let scope_impact = signal.scope_impact();
+        proposals.push(RoleDefinitionRefinementProposal {
+            tier,
+            definition,
+            change_key: signal.change_key().to_string(),
+            scope_impact,
+            observation_count: instances.len(),
+            repo_ids: repo_ids.into_iter().collect(),
+            session_ids: session_ids.into_iter().collect(),
+            archive_ids: archive_ids.into_iter().collect(),
+            evidence_refs: evidence_refs.into_iter().collect(),
+            rationale: match (tier, scope_impact) {
+                (PromotionTier::ProjectOverride, ScopeImpact::Widening) => {
+                    "repeated evidence in one repository suggests a wider role scope; widening is suspect by default and requires human review as a Tier 1 override".to_string()
+                }
+                (PromotionTier::InstitutionalRevision, ScopeImpact::Widening) => {
+                    "independent evidence across repositories suggests a wider role scope; widening is suspect by default and requires a PR-gated Tier 2 review".to_string()
+                }
+                (PromotionTier::ProjectOverride, _) => {
+                    "repeated evidence in one repository suggests a narrower or behavior-only role refinement for human review as a Tier 1 override".to_string()
+                }
+                (PromotionTier::InstitutionalRevision, _) => {
+                    "independent evidence across repositories suggests a role refinement for PR-gated Tier 2 review".to_string()
+                }
+            },
+        });
+    }
+    proposals
+}
+
+fn role_refinement_learnings(
+    proposals: &[RoleDefinitionRefinementProposal],
+) -> Vec<UnreviewedLearningSubmission> {
+    proposals
+        .iter()
+        .filter_map(|proposal| {
+            let session = proposal.session_ids.last()?.clone();
+            let definition = format!(
+                "{}@{}",
+                proposal.definition.definition_id,
+                proposal.definition.definition_version
+            );
+            Some(UnreviewedLearningSubmission {
+                session,
+                task: "post-run role-definition refinement proposal".to_string(),
+                outcome: UNREVIEWED_OUTCOME.to_string(),
+                keywords: vec![
+                    "role-definition".to_string(),
+                    definition.clone(),
+                    proposal.change_key.clone(),
+                    match proposal.scope_impact {
+                        ScopeImpact::Narrowing => "narrowing",
+                        ScopeImpact::Widening => "widening",
+                        ScopeImpact::NoScopeChange => "no-scope-change",
+                    }
+                    .to_string(),
+                ],
+                insight: format!(
+                    "Archived evidence proposes an unreviewed {} refinement for {definition} from {} independent session instance(s). The definition was not modified; evidence: {}.",
+                    proposal.change_key,
+                    proposal.observation_count,
+                    proposal.evidence_refs.join(", ")
+                ),
+                files_touched: Vec::new(),
+            })
+        })
+        .collect()
+}
+
+fn add_optional(total: &mut Option<usize>, value: Option<usize>) {
+    if let Some(value) = value {
+        *total.get_or_insert(0) += value;
+    }
+}
+
+fn aggregate_role_definitions(runs: &[PerRunRetro]) -> Vec<RoleDefinitionAggregate> {
+    let mut groups: BTreeMap<RoleDefinitionKey, RoleDefinitionAggregate> = BTreeMap::new();
+    for run in runs {
+        for metric in &run.role_definitions {
+            let aggregate = groups
+                .entry(metric.definition.clone())
+                .or_insert_with(|| RoleDefinitionAggregate {
+                    definition: metric.definition.clone(),
+                    run_count: 0,
+                    repo_ids: Vec::new(),
+                    session_ids: Vec::new(),
+                    archive_ids: Vec::new(),
+                    additional_attempts: None,
+                    remediation_detours: None,
+                    caught_defects: None,
+                    escaped_defects: None,
+                    gotcha_edges_eligible: None,
+                    gotcha_targets_attempted: None,
+                    confirmed_scope_gaps: 0,
+                });
+            aggregate.run_count += 1;
+            aggregate.repo_ids.push(run.repo_id.clone());
+            aggregate.session_ids.push(run.session_id.clone());
+            aggregate.archive_ids.push(run.archive_id.clone());
+            add_optional(
+                &mut aggregate.additional_attempts,
+                metric.additional_attempts,
+            );
+            add_optional(
+                &mut aggregate.remediation_detours,
+                metric.remediation_detours,
+            );
+            add_optional(&mut aggregate.caught_defects, metric.caught_defects);
+            add_optional(&mut aggregate.escaped_defects, metric.escaped_defects);
+            add_optional(
+                &mut aggregate.gotcha_edges_eligible,
+                metric.gotcha_edges_eligible,
+            );
+            add_optional(
+                &mut aggregate.gotcha_targets_attempted,
+                metric.gotcha_targets_attempted,
+            );
+            aggregate.confirmed_scope_gaps += metric.confirmed_scope_gaps;
+        }
+    }
+    groups
+        .into_values()
+        .map(|mut aggregate| {
+            aggregate.repo_ids.sort();
+            aggregate.repo_ids.dedup();
+            aggregate.session_ids.sort();
+            aggregate.session_ids.dedup();
+            aggregate.archive_ids.sort();
+            aggregate.archive_ids.dedup();
+            aggregate
+        })
+        .collect()
 }
 
 fn aggregate_templates(runs: &[PerRunRetro]) -> Vec<TemplateAggregate> {

--- a/src-tauri/src/orchestrator/work_graph/review.rs
+++ b/src-tauri/src/orchestrator/work_graph/review.rs
@@ -11,6 +11,11 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::orchestrator::org_graph::adjudication::{
+    AdjudicationDeclaration, AdjudicationPolicy, DeclaredAdjudicator, VerificationDuty,
+};
+use crate::orchestrator::org_graph::{ContextBoundary, SignalClass};
+
 use super::{
     BindingRef, CompositeExpansion, EdgeKind, EdgeProvenance, NodeContract, NodeKind,
     NodeStatus, TaskGraph, TaskId, WorkEdge, WorkNode,
@@ -18,6 +23,8 @@ use super::{
 
 pub const MULTI_LENS_REVIEW_TEMPLATE: &str = "multi-lens-review";
 pub const JUDGE_PRINCE_REMEDIATION_TEMPLATE: &str = "judge-prince-remediation";
+pub const VERIFICATION_DUTY_PARAMETER: &str = "verification_duty";
+pub const ADJUDICATION_DECLARATION_PARAMETER: &str = "adjudication";
 const MAX_REMEDIATION_ITERATIONS: u8 = 8;
 
 /// One deliberately distinct way to inspect a target.
@@ -57,6 +64,10 @@ pub struct ReviewTemplate {
     pub rubric: Vec<String>,
     pub verdict_binding: BindingRef,
     pub remediation_binding: BindingRef,
+    #[serde(default)]
+    pub verification_duty: VerificationDuty,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adjudication: Option<AdjudicationDeclaration>,
     #[serde(default = "default_remediation_iterations")]
     pub remediation_iterations: u8,
 }
@@ -93,6 +104,15 @@ impl ReviewTemplate {
             ],
             verdict_binding: BindingRef::Role("evaluator".to_string()),
             remediation_binding: BindingRef::Role("prince".to_string()),
+            verification_duty: VerificationDuty {
+                signal_name: Some("review findings against the declared rubric".to_string()),
+                signal_class: Some(SignalClass::Judgmental),
+                context_boundary: ContextBoundary::Artifact,
+            },
+            adjudication: Some(AdjudicationDeclaration {
+                policy: AdjudicationPolicy::Consensus { required: 2 },
+                adjudicator: Some(DeclaredAdjudicator::new("prince")),
+            }),
             remediation_iterations: default_remediation_iterations(),
         }
     }
@@ -488,8 +508,8 @@ fn append_review_round(
             lens.binding.clone(),
             NodeStatus::Pending,
         );
-        lens_node.expansion = Some(expansion_metadata(
-            MULTI_LENS_REVIEW_TEMPLATE,
+        lens_node.expansion = Some(review_expansion_metadata(
+            template,
             &target.id,
             round,
             Some((&lens.id, &lens.focus)),
@@ -538,8 +558,8 @@ fn append_review_round(
         template.verdict_binding.clone(),
         NodeStatus::Pending,
     );
-    verdict_node.expansion = Some(expansion_metadata(
-        MULTI_LENS_REVIEW_TEMPLATE,
+    verdict_node.expansion = Some(review_expansion_metadata(
+        template,
         &target.id,
         round,
         None,
@@ -633,6 +653,28 @@ fn expansion_metadata(
         template: template.to_string(),
         parameters,
     }
+}
+
+fn review_expansion_metadata(
+    template: &ReviewTemplate,
+    target: &str,
+    round: u8,
+    lens: Option<(&str, &str)>,
+) -> CompositeExpansion {
+    let mut metadata = expansion_metadata(MULTI_LENS_REVIEW_TEMPLATE, target, round, lens);
+    metadata.parameters.insert(
+        VERIFICATION_DUTY_PARAMETER.to_string(),
+        serde_json::to_string(&template.verification_duty)
+            .expect("verification duty has a serializable schema"),
+    );
+    if let Some(adjudication) = template.adjudication.as_ref() {
+        metadata.parameters.insert(
+            ADJUDICATION_DECLARATION_PARAMETER.to_string(),
+            serde_json::to_string(adjudication)
+                .expect("adjudication declaration has a serializable schema"),
+        );
+    }
+    metadata
 }
 
 fn push_node(

--- a/src-tauri/src/orchestrator/work_graph/runtime.rs
+++ b/src-tauri/src/orchestrator/work_graph/runtime.rs
@@ -17,6 +17,10 @@ use crate::domain::event::{Event, EventType};
 use crate::domain::run_journal::{
     Confidence, LedgerEntry, RunJournalEntry, StepKind, StepStatus,
 };
+use crate::orchestrator::org_graph::adjudication::{
+    adjudicate_contradiction, AdjudicationDeclaration, AdjudicationError,
+    AdjudicationRecord, AdjudicationResolution, SourceVerdict, SourceVerdictValue,
+};
 
 use super::review::{
     instantiate_checkpoint_wave, instantiate_review_templates, route_failed_verdict,
@@ -165,6 +169,7 @@ pub enum GraphMutationType {
     ReviewRoundAdded,
     ReviewVerdictRecorded,
     RemediationDetour,
+    ContradictionAdjudicated,
     CheckpointInserted,
     Other,
 }
@@ -421,6 +426,203 @@ pub fn record_review_verdict_and_record(
         },
     )?;
     Ok(delta)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AdjudicationGraphError {
+    Decision(AdjudicationError),
+    UnknownReviewVerdict(TaskId),
+    DuplicateRuntimeNode(TaskId),
+}
+
+impl fmt::Display for AdjudicationGraphError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decision(error) => write!(formatter, "review adjudication failed: {error}"),
+            Self::UnknownReviewVerdict(id) => {
+                write!(formatter, "review verdict node {id} does not exist")
+            }
+            Self::DuplicateRuntimeNode(id) => {
+                write!(formatter, "runtime adjudication node {id} already exists")
+            }
+        }
+    }
+}
+
+impl Error for AdjudicationGraphError {}
+
+impl From<AdjudicationError> for AdjudicationGraphError {
+    fn from(error: AdjudicationError) -> Self {
+        Self::Decision(error)
+    }
+}
+
+/// Record a contradictory source-verdict set and its separate adjudication.
+/// Ordinary FAIL continues through `route_failed_verdict_and_record`; this path
+/// deliberately emits a different mutation type and never creates remediation.
+pub fn route_contradictory_verdicts_and_record(
+    session_id: &str,
+    graph: &mut WorkGraph,
+    review_verdict_id: &str,
+    declaration: &AdjudicationDeclaration,
+    verdicts: &[SourceVerdict],
+) -> Result<
+    (AdjudicationRecord, Option<GraphMutationDelta>),
+    GraphMutationError<AdjudicationGraphError>,
+> {
+    let mut source_refs = verdicts
+        .iter()
+        .map(|verdict| format!("source-verdict:{}", verdict.source_id))
+        .collect::<Vec<_>>();
+    source_refs.sort();
+    mutate_and_record(
+        session_id,
+        graph,
+        GraphMutationType::ContradictionAdjudicated,
+        source_refs,
+        |graph| {
+            let record = adjudicate_contradiction(declaration, verdicts)?;
+            let review_position = graph
+                .nodes
+                .iter()
+                .position(|node| node.id == review_verdict_id)
+                .ok_or_else(|| {
+                    AdjudicationGraphError::UnknownReviewVerdict(
+                        review_verdict_id.to_string(),
+                    )
+                })?;
+            let mut known_ids = graph
+                .nodes
+                .iter()
+                .map(|node| node.id.clone())
+                .collect::<std::collections::BTreeSet<_>>();
+            let source_nodes = record
+                .source_verdicts
+                .iter()
+                .map(|verdict| {
+                    (
+                        verdict.clone(),
+                        format!(
+                            "{review_verdict_id}::source-verdict::{}",
+                            verdict.source_id
+                        ),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let adjudication_id = format!("{review_verdict_id}::adjudication");
+            for (_, id) in &source_nodes {
+                if !known_ids.insert(id.clone()) {
+                    return Err(AdjudicationGraphError::DuplicateRuntimeNode(id.clone()));
+                }
+            }
+            if !known_ids.insert(adjudication_id.clone()) {
+                return Err(AdjudicationGraphError::DuplicateRuntimeNode(
+                    adjudication_id.clone(),
+                ));
+            }
+
+            // A contradiction is not a failed aggregate verdict. It pauses at
+            // the explicit adjudication boundary instead of activating Prince
+            // remediation.
+            graph.nodes[review_position].status = NodeStatus::Blocked;
+            for (verdict, id) in &source_nodes {
+                let mut parameters = BTreeMap::new();
+                parameters.insert("source_id".to_string(), verdict.source_id.clone());
+                parameters.insert(
+                    "verdict".to_string(),
+                    serde_json::to_string(&verdict.verdict)
+                        .expect("source verdict value is serializable"),
+                );
+                parameters.insert("rationale".to_string(), verdict.rationale.clone());
+                let mut node = WorkNode::new(
+                    id,
+                    NodeKind::Review,
+                    format!("{} source verdict", verdict.source_id),
+                    NodeContract {
+                        inputs: vec![format!("{}:evidence", verdict.source_id)],
+                        outputs: vec![format!("{id}:verdict")],
+                        acceptance: vec!["retain the source verdict unchanged".to_string()],
+                    },
+                    BindingRef::Role("evaluator".to_string()),
+                    match verdict.verdict {
+                        SourceVerdictValue::Pass => NodeStatus::Completed,
+                        SourceVerdictValue::Fail => NodeStatus::Failed,
+                    },
+                );
+                node.expansion = Some(super::schema::CompositeExpansion {
+                    template: "source-review-verdict".to_string(),
+                    parameters,
+                });
+                graph.nodes.push(node);
+            }
+
+            let mut parameters = BTreeMap::new();
+            parameters.insert(
+                "policy".to_string(),
+                serde_json::to_string(&record.policy)
+                    .expect("adjudication policy is serializable"),
+            );
+            parameters.insert(
+                "adjudicator".to_string(),
+                serde_json::to_string(&record.adjudicator)
+                    .expect("declared adjudicator is serializable"),
+            );
+            parameters.insert(
+                "resolution".to_string(),
+                serde_json::to_string(&record.resolution)
+                    .expect("adjudication resolution is serializable"),
+            );
+            parameters.insert(
+                "source_verdicts".to_string(),
+                serde_json::to_string(&record.source_verdicts)
+                    .expect("source verdict records are serializable"),
+            );
+            let adjudication_status = match &record.resolution {
+                AdjudicationResolution::ConsensusPass
+                | AdjudicationResolution::Findings { .. } => NodeStatus::Completed,
+                AdjudicationResolution::ConsensusFail => NodeStatus::Failed,
+                AdjudicationResolution::ConsensusUnresolved { .. }
+                | AdjudicationResolution::Escalated { .. }
+                | AdjudicationResolution::HumanGate => NodeStatus::Blocked,
+            };
+            let mut adjudication_node = WorkNode::new(
+                &adjudication_id,
+                NodeKind::Join,
+                format!("Adjudication for {review_verdict_id}"),
+                NodeContract {
+                    inputs: source_nodes
+                        .iter()
+                        .map(|(_, id)| format!("{id}:verdict"))
+                        .collect(),
+                    outputs: vec![format!("{adjudication_id}:resolution")],
+                    acceptance: vec![
+                        "apply the declared policy without arrival-order bias".to_string(),
+                    ],
+                },
+                BindingRef::Role(record.adjudicator.role_id.clone()),
+                adjudication_status,
+            );
+            adjudication_node.expansion = Some(super::schema::CompositeExpansion {
+                template: "review-adjudication".to_string(),
+                parameters,
+            });
+            graph.nodes.push(adjudication_node);
+            for (_, source_id) in &source_nodes {
+                graph.edges.push(
+                    WorkEdge::new(
+                        source_id,
+                        &adjudication_id,
+                        EdgeKind::Informs,
+                        EdgeProvenance::Runtime,
+                    )
+                    .with_rationale(
+                        "the adjudication retains this source verdict as independent evidence",
+                    ),
+                );
+            }
+            Ok(record)
+        },
+    )
 }
 
 pub fn instantiate_checkpoint_wave_and_record(

--- a/src-tauri/src/orchestrator/work_graph/validate.rs
+++ b/src-tauri/src/orchestrator/work_graph/validate.rs
@@ -4,7 +4,21 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::error::Error;
 use std::fmt;
 
-use super::schema::{EdgeKind, TaskGraph, TaskId};
+use crate::orchestrator::org_graph::adjudication::{
+    AdjudicationDeclaration, VerificationDuty,
+};
+use crate::orchestrator::org_graph::boundary::{
+    context_boundary_satisfies, required_context_boundary,
+    verification_duty_declares_signal_class, verification_duty_has_named_signal,
+};
+use crate::orchestrator::org_graph::ownership::verification_duty_gaps;
+use crate::orchestrator::org_graph::{ContextBoundary, SignalClass};
+
+use super::review::{
+    ADJUDICATION_DECLARATION_PARAMETER, MULTI_LENS_REVIEW_TEMPLATE,
+    VERIFICATION_DUTY_PARAMETER,
+};
+use super::schema::{EdgeKind, NodeKind, TaskGraph, TaskId};
 use super::toposort::topological_sort;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -15,6 +29,10 @@ pub struct PlanReadyValidation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PlanReadyWarning {
     OrphanSubtrees { task_ids: Vec<TaskId> },
+    UnassignedVerificationDuty {
+        task_class: String,
+        task_ids: Vec<TaskId>,
+    },
 }
 
 impl fmt::Display for PlanReadyWarning {
@@ -23,6 +41,14 @@ impl fmt::Display for PlanReadyWarning {
             Self::OrphanSubtrees { task_ids } => write!(
                 formatter,
                 "orphan task subtrees are disconnected from the first plan component: {}",
+                task_ids.join(", ")
+            ),
+            Self::UnassignedVerificationDuty {
+                task_class,
+                task_ids,
+            } => write!(
+                formatter,
+                "task class {task_class} has no assigned verification duty for: {}",
                 task_ids.join(", ")
             ),
         }
@@ -40,6 +66,17 @@ pub enum PlanReadyError {
     DuplicateTaskIds { task_ids: Vec<TaskId> },
     DanglingDependencies { references: Vec<DanglingDependency> },
     Cycle { task_ids: Vec<TaskId> },
+    MissingVerificationSignal { review_id: TaskId },
+    MissingVerificationSignalClass { review_id: TaskId },
+    InsufficientVerificationIsolation {
+        review_id: TaskId,
+        signal_class: SignalClass,
+        actual: ContextBoundary,
+        required: ContextBoundary,
+    },
+    InvalidReviewAuthorityMetadata { review_id: TaskId, field: String },
+    MissingAdjudicator { review_id: TaskId },
+    AdjudicatorLacksAuthority { review_id: TaskId, role_id: String },
 }
 
 impl fmt::Display for PlanReadyError {
@@ -67,6 +104,35 @@ impl fmt::Display for PlanReadyError {
                 formatter,
                 "PlanReady rejected: dependency cycle contains: {}",
                 task_ids.join(", ")
+            ),
+            Self::MissingVerificationSignal { review_id } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} has no named verification signal"
+            ),
+            Self::MissingVerificationSignalClass { review_id } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} has no declared verification signal class"
+            ),
+            Self::InsufficientVerificationIsolation {
+                review_id,
+                signal_class,
+                actual,
+                required,
+            } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} uses {actual:?} context for {signal_class:?} signal; requires {required:?} or stronger isolation"
+            ),
+            Self::InvalidReviewAuthorityMetadata { review_id, field } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} has invalid {field} metadata"
+            ),
+            Self::MissingAdjudicator { review_id } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} declares no adjudicator"
+            ),
+            Self::AdjudicatorLacksAuthority { review_id, role_id } => write!(
+                formatter,
+                "PlanReady rejected: review {review_id} adjudicator {role_id} lacks adjudication authority"
             ),
         }
     }
@@ -123,9 +189,88 @@ pub fn validate_plan_ready(graph: &TaskGraph) -> Result<PlanReadyValidation, Pla
         });
     }
 
-    Ok(PlanReadyValidation {
-        warnings: orphan_warnings(graph),
-    })
+    validate_review_authority(graph)?;
+
+    let mut warnings = orphan_warnings(graph);
+    warnings.extend(
+        verification_duty_gaps(graph)
+            .into_iter()
+            .map(|gap| PlanReadyWarning::UnassignedVerificationDuty {
+                task_class: gap.task_class,
+                task_ids: gap.unassigned_task_ids,
+            }),
+    );
+    Ok(PlanReadyValidation { warnings })
+}
+
+fn validate_review_authority(graph: &TaskGraph) -> Result<(), PlanReadyError> {
+    for node in graph.nodes.iter().filter(|node| {
+        node.kind == NodeKind::Join
+            && node.expansion.as_ref().is_some_and(|expansion| {
+                expansion.template == MULTI_LENS_REVIEW_TEMPLATE
+            })
+    }) {
+        let expansion = node.expansion.as_ref().expect("review expansion checked");
+        let duty = match expansion.parameters.get(VERIFICATION_DUTY_PARAMETER) {
+            Some(encoded) => serde_json::from_str::<VerificationDuty>(encoded).map_err(|_| {
+                PlanReadyError::InvalidReviewAuthorityMetadata {
+                    review_id: node.id.clone(),
+                    field: VERIFICATION_DUTY_PARAMETER.to_string(),
+                }
+            })?,
+            None => VerificationDuty::default(),
+        };
+        if !verification_duty_has_named_signal(duty.signal_name.as_deref()) {
+            return Err(PlanReadyError::MissingVerificationSignal {
+                review_id: node.id.clone(),
+            });
+        }
+        if !verification_duty_declares_signal_class(duty.signal_class) {
+            return Err(PlanReadyError::MissingVerificationSignalClass {
+                review_id: node.id.clone(),
+            });
+        }
+        let signal_class = duty
+            .signal_class
+            .expect("the explicit signal class was checked above");
+        let required = required_context_boundary(signal_class);
+        if !context_boundary_satisfies(signal_class, duty.context_boundary) {
+            return Err(PlanReadyError::InsufficientVerificationIsolation {
+                review_id: node.id.clone(),
+                signal_class,
+                actual: duty.context_boundary,
+                required,
+            });
+        }
+
+        let declaration = expansion
+            .parameters
+            .get(ADJUDICATION_DECLARATION_PARAMETER)
+            .ok_or_else(|| PlanReadyError::MissingAdjudicator {
+                review_id: node.id.clone(),
+            })
+            .and_then(|encoded| {
+                serde_json::from_str::<AdjudicationDeclaration>(encoded).map_err(|_| {
+                    PlanReadyError::InvalidReviewAuthorityMetadata {
+                        review_id: node.id.clone(),
+                        field: ADJUDICATION_DECLARATION_PARAMETER.to_string(),
+                    }
+                })
+            })?;
+        let adjudicator = declaration
+            .adjudicator
+            .filter(|adjudicator| !adjudicator.role_id.trim().is_empty())
+            .ok_or_else(|| PlanReadyError::MissingAdjudicator {
+                review_id: node.id.clone(),
+            })?;
+        if !adjudicator.authority.may_adjudicate {
+            return Err(PlanReadyError::AdjudicatorLacksAuthority {
+                review_id: node.id.clone(),
+                role_id: adjudicator.role_id,
+            });
+        }
+    }
+    Ok(())
 }
 
 fn orphan_warnings(graph: &TaskGraph) -> Vec<PlanReadyWarning> {

--- a/src-tauri/src/pty/manager.rs
+++ b/src-tauri/src/pty/manager.rs
@@ -6,6 +6,7 @@ use parking_lot::{Mutex, RwLock};
 use serde::Serialize;
 
 use super::session::{AgentRole, AgentStatus, PtyError, PtySession, read_from_reader};
+use crate::adapters::pty_submit_policy;
 use crate::cli::agent_store;
 use crate::tauri_shim::{AppHandle, Emitter};
 
@@ -145,6 +146,7 @@ impl PtyManager {
             id.clone(),
             role,
             command,
+            pty_submit_policy(command),
             &effective_args,
             cwd,
             cols,
@@ -334,6 +336,17 @@ impl PtyManager {
         sessions.get(id).map(|session| session.write_records())
     }
 
+    #[cfg(all(test, windows))]
+    pub fn submit_policy_for_test(
+        &self,
+        id: &str,
+    ) -> Option<crate::adapters::PtySubmitPolicy> {
+        let sessions = self.sessions.read();
+        sessions
+            .get(id)
+            .map(|session| session.submit_policy_for_test())
+    }
+
     pub fn list_sessions(&self) -> Vec<(String, AgentRole, AgentStatus)> {
         let sessions = self.sessions.read();
         sessions
@@ -354,11 +367,101 @@ impl Default for PtyManager {
 #[cfg(all(test, windows))]
 mod tests {
     use super::*;
+    use crate::pty::{RoleDefinitionRef, WorkerRole};
 
     fn worker_role() -> AgentRole {
         AgentRole::Worker {
             index: 1,
             parent: None,
+        }
+    }
+
+    fn public_struct_fields(source: &str, struct_name: &str) -> Vec<String> {
+        let marker = format!("pub struct {struct_name} {{");
+        let body = source
+            .split_once(&marker)
+            .unwrap_or_else(|| panic!("missing {struct_name}"))
+            .1;
+
+        body.lines()
+            .take_while(|line| line.trim() != "}")
+            .filter_map(|line| {
+                line.split("//")
+                    .next()
+                    .map(str::trim)
+                    .and_then(|line| line.strip_prefix("pub "))
+                    .map(|field| field.trim_end_matches(',').to_string())
+            })
+            .collect()
+    }
+
+    #[test]
+    fn worker_position_and_resolved_identity_are_independent() {
+        let position = AgentRole::Worker {
+            index: 7,
+            parent: Some("queen".to_string()),
+        };
+        let mut identity = WorkerRole::new("reviewer", "Reviewer", "codex");
+        identity.resolved_definition = Some(RoleDefinitionRef {
+            id: "security-reviewer".to_string(),
+            version: 3,
+        });
+
+        match position {
+            AgentRole::Worker { index, parent } => {
+                assert_eq!(index, 7);
+                assert_eq!(parent.as_deref(), Some("queen"));
+            }
+            other => panic!("expected worker position, got {other:?}"),
+        }
+        assert_eq!(identity.role_type, "reviewer");
+        assert_eq!(
+            identity.resolved_definition,
+            Some(RoleDefinitionRef {
+                id: "security-reviewer".to_string(),
+                version: 3,
+            })
+        );
+    }
+
+    #[test]
+    fn worker_role_shape_matches_the_windows_test_stub() {
+        let production = public_struct_fields(include_str!("session.rs"), "WorkerRole");
+        let test_stub = public_struct_fields(include_str!("session_stub.rs"), "WorkerRole");
+        let expected = vec![
+            "role_type: String",
+            "label: String",
+            "default_cli: String",
+            "prompt_template: Option<String>",
+            "resolved_definition: Option<RoleDefinitionRef>",
+        ];
+
+        assert_eq!(production, expected);
+        assert_eq!(test_stub, expected);
+    }
+
+    #[test]
+    fn manager_binds_submit_policy_per_adapter_session() {
+        let manager = PtyManager::new();
+        for (id, command, expected_adapter) in [
+            ("codex-policy-agent", "codex", "codex"),
+            ("claude-policy-agent", "claude", "claude"),
+            ("cursor-policy-agent", "wsl", "cursor"),
+        ] {
+            manager
+                .create_session(
+                    id.to_string(),
+                    worker_role(),
+                    command,
+                    &[],
+                    None,
+                    80,
+                    24,
+                )
+                .unwrap();
+            let policy = manager.submit_policy_for_test(id).unwrap();
+            assert_eq!(policy.adapter, Some(expected_adapter));
+            assert_eq!(policy.default_gap, Duration::from_millis(50));
         }
     }
 
@@ -411,7 +514,7 @@ mod tests {
     }
 
     #[test]
-    fn submit_writes_payload_then_bare_enter_separately() {
+    fn submit_writes_one_multiline_payload_then_one_bare_enter() {
         let manager = PtyManager::new();
         manager
             .create_session(
@@ -425,14 +528,48 @@ mod tests {
             )
             .unwrap();
 
-        manager.submit("submit-agent", b"hello").unwrap();
+        manager
+            .submit("submit-agent", b"line one\nline two\nline three")
+            .unwrap();
 
         let writes = manager.write_records_for_test("submit-agent").unwrap();
-        assert_eq!(writes, vec![b"hello".to_vec(), b"\r".to_vec()]);
+        assert_eq!(
+            writes,
+            vec![b"line one\nline two\nline three".to_vec(), b"\r".to_vec()]
+        );
         assert!(!writes[0].ends_with(b"\r"));
         assert!(!writes[0].ends_with(b"\n"));
         assert_eq!(writes[1], b"\r");
         assert!(!writes[1].contains(&b'\n'));
+    }
+
+    #[test]
+    fn unsubmitted_stub_write_is_visible_in_recent_output() {
+        const SENTINEL: &[u8] = b"UNSUBMITTED_SENTINEL";
+
+        let manager = PtyManager::new();
+        manager
+            .create_session(
+                "unsubmitted-agent".to_string(),
+                worker_role(),
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+
+        manager.write("unsubmitted-agent", SENTINEL).unwrap();
+
+        assert_eq!(
+            manager.recent_output("unsubmitted-agent").as_deref(),
+            Some("UNSUBMITTED_SENTINEL")
+        );
+        assert_eq!(
+            manager.write_records_for_test("unsubmitted-agent").unwrap(),
+            vec![SENTINEL.to_vec()]
+        );
     }
 
     #[test]
@@ -460,7 +597,6 @@ mod tests {
 
         let (start_writer_tx, start_writer_rx) = std::sync::mpsc::channel();
         let (writer_attempted_tx, writer_attempted_rx) = std::sync::mpsc::channel();
-        let (writer_done_tx, writer_done_rx) = std::sync::mpsc::channel();
         let concurrent_manager = Arc::clone(&manager);
         let concurrent_writer = thread::spawn(move || {
             start_writer_rx.recv().unwrap();
@@ -468,7 +604,6 @@ mod tests {
             concurrent_manager
                 .write("atomic-submit-agent", b"interloper")
                 .unwrap();
-            writer_done_tx.send(()).unwrap();
         });
 
         let submit_manager = Arc::clone(&manager);
@@ -481,12 +616,14 @@ mod tests {
         assert!(session.wait_for_submit_payload_for_test());
         start_writer_tx.send(()).unwrap();
         writer_attempted_rx.recv().unwrap();
-        let interleaved = writer_done_rx.recv_timeout(Duration::from_millis(100)).is_ok();
+        assert!(
+            session.writer_locked_for_test(),
+            "submit must retain the writer lock between payload and Enter"
+        );
         session.resume_submit_for_test();
         submitter.join().unwrap();
         concurrent_writer.join().unwrap();
 
-        assert!(!interleaved, "concurrent write completed before Enter");
         assert_eq!(
             manager
                 .write_records_for_test("atomic-submit-agent")

--- a/src-tauri/src/pty/mod.rs
+++ b/src-tauri/src/pty/mod.rs
@@ -6,4 +6,4 @@ mod session;
 mod session;
 
 pub use manager::PtyManager;
-pub use session::{AgentConfig, AgentRole, AgentStatus, WorkerRole};
+pub use session::{AgentConfig, AgentRole, AgentStatus, RoleDefinitionRef, WorkerRole};

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -154,13 +154,86 @@ impl MasterPtyHandle {
 /// Maximum chunk size for PTY writes (16KB) - respects Windows pipe buffer limits
 const CHUNK_SIZE: usize = 16 * 1024;
 
+// BEGIN SHARED SUBMIT GAP OVERRIDE POLICY
 const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
+/// Safety ceiling for the operator override, not a submit-gap default.
+///
+/// Five minutes bounds how long `submit` can hold the per-session writer mutex while preserving
+/// the known successful 65-second observation for the future U1 sweep.
+const MAX_PTY_SUBMIT_GAP_OVERRIDE_MS: u64 = 300_000;
 static RUNTIME_SUBMIT_GAP: OnceLock<Option<Duration>> = OnceLock::new();
 
-fn submit_gap_from_override(value: Option<&str>) -> Option<Duration> {
-    value
-        .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
-        .map(Duration::from_millis)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitGapOverride {
+    Unset,
+    Valid(Duration),
+    Invalid(SubmitGapInvalidReason),
+    OverLimit { requested_ms: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitGapInvalidReason {
+    NonUnicode,
+    NotUnsignedInteger,
+    Overflow,
+}
+
+fn parse_submit_gap_override(value: Option<&std::ffi::OsStr>) -> SubmitGapOverride {
+    let Some(value) = value else {
+        return SubmitGapOverride::Unset;
+    };
+    let Some(milliseconds) = value.to_str() else {
+        return SubmitGapOverride::Invalid(SubmitGapInvalidReason::NonUnicode);
+    };
+
+    match milliseconds.trim().parse::<u64>() {
+        Ok(requested_ms) if requested_ms <= MAX_PTY_SUBMIT_GAP_OVERRIDE_MS => {
+            SubmitGapOverride::Valid(Duration::from_millis(requested_ms))
+        }
+        Ok(requested_ms) => SubmitGapOverride::OverLimit { requested_ms },
+        Err(error)
+            if matches!(
+                error.kind(),
+                &std::num::IntErrorKind::PosOverflow | &std::num::IntErrorKind::NegOverflow
+            ) =>
+        {
+            SubmitGapOverride::Invalid(SubmitGapInvalidReason::Overflow)
+        }
+        Err(_) => SubmitGapOverride::Invalid(SubmitGapInvalidReason::NotUnsignedInteger),
+    }
+}
+
+fn cached_submit_gap_override<F>(
+    cache: &OnceLock<Option<Duration>>,
+    value: Option<&std::ffi::OsStr>,
+    warn: F,
+) -> Option<Duration>
+where
+    F: FnOnce(SubmitGapOverride),
+{
+    *cache.get_or_init(|| match parse_submit_gap_override(value) {
+        SubmitGapOverride::Unset => None,
+        SubmitGapOverride::Valid(duration) => Some(duration),
+        rejected @ (SubmitGapOverride::Invalid(_) | SubmitGapOverride::OverLimit { .. }) => {
+            warn(rejected);
+            None
+        }
+    })
+}
+
+fn warn_rejected_submit_gap_override(override_value: SubmitGapOverride) {
+    match override_value {
+        SubmitGapOverride::Invalid(reason) => tracing::warn!(
+            ?reason,
+            "Ignoring invalid {SUBMIT_GAP_ENV} override; using the adapter default"
+        ),
+        SubmitGapOverride::OverLimit { requested_ms } => tracing::warn!(
+            requested_ms,
+            safety_ceiling_ms = MAX_PTY_SUBMIT_GAP_OVERRIDE_MS,
+            "Rejecting over-limit {SUBMIT_GAP_ENV} override; using the adapter default"
+        ),
+        SubmitGapOverride::Unset | SubmitGapOverride::Valid(_) => {}
+    }
 }
 
 fn resolve_submit_gap(
@@ -171,12 +244,15 @@ fn resolve_submit_gap(
 }
 
 fn submit_gap(policy: PtySubmitPolicy) -> Duration {
-    let override_gap = *RUNTIME_SUBMIT_GAP.get_or_init(|| {
-        let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
-        submit_gap_from_override(override_value.as_deref())
-    });
+    let override_value = std::env::var_os(SUBMIT_GAP_ENV);
+    let override_gap = cached_submit_gap_override(
+        &RUNTIME_SUBMIT_GAP,
+        override_value.as_deref(),
+        warn_rejected_submit_gap_override,
+    );
     resolve_submit_gap(policy, override_gap)
 }
+// END SHARED SUBMIT GAP OVERRIDE POLICY
 
 /// Bracketed paste mode escape sequences
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 use parking_lot::Mutex;
 use thiserror::Error;
 
+use crate::adapters::PtySubmitPolicy;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AgentRole {
     MasterPlanner,  // Initial planning agent that generates plan.md
@@ -36,12 +38,20 @@ pub enum AgentStatus {
 }
 
 /// Worker role configuration
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RoleDefinitionRef {
+    pub id: String,
+    pub version: u32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkerRole {
     pub role_type: String,          // "backend", "frontend", "coherence", "simplify", or custom
     pub label: String,              // Display name
     pub default_cli: String,        // Default CLI for this role
     pub prompt_template: Option<String>, // Path to template or inline prompt
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_definition: Option<RoleDefinitionRef>,
 }
 
 impl WorkerRole {
@@ -51,6 +61,7 @@ impl WorkerRole {
             label: label.to_string(),
             default_cli: default_cli.to_string(),
             prompt_template: None,
+            resolved_definition: None,
         }
     }
 }
@@ -143,28 +154,28 @@ impl MasterPtyHandle {
 /// Maximum chunk size for PTY writes (16KB) - respects Windows pipe buffer limits
 const CHUNK_SIZE: usize = 16 * 1024;
 
-/// Unvalidated default; override with `HIVE_PTY_SUBMIT_GAP_MS` for the #226 sweep.
-///
-/// Under load, measured payload/Enter separations of 1.2-2.7 s failed twice,
-/// while roughly 4-5 s succeeded twice and 65 s succeeded once. Agent busy
-/// state was uncontrolled, so those observations do not justify replacing the
-/// compiled 50 ms default with another guess.
-const SUBMIT_GAP: Duration = Duration::from_millis(50);
 const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
-static RUNTIME_SUBMIT_GAP: OnceLock<Duration> = OnceLock::new();
+static RUNTIME_SUBMIT_GAP: OnceLock<Option<Duration>> = OnceLock::new();
 
-fn submit_gap_from_override(value: Option<&str>) -> Duration {
+fn submit_gap_from_override(value: Option<&str>) -> Option<Duration> {
     value
         .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
         .map(Duration::from_millis)
-        .unwrap_or(SUBMIT_GAP)
 }
 
-fn submit_gap() -> Duration {
-    *RUNTIME_SUBMIT_GAP.get_or_init(|| {
+fn resolve_submit_gap(
+    policy: PtySubmitPolicy,
+    override_gap: Option<Duration>,
+) -> Duration {
+    override_gap.unwrap_or(policy.default_gap)
+}
+
+fn submit_gap(policy: PtySubmitPolicy) -> Duration {
+    let override_gap = *RUNTIME_SUBMIT_GAP.get_or_init(|| {
         let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
         submit_gap_from_override(override_value.as_deref())
-    })
+    });
+    resolve_submit_gap(policy, override_gap)
 }
 
 /// Bracketed paste mode escape sequences
@@ -211,6 +222,7 @@ const RECENT_OUTPUT_CAPACITY: usize = 8 * 1024;
 pub struct PtySession {
     pub role: AgentRole,
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
+    submit_policy: PtySubmitPolicy,
     writer: Arc<Mutex<SendWriter>>,
     reader: Arc<Mutex<SendReader>>,
     child: Arc<Mutex<Option<Box<dyn portable_pty::Child + Send + Sync>>>>,
@@ -252,6 +264,7 @@ impl PtySession {
         _id: String,
         role: AgentRole,
         command: &str,
+        submit_policy: PtySubmitPolicy,
         args: &[&str],
         cwd: Option<&str>,
         cols: u16,
@@ -328,6 +341,7 @@ impl PtySession {
         Ok(Self {
             role,
             status: Arc::new(parking_lot::RwLock::new(AgentStatus::Starting)),
+            submit_policy,
             writer: Arc::new(Mutex::new(SendWriter(writer))),
             reader: Arc::new(Mutex::new(SendReader(reader))),
             child: Arc::new(Mutex::new(Some(child))),
@@ -373,7 +387,7 @@ impl PtySession {
         Self::write_locked(&mut writer, data)?;
         // Keep the per-session writer locked so no concurrent write can be
         // interleaved and accidentally submitted by this Enter.
-        std::thread::sleep(submit_gap());
+        std::thread::sleep(submit_gap(self.submit_policy));
         Self::write_locked(&mut writer, b"\r")
     }
 

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -125,14 +125,86 @@ unsafe impl Send for SendWriter {}
 unsafe impl Sync for SendWriter {}
 
 const CHUNK_SIZE: usize = 16 * 1024;
+// BEGIN SHARED SUBMIT GAP OVERRIDE POLICY
 const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
+/// Safety ceiling for the operator override, not a submit-gap default.
+///
+/// Five minutes bounds how long `submit` can hold the per-session writer mutex while preserving
+/// the known successful 65-second observation for the future U1 sweep.
+const MAX_PTY_SUBMIT_GAP_OVERRIDE_MS: u64 = 300_000;
 static RUNTIME_SUBMIT_GAP: OnceLock<Option<Duration>> = OnceLock::new();
-const SUBMIT_GAP_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 
-fn submit_gap_from_override(value: Option<&str>) -> Option<Duration> {
-    value
-        .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
-        .map(Duration::from_millis)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitGapOverride {
+    Unset,
+    Valid(Duration),
+    Invalid(SubmitGapInvalidReason),
+    OverLimit { requested_ms: u64 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SubmitGapInvalidReason {
+    NonUnicode,
+    NotUnsignedInteger,
+    Overflow,
+}
+
+fn parse_submit_gap_override(value: Option<&std::ffi::OsStr>) -> SubmitGapOverride {
+    let Some(value) = value else {
+        return SubmitGapOverride::Unset;
+    };
+    let Some(milliseconds) = value.to_str() else {
+        return SubmitGapOverride::Invalid(SubmitGapInvalidReason::NonUnicode);
+    };
+
+    match milliseconds.trim().parse::<u64>() {
+        Ok(requested_ms) if requested_ms <= MAX_PTY_SUBMIT_GAP_OVERRIDE_MS => {
+            SubmitGapOverride::Valid(Duration::from_millis(requested_ms))
+        }
+        Ok(requested_ms) => SubmitGapOverride::OverLimit { requested_ms },
+        Err(error)
+            if matches!(
+                error.kind(),
+                &std::num::IntErrorKind::PosOverflow | &std::num::IntErrorKind::NegOverflow
+            ) =>
+        {
+            SubmitGapOverride::Invalid(SubmitGapInvalidReason::Overflow)
+        }
+        Err(_) => SubmitGapOverride::Invalid(SubmitGapInvalidReason::NotUnsignedInteger),
+    }
+}
+
+fn cached_submit_gap_override<F>(
+    cache: &OnceLock<Option<Duration>>,
+    value: Option<&std::ffi::OsStr>,
+    warn: F,
+) -> Option<Duration>
+where
+    F: FnOnce(SubmitGapOverride),
+{
+    *cache.get_or_init(|| match parse_submit_gap_override(value) {
+        SubmitGapOverride::Unset => None,
+        SubmitGapOverride::Valid(duration) => Some(duration),
+        rejected @ (SubmitGapOverride::Invalid(_) | SubmitGapOverride::OverLimit { .. }) => {
+            warn(rejected);
+            None
+        }
+    })
+}
+
+fn warn_rejected_submit_gap_override(override_value: SubmitGapOverride) {
+    match override_value {
+        SubmitGapOverride::Invalid(reason) => tracing::warn!(
+            ?reason,
+            "Ignoring invalid {SUBMIT_GAP_ENV} override; using the adapter default"
+        ),
+        SubmitGapOverride::OverLimit { requested_ms } => tracing::warn!(
+            requested_ms,
+            safety_ceiling_ms = MAX_PTY_SUBMIT_GAP_OVERRIDE_MS,
+            "Rejecting over-limit {SUBMIT_GAP_ENV} override; using the adapter default"
+        ),
+        SubmitGapOverride::Unset | SubmitGapOverride::Valid(_) => {}
+    }
 }
 
 fn resolve_submit_gap(
@@ -143,12 +215,17 @@ fn resolve_submit_gap(
 }
 
 fn submit_gap(policy: PtySubmitPolicy) -> Duration {
-    let override_gap = *RUNTIME_SUBMIT_GAP.get_or_init(|| {
-        let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
-        submit_gap_from_override(override_value.as_deref())
-    });
+    let override_value = std::env::var_os(SUBMIT_GAP_ENV);
+    let override_gap = cached_submit_gap_override(
+        &RUNTIME_SUBMIT_GAP,
+        override_value.as_deref(),
+        warn_rejected_submit_gap_override,
+    );
     resolve_submit_gap(policy, override_gap)
 }
+// END SHARED SUBMIT GAP OVERRIDE POLICY
+
+const SUBMIT_GAP_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
@@ -452,35 +529,176 @@ pub fn read_from_reader(
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_submit_gap, sanitize_bracketed_paste, submit_gap_from_override,
-        BRACKETED_PASTE_END,
+        cached_submit_gap_override, parse_submit_gap_override, resolve_submit_gap,
+        sanitize_bracketed_paste, SubmitGapInvalidReason, SubmitGapOverride,
+        BRACKETED_PASTE_END, MAX_PTY_SUBMIT_GAP_OVERRIDE_MS,
     };
     use crate::adapters::PtySubmitPolicy;
+    use std::cell::Cell;
+    use std::ffi::OsStr;
+    use std::sync::OnceLock;
     use std::time::Duration;
 
     #[test]
-    fn submit_gap_override_parses_milliseconds() {
+    fn submit_gap_override_distinguishes_all_supported_and_rejected_inputs() {
+        assert_eq!(parse_submit_gap_override(None), SubmitGapOverride::Unset);
         assert_eq!(
-            submit_gap_from_override(Some(" 4500 ")),
-            Some(Duration::from_millis(4_500))
+            parse_submit_gap_override(Some(OsStr::new("0"))),
+            SubmitGapOverride::Valid(Duration::ZERO)
         );
-        assert_eq!(submit_gap_from_override(Some("0")), Some(Duration::ZERO));
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new(" 4500 "))),
+            SubmitGapOverride::Valid(Duration::from_millis(4_500))
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("65000"))),
+            SubmitGapOverride::Valid(Duration::from_secs(65))
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("not-a-number"))),
+            SubmitGapOverride::Invalid(SubmitGapInvalidReason::NotUnsignedInteger)
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("18446744073709551616"))),
+            SubmitGapOverride::Invalid(SubmitGapInvalidReason::Overflow)
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("300001"))),
+            SubmitGapOverride::OverLimit {
+                requested_ms: 300_001
+            }
+        );
     }
 
     #[test]
-    fn invalid_submit_gap_override_defers_to_the_session_policy() {
-        assert_eq!(submit_gap_from_override(Some("not-a-number")), None);
-        assert_eq!(submit_gap_from_override(Some("-1")), None);
-        assert_eq!(submit_gap_from_override(None), None);
-
+    fn rejected_submit_gap_override_warns_once_and_defers_to_the_session_policy() {
         let adapter_policy = PtySubmitPolicy {
             adapter: Some("future-tuned-adapter"),
             default_gap: Duration::from_millis(123),
         };
-        assert_eq!(resolve_submit_gap(adapter_policy, None), Duration::from_millis(123));
+
+        for (raw, expected_warning) in [
+            (
+                "not-a-number",
+                SubmitGapOverride::Invalid(SubmitGapInvalidReason::NotUnsignedInteger),
+            ),
+            (
+                "18446744073709551616",
+                SubmitGapOverride::Invalid(SubmitGapInvalidReason::Overflow),
+            ),
+            (
+                "300001",
+                SubmitGapOverride::OverLimit {
+                    requested_ms: 300_001,
+                },
+            ),
+        ] {
+            let cache = OnceLock::new();
+            let warning_count = Cell::new(0);
+            let warning = Cell::new(None);
+            let override_gap = cached_submit_gap_override(
+                &cache,
+                Some(OsStr::new(raw)),
+                |rejected| {
+                    warning_count.set(warning_count.get() + 1);
+                    warning.set(Some(rejected));
+                },
+            );
+
+            assert_eq!(override_gap, None);
+            assert_eq!(warning.get(), Some(expected_warning));
+            assert_eq!(resolve_submit_gap(adapter_policy, override_gap), adapter_policy.default_gap);
+
+            let second = cached_submit_gap_override(
+                &cache,
+                Some(OsStr::new("65000")),
+                |_| warning_count.set(warning_count.get() + 1),
+            );
+            assert_eq!(second, None, "a rejected process override stays rejected");
+            assert_eq!(warning_count.get(), 1, "a rejected override warns once");
+        }
+
+        let valid_cache = OnceLock::new();
+        let valid_warning_count = Cell::new(0);
+        let valid = cached_submit_gap_override(
+            &valid_cache,
+            Some(OsStr::new("65000")),
+            |_| valid_warning_count.set(valid_warning_count.get() + 1),
+        );
+        assert_eq!(valid, Some(Duration::from_secs(65)));
+        assert_eq!(valid_warning_count.get(), 0);
+
+        let unset_cache = OnceLock::new();
+        let unset_warning_count = Cell::new(0);
+        let unset = cached_submit_gap_override(&unset_cache, None, |_| {
+            unset_warning_count.set(unset_warning_count.get() + 1)
+        });
+        assert_eq!(unset, None);
+        assert_eq!(unset_warning_count.get(), 0);
+    }
+
+    #[test]
+    fn review_fix_submit_gap_override_rejects_values_above_the_safety_ceiling() {
         assert_eq!(
-            resolve_submit_gap(adapter_policy, Some(Duration::from_millis(4_500))),
-            Duration::from_millis(4_500)
+            parse_submit_gap_override(Some(OsStr::new("65000"))),
+            SubmitGapOverride::Valid(Duration::from_secs(65)),
+            "the known 65-second success must remain representable"
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("300000"))),
+            SubmitGapOverride::Valid(Duration::from_millis(
+                MAX_PTY_SUBMIT_GAP_OVERRIDE_MS
+            )),
+            "the named safety ceiling itself remains valid"
+        );
+        assert_eq!(
+            parse_submit_gap_override(Some(OsStr::new("300001"))),
+            SubmitGapOverride::OverLimit {
+                requested_ms: 300_001
+            },
+            "an override above the 300-second safety ceiling must be rejected, not clamped"
+        );
+    }
+
+    #[test]
+    fn submit_gap_override_policy_matches_the_production_session() {
+        fn policy_block(source: &str) -> String {
+            source
+                .split_once("// BEGIN SHARED SUBMIT GAP OVERRIDE POLICY")
+                .expect("policy start marker")
+                .1
+                .split_once("// END SHARED SUBMIT GAP OVERRIDE POLICY")
+                .expect("policy end marker")
+                .0
+                .replace("\r\n", "\n")
+        }
+
+        let production = policy_block(include_str!("session.rs"));
+        let test_stub = policy_block(include_str!("session_stub.rs"));
+        assert_eq!(production, test_stub, "the Windows shim must not drift");
+    }
+
+    #[test]
+    fn review_fix_documented_pty_buffer_sample_byte_count_matches_output() {
+        let document = include_str!("../../../docs/pty-submit-sweep.md");
+        let json_sample = document
+            .split_once("```json")
+            .expect("documented JSON sample")
+            .1
+            .split_once("```")
+            .expect("closed JSON sample")
+            .0;
+        let sample: serde_json::Value =
+            serde_json::from_str(json_sample).expect("valid documented JSON sample");
+        let output = sample["output"].as_str().expect("sample output string");
+        let byte_count = sample["byte_count"]
+            .as_u64()
+            .expect("sample byte_count") as usize;
+
+        assert_eq!(
+            byte_count,
+            output.len(),
+            "documented byte_count must equal the UTF-8 byte length of output"
         );
     }
 

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -9,6 +9,8 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use thiserror::Error;
 
+use crate::adapters::PtySubmitPolicy;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum AgentRole {
     MasterPlanner,
@@ -33,12 +35,20 @@ pub enum AgentStatus {
     Error(String),
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, schemars::JsonSchema)]
+pub struct RoleDefinitionRef {
+    pub id: String,
+    pub version: u32,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct WorkerRole {
     pub role_type: String,
     pub label: String,
     pub default_cli: String,
     pub prompt_template: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved_definition: Option<RoleDefinitionRef>,
 }
 
 impl WorkerRole {
@@ -48,6 +58,7 @@ impl WorkerRole {
             label: label.to_string(),
             default_cli: default_cli.to_string(),
             prompt_template: None,
+            resolved_definition: None,
         }
     }
 }
@@ -114,35 +125,36 @@ unsafe impl Send for SendWriter {}
 unsafe impl Sync for SendWriter {}
 
 const CHUNK_SIZE: usize = 16 * 1024;
-/// Unvalidated default; override with `HIVE_PTY_SUBMIT_GAP_MS` for the #226 sweep.
-///
-/// Under load, measured payload/Enter separations of 1.2-2.7 s failed twice,
-/// while roughly 4-5 s succeeded twice and 65 s succeeded once. Agent busy
-/// state was uncontrolled, so those observations do not justify replacing the
-/// compiled 50 ms default with another guess.
-const SUBMIT_GAP: Duration = Duration::from_millis(50);
 const SUBMIT_GAP_ENV: &str = "HIVE_PTY_SUBMIT_GAP_MS";
-static RUNTIME_SUBMIT_GAP: OnceLock<Duration> = OnceLock::new();
+static RUNTIME_SUBMIT_GAP: OnceLock<Option<Duration>> = OnceLock::new();
 const SUBMIT_GAP_TEST_TIMEOUT: Duration = Duration::from_secs(1);
 
-fn submit_gap_from_override(value: Option<&str>) -> Duration {
+fn submit_gap_from_override(value: Option<&str>) -> Option<Duration> {
     value
         .and_then(|milliseconds| milliseconds.trim().parse::<u64>().ok())
         .map(Duration::from_millis)
-        .unwrap_or(SUBMIT_GAP)
 }
 
-fn submit_gap() -> Duration {
-    *RUNTIME_SUBMIT_GAP.get_or_init(|| {
+fn resolve_submit_gap(
+    policy: PtySubmitPolicy,
+    override_gap: Option<Duration>,
+) -> Duration {
+    override_gap.unwrap_or(policy.default_gap)
+}
+
+fn submit_gap(policy: PtySubmitPolicy) -> Duration {
+    let override_gap = *RUNTIME_SUBMIT_GAP.get_or_init(|| {
         let override_value = std::env::var(SUBMIT_GAP_ENV).ok();
         submit_gap_from_override(override_value.as_deref())
-    })
+    });
+    resolve_submit_gap(policy, override_gap)
 }
 const BRACKETED_PASTE_START: &[u8] = b"\x1b[200~";
 const BRACKETED_PASTE_END: &[u8] = b"\x1b[201~";
 
 struct RecordingWriter {
     writes: Arc<Mutex<Vec<Vec<u8>>>>,
+    recent_output: Arc<Mutex<VecDeque<u8>>>,
 }
 
 #[derive(Default)]
@@ -155,6 +167,13 @@ struct SubmitGapControl {
 impl Write for RecordingWriter {
     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
         self.writes.lock().push(buf.to_vec());
+        let mut recent_output = self.recent_output.lock();
+        for byte in buf {
+            if recent_output.len() == RECENT_OUTPUT_CAPACITY {
+                recent_output.pop_front();
+            }
+            recent_output.push_back(*byte);
+        }
         Ok(buf.len())
     }
 
@@ -202,6 +221,7 @@ const RECENT_OUTPUT_CAPACITY: usize = 8 * 1024;
 pub struct PtySession {
     pub role: AgentRole,
     pub status: Arc<parking_lot::RwLock<AgentStatus>>,
+    submit_policy: PtySubmitPolicy,
     writer: Arc<Mutex<SendWriter>>,
     write_records: Arc<Mutex<Vec<Vec<u8>>>>,
     submit_gap_control: Arc<(Mutex<SubmitGapControl>, Condvar)>,
@@ -231,17 +251,23 @@ impl PtySession {
         _id: String,
         role: AgentRole,
         _command: &str,
+        submit_policy: PtySubmitPolicy,
         args: &[&str],
         _cwd: Option<&str>,
         _cols: u16,
         _rows: u16,
     ) -> Result<Self, PtyError> {
         let write_records = Arc::new(Mutex::new(Vec::new()));
+        let recent_output = Arc::new(Mutex::new(VecDeque::with_capacity(
+            RECENT_OUTPUT_CAPACITY,
+        )));
         let session = Self {
             role,
             status: Arc::new(parking_lot::RwLock::new(AgentStatus::Starting)),
+            submit_policy,
             writer: Arc::new(Mutex::new(SendWriter(Box::new(RecordingWriter {
                 writes: Arc::clone(&write_records),
+                recent_output: Arc::clone(&recent_output),
             })))),
             write_records,
             submit_gap_control: Arc::new((Mutex::new(SubmitGapControl::default()), Condvar::new())),
@@ -249,9 +275,7 @@ impl PtySession {
                 Vec::new(),
             ))))),
             args: args.iter().map(|arg| arg.to_string()).collect(),
-            recent_output: Arc::new(Mutex::new(VecDeque::with_capacity(
-                RECENT_OUTPUT_CAPACITY,
-            ))),
+            recent_output,
         };
 
         // #207 test fixture: a flag-borne sentinel is the only way an integration test
@@ -320,6 +344,14 @@ impl PtySession {
         changed.notify_all();
     }
 
+    pub fn submit_policy_for_test(&self) -> PtySubmitPolicy {
+        self.submit_policy
+    }
+
+    pub fn writer_locked_for_test(&self) -> bool {
+        self.writer.try_lock().is_none()
+    }
+
     fn pause_submit_after_payload_if_requested(&self) {
         let (control, changed) = &*self.submit_gap_control;
         let mut control = control.lock();
@@ -349,7 +381,7 @@ impl PtySession {
         let mut writer = self.writer.lock();
         Self::write_locked(&mut writer, data)?;
         self.pause_submit_after_payload_if_requested();
-        std::thread::sleep(submit_gap());
+        std::thread::sleep(submit_gap(self.submit_policy));
         Self::write_locked(&mut writer, b"\r")
     }
 
@@ -420,24 +452,36 @@ pub fn read_from_reader(
 #[cfg(test)]
 mod tests {
     use super::{
-        sanitize_bracketed_paste, submit_gap_from_override, BRACKETED_PASTE_END, SUBMIT_GAP,
+        resolve_submit_gap, sanitize_bracketed_paste, submit_gap_from_override,
+        BRACKETED_PASTE_END,
     };
+    use crate::adapters::PtySubmitPolicy;
     use std::time::Duration;
 
     #[test]
     fn submit_gap_override_parses_milliseconds() {
         assert_eq!(
             submit_gap_from_override(Some(" 4500 ")),
-            Duration::from_millis(4_500)
+            Some(Duration::from_millis(4_500))
         );
-        assert_eq!(submit_gap_from_override(Some("0")), Duration::ZERO);
+        assert_eq!(submit_gap_from_override(Some("0")), Some(Duration::ZERO));
     }
 
     #[test]
-    fn invalid_submit_gap_override_falls_back_to_default() {
-        assert_eq!(submit_gap_from_override(Some("not-a-number")), SUBMIT_GAP);
-        assert_eq!(submit_gap_from_override(Some("-1")), SUBMIT_GAP);
-        assert_eq!(submit_gap_from_override(None), SUBMIT_GAP);
+    fn invalid_submit_gap_override_defers_to_the_session_policy() {
+        assert_eq!(submit_gap_from_override(Some("not-a-number")), None);
+        assert_eq!(submit_gap_from_override(Some("-1")), None);
+        assert_eq!(submit_gap_from_override(None), None);
+
+        let adapter_policy = PtySubmitPolicy {
+            adapter: Some("future-tuned-adapter"),
+            default_gap: Duration::from_millis(123),
+        };
+        assert_eq!(resolve_submit_gap(adapter_policy, None), Duration::from_millis(123));
+        assert_eq!(
+            resolve_submit_gap(adapter_policy, Some(Duration::from_millis(4_500))),
+            Duration::from_millis(4_500)
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/cell_status.rs
+++ b/src-tauri/src/session/cell_status.rs
@@ -283,6 +283,8 @@ mod tests {
                     status,
                     config: AgentConfig::default(),
                     parent_id: None,
+                    role_definition_id: None,
+                    role_definition_version: None,
                     commit_sha: None,
                     base_commit_sha: None,
                 })
@@ -515,6 +517,8 @@ mod tests {
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -526,6 +530,8 @@ mod tests {
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -552,6 +558,8 @@ mod tests {
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -563,6 +571,8 @@ mod tests {
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -15,8 +15,17 @@ use crate::coordination::queue_manager::{heartbeat_cadence_label, STUCK_CUTOFF_S
 use crate::coordination::{HierarchyNode, StateManager, WorkerStateInfo};
 use crate::domain::{ArtifactBundle, HiveExecutionPolicy, HiveLaunchKind, WorkspaceStrategy};
 use crate::events::{EventBus, EventEmitter};
+use crate::orchestrator::org_graph::definitions::{
+    resolve_role_definition, role_prompt_template, ResolvedRoleDefinition,
+};
+use crate::orchestrator::org_graph::composition::{
+    compose_context, render_composed_context, spawn_context_from_work_graph_task, SpawnContext,
+};
+use crate::orchestrator::org_graph::RoleDefinition;
 use crate::orchestrator::session_orchestrator::SessionOrchestrator;
-use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager, WorkerRole};
+use crate::pty::{
+    AgentConfig, AgentRole, AgentStatus, PtyManager, RoleDefinitionRef, WorkerRole,
+};
 use crate::session::cell_status::{
     agent_in_cell, derive_cell_status_name, derive_cell_status_name_for_state, session_cell_ids,
     variant_to_cell_id, PRIMARY_CELL_ID, RESOLVER_CELL_ID,
@@ -373,6 +382,10 @@ pub struct AgentInfo {
     pub status: AgentStatus,
     pub config: AgentConfig,
     pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_definition_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_definition_version: Option<u32>,
     #[serde(default)]
     pub commit_sha: Option<String>,
     #[serde(default)]
@@ -897,13 +910,13 @@ fn cell_status_changes_for_transition(
     changes
 }
 /// Generate CLI-specific polling instructions based on the CLI's behavioral profile
-fn get_polling_instructions(
+pub(crate) fn get_polling_instructions(
     cli: &str,
     task_file: &str,
-    role_type: Option<&str>,
+    role_definition: Option<&RoleDefinition>,
     _heartbeat_command: Option<&str>,
 ) -> String {
-    let read_instruction = match CliRegistry::get_behavior_for_role(cli, role_type) {
+    let read_instruction = match CliRegistry::get_behavior_for_role(cli, role_definition) {
         CliBehavior::ExplicitPolling => "Read the task file once before starting work.",
         CliBehavior::ActionProne => "Read the complete task file before taking any action.",
         CliBehavior::InstructionFollowing => "Read and follow the complete task file.",
@@ -1143,6 +1156,8 @@ impl SessionController {
                 status: AgentStatus::Running,
                 config: queen_config,
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -1199,6 +1214,8 @@ impl SessionController {
                     status: AgentStatus::Running,
                     config: worker_config,
                     parent_id: Some(format!("{}-queen", session_id)),
+                    role_definition_id: None,
+                    role_definition_version: None,
                     commit_sha: None,
                     base_commit_sha: None,
                 });
@@ -2174,6 +2191,18 @@ impl SessionController {
         session: &mut Session,
         new_state: SessionState,
     ) -> Vec<(String, String, String)> {
+        Self::set_session_state_with_snapshot(
+            self.storage.as_deref(),
+            session,
+            new_state,
+        )
+    }
+
+    fn set_session_state_with_snapshot(
+        storage: Option<&SessionStorage>,
+        session: &mut Session,
+        new_state: SessionState,
+    ) -> Vec<(String, String, String)> {
         let from_kind = session.state.kind();
         let to_kind = new_state.kind();
         let trigger = super::transitions::trigger_for(from_kind, to_kind)
@@ -2181,7 +2210,21 @@ impl SessionController {
         let _ = super::transitions::validate_and_log(from_kind, to_kind, trigger);
         let changes = cell_status_changes_for_transition(session, &new_state);
         session.state = new_state;
+        Self::emit_work_graph_snapshot_for_session_state(storage, session);
         changes
+    }
+
+    fn emit_work_graph_snapshot_for_session_state(
+        storage: Option<&SessionStorage>,
+        session: &Session,
+    ) {
+        if let Some(storage) = storage {
+            let manager = StateManager::new(storage.session_dir(&session.id));
+            let stage = format!("{:?}", session.state.kind());
+            if let Err(error) = manager.emit_work_graph_snapshot(&stage) {
+                tracing::warn!(session_id = %session.id, stage, "Failed to emit work-graph lifecycle snapshot: {error}");
+            }
+        }
     }
 
     fn persist_then_emit_session_update(
@@ -2200,6 +2243,20 @@ impl SessionController {
     pub fn insert_test_session(&self, session: Session) {
         let mut sessions = self.sessions.write();
         sessions.insert(session.id.clone(), session);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn transition_test_session(
+        &self,
+        session_id: &str,
+        new_state: SessionState,
+    ) -> Result<(), String> {
+        let mut sessions = self.sessions.write();
+        let session = sessions
+            .get_mut(session_id)
+            .ok_or_else(|| format!("Session not found: {session_id}"))?;
+        self.set_session_state_with_events(session, new_state);
+        Ok(())
     }
 
     /// Persist an in-memory test session to storage, so read paths that
@@ -2376,7 +2433,8 @@ impl SessionController {
                 if let Err(err) = self.persist_then_emit_session_update(id, changes) {
                     let mut sessions = self.sessions.write();
                     if let Some(session) = sessions.get_mut(id) {
-                        session.state = previous_session_state;
+                        let _ =
+                            self.set_session_state_with_events(session, previous_session_state);
                         session.auth_strategy = previous_auth_strategy;
                     }
                     self.finish_scratch_pty_cleanup(id);
@@ -2408,7 +2466,8 @@ impl SessionController {
             if let Err(err) = self.update_session_storage_checked(session_id) {
                 let mut sessions = self.sessions.write();
                 if let Some(session) = sessions.get_mut(session_id) {
-                    session.state = previous_session_state;
+                    let _ = self
+                        .set_session_state_with_events(session, previous_session_state);
                     session.auth_strategy = previous_auth_strategy;
                 }
                 return Err(CompletionError::storage(err));
@@ -6286,10 +6345,21 @@ When the objective and every configured gate are complete, send this `completed`
             objective = objective,
         )
     }
+
+    pub(crate) fn polling_instructions_for_definition(
+        cli: &str,
+        task_file: &str,
+        definition: Option<&RoleDefinition>,
+    ) -> String {
+        get_polling_instructions(cli, task_file, definition, None)
+    }
+
     /// Build a worker's role prompt
-    fn build_worker_prompt(
+    pub(crate) fn build_worker_prompt(
         index: u8,
         config: &AgentConfig,
+        resolved_role: &ResolvedRoleDefinition,
+        spawn_context: &SpawnContext,
         queen_id: &str,
         session_id: &str,
         project_path: &Path,
@@ -6430,6 +6500,10 @@ When the objective and every configured gate are complete, send this `completed`
             },
             stop_conditions: &stop_conditions,
         });
+        let composed_context = render_composed_context(&compose_context(
+            resolved_role.definition.as_ref(),
+            spawn_context,
+        ));
 
         let agent_id = format!("{session_id}-worker-{index}");
         let activation_wait_heartbeat = heartbeat_snippet(
@@ -6442,10 +6516,7 @@ When the objective and every configured gate are complete, send this `completed`
         let polling_instructions = get_polling_instructions(
             &config.cli,
             &task_file,
-            config
-                .role
-                .as_ref()
-                .map(|worker_role| worker_role.role_type.as_str()),
+            resolved_role.definition.as_ref(),
             Some(&activation_wait_heartbeat),
         );
         let working_heartbeat = heartbeat_snippet(
@@ -6550,7 +6621,7 @@ Before marking the task COMPLETED, POST one durable learning record to /api/sess
 
 {assignment}
 
-{role_section}
+{composed_context}{role_section}
 
 ## Runtime
 
@@ -6601,6 +6672,7 @@ treated as stuck and requeued.
             delegation = delegation,
             workspace_contract = workspace_contract,
             assignment = assignment,
+            composed_context = composed_context,
             role_section = role_section,
             session_id = session_id,
             queen_id = queen_id,
@@ -7975,6 +8047,8 @@ Last updated: {timestamp}
                 status: AgentStatus::Running,
                 config: solo_config.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             }],
@@ -8302,6 +8376,8 @@ Last updated: {timestamp}
             status: AgentStatus::Running,
             config: config.queen_config.clone(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         });
@@ -8320,10 +8396,13 @@ Last updated: {timestamp}
         for (i, worker_config) in workers_to_spawn.iter().enumerate() {
             let index = (i + 1) as u8;
             let worker_id = format!("{}-worker-{}", session_id, index);
-            let worker_role = worker_config
+            let mut worker_role = worker_config
                 .role
                 .clone()
                 .unwrap_or_else(|| WorkerRole::new("general", "Worker", &worker_config.cli));
+            let resolved_role =
+                self.resolve_worker_role_definition(&project_path, &worker_role.role_type);
+            Self::attach_resolved_definition(&mut worker_role, &resolved_role);
             let worker_config =
                 Self::apply_worker_identity(index, &worker_role, worker_config.clone());
             let (cmd, mut args) = Self::build_command(&worker_config);
@@ -8402,6 +8481,8 @@ Last updated: {timestamp}
             let worker_prompt = Self::build_worker_prompt(
                 index,
                 &worker_config,
+                &resolved_role,
+                &SpawnContext::default(),
                 &queen_id,
                 &session_id,
                 &project_path,
@@ -8471,6 +8552,14 @@ Last updated: {timestamp}
                 status: AgentStatus::Running,
                 config: worker_config.clone(),
                 parent_id: Some(queen_id.clone()),
+                role_definition_id: resolved_role
+                    .definition
+                    .as_ref()
+                    .map(|definition| definition.id.clone()),
+                role_definition_version: resolved_role
+                    .definition
+                    .as_ref()
+                    .map(|definition| definition.version),
                 commit_sha: None,
                 base_commit_sha: worker_base_commit_sha,
             });
@@ -8932,6 +9021,8 @@ phases and do EXACTLY this, then stop:
                 status: AgentStatus::Running,
                 config: variant_agent_config,
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             };
@@ -9362,6 +9453,8 @@ phases and do EXACTLY this, then stop:
                 status: AgentStatus::Running,
                 config: agent_config,
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -9401,6 +9494,91 @@ phases and do EXACTLY this, then stop:
             .and_then(|config| config.global_wiki_path)
             .filter(|path| !path.trim().is_empty())
             .map(|path| PathBuf::from(expand_tilde(&path)))
+    }
+
+    fn resolve_worker_role_definition(
+        &self,
+        project_path: &Path,
+        role_type: &str,
+    ) -> ResolvedRoleDefinition {
+        let institutional_root = self.configured_institutional_wiki_root();
+        let resolved = resolve_role_definition(
+            project_path,
+            institutional_root.as_deref(),
+            role_type,
+        );
+        for issue in &resolved.issues {
+            tracing::warn!(
+                role_id = %resolved.requested_id,
+                issue = ?issue.kind,
+                source_ref = %issue.source_ref,
+                detail = %issue.detail,
+                "Role definition resolution reported an omission"
+            );
+        }
+        resolved
+    }
+
+    fn attach_resolved_definition(
+        role: &mut WorkerRole,
+        resolved: &ResolvedRoleDefinition,
+    ) {
+        role.prompt_template = Some(
+            resolved
+                .definition
+                .as_ref()
+                .and_then(|definition| definition.prompt_template.clone())
+                .unwrap_or_else(|| role_prompt_template(&role.role_type)),
+        );
+        role.resolved_definition = resolved.definition.as_ref().map(|definition| {
+            RoleDefinitionRef {
+                id: definition.id.clone(),
+                version: definition.version,
+            }
+        });
+    }
+
+    /// Load only the task-scoped knowledge edges for an explicitly identified
+    /// plan task. Missing graph evidence is an empty scope; it is never
+    /// reconstructed from prompt text or the process working directory.
+    fn spawn_context_for_plan_task(
+        &self,
+        session_id: &str,
+        plan_task_id: Option<&str>,
+    ) -> SpawnContext {
+        let Some(plan_task_id) = plan_task_id.map(str::trim).filter(|id| !id.is_empty()) else {
+            return SpawnContext::default();
+        };
+        let Some(storage) = self.storage.as_ref() else {
+            return SpawnContext::default();
+        };
+        let state_manager = StateManager::new(storage.session_dir(session_id));
+        let composition = match state_manager.read_graph_composition_state() {
+            Ok(Some(composition)) => composition,
+            Ok(None) => return SpawnContext::default(),
+            Err(error) => {
+                tracing::warn!(
+                    session_id,
+                    plan_task_id,
+                    "Failed to read task-scoped work-graph context: {error}"
+                );
+                return SpawnContext::default();
+            }
+        };
+        if !composition
+            .graph
+            .nodes
+            .iter()
+            .any(|node| node.id == plan_task_id)
+        {
+            tracing::warn!(
+                session_id,
+                plan_task_id,
+                "Plan task was absent while composing worker context"
+            );
+            return SpawnContext::default();
+        }
+        spawn_context_from_work_graph_task(&composition.graph, plan_task_id)
     }
 
     fn planning_codegraph_artifact_path(project_path: &Path, session_id: &str) -> PathBuf {
@@ -9812,6 +9990,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: config.queen_config.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -9927,6 +10107,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: queen_cfg.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -10057,6 +10239,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: queen_cfg.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -10271,6 +10455,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: queen_cfg,
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -10390,6 +10576,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: variant_agent_config,
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -10652,6 +10840,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: config.queen_config.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -10758,8 +10948,16 @@ The backend composed and persisted the following authoritative skeleton before l
             return Ok(());
         }
 
-        let worker_config = &config.workers[worker_index];
         let index = (worker_index + 1) as u8;
+        let source_config = &config.workers[worker_index];
+        let mut worker_role = source_config
+            .role
+            .clone()
+            .unwrap_or_else(|| WorkerRole::new("general", "Worker", &source_config.cli));
+        let resolved_role =
+            self.resolve_worker_role_definition(&session.project_path, &worker_role.role_type);
+        Self::attach_resolved_definition(&mut worker_role, &resolved_role);
+        let worker_config = Self::apply_worker_identity(index, &worker_role, source_config.clone());
         let worker_branch = format!("hive/{}/worker-{}", session_id, index);
 
         // #125 resume guard: if this worker-spawn write-step is already journaled
@@ -10875,7 +11073,9 @@ The backend composed and persisted the following authoritative skeleton before l
         // 3. Write worker prompt to file
         let worker_prompt = Self::build_worker_prompt(
             index,
-            worker_config,
+            &worker_config,
+            &resolved_role,
+            &SpawnContext::default(),
             queen_id,
             session_id,
             &session.project_path,
@@ -10903,7 +11103,7 @@ The backend composed and persisted the following authoritative skeleton before l
         let prompt_path = prompt_file.to_string_lossy().to_string();
 
         // 4. Build command with prompt
-        let (cmd, mut args) = Self::build_command(worker_config);
+        let (cmd, mut args) = Self::build_command(&worker_config);
         Self::add_prompt_to_args(&cmd, &mut args, &prompt_path);
 
         // 5. Spawn the worker (use worker_cwd as PTY cwd)
@@ -10947,6 +11147,14 @@ The backend composed and persisted the following authoritative skeleton before l
                     status: AgentStatus::Running,
                     config: worker_config.clone(),
                     parent_id: Some(queen_id.to_string()),
+                    role_definition_id: resolved_role
+                        .definition
+                        .as_ref()
+                        .map(|definition| definition.id.clone()),
+                    role_definition_version: resolved_role
+                        .definition
+                        .as_ref()
+                        .map(|definition| definition.version),
                     commit_sha: None,
                     base_commit_sha: Some(worker_base_commit_sha.clone()),
                 };
@@ -11232,6 +11440,10 @@ The backend composed and persisted the following authoritative skeleton before l
                 let mut sessions = self.sessions.write();
                 if let Some(session) = sessions.get_mut(session_id) {
                     *session = previous_session;
+                    Self::emit_work_graph_snapshot_for_session_state(
+                        Some(storage.as_ref()),
+                        session,
+                    );
                 }
                 return Err(err);
             }
@@ -11309,6 +11521,10 @@ The backend composed and persisted the following authoritative skeleton before l
                 let mut sessions = self.sessions.write();
                 if let Some(session) = sessions.get_mut(session_id) {
                     *session = previous_session;
+                    Self::emit_work_graph_snapshot_for_session_state(
+                        Some(storage.as_ref()),
+                        session,
+                    );
                 }
                 return Err(err);
             }
@@ -11400,6 +11616,10 @@ The backend composed and persisted the following authoritative skeleton before l
                 let mut sessions = self.sessions.write();
                 if let Some(session) = sessions.get_mut(session_id) {
                     *session = previous_session;
+                    Self::emit_work_graph_snapshot_for_session_state(
+                        Some(storage.as_ref()),
+                        session,
+                    );
                 }
                 return Err(err);
             }
@@ -11768,16 +11988,11 @@ The backend composed and persisted the following authoritative skeleton before l
                     let mut sessions = sessions.write();
                     if let Some(session) = sessions.get_mut(&sid) {
                         let previous_state = session.state.clone();
-                        let changes = cell_status_changes_for_transition(
+                        let changes = SessionController::set_session_state_with_snapshot(
+                            storage.as_deref(),
                             session,
-                            &SessionState::QaInconclusive,
+                            SessionState::QaInconclusive,
                         );
-                        let _ = super::transitions::validate_and_log(
-                            session.state.kind(),
-                            super::transitions::SessionStateKind::QaInconclusive,
-                            super::transitions::TransitionTrigger::QaTimedOut,
-                        );
-                        session.state = SessionState::QaInconclusive;
                         Some((previous_state, changes, session.clone()))
                     } else {
                         None
@@ -11798,7 +12013,11 @@ The backend composed and persisted the following authoritative skeleton before l
                             );
                             let mut sessions = sessions.write();
                             if let Some(session) = sessions.get_mut(&sid) {
-                                session.state = previous_state;
+                                let _ = SessionController::set_session_state_with_snapshot(
+                                    Some(storage.as_ref()),
+                                    session,
+                                    previous_state,
+                                );
                             }
                             return;
                         }
@@ -12053,6 +12272,8 @@ The backend composed and persisted the following authoritative skeleton before l
                     status: AgentStatus::Running,
                     config: judge_config,
                     parent_id: None,
+                    role_definition_id: None,
+                    role_definition_version: None,
                     commit_sha: None,
                     base_commit_sha: None,
                 };
@@ -12351,6 +12572,8 @@ The backend composed and persisted the following authoritative skeleton before l
                     status: AgentStatus::Running,
                     config: judge_config,
                     parent_id: None,
+                    role_definition_id: None,
+                    role_definition_version: None,
                     commit_sha: None,
                     base_commit_sha: None,
                 };
@@ -12801,6 +13024,8 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config: config.queen_config.clone(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         });
@@ -12986,12 +13211,32 @@ The backend composed and persisted the following authoritative skeleton before l
                 state_manager
                     .write_work_graph(&graph)
                     .map_err(|error| format!("Failed to persist plan work graph: {error}"))?;
+                let ownership_state =
+                    crate::orchestrator::org_graph::ownership::OwnershipSessionState::from_plan(
+                        &graph,
+                        crate::orchestrator::org_graph::ownership::orchestrator_nodes_for_plan(
+                            &graph,
+                        ),
+                        &[],
+                    )
+                    .map_err(|error| {
+                        format!("Failed to build orchestrator ownership state: {error}")
+                    })?;
+                state_manager
+                    .write_ownership_session_state(&ownership_state)
+                    .map_err(|error| {
+                        format!("Failed to persist orchestrator ownership state: {error}")
+                    })?;
             }
             let previous_session = session.clone();
             let changes = self.set_session_state_with_events(session, SessionState::PlanReady);
             if let Some(storage) = self.storage.as_ref() {
                 if let Err(error) = Self::persist_session_snapshot(storage, session, session_id) {
                     *session = previous_session;
+                    Self::emit_work_graph_snapshot_for_session_state(
+                        Some(storage.as_ref()),
+                        session,
+                    );
                     return Err(error);
                 }
             }
@@ -13213,7 +13458,13 @@ The backend composed and persisted the following authoritative skeleton before l
                         role_type: rt.clone(),
                         label: pa.config.label.clone().unwrap_or_default(),
                         default_cli: pa.config.cli.clone(),
-                        prompt_template: pa.config.initial_prompt.clone(),
+                        prompt_template: Some(role_prompt_template(rt)),
+                        resolved_definition: pa.role_definition_id.as_ref().zip(
+                            pa.role_definition_version,
+                        ).map(|(id, version)| RoleDefinitionRef {
+                            id: id.clone(),
+                            version,
+                        }),
                     }),
                     initial_prompt: pa.config.initial_prompt.clone(),
                 };
@@ -13224,6 +13475,8 @@ The backend composed and persisted the following authoritative skeleton before l
                     status: AgentStatus::Completed,
                     config,
                     parent_id: pa.parent_id.clone(),
+                    role_definition_id: pa.role_definition_id.clone(),
+                    role_definition_version: pa.role_definition_version,
                     commit_sha: pa.commit_sha.clone(),
                     base_commit_sha: pa.base_commit_sha.clone(),
                 })
@@ -13379,6 +13632,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: config.queen_config.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -13523,6 +13778,8 @@ The backend composed and persisted the following authoritative skeleton before l
                 status: AgentStatus::Running,
                 config: config.queen_config.clone(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -13964,7 +14221,7 @@ The backend composed and persisted the following authoritative skeleton before l
         &self,
         session_id: &str,
         config: AgentConfig,
-        role: WorkerRole,
+        mut role: WorkerRole,
         parent_id: Option<String>,
         expected_index: Option<u8>,
         plan_task_id: Option<&str>,
@@ -14000,6 +14257,9 @@ The backend composed and persisted the following authoritative skeleton before l
         // Generate worker ID
         let worker_id = format!("{}-worker-{}", session_id, worker_index);
 
+        let resolved_role =
+            self.resolve_worker_role_definition(&session.project_path, &role.role_type);
+        Self::attach_resolved_definition(&mut role, &resolved_role);
         let config_with_role = Self::apply_worker_identity(worker_index, &role, config);
         let (cmd, mut args) = Self::build_command(&config_with_role);
         let uses_shared_workspace = !session.no_git
@@ -14086,9 +14346,12 @@ The backend composed and persisted the following authoritative skeleton before l
         };
 
         // Write worker prompt to file and add to args
+        let spawn_context = self.spawn_context_for_plan_task(session_id, plan_task_id);
         let worker_prompt = Self::build_worker_prompt(
             worker_index,
             &config_with_role,
+            &resolved_role,
+            &spawn_context,
             &actual_parent_id,
             session_id,
             &session.project_path,
@@ -14165,6 +14428,14 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config: agent_config,
             parent_id: Some(actual_parent_id),
+            role_definition_id: resolved_role
+                .definition
+                .as_ref()
+                .map(|definition| definition.id.clone()),
+            role_definition_version: resolved_role
+                .definition
+                .as_ref()
+                .map(|definition| definition.version),
             commit_sha: None,
             base_commit_sha: worker_base_commit_sha,
         };
@@ -14337,6 +14608,8 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config,
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -14487,6 +14760,8 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config,
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -14608,6 +14883,8 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config,
             parent_id: Some(evaluator_id),
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -14751,6 +15028,8 @@ The backend composed and persisted the following authoritative skeleton before l
             status: AgentStatus::Running,
             config: agent_config,
             parent_id: Some(queen_id),
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         };
@@ -14856,6 +15135,8 @@ The backend composed and persisted the following authoritative skeleton before l
                         initial_prompt: a.config.initial_prompt.clone(),
                     },
                     parent_id: a.parent_id.clone(),
+                    role_definition_id: a.role_definition_id.clone(),
+                    role_definition_version: a.role_definition_version,
                     commit_sha: a.commit_sha.clone(),
                     base_commit_sha: a.base_commit_sha.clone(),
                 }
@@ -14893,6 +15174,13 @@ The backend composed and persisted the following authoritative skeleton before l
             worktree_branch: session.worktree_branch.clone(),
             no_git: session.no_git,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn persisted_snapshot_for_test(
+        session: &Session,
+    ) -> crate::storage::PersistedSession {
+        Self::session_to_persisted_snapshot(session)
     }
 
     fn init_session_storage(&self, session: &Session) {
@@ -15307,6 +15595,7 @@ mod tests {
     };
     use super::{heartbeat_cadence_label, CliBehavior, CliRegistry};
     use crate::domain::{ArtifactBundle, HiveExecutionPolicy, WorkspaceStrategy};
+    use crate::orchestrator::org_graph::composition::SpawnContext;
     use crate::pty::{AgentRole, AgentStatus, PtyManager, WorkerRole};
     use crate::workspace::git::current_head;
     use chrono::{Duration, Utc};
@@ -15840,12 +16129,19 @@ mod tests {
 
         let task_path = SessionController::task_file_path_for_session_worker(&restored, 2)
             .expect("Research task path");
+        let resolved = crate::orchestrator::org_graph::definitions::resolve_role_definition(
+            &restored.project_path,
+            None,
+            "researcher",
+        );
         let prompt = SessionController::build_worker_prompt(
             2,
             &AgentConfig {
                 role: Some(WorkerRole::new("researcher", "Researcher", "claude")),
                 ..AgentConfig::default()
             },
+            &resolved,
+            &SpawnContext::default(),
             "legacy-research-queen",
             &restored.id,
             &restored.project_path,
@@ -15892,6 +16188,11 @@ mod tests {
 
     fn worker_prompt_for_cli(cli: &str) -> String {
         let temp = tempfile::tempdir().expect("temp project");
+        let resolved = crate::orchestrator::org_graph::definitions::resolve_role_definition(
+            temp.path(),
+            None,
+            "backend",
+        );
         SessionController::build_worker_prompt(
             1,
             &AgentConfig {
@@ -15899,6 +16200,8 @@ mod tests {
                 role: Some(WorkerRole::new("backend", "Backend", cli)),
                 ..AgentConfig::default()
             },
+            &resolved,
+            &SpawnContext::default(),
             "session-141-queen",
             "session-141",
             temp.path(),
@@ -15967,7 +16270,9 @@ mod tests {
             let activation = super::get_polling_instructions(
                 cli,
                 "worker-1-task.md",
-                Some("backend"),
+                Some(&crate::orchestrator::org_graph::RoleDefinition::empty(
+                    "backend",
+                )),
                 Some("HEARTBEAT_COMMAND"),
             );
             assert!(
@@ -15999,7 +16304,9 @@ mod tests {
             let activation = super::get_polling_instructions(
                 cli,
                 "worker-1-task.md",
-                Some("backend"),
+                Some(&crate::orchestrator::org_graph::RoleDefinition::empty(
+                    "backend",
+                )),
                 Some("HEARTBEAT_COMMAND"),
             );
             assert!(
@@ -16018,7 +16325,9 @@ mod tests {
             let instructions = super::get_polling_instructions(
                 representative_cli_for(&behavior),
                 "worker-1-task.md",
-                Some("backend"),
+                Some(&crate::orchestrator::org_graph::RoleDefinition::empty(
+                    "backend",
+                )),
                 Some("HEARTBEAT_COMMAND"),
             );
             assert!(instructions.contains("Queue Activation"));
@@ -16311,9 +16620,16 @@ mod tests {
     fn live_worker_prompt_uses_actual_codex_capabilities_and_topology_git_contract() {
         let shared_policy = shared_meta_harness_policy();
         let principal = codex_principal();
+        let resolved = crate::orchestrator::org_graph::definitions::resolve_role_definition(
+            Path::new("/repo"),
+            None,
+            "backend",
+        );
         let shared_prompt = SessionController::build_worker_prompt(
             1,
             &principal,
+            &resolved,
+            &SpawnContext::default(),
             "session-modern-queen",
             "session-modern",
             Path::new("/repo"),
@@ -16349,6 +16665,8 @@ mod tests {
         let isolated_prompt = SessionController::build_worker_prompt(
             1,
             &principal,
+            &resolved,
+            &SpawnContext::default(),
             "session-modern-queen",
             "session-modern",
             Path::new("/repo"),
@@ -16367,6 +16685,8 @@ mod tests {
         let no_workspace_prompt = SessionController::build_worker_prompt(
             1,
             &principal,
+            &resolved,
+            &SpawnContext::default(),
             "session-modern-queen",
             "session-modern",
             Path::new("/repo"),
@@ -16466,9 +16786,16 @@ mod tests {
             workspace_strategy: crate::domain::WorkspaceStrategy::None,
             ..HiveExecutionPolicy::default()
         };
+        let resolved = crate::orchestrator::org_graph::definitions::resolve_role_definition(
+            temp.path(),
+            None,
+            "researcher",
+        );
         let prompt = SessionController::build_worker_prompt(
             1,
             &cfg,
+            &resolved,
+            &SpawnContext::default(),
             "queen",
             session_id,
             temp.path(),
@@ -16521,12 +16848,19 @@ mod tests {
             "Test task",
             "claude",
         );
+        let resolved = crate::orchestrator::org_graph::definitions::resolve_role_definition(
+            Path::new("."),
+            None,
+            "backend",
+        );
         let worker_prompt = SessionController::build_worker_prompt(
             1,
             &AgentConfig {
                 role: Some(WorkerRole::new("backend", "Backend", "claude")),
                 ..AgentConfig::default()
             },
+            &resolved,
+            &SpawnContext::default(),
             "session-scope-equality-queen",
             session_id,
             Path::new("."),
@@ -16750,6 +17084,8 @@ mod tests {
                 status: AgentStatus::Running,
                 config: AgentConfig::default(),
                 parent_id: Some(format!("{session_id}-queen")),
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: current_head(&worker_worktree).ok(),
             }],
@@ -16784,6 +17120,8 @@ mod tests {
                 status: AgentStatus::Completed,
                 config: AgentConfig::default(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });
@@ -17012,6 +17350,8 @@ mod tests {
             status: AgentStatus::Running,
             config: AgentConfig::default(),
             parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
             commit_sha: None,
             base_commit_sha: None,
         }];
@@ -17022,6 +17362,8 @@ mod tests {
                 status: AgentStatus::Running,
                 config: AgentConfig::default(),
                 parent_id: None,
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             });

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -1948,6 +1948,39 @@ mod tests {
     }
 
     #[test]
+    fn a33_populated_persisted_agent_role_reference_round_trips() {
+        let agent = PersistedAgentInfo {
+            id: "agent-reviewer".to_string(),
+            role: "Worker(1)".to_string(),
+            config: PersistedAgentConfig {
+                cli: "codex".to_string(),
+                model: Some("gpt-5.6-sol".to_string()),
+                flags: vec!["--search".to_string()],
+                label: Some("Independent Reviewer".to_string()),
+                name: None,
+                description: Some("Review the implementation".to_string()),
+                role_type: Some("reviewer".to_string()),
+                initial_prompt: None,
+            },
+            parent_id: Some("session-queen".to_string()),
+            role_definition_id: Some("reviewer".to_string()),
+            role_definition_version: Some(7),
+            commit_sha: Some("abc123".to_string()),
+            base_commit_sha: Some("def456".to_string()),
+        };
+
+        let encoded = serde_json::to_value(&agent).expect("serialize populated agent");
+        assert_eq!(encoded["role_definition_id"], "reviewer");
+        assert_eq!(encoded["role_definition_version"], 7);
+
+        let decoded: PersistedAgentInfo =
+            serde_json::from_value(encoded).expect("deserialize populated agent");
+        assert_eq!(decoded.role_definition_id.as_deref(), Some("reviewer"));
+        assert_eq!(decoded.role_definition_version, Some(7));
+        assert_eq!(decoded.config.role_type.as_deref(), Some("reviewer"));
+    }
+
+    #[test]
     fn test_load_session_if_newer_and_clean_uses_cached_hash() {
         let (storage, _temp_dir) = create_test_storage();
         let session = sample_persisted_session("refresh-hash-session");

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -291,6 +291,10 @@ pub struct PersistedAgentInfo {
     pub role: String,
     pub config: PersistedAgentConfig,
     pub parent_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_definition_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub role_definition_version: Option<u32>,
     #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
     pub commit_sha: Option<String>,
     #[serde(default, deserialize_with = "deserialize_optional_trimmed_string")]
@@ -1763,6 +1767,8 @@ mod tests {
                     initial_prompt: None,
                 },
                 parent_id: Some(format!("{session_id}-queen")),
+                role_definition_id: None,
+                role_definition_version: None,
                 commit_sha: None,
                 base_commit_sha: None,
             }],
@@ -1937,6 +1943,8 @@ mod tests {
 
         let agent: PersistedAgentInfo = serde_json::from_str(json).unwrap();
         assert_eq!(agent.commit_sha, None);
+        assert_eq!(agent.role_definition_id, None);
+        assert_eq!(agent.role_definition_version, None);
     }
 
     #[test]

--- a/src-tauri/src/storage/queue.rs
+++ b/src-tauri/src/storage/queue.rs
@@ -2,7 +2,8 @@
 //!
 //! Built on top of #124's [`ApplicationStateDb`] (the single shared `application_state.db`).
 //! This module owns one additive table, `agent_run_queue`, created via an idempotent
-//! [`ensure_schema`] (`CREATE TABLE IF NOT EXISTS` + indexes) called once at startup.
+//! [`ensure_schema`] (`CREATE TABLE IF NOT EXISTS` + guarded additive migrations + indexes)
+//! called once at startup.
 //!
 //! # The atomic-claim invariant
 //!
@@ -85,6 +86,14 @@ pub struct QueueRow {
     pub last_status: Option<String>,
     /// Unix epoch millis of the last heartbeat, or `None` if never heartbeated.
     pub heartbeat_at: Option<i64>,
+    /// Session-local monotonic identity for the current assignment of this row.
+    ///
+    /// `0` is the honest sentinel for rows migrated from a schema that did not record
+    /// assignment order. Claims/rebinds and assignment-invalidating releases mint a positive
+    /// value; heartbeats preserve it so callers can address the same assignment after the row
+    /// reaches `finalized`.
+    #[serde(default)]
+    pub assignment_id: i64,
     /// Human-readable reason recorded when dependency failure/cancellation blocks this row.
     pub blocked_reason: Option<String>,
     pub created_at: i64,
@@ -173,8 +182,9 @@ pub enum SpawnFailureRelease {
 
 /// Create the `agent_run_queue` table (+ indexes) if absent.
 ///
-/// Additive-only and idempotent: safe to call at every startup. Uses plain
-/// `IF NOT EXISTS`, leaving #124's `schema_meta` version table untouched.
+/// Additive-only and idempotent: safe to call at every startup. The fresh DDL is followed by
+/// guarded `ALTER TABLE ... ADD COLUMN` migrations, leaving #124's `schema_meta` version table
+/// untouched.
 pub fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute(
         "CREATE TABLE IF NOT EXISTS agent_run_queue (
@@ -191,11 +201,32 @@ pub fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
             no_progress_count  INTEGER NOT NULL DEFAULT 0,
             last_status        TEXT,
             heartbeat_at       INTEGER,
+            assignment_id      INTEGER NOT NULL DEFAULT 0,
             created_at         INTEGER NOT NULL,
             updated_at         INTEGER NOT NULL
         )",
         [],
     )?;
+    let has_assignment_id = {
+        let mut stmt = conn.prepare("PRAGMA table_info(agent_run_queue)")?;
+        let mut rows = stmt.query([])?;
+        let mut found = false;
+        while let Some(row) = rows.next()? {
+            let column_name: String = row.get(1)?;
+            if column_name == "assignment_id" {
+                found = true;
+                break;
+            }
+        }
+        found
+    };
+    if !has_assignment_id {
+        conn.execute(
+            "ALTER TABLE agent_run_queue
+             ADD COLUMN assignment_id INTEGER NOT NULL DEFAULT 0",
+            [],
+        )?;
+    }
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_agent_run_queue_session_status
          ON agent_run_queue(session_id, status)",
@@ -209,6 +240,11 @@ pub fn ensure_schema(conn: &Connection) -> rusqlite::Result<()> {
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_agent_run_queue_session_task_status
          ON agent_run_queue(session_id, task_id, status)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_agent_run_queue_worker_assignment
+         ON agent_run_queue(session_id, worker_id, assignment_id DESC)",
         [],
     )?;
     conn.execute(
@@ -327,8 +363,8 @@ impl QueueRepo {
                 "INSERT INTO agent_run_queue
                     (id, task_id, session_id, worker_id, role_type, cli, status, payload,
                      attempts, continuation_count, no_progress_count, last_status,
-                     heartbeat_at, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                     heartbeat_at, assignment_id, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
                  ON CONFLICT(id) DO NOTHING",
                 params![
                     row.id,
@@ -344,6 +380,7 @@ impl QueueRepo {
                     row.no_progress_count,
                     row.last_status,
                     row.heartbeat_at,
+                    row.assignment_id,
                     row.created_at,
                     row.updated_at,
                 ],
@@ -418,8 +455,8 @@ impl QueueRepo {
                 "INSERT INTO agent_run_queue
                     (id, task_id, session_id, worker_id, role_type, cli, status, payload,
                      attempts, continuation_count, no_progress_count, last_status,
-                     heartbeat_at, created_at, updated_at)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
+                     heartbeat_at, assignment_id, created_at, updated_at)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
                  ON CONFLICT(id) DO NOTHING",
                 params![
                     row.id,
@@ -435,6 +472,7 @@ impl QueueRepo {
                     row.no_progress_count,
                     row.last_status,
                     row.heartbeat_at,
+                    row.assignment_id,
                     row.created_at,
                     row.updated_at,
                 ],
@@ -596,7 +634,12 @@ impl QueueRepo {
                      attempts = attempts + 1,
                      updated_at = ?2,
                      heartbeat_at = ?2,
-                     worker_id = COALESCE(?4, worker_id)
+                     worker_id = COALESCE(?4, worker_id),
+                     assignment_id = (
+                         SELECT COALESCE(MAX(assignments.assignment_id), 0) + 1
+                         FROM agent_run_queue AS assignments
+                         WHERE assignments.session_id = agent_run_queue.session_id
+                     )
                  WHERE id = ?1
                    AND (status = 'queued'
                         OR (status = 'running'
@@ -781,14 +824,16 @@ impl QueueRepo {
         now_ms: i64,
     ) -> Result<bool, StorageError> {
         self.db.with_conn(|conn| {
+            let assignment_id = next_assignment_id_for_row(conn, id)?;
             conn.execute(
                 "UPDATE agent_run_queue
                  SET status = 'queued',
                      worker_id = CASE
                          WHEN task_id IS NOT NULL THEN 'pending:' || id ELSE worker_id END,
-                     updated_at = ?3
+                     updated_at = ?3,
+                     assignment_id = ?4
                  WHERE id = ?1 AND status = 'running' AND attempts = ?2",
-                params![id, expected_attempts, now_ms],
+                params![id, expected_attempts, now_ms, assignment_id],
             )?;
             Ok(conn.changes() == 1)
         })
@@ -803,11 +848,12 @@ impl QueueRepo {
     ) -> Result<bool, StorageError> {
         self.db.with_conn(|conn| {
             let tx = conn.unchecked_transaction()?;
+            let assignment_id = next_assignment_id_for_row(&tx, id)?;
             let changed = tx.execute(
                 "UPDATE agent_run_queue
-                 SET status = 'failed', updated_at = ?3
+                 SET status = 'failed', updated_at = ?3, assignment_id = ?4
                  WHERE id = ?1 AND status = 'running' AND attempts = ?2",
-                params![id, expected_attempts, now_ms],
+                params![id, expected_attempts, now_ms, assignment_id],
             )?;
             if changed == 1 {
                 let root: Option<(String, Option<String>)> = tx
@@ -876,18 +922,20 @@ impl QueueRepo {
             } else {
                 ("queued", SpawnFailureRelease::Requeued { failures })
             };
+            let assignment_id = next_assignment_id_for_row(&tx, id)?;
             let changed = tx.execute(
                 "UPDATE agent_run_queue
                  SET status = ?4,
                      worker_id = CASE
                          WHEN ?4 = 'queued' AND task_id IS NOT NULL
                          THEN 'pending:' || id ELSE worker_id END,
-                     updated_at = ?5
+                     updated_at = ?5,
+                     assignment_id = ?6
                  WHERE id = ?1
                    AND status = 'running'
                    AND attempts = ?2
                    AND worker_id = ?3",
-                params![id, expected_attempts, worker_id, status, now_ms],
+                params![id, expected_attempts, worker_id, status, now_ms, assignment_id],
             )?;
             if changed != 1 {
                 tx.rollback()?;
@@ -939,14 +987,16 @@ impl QueueRepo {
     pub fn release_claim_manual(&self, id: &str, now_ms: i64) -> Result<bool, StorageError> {
         self.db.with_conn(|conn| {
             let tx = conn.unchecked_transaction()?;
+            let assignment_id = next_assignment_id_for_row(&tx, id)?;
             let changed = tx.execute(
                 "UPDATE agent_run_queue
                  SET status = 'queued',
                      worker_id = CASE
                          WHEN task_id IS NOT NULL THEN 'pending:' || id ELSE worker_id END,
-                     updated_at = ?2
+                     updated_at = ?2,
+                     assignment_id = ?3
                  WHERE id = ?1 AND status IN ('running', 'failed')",
-                params![id, now_ms],
+                params![id, now_ms, assignment_id],
             )?;
             if changed == 1 {
                 tx.execute(
@@ -990,7 +1040,47 @@ impl QueueRepo {
         status: &str,
         now_ms: i64,
     ) -> Result<bool, StorageError> {
+        Ok(self
+            .record_heartbeat_for_assignment(session_id, worker_id, None, status, now_ms)?
+            .is_some())
+    }
+
+    /// Record a heartbeat against exactly one assignment and return its queue-row id.
+    ///
+    /// When `assignment_id` is supplied, a stale or mismatched identity updates nothing; it
+    /// never falls back to another row sharing the worker slot. Legacy prompts omit it, so the
+    /// server deterministically resolves the live row first, then the greatest durable
+    /// assignment id. The final `id` tie-break applies only to migrated sentinel-0 history,
+    /// whose real assignment order cannot be reconstructed without inventing data.
+    pub fn record_heartbeat_for_assignment(
+        &self,
+        session_id: &str,
+        worker_id: &str,
+        assignment_id: Option<i64>,
+        status: &str,
+        now_ms: i64,
+    ) -> Result<Option<String>, StorageError> {
         self.db.with_conn(|conn| {
+            let target: Option<(String, i64)> = conn
+                .query_row(
+                    "SELECT id, assignment_id
+                     FROM agent_run_queue
+                     WHERE session_id = ?1
+                       AND worker_id = ?2
+                       AND status IN ('queued', 'running', 'finalized')
+                       AND (?3 IS NULL OR assignment_id = ?3)
+                     ORDER BY CASE status WHEN 'running' THEN 0 ELSE 1 END,
+                              assignment_id DESC,
+                              CASE status WHEN 'queued' THEN 0 ELSE 1 END,
+                              id DESC
+                     LIMIT 1",
+                    params![session_id, worker_id, assignment_id],
+                    |row| Ok((row.get(0)?, row.get(1)?)),
+                )
+                .optional()?;
+            let Some((id, resolved_assignment_id)) = target else {
+                return Ok(None);
+            };
             conn.execute(
                 "UPDATE agent_run_queue
                  SET status = CASE
@@ -1010,11 +1100,12 @@ impl QueueRepo {
                          THEN continuation_count + 1 ELSE continuation_count END,
                      last_status = CASE
                          WHEN status IN ('queued', 'running') THEN ?4 ELSE last_status END
-                 WHERE session_id = ?1 AND worker_id = ?2
-                    AND status IN ('queued', 'running', 'finalized')",
-                params![session_id, worker_id, now_ms, status],
+                 WHERE id = ?1
+                   AND assignment_id = ?2
+                   AND status IN ('queued', 'running', 'finalized')",
+                params![id, resolved_assignment_id, now_ms, status],
             )?;
-            Ok(conn.changes() >= 1)
+            Ok((conn.changes() == 1).then_some(id))
         })
     }
 
@@ -1029,8 +1120,9 @@ impl QueueRepo {
         now_ms: i64,
     ) -> Result<Vec<String>, StorageError> {
         self.db.with_conn(|conn| {
+            let tx = conn.unchecked_transaction()?;
             let ids: Vec<String> = {
-                let mut stmt = conn.prepare(
+                let mut stmt = tx.prepare(
                     "SELECT id FROM agent_run_queue
                      WHERE status = 'running'
                        AND (heartbeat_at IS NULL OR heartbeat_at < ?1)",
@@ -1040,18 +1132,22 @@ impl QueueRepo {
                     .collect::<rusqlite::Result<Vec<_>>>()?;
                 rows
             };
-            if !ids.is_empty() {
-                conn.execute(
+            for id in &ids {
+                let assignment_id = next_assignment_id_for_row(&tx, id)?;
+                tx.execute(
                     "UPDATE agent_run_queue
                      SET status = 'queued',
                          worker_id = CASE
                              WHEN task_id IS NOT NULL THEN 'pending:' || id ELSE worker_id END,
-                         updated_at = ?2
-                     WHERE status = 'running'
-                       AND (heartbeat_at IS NULL OR heartbeat_at < ?1)",
-                    params![stuck_cutoff_ms, now_ms],
+                         updated_at = ?3,
+                         assignment_id = ?4
+                     WHERE id = ?1
+                       AND status = 'running'
+                       AND (heartbeat_at IS NULL OR heartbeat_at < ?2)",
+                    params![id, stuck_cutoff_ms, now_ms, assignment_id],
                 )?;
             }
+            tx.commit()?;
             Ok(ids)
         })
     }
@@ -1095,14 +1191,16 @@ impl QueueRepo {
     /// PTY no longer exists). Returns `true` if a row changed.
     pub fn requeue_running(&self, id: &str, now_ms: i64) -> Result<bool, StorageError> {
         self.db.with_conn(|conn| {
+            let assignment_id = next_assignment_id_for_row(conn, id)?;
             conn.execute(
                 "UPDATE agent_run_queue
                  SET status = 'queued',
                      worker_id = CASE
                          WHEN task_id IS NOT NULL THEN 'pending:' || id ELSE worker_id END,
-                     updated_at = ?2
+                     updated_at = ?2,
+                     assignment_id = ?3
                  WHERE id = ?1 AND status = 'running'",
-                params![id, now_ms],
+                params![id, now_ms, assignment_id],
             )?;
             Ok(conn.changes() == 1)
         })
@@ -1115,8 +1213,8 @@ impl QueueRepo {
                 "SELECT queue.id, queue.task_id, queue.session_id, queue.worker_id,
                         queue.role_type, queue.cli, queue.status, queue.payload,
                         queue.attempts, queue.continuation_count, queue.no_progress_count,
-                        queue.last_status, queue.heartbeat_at, queue.created_at, queue.updated_at,
-                        block.reason
+                        queue.last_status, queue.heartbeat_at, queue.assignment_id,
+                        queue.created_at, queue.updated_at, block.reason
                  FROM agent_run_queue AS queue
                  LEFT JOIN agent_run_queue_blocks AS block ON block.queue_id = queue.id
                  WHERE queue.session_id = ?1
@@ -1137,8 +1235,8 @@ impl QueueRepo {
                     "SELECT queue.id, queue.task_id, queue.session_id, queue.worker_id,
                             queue.role_type, queue.cli, queue.status, queue.payload,
                             queue.attempts, queue.continuation_count, queue.no_progress_count,
-                            queue.last_status, queue.heartbeat_at, queue.created_at, queue.updated_at,
-                            block.reason
+                            queue.last_status, queue.heartbeat_at, queue.assignment_id,
+                            queue.created_at, queue.updated_at, block.reason
                      FROM agent_run_queue AS queue
                      LEFT JOIN agent_run_queue_blocks AS block ON block.queue_id = queue.id
                      WHERE queue.id = ?1",
@@ -1226,6 +1324,21 @@ impl QueueRepo {
     }
 }
 
+/// Mint the next honest assignment identity within the target row's session.
+///
+/// The shared application-state connection is process-serialized, so reading the maximum and
+/// consuming it in the caller's UPDATE cannot race another queue mutation. Gaps are harmless;
+/// ordering and exact equality are the protocol properties.
+fn next_assignment_id_for_row(conn: &Connection, id: &str) -> rusqlite::Result<i64> {
+    conn.query_row(
+        "SELECT COALESCE(MAX(assignment_id), 0) + 1
+         FROM agent_run_queue
+         WHERE session_id = (SELECT session_id FROM agent_run_queue WHERE id = ?1)",
+        params![id],
+        |row| row.get(0),
+    )
+}
+
 fn row_to_queue_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueRow> {
     let status_tag: String = row.get(6)?;
     let payload_text: String = row.get(7)?;
@@ -1246,9 +1359,10 @@ fn row_to_queue_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueRow> {
         no_progress_count: row.get(10)?,
         last_status: row.get(11)?,
         heartbeat_at: row.get(12)?,
-        created_at: row.get(13)?,
-        updated_at: row.get(14)?,
-        blocked_reason: row.get(15)?,
+        assignment_id: row.get(13)?,
+        created_at: row.get(14)?,
+        updated_at: row.get(15)?,
+        blocked_reason: row.get(16)?,
     })
 }
 
@@ -1436,6 +1550,7 @@ mod tests {
             no_progress_count: 0,
             last_status: None,
             heartbeat_at: None,
+            assignment_id: 0,
             blocked_reason: None,
             created_at: 1000,
             updated_at: 1000,
@@ -1447,6 +1562,108 @@ mod tests {
         let repo = repo();
         repo.ensure_schema().unwrap();
         repo.ensure_schema().unwrap();
+    }
+
+    #[test]
+    fn ensure_schema_upgrades_legacy_queue_without_losing_rows() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("legacy-application-state.db");
+        {
+            let legacy = Connection::open(&db_path).unwrap();
+            legacy
+                .execute(
+                    "CREATE TABLE agent_run_queue (
+                id                 TEXT PRIMARY KEY,
+                task_id            TEXT,
+                session_id         TEXT NOT NULL,
+                worker_id          TEXT NOT NULL,
+                role_type          TEXT NOT NULL,
+                cli                TEXT NOT NULL,
+                status             TEXT NOT NULL,
+                payload            TEXT NOT NULL,
+                attempts           INTEGER NOT NULL DEFAULT 0,
+                continuation_count INTEGER NOT NULL DEFAULT 0,
+                no_progress_count  INTEGER NOT NULL DEFAULT 0,
+                last_status        TEXT,
+                heartbeat_at       INTEGER,
+                created_at         INTEGER NOT NULL,
+                updated_at         INTEGER NOT NULL
+            )",
+                    [],
+                )
+                .unwrap();
+            legacy
+                .execute(
+                    "INSERT INTO agent_run_queue
+                (id, task_id, session_id, worker_id, role_type, cli, status, payload,
+                 attempts, continuation_count, no_progress_count, last_status,
+                 heartbeat_at, created_at, updated_at)
+             VALUES ('legacy-run', 'T2', 'legacy-session', 'legacy-worker', 'backend',
+                     'codex', 'finalized', '{\"sentinel\":true}', 3, 4, 5, 'completed',
+                     1234, 1000, 2000)",
+                    [],
+                )
+                .unwrap();
+            legacy
+                .execute(
+                    "INSERT INTO agent_run_queue
+                        SELECT 'legacy-run-2', task_id, session_id, 'legacy-worker-2',
+                               role_type, cli, status, payload, attempts, continuation_count,
+                               no_progress_count, last_status, heartbeat_at, created_at, updated_at
+                        FROM agent_run_queue WHERE id = 'legacy-run'",
+                    [],
+                )
+                .unwrap();
+        }
+
+        let conn = Connection::open(&db_path).unwrap();
+        ensure_schema(&conn).unwrap();
+        ensure_schema(&conn).unwrap();
+
+        let columns = {
+            let mut stmt = conn.prepare("PRAGMA table_info(agent_run_queue)").unwrap();
+            stmt.query_map([], |row| row.get::<_, String>(1))
+                .unwrap()
+                .collect::<rusqlite::Result<Vec<_>>>()
+                .unwrap()
+        };
+        assert!(
+            columns.iter().any(|column| column == "assignment_id"),
+            "the deployed table must gain the assignment identity column"
+        );
+        let row_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM agent_run_queue", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(row_count, 2, "every legacy row must survive the migration");
+        let retained: (i64, String, String, i64, i64, i64) = conn
+            .query_row(
+                "SELECT COUNT(*), id, payload, attempts, heartbeat_at, assignment_id
+                 FROM agent_run_queue WHERE id = 'legacy-run'",
+                [],
+                |row| {
+                    Ok((
+                        row.get(0)?,
+                        row.get(1)?,
+                        row.get(2)?,
+                        row.get(3)?,
+                        row.get(4)?,
+                        row.get(5)?,
+                    ))
+                },
+            )
+            .unwrap();
+        assert_eq!(
+            retained,
+            (
+                1,
+                "legacy-run".to_string(),
+                "{\"sentinel\":true}".to_string(),
+                3,
+                1234,
+                0,
+            ),
+            "migration must preserve the full legacy row and leave unknown history unstamped"
+        );
     }
 
     #[test]

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -8,8 +8,10 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::cli::CliBehavior;
 use crate::coordination::queue_manager::{heartbeat_cadence_label, HEARTBEAT_MAX_INTERVAL_SECS};
 use crate::domain::{SessionMode, WorkspaceStrategy};
+use crate::orchestrator::org_graph::{AuthorityScope, KnowledgeRef};
 use crate::pty::WorkerRole;
 use crate::session::SessionType;
 
@@ -121,12 +123,20 @@ pub struct SessionTemplate {
     pub is_builtin: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct CellTemplate {
     pub role: String,
     pub cli: String,
     pub model: Option<String>,
     pub prompt_template: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub knowledge_scope: Vec<KnowledgeRef>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lens: Option<String>,
+    #[serde(default)]
+    pub authority: AuthorityScope,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub behavior: Option<CliBehavior>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -156,18 +166,21 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                     cli: "claude".to_string(),
                     model: Some("opus".to_string()),
                     prompt_template: "queen-hive".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "backend".to_string(),
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-sol".to_string()),
                     prompt_template: "roles/backend".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "frontend".to_string(),
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-sol".to_string()),
                     prompt_template: "roles/frontend".to_string(),
+                    ..CellTemplate::default()
                 },
             ],
             workspace_strategy: WorkspaceStrategy::SharedCell,
@@ -195,24 +208,28 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                     cli: "claude".to_string(),
                     model: Some("opus".to_string()),
                     prompt_template: "queen-hive".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "backend".to_string(),
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-sol".to_string()),
                     prompt_template: "roles/backend".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "frontend".to_string(),
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-sol".to_string()),
                     prompt_template: "roles/frontend".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "coherence".to_string(),
                     cli: "droid".to_string(),
                     model: Some("glm-5.1".to_string()),
                     prompt_template: "roles/coherence".to_string(),
+                    ..CellTemplate::default()
                 },
             ],
             workspace_strategy: WorkspaceStrategy::SharedCell,
@@ -232,6 +249,7 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-sol".to_string()),
                     prompt_template: "fusion-worker".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "candidate-b".to_string(),
@@ -240,12 +258,14 @@ pub fn builtin_session_templates() -> Vec<SessionTemplate> {
                     cli: "codex".to_string(),
                     model: Some("gpt-5.6-terra".to_string()),
                     prompt_template: "fusion-worker".to_string(),
+                    ..CellTemplate::default()
                 },
                 CellTemplate {
                     role: "resolver".to_string(),
                     cli: "claude".to_string(),
                     model: Some("opus".to_string()),
                     prompt_template: "resolver".to_string(),
+                    ..CellTemplate::default()
                 },
             ],
             workspace_strategy: WorkspaceStrategy::IsolatedCell,
@@ -266,6 +286,7 @@ pub fn builtin_role_packs() -> Vec<RolePack> {
                 cli: "claude".to_string(),
                 model: Some("opus".to_string()),
                 prompt_template: "queen-hive".to_string(),
+                ..CellTemplate::default()
             }],
         },
         RolePack {
@@ -276,6 +297,7 @@ pub fn builtin_role_packs() -> Vec<RolePack> {
                 cli: "codex".to_string(),
                 model: Some("gpt-5.6-sol".to_string()),
                 prompt_template: "roles/backend".to_string(),
+                ..CellTemplate::default()
             }],
         },
         RolePack {
@@ -286,6 +308,7 @@ pub fn builtin_role_packs() -> Vec<RolePack> {
                 cli: "droid".to_string(),
                 model: Some("glm-5.1".to_string()),
                 prompt_template: "roles/coherence".to_string(),
+                ..CellTemplate::default()
             }],
         },
         RolePack {
@@ -296,6 +319,7 @@ pub fn builtin_role_packs() -> Vec<RolePack> {
                 cli: "claude".to_string(),
                 model: Some("opus".to_string()),
                 prompt_template: "resolver".to_string(),
+                ..CellTemplate::default()
             }],
         },
     ]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.43.1",
+  "version": "0.44.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Closes #226
Closes #227
Closes #228
Closes #229
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #235
Closes #237

Epic #228 carries no code of its own — it closes with its seven children above.

The work graph shipped and answers *what gets done in what order*. Nothing answered *who is doing it*, and nothing could **see** the graph at all. This PR adds semantic identity to agents, makes every session's graph retrievable, and fixes two correctness defects that were corrupting the evidence those surfaces report.

## Gates

| Gate | Result |
|---|---|
| `cargo test --lib` | **799 passed, 0 failed**, 1 ignored |
| `python tools/codegraph/ci_gate.py --lang rs --root .` | **146 modules, 0 findings, 0 certain** |
| `python tools/codegraph/verify_vendor.py` | 3 vendored analyzers OK |
| `cargo check --tests` | PASS |

The reachability result matters here: seven new modules (`org_graph/{schema,definitions,composition,ownership,boundary,adjudication}` plus two HTTP handlers) each had to reach a production call path **in this same PR**. Zero certain findings means none of them shipped as an unread library.

## Org graph — #229, #230, #231, #232, #233, #234, #235

**Role schema.** `RoleDefinition`, `KnowledgeRef`, `AuthorityScope`, `ContextBoundary`, `SignalClass`, `RoleLens`. `KnowledgeRef` holds a pointer plus a bounded summary and never embeds the referenced document — #228 invariant 3 enforced in the type, not by discipline. `get_behavior_for_role`'s hardcoded `Some("evaluator")` arm is deleted; behavior is declared data.

**Two-tier resolution.** Institutional base + project override, resolved against the **session project path, not the CWD**. That distinction is load-bearing: `.ai-docs/` is gitignored and absent from every agent worktree, so a CWD-keyed loader would silently resolve to nothing while every test passed. Resolved definition id **and version** are recorded on `AgentInfo` and persist across restart/archive.

**Composition.** Deterministic role+task merge with a per-node budget that truncates by declared priority and **names what was dropped**, plus a fraction-based anti-hub lint reusing the existing thresholds. Wired into `build_worker_prompt` — definitions that resolve but never reach a prompt would satisfy unit tests and change nothing.

**Authority and adjudication.** Orchestrators become owned nodes with declared footprints, surfaced in session state. Contradiction resolves from a **canonically sorted verdict set, independent of arrival order**, with a declared adjudicator; a subgraph with no adjudicator fails validation rather than defaulting to the orchestrator. Contradiction and ordinary failure are proven to take different code paths by asserting distinct typed mutation variants.

**Verification properties.** Context boundaries scale by signal class — judgmental signals require isolation, mechanical ones provably do not. Role definitions compound through the retro pipeline: proposals land `unreviewed`, never auto-apply or auto-commit, promotion requires independent instances from more than one repo, and **widening is flagged distinctly from narrowing**.

## Work-graph read API and lifecycle — #227

`GET /api/sessions/{id}/work-graph?view=plan|runtime|divergence`, live state with archive fallback. Node payloads are bounded — a negative assertion proves no full task body crosses the wire. Adds the missing longest-path `critical_path` helper (waves derive from toposort levels, lane from `BindingRef`).

The graph is now emitted **on state transitions** rather than on demand. `session.state` is assigned in exactly one production place; an audit found **eight** paths that bypassed emission — four direct assignments and four whole-session `*session = previous_session` restores that left an already-written artifact stale. All eight now emit, including on rollback. Without this the lifecycle test would have passed while `work-graph.html` reported `Completed` after a *rejected* completion, or missed the QA-timeout state entirely.

## Queue row identity — #237

Rows carry a durable monotonic assignment identity, added via a **`PRAGMA table_info`-guarded `ALTER TABLE`**. `CREATE TABLE IF NOT EXISTS` silently no-ops on an existing table, so a fresh-install-only change would have worked on new installs and broken every upgrade in the field. The upgrade fixture opens a real pre-column database and proves rows survive.

Heartbeats now update only their originating row, and `WorkerFinalized` follows row identity instead of the oldest worker-slot match — a reused slot no longer attributes completion to a stale task. Identity advances even at a fixed millisecond, so the fix does not reintroduce the ordering ambiguity that made `created_at` useless.

## PTY submit — #226

**This issue is materially different from its filing.** PR #236 already landed the `\r\n` fix; the code it cites no longer exists. What remained open was the empirical half — no HTTP route exposed PTY buffer contents, so the operator was the instrument.

This adds a read-only PTY buffer endpoint making submit measurable without a human at the keyboard, and converts the gap into per-adapter policy. `pty.paste` still does not auto-submit.

### Sweep status — measured vs unmeasured

**No cell of the `codex` x `claude` x (~100 B / ~2.5 KB / multi-line) matrix was measured in this PR.** `SUBMIT_GAP = 50 ms` is **retained as a documented, still-unvalidated default**.

The only observations on record (1.2–2.7 s failed twice, 4–5 s succeeded twice, 65 s succeeded once, agent busy state uncontrolled) suggest 50 ms is likely wrong by roughly two orders of magnitude. It is deliberately unchanged: replacing one unvalidated constant with another is exactly what `pty/session.rs` warns against. The live sweep needs a real session and an operator who does not touch the keyboard — any "did the agent act?" observable is confounded otherwise, and an earlier probe was scored as a pass and was wrong. `docs/pty-submit-sweep.md` gives the runnable procedure.

## Verification discipline

Six adversarial mutations were run against the new gates; **all six were killed, none survived**. Each was reverted immediately and the file restored to a captured SHA-256 — necessary because six agents shared this worktree. Representative kills:

- `Option<RoleDefinitionRef>` changed to `::std::option::Option<...>` (semantically identical, source-distinct) still killed the `session.rs`/`session_stub.rs` mirror test — proving the Windows-only drift is caught by shape, not text.
- Removing `validate_agent_id` from the PTY handler dropped the traversal case from `400` to `404`.
- Renaming `EdgeProvenance::Codegraph` to the `planner` wire value collapsed the four-class assertion to three.
- Adding the full `WorkNode::title` to the node response tripped the bounded-payload assertion.

**This is a partial pass, not exhaustive.** T15 was frozen at six logged mutations so the branch could be committed clean; the remaining authorized mutations were not started. An in-flight seventh probe was aborted and reverted, and is deliberately not counted.

### Known limitation — the ownership write-detector is not yet invoked in production

`OwnershipSessionState::record_write_attempt` and its persistence wrapper `record_orchestrator_write_attempt` (`coordination/state.rs`) currently have **no production caller** — every invocation is a test.

The plan specifies A22 as a *fixture reproducing the `d1e86179` restore race*, and that fixture exists and passes, so the criterion is met as written. But the honest statement is narrower than "orchestrator writes are detected": the detector is proven correct and **is not yet wired to a real write site**, so it does not currently catch anything at runtime. Wiring it to production write paths is a follow-up.

Independent adjudication of the external review also found the detector **fails open for an undeclared actor** and that path comparison is not normalized; both are fixed in this branch.

## Scope notes

- **#220 stays open.** Backend and lifecycle guarantee only — no frontend changes. New `AgentInfo` fields are `Option`/`#[serde(default)]` so the Svelte mirrors compile untouched.
- **Tier 2 role definitions cannot land here.** They live in the shared knowledge repo and are PR-gated there. This ships the two-tier **resolver** plus the repo-local `roles/` set (15 definitions); Tier 2 is a configured path that resolves when present and **reports absence explicitly**. Authoring the institutional set is a follow-up PR in that repo.
- `AgentRole` gains no new variant — the 35+ match-site expansion is deliberately avoided. Position (`Worker { index, parent }`) and identity are separately addressable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-only work-graph views for plans, runtime status, and divergence, including dependencies, provenance, scheduling, and archived results.
  * Added PTY output retrieval for recent agent activity.
  * Added role definitions with configurable prompts, knowledge scopes, authority, and verification guidance.
  * Added review contradiction handling and evidence-based refinement proposals.
* **Bug Fixes**
  * Improved worker assignment tracking so stale heartbeats cannot update reassigned workers.
  * Improved PTY submission timing across supported command-line adapters.
* **Documentation**
  * Added a procedure for measuring and validating PTY submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->