### PR TITLE
feat(ui): work-graph view in the right rail (#220)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.44.0"
+version = "0.44.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.44.0"
+version = "0.44.1"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/RightPanel.svelte
+++ b/src/lib/components/RightPanel.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
-  import { ChartBar, ChatCenteredText, ClockCounterClockwise, FileText, ListBullets, NotePencil } from 'phosphor-svelte';
+  import { ChartBar, ChatCenteredText, ClockCounterClockwise, FileText, Graph, ListBullets, NotePencil } from 'phosphor-svelte';
   import { layout, RAIL_WIDTH, type RightPanelTab } from '$lib/stores/layout';
   import StatusPanel from './StatusPanel.svelte';
   import PlanView from './PlanView.svelte';
+  import WorkGraphView from './workgraph/WorkGraphView.svelte';
   import CoordinationPanel from './CoordinationPanel.svelte';
   import ConversationViewer from './ConversationViewer.svelte';
   import TimelineView from './timeline/TimelineView.svelte';
@@ -12,6 +13,7 @@
   const TABS: Array<{ id: RightPanelTab; label: string; icon: typeof ChartBar }> = [
     { id: 'status', label: 'Status', icon: ChartBar },
     { id: 'plan', label: 'Plan', icon: NotePencil },
+    { id: 'graph', label: 'Graph', icon: Graph },
     { id: 'files', label: 'Files', icon: FileText },
     { id: 'logs', label: 'Logs', icon: ListBullets },
     { id: 'chat', label: 'Chat', icon: ChatCenteredText },
@@ -71,6 +73,8 @@
         <StatusPanel />
       {:else if activeTab === 'plan'}
         <PlanView />
+      {:else if activeTab === 'graph'}
+        <WorkGraphView />
       {:else if activeTab === 'logs'}
         <CoordinationPanel />
       {:else if activeTab === 'timeline'}

--- a/src/lib/components/workgraph/WorkGraphView.svelte
+++ b/src/lib/components/workgraph/WorkGraphView.svelte
@@ -1,0 +1,496 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { activeSession } from '$lib/stores/sessions';
+  import { apiUrl } from '$lib/config';
+  import SkelBar from '../SkelBar.svelte';
+
+  type NodeStatus =
+    | 'pending'
+    | 'ready'
+    | 'running'
+    | 'completed'
+    | 'failed'
+    | 'blocked'
+    | 'cancelled';
+
+  type EdgeProvenance = 'planner' | 'codegraph' | 'knowledge' | 'runtime';
+
+  interface BindingRef {
+    kind: 'role' | 'zone';
+    value: string;
+  }
+
+  interface WorkGraphNode {
+    id: string;
+    status: NodeStatus;
+    lane: BindingRef;
+    contract_summary: { input_count: number; output_count: number; acceptance_count: number };
+  }
+
+  interface WorkGraphEdge {
+    source: string;
+    target: string;
+    kind: string;
+    provenance: EdgeProvenance;
+  }
+
+  interface WorkGraphResponse {
+    view: 'plan' | 'runtime' | 'divergence';
+    source: 'live' | 'archive';
+    nodes: WorkGraphNode[];
+    edges: WorkGraphEdge[];
+    waves: string[][];
+    status_by_node: Record<string, NodeStatus>;
+    lane_assignment: Record<string, BindingRef>;
+    critical_path: string[];
+    divergence: unknown | null;
+  }
+
+  const VIEWS = [
+    { id: 'runtime', label: 'Runtime' },
+    { id: 'plan', label: 'Plan' },
+    { id: 'divergence', label: 'Divergence' }
+  ] as const;
+
+  type ViewId = (typeof VIEWS)[number]['id'];
+
+  // Lane hues. Lanes are categorical, so colour is assigned by first-seen order
+  // and kept stable for the lifetime of the payload.
+  const LANE_HUES = [190, 265, 25, 330, 95, 45];
+
+  const POLL_MS = 3000;
+  const NODE_W = 62;
+  const NODE_H = 26;
+  const GAP_X = 12;
+  const GAP_Y = 34;
+  const PAD = 14;
+
+  let graph = $state<WorkGraphResponse | null>(null);
+  let loading = $state(false);
+  let error = $state<string | null>(null);
+  let view = $state<ViewId>('runtime');
+  let poll: ReturnType<typeof setInterval> | null = null;
+  let lastKey = '';
+
+  let sessionId = $derived($activeSession?.id ?? null);
+
+  async function load(id: string, which: ViewId, showSpinner: boolean) {
+    if (showSpinner) loading = true;
+    try {
+      const res = await fetch(apiUrl(`/api/sessions/${id}/work-graph?view=${which}`));
+      if (!res.ok) {
+        const raw = await res.text();
+        let detail = raw;
+        try {
+          detail = (JSON.parse(raw) as { error?: string }).error ?? raw;
+        } catch {
+          // non-JSON body — surface it verbatim
+        }
+        throw new Error(detail || `HTTP ${res.status}`);
+      }
+      graph = (await res.json()) as WorkGraphResponse;
+      error = null;
+    } catch (e) {
+      error = e instanceof Error ? e.message : String(e);
+    } finally {
+      loading = false;
+    }
+  }
+
+  function stopPoll() {
+    if (poll) {
+      clearInterval(poll);
+      poll = null;
+    }
+  }
+
+  $effect(() => {
+    const id = sessionId;
+    const which = view;
+    stopPoll();
+    if (!id) {
+      graph = null;
+      return;
+    }
+    const key = `${id}:${which}`;
+    void load(id, which, key !== lastKey);
+    lastKey = key;
+    poll = setInterval(() => void load(id, which, false), POLL_MS);
+  });
+
+  onDestroy(stopPoll);
+
+  const laneKey = (lane: BindingRef | undefined) =>
+    lane ? `${lane.kind}:${lane.value}` : 'unassigned';
+
+  let lanes = $derived.by(() => {
+    const seen: string[] = [];
+    for (const node of graph?.nodes ?? []) {
+      const key = laneKey(node.lane);
+      if (!seen.includes(key)) seen.push(key);
+    }
+    return seen;
+  });
+
+  function laneHue(key: string): number {
+    const index = lanes.indexOf(key);
+    return LANE_HUES[(index < 0 ? 0 : index) % LANE_HUES.length];
+  }
+
+  interface Placed {
+    id: string;
+    x: number;
+    y: number;
+    status: NodeStatus;
+    laneK: string;
+    onCritical: boolean;
+  }
+
+  let layout = $derived.by(() => {
+    const placed = new Map<string, Placed>();
+    const waves = graph?.waves ?? [];
+    const statuses = graph?.status_by_node ?? {};
+    const assignment = graph?.lane_assignment ?? {};
+    const critical = new Set(graph?.critical_path ?? []);
+    let width = 0;
+
+    waves.forEach((wave, row) => {
+      // Order within a wave by lane so lanes read as columns wherever the
+      // dependency structure allows it.
+      const ordered = [...wave].sort(
+        (a, b) => lanes.indexOf(laneKey(assignment[a])) - lanes.indexOf(laneKey(assignment[b]))
+      );
+      ordered.forEach((id, col) => {
+        const x = PAD + col * (NODE_W + GAP_X);
+        placed.set(id, {
+          id,
+          x,
+          y: PAD + row * (NODE_H + GAP_Y),
+          status: statuses[id] ?? 'pending',
+          laneK: laneKey(assignment[id]),
+          onCritical: critical.has(id)
+        });
+        width = Math.max(width, x + NODE_W);
+      });
+    });
+
+    const height = PAD + waves.length * (NODE_H + GAP_Y);
+    return { placed, width: width + PAD, height: height + PAD - GAP_Y + NODE_H };
+  });
+
+  let links = $derived.by(() =>
+    (graph?.edges ?? [])
+      .map((edge) => {
+        const from = layout.placed.get(edge.source);
+        const to = layout.placed.get(edge.target);
+        if (!from || !to) return null;
+        return {
+          key: `${edge.source}->${edge.target}:${edge.kind}`,
+          x1: from.x + NODE_W / 2,
+          y1: from.y + NODE_H,
+          x2: to.x + NODE_W / 2,
+          y2: to.y,
+          provenance: edge.provenance,
+          onCritical: from.onCritical && to.onCritical
+        };
+      })
+      .filter((l): l is NonNullable<typeof l> => l !== null)
+  );
+
+  let nodes = $derived.by(() => [...layout.placed.values()]);
+  let isEmpty = $derived(!loading && !error && graph !== null && graph.nodes.length === 0);
+</script>
+
+<div class="wg">
+  <div class="wg-controls">
+    {#each VIEWS as option (option.id)}
+      <button
+        type="button"
+        class={`lattice-btn lattice-btn--xs ${view === option.id ? 'lattice-btn--primary' : 'lattice-btn--ghost'}`}
+        onclick={() => (view = option.id)}
+      >
+        {option.label}
+      </button>
+    {/each}
+    {#if graph}
+      <span class="wg-source" title="Where this projection came from">{graph.source}</span>
+    {/if}
+  </div>
+
+  <div class="wg-canvas">
+    {#if loading && !graph}
+      <div class="wg-pad">
+        {#each ['46%', '72%', '58%', '80%'] as barWidth}
+          <SkelBar width={barWidth} height="1.6rem" radius="md" />
+        {/each}
+      </div>
+    {:else if error}
+      <div class="wg-msg wg-msg--error">
+        <p class="wg-msg-title">Could not load the work graph</p>
+        <p class="wg-msg-body">{error}</p>
+      </div>
+    {:else if !sessionId}
+      <div class="wg-msg">
+        <p class="wg-msg-title">No active session</p>
+      </div>
+    {:else if isEmpty}
+      <div class="wg-msg">
+        <p class="wg-msg-title">No work graph for this session</p>
+        <p class="wg-msg-body">
+          The endpoint answered, so this is not a connection problem — the session simply has no
+          graph to project. A graph is built when a plan is parsed at <code>PlanReady</code>;
+          sessions started before the work graph shipped have none.
+        </p>
+      </div>
+    {:else if graph}
+      <svg
+        class="wg-svg"
+        width={layout.width}
+        height={layout.height}
+        viewBox={`0 0 ${layout.width} ${layout.height}`}
+        role="img"
+        aria-label={`Work graph: ${graph.nodes.length} nodes across ${graph.waves.length} waves`}
+      >
+        <g class="wg-edges">
+          {#each links as link (link.key)}
+            <line
+              x1={link.x1}
+              y1={link.y1}
+              x2={link.x2}
+              y2={link.y2}
+              class={`wg-edge wg-edge--${link.provenance}`}
+              class:critical={link.onCritical}
+            />
+          {/each}
+        </g>
+        <g class="wg-nodes">
+          {#each nodes as node (node.id)}
+            <g class="wg-node" class:critical={node.onCritical}>
+              <rect
+                x={node.x}
+                y={node.y}
+                width={NODE_W}
+                height={NODE_H}
+                rx="5"
+                class={`wg-box wg-box--${node.status}`}
+                style={`--lane: hsl(${laneHue(node.laneK)} 70% 58%)`}
+              >
+                <title>{node.id} — {node.status} · {node.laneK}</title>
+              </rect>
+              <text
+                x={node.x + NODE_W / 2}
+                y={node.y + NODE_H / 2 + 4}
+                text-anchor="middle"
+                class="wg-label"
+              >{node.id}</text>
+            </g>
+          {/each}
+        </g>
+      </svg>
+    {/if}
+  </div>
+
+  {#if graph && graph.nodes.length > 0}
+    <div class="wg-legend">
+      <span class="wg-key"><i class="sw sw--completed"></i>done</span>
+      <span class="wg-key"><i class="sw sw--running"></i>running</span>
+      <span class="wg-key"><i class="sw sw--ready"></i>ready</span>
+      <span class="wg-key"><i class="sw sw--blocked"></i>blocked</span>
+      <span class="wg-key"><i class="sw sw--pending"></i>not started</span>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .wg {
+    position: relative;
+    display: flex;
+    flex: 1;
+    min-height: 0;
+    flex-direction: column;
+  }
+
+  /* Floating control scrim over the canvas, not a structural toolbar row. */
+  .wg-controls {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    z-index: 2;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 4px;
+    border-radius: var(--radius-md);
+    background: color-mix(in srgb, var(--bg-void) 82%, transparent);
+    backdrop-filter: blur(4px);
+  }
+
+  .wg-source {
+    padding-left: 2px;
+    color: var(--text-disabled);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .wg-canvas {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+  }
+
+  .wg-pad {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 12px;
+  }
+
+  .wg-svg {
+    display: block;
+  }
+
+  .wg-msg {
+    padding: 28px 16px;
+    color: var(--text-secondary);
+  }
+
+  .wg-msg-title {
+    margin: 0 0 6px;
+    color: var(--text-primary);
+    font-size: 13px;
+  }
+
+  .wg-msg-body {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.6;
+  }
+
+  .wg-msg--error .wg-msg-title {
+    color: var(--status-error);
+  }
+
+  .wg-edge {
+    stroke-width: 1;
+    opacity: 0.55;
+  }
+
+  .wg-edge--planner {
+    stroke: var(--text-disabled);
+  }
+
+  .wg-edge--codegraph {
+    stroke: var(--accent-cyan);
+    stroke-dasharray: 3 3;
+  }
+
+  .wg-edge--knowledge {
+    stroke: var(--status-warning);
+    stroke-dasharray: 1 4;
+  }
+
+  .wg-edge--runtime {
+    stroke: var(--status-success);
+  }
+
+  .wg-edge.critical {
+    stroke-width: 2;
+    opacity: 0.9;
+  }
+
+  /* Fill encodes status; the lane stripe encodes ownership. Blocked is a solid
+     error fill and pending is a dashed hollow outline — the two states that read
+     identically in a task list must never read identically here. */
+  .wg-box {
+    stroke: var(--lane);
+    stroke-width: 2;
+  }
+
+  .wg-box--pending {
+    fill: transparent;
+    stroke-dasharray: 3 3;
+    opacity: 0.65;
+  }
+
+  .wg-box--ready {
+    fill: color-mix(in srgb, var(--accent-cyan) 18%, transparent);
+  }
+
+  .wg-box--running {
+    fill: color-mix(in srgb, var(--accent-cyan) 45%, transparent);
+  }
+
+  .wg-box--completed {
+    fill: color-mix(in srgb, var(--status-success) 40%, transparent);
+  }
+
+  .wg-box--blocked {
+    fill: color-mix(in srgb, var(--status-error) 45%, transparent);
+  }
+
+  .wg-box--failed {
+    fill: color-mix(in srgb, var(--status-error) 45%, transparent);
+    stroke-dasharray: 2 2;
+  }
+
+  .wg-box--cancelled {
+    fill: transparent;
+    opacity: 0.4;
+  }
+
+  .wg-node.critical .wg-box {
+    stroke-width: 3;
+  }
+
+  .wg-label {
+    fill: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    pointer-events: none;
+  }
+
+  .wg-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px 10px;
+    padding: 6px 10px;
+    box-shadow: var(--edge-seam);
+    color: var(--text-secondary);
+    font-size: 10px;
+  }
+
+  .wg-key {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .sw {
+    width: 9px;
+    height: 9px;
+    border: 1px solid var(--text-disabled);
+    border-radius: 2px;
+  }
+
+  .sw--completed {
+    background: color-mix(in srgb, var(--status-success) 40%, transparent);
+  }
+
+  .sw--running {
+    background: color-mix(in srgb, var(--accent-cyan) 45%, transparent);
+  }
+
+  .sw--ready {
+    background: color-mix(in srgb, var(--accent-cyan) 18%, transparent);
+  }
+
+  .sw--blocked {
+    background: color-mix(in srgb, var(--status-error) 45%, transparent);
+  }
+
+  .sw--pending {
+    background: transparent;
+    border-style: dashed;
+  }
+</style>

--- a/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
+++ b/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+const storeMocks = vi.hoisted(() => ({
+  setActiveSession: undefined as ((session: { id: string } | null) => void) | undefined,
+}));
+
+vi.mock('$lib/stores/sessions', async () => {
+  const { writable } = await import('svelte/store');
+  const activeSession = writable<{ id: string } | null>({ id: 'session-a' });
+  storeMocks.setActiveSession = activeSession.set;
+  return { activeSession };
+});
+
+vi.mock('$lib/config', () => ({
+  apiUrl: (path: string) => `http://localhost:18800${path}`,
+}));
+
+import WorkGraphView from './WorkGraphView.svelte';
+
+const ROLE = (value: string) => ({ kind: 'role' as const, value });
+
+function payload(overrides: Record<string, unknown> = {}) {
+  return {
+    view: 'runtime',
+    source: 'live',
+    nodes: [
+      { id: 'T1', status: 'completed', lane: ROLE('backend'), contract_summary: { input_count: 1, output_count: 1, acceptance_count: 1 } },
+      { id: 'T2', status: 'blocked', lane: ROLE('backend'), contract_summary: { input_count: 1, output_count: 1, acceptance_count: 1 } },
+      { id: 'T3', status: 'pending', lane: ROLE('frontend'), contract_summary: { input_count: 0, output_count: 1, acceptance_count: 1 } },
+    ],
+    edges: [
+      { source: 'T1', target: 'T2', kind: 'depends_on', provenance: 'planner' },
+      { source: 'T1', target: 'T3', kind: 'touches', provenance: 'codegraph' },
+    ],
+    waves: [['T1'], ['T2', 'T3']],
+    status_by_node: { T1: 'completed', T2: 'blocked', T3: 'pending' },
+    lane_assignment: { T1: ROLE('backend'), T2: ROLE('backend'), T3: ROLE('frontend') },
+    critical_path: ['T1', 'T2'],
+    provenance_by_edge: [],
+    divergence: null,
+    ...overrides,
+  };
+}
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+/** Let the $effect fire and its awaited fetch settle. */
+async function settle() {
+  await tick();
+  await Promise.resolve();
+  await tick();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  storeMocks.setActiveSession?.({ id: 'session-a' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('WorkGraphView', () => {
+  it('requests the work-graph projection for the active session', async () => {
+    const fetchMock = mockFetch(payload());
+    render(WorkGraphView);
+    await settle();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:18800/api/sessions/session-a/work-graph?view=runtime'
+    );
+  });
+
+  it('renders one node per task, positioned by wave', async () => {
+    mockFetch(payload());
+    const { container } = render(WorkGraphView);
+    await settle();
+
+    const boxes = container.querySelectorAll('.wg-box');
+    expect(boxes).toHaveLength(3);
+
+    // Wave 0 sits above wave 1 — the layout must express dependency depth.
+    // Match on the rendered label — a node's textContent also carries its
+    // <title> tooltip, so a whole-node text match never equals the bare id.
+    const y = (id: string) =>
+      Number(
+        [...container.querySelectorAll('.wg-node')]
+          .find((node) => node.querySelector('.wg-label')?.textContent?.trim() === id)
+          ?.querySelector('.wg-box')
+          ?.getAttribute('y')
+      );
+    expect(y('T1')).toBeLessThan(y('T2'));
+    expect(y('T2')).toBe(y('T3'));
+  });
+
+  it('renders blocked and not-started nodes with different classes', async () => {
+    // The acceptance criterion: these two read identically in a task list and
+    // must never read identically here.
+    mockFetch(payload());
+    const { container } = render(WorkGraphView);
+    await settle();
+
+    expect(container.querySelector('.wg-box--blocked')).not.toBeNull();
+    expect(container.querySelector('.wg-box--pending')).not.toBeNull();
+    expect(container.querySelector('.wg-box--blocked')?.className.baseVal).not.toBe(
+      container.querySelector('.wg-box--pending')?.className.baseVal
+    );
+  });
+
+  it('marks critical-path nodes distinctly', async () => {
+    mockFetch(payload());
+    const { container } = render(WorkGraphView);
+    await settle();
+
+    expect(container.querySelectorAll('.wg-node.critical')).toHaveLength(2);
+  });
+
+  it('distinguishes edge provenance classes', async () => {
+    mockFetch(payload());
+    const { container } = render(WorkGraphView);
+    await settle();
+
+    expect(container.querySelector('.wg-edge--planner')).not.toBeNull();
+    expect(container.querySelector('.wg-edge--codegraph')).not.toBeNull();
+  });
+
+  it('explains an empty graph instead of rendering a blank canvas', async () => {
+    mockFetch(
+      payload({ nodes: [], edges: [], waves: [], status_by_node: {}, lane_assignment: {}, critical_path: [] })
+    );
+    const { container } = render(WorkGraphView);
+    await settle();
+
+    expect(screen.getByText('No work graph for this session')).toBeTruthy();
+    expect(container.querySelector('.wg-svg')).toBeNull();
+  });
+
+  it('surfaces a failed request rather than an empty state', async () => {
+    mockFetch({ error: 'Session not found: session-a' }, false, 404);
+    render(WorkGraphView);
+    await settle();
+
+    expect(screen.getByText('Could not load the work graph')).toBeTruthy();
+    expect(screen.getByText('Session not found: session-a')).toBeTruthy();
+  });
+});

--- a/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
+++ b/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
@@ -55,6 +55,17 @@ function mockFetch(body: unknown, ok = true, status = 200) {
   return fetchMock;
 }
 
+/**
+ * Find a node's rect by its task id. Match on the rendered label — a node's
+ * textContent also carries its <title> tooltip, so a whole-node text match
+ * never equals the bare id.
+ */
+function boxFor(container: HTMLElement, id: string): Element | null | undefined {
+  return [...container.querySelectorAll('.wg-node')]
+    .find((node) => node.querySelector('.wg-label')?.textContent?.trim() === id)
+    ?.querySelector('.wg-box');
+}
+
 /** Let the $effect fire and its awaited fetch settle. */
 async function settle() {
   await tick();
@@ -94,31 +105,28 @@ describe('WorkGraphView', () => {
     expect(boxes).toHaveLength(3);
 
     // Wave 0 sits above wave 1 — the layout must express dependency depth.
-    // Match on the rendered label — a node's textContent also carries its
-    // <title> tooltip, so a whole-node text match never equals the bare id.
-    const y = (id: string) =>
-      Number(
-        [...container.querySelectorAll('.wg-node')]
-          .find((node) => node.querySelector('.wg-label')?.textContent?.trim() === id)
-          ?.querySelector('.wg-box')
-          ?.getAttribute('y')
-      );
+    const y = (id: string) => Number(boxFor(container, id)?.getAttribute('y'));
     expect(y('T1')).toBeLessThan(y('T2'));
     expect(y('T2')).toBe(y('T3'));
   });
 
-  it('renders blocked and not-started nodes with different classes', async () => {
+  it('maps blocked and not-started to mutually exclusive treatments', async () => {
     // The acceptance criterion: these two read identically in a task list and
-    // must never read identically here.
+    // must never read identically here. Assert the payload status → modifier
+    // mapping by task id (not by selecting on the modifier, which would be
+    // tautological), and assert exclusivity in both directions so a bug that
+    // applied both classes could not pass.
     mockFetch(payload());
     const { container } = render(WorkGraphView);
     await settle();
 
-    expect(container.querySelector('.wg-box--blocked')).not.toBeNull();
-    expect(container.querySelector('.wg-box--pending')).not.toBeNull();
-    expect(container.querySelector('.wg-box--blocked')?.className.baseVal).not.toBe(
-      container.querySelector('.wg-box--pending')?.className.baseVal
-    );
+    const blocked = boxFor(container, 'T2'); // status: blocked in the payload
+    const pending = boxFor(container, 'T3'); // status: pending in the payload
+
+    expect(blocked?.classList.contains('wg-box--blocked')).toBe(true);
+    expect(blocked?.classList.contains('wg-box--pending')).toBe(false);
+    expect(pending?.classList.contains('wg-box--pending')).toBe(true);
+    expect(pending?.classList.contains('wg-box--blocked')).toBe(false);
   });
 
   it('marks critical-path nodes distinctly', async () => {

--- a/src/lib/stores/layout.ts
+++ b/src/lib/stores/layout.ts
@@ -1,6 +1,6 @@
 import { writable } from 'svelte/store';
 
-export type RightPanelTab = 'status' | 'plan' | 'logs' | 'chat' | 'timeline' | 'files';
+export type RightPanelTab = 'status' | 'plan' | 'graph' | 'logs' | 'chat' | 'timeline' | 'files';
 
 export interface LayoutState {
   leftCollapsed: boolean;


### PR DESCRIPTION
Closes #220. Builds the surface for the read API that shipped in #238 — the work graph has been queryable since v0.44.0 with nothing rendering it.

## What you get

A **Graph** tab in the right rail, between Plan and Files. Waves render as rows (dependency depth), lane assignment drives node colour, and status drives the fill.

- **Blocked and not-started are deliberately opposite treatments** — solid error fill vs dashed hollow outline. Those are the two states that read identically in a task list, and that is exactly what hid a zero-progress lane in session `d1e86179` while the prose log narrated it as active and unblocked.
- **Critical path** thickens node strokes and its edges.
- **Edge provenance is visually distinct** — planner / codegraph / knowledge / runtime each get their own stroke treatment, so a deterministic `touches` edge never reads as an authored dependency.
- **Plan / Runtime / Divergence toggle** in a floating control scrim over the canvas, matching `KnowledgeGraph.svelte:751` ("Floating graph-control scrim, not a structural panel surface") rather than taking a structural toolbar row.
- Polls every 3s while a session is active; the `live` / `archive` source is labelled so you always know whether you are looking at a running session or its archive.

## Integration approach

One entry in the existing `TABS` registry plus one member on the `RightPanelTab` union. That is the whole wiring — collapse (Ctrl+J), `ResizeHandle`, and the rail active/ghost states are all inherited, with **no bespoke layout code**. `AgentTree.svelte` keeps rendering the org tree; this renders the task DAG. The two surfaces stay separate.

## An empty graph explains itself

This is the part I would keep even if you change everything else. Hitting the live endpoint today returns `nodes: 0, edges: 0` for existing sessions — including the 16-task `d1e86179`. So the first thing this view would otherwise have shown you is a blank canvas, and the natural conclusion would be "the view is broken."

Three conditions are now distinguished on screen:

| condition | what it says |
|---|---|
| no active session | "No active session" |
| request failed | "Could not load the work graph" + the server's own error text |
| endpoint answered, zero nodes | "No work graph for this session" + why: a graph is built when a plan is parsed at `PlanReady`, and sessions started before the work graph shipped have none |

**Still worth confirming separately:** whether a session launched *under* the installed build populates a graph. If a fresh session is also empty, population is not reaching the session-start path and that is a backend bug this PR will now make obvious rather than hide.

## Not in this PR

**Pop-out into a free-floating window** — #220 lists it and it is not here. The precedent (`SessionHeader.svelte:176, 400-403`, the preview dock/pop-out) is a bigger lift than the view itself, and the view is what unblocks looking at a graph today. I would rather ship the tab now and do pop-out as its own change than hold this behind it. Say the word and I will follow up; the issue can stay open for that alone.

Force-directed layout is also deliberately not used: waves-as-rows is what makes the wave structure legible, and `forceSim.ts` remains available if a free-form view is ever wanted alongside it.

## Verification

- `npm run check` — 0 errors, 0 warnings
- `npm test` — 31 files, 162 tests, all passing
- 7 new tests in `WorkGraphView.svelte.test.ts` covering: the request URL, one node per task positioned by wave, **blocked vs not-started rendering differently** (the acceptance criterion), critical-path marking, provenance-distinct edges, the empty-graph explanation, and a failed request surfacing the server's error instead of an empty state

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Graph tab to the right-side panel.
  - Introduced an interactive work-graph view showing task waves, lanes, statuses, dependencies, provenance, and critical-path indicators.
  - Added graph-source labels, legends, responsive scrolling, and loading, empty, and error states.
  - Graph data refreshes automatically while viewing the active session.

- **Bug Fixes**
  - Improved visibility of blocked and pending tasks through distinct visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->