### PR TITLE
fix: work-graph lifecycle, queue integrity, conversation identity, inject observability (v0.45.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.44.1"
+version = "0.45.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.44.1"
+version = "0.45.0"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/artifacts/resolver_input.rs
+++ b/src-tauri/src/artifacts/resolver_input.rs
@@ -39,8 +39,7 @@ pub fn assemble_resolver_input(
 
     Ok(ResolverInput {
         queen_summary: storage
-            .read_latest_conversation_message(session_id, &format!("{session_id}-queen"))?
-            .or(storage.read_latest_conversation_message(session_id, "queen")?),
+            .read_latest_conversation_message(session_id, &format!("{session_id}-queen"))?,
         candidates,
     })
 }
@@ -111,5 +110,28 @@ mod tests {
         assert_eq!(input.queen_summary.as_deref(), Some("Pick the safer variant"));
         assert_eq!(input.candidates.len(), 1);
         assert_eq!(input.candidates[0].cell_id, "variant-a");
+    }
+
+    #[test]
+    fn canonical_queen_summary_does_not_read_stale_legacy_candidate() {
+        let storage_root = TempDir::new().unwrap();
+        let storage = SessionStorage::new_with_base(storage_root.path().to_path_buf()).unwrap();
+        storage.create_session_dir("session-c").unwrap();
+        let conversations = storage.session_dir("session-c").join("conversations");
+        let legacy_path = conversations.join("queen.md");
+        std::fs::remove_file(&legacy_path).unwrap();
+        std::fs::create_dir(&legacy_path).unwrap();
+        std::fs::write(
+            conversations.join("session-c-queen.md"),
+            "---\n[2026-04-08T23:30:00Z] from @queen\nUse the canonical summary\n\n",
+        )
+        .unwrap();
+
+        let input = assemble_resolver_input(&storage, "session-c", Vec::new()).unwrap();
+
+        assert_eq!(
+            input.queen_summary.as_deref(),
+            Some("Use the canonical summary")
+        );
     }
 }

--- a/src-tauri/src/artifacts/resolver_input.rs
+++ b/src-tauri/src/artifacts/resolver_input.rs
@@ -38,7 +38,9 @@ pub fn assemble_resolver_input(
     }
 
     Ok(ResolverInput {
-        queen_summary: storage.read_latest_conversation_message(session_id, "queen")?,
+        queen_summary: storage
+            .read_latest_conversation_message(session_id, &format!("{session_id}-queen"))?
+            .or(storage.read_latest_conversation_message(session_id, "queen")?),
         candidates,
     })
 }

--- a/src-tauri/src/coordination/injection.rs
+++ b/src-tauri/src/coordination/injection.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use parking_lot::RwLock;
 use thiserror::Error;
 
@@ -8,6 +9,29 @@ use crate::storage::SessionStorage;
 use crate::tauri_shim::{AppHandle, Emitter};
 
 use super::{CoordinationMessage, StateManager, WorkerStateInfo};
+
+/// Sender-side facts captured around a successful PTY injection.
+///
+/// The optional PTY values are raw snapshots and compatibility counters captured immediately
+/// around the write. The HTTP inject routes perform the bounded post-submit observation from the
+/// after-write snapshot; neither kind of ring change proves that the agent took a turn.
+#[derive(Debug, Clone)]
+pub struct InjectionReceipt {
+    pub write_started_at: DateTime<Utc>,
+    pub submitted_at: DateTime<Utc>,
+    pub observation_started_at: DateTime<Utc>,
+    pub payload_bytes_written: usize,
+    pub submit_keystroke_issued: bool,
+    pub submit_bytes_written: usize,
+    pub pty_output_before: Option<String>,
+    pub pty_output_after_write: Option<String>,
+    pub pty_activity_observed: Option<bool>,
+    pub pty_output_bytes_before: Option<usize>,
+    pub pty_output_bytes_after_write: Option<usize>,
+    pub pty_output_bytes_after: Option<usize>,
+    pub observation_window_ms: u64,
+    pub observation_elapsed_ms: u64,
+}
 
 #[derive(Debug, Error)]
 pub enum InjectionError {
@@ -55,7 +79,7 @@ impl InjectionManager {
         target_worker_id: &str,
         message: &str,
         submit: bool,
-    ) -> Result<(), InjectionError> {
+    ) -> Result<InjectionReceipt, InjectionError> {
         // Validate sender is Queen (ID should end with -queen)
         if !queen_id.ends_with("-queen") {
             return Err(InjectionError::NotAuthorized(
@@ -88,7 +112,7 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Only persist watcher-visible state after PTY delivery succeeds.
-        self.write_to_agent(target_worker_id, message, submit)?;
+        let receipt = self.write_to_agent(target_worker_id, message, submit)?;
 
         if target_worker_id.ends_with("-evaluator") {
             self.write_session_peer_message(session_id, |state| {
@@ -101,7 +125,7 @@ impl InjectionManager {
             let _ = app_handle.emit("coordination-message", &coord_message);
         }
 
-        Ok(())
+        Ok(receipt)
     }
 
     /// Evaluator injects a message to the Queen or its QA workers.
@@ -112,7 +136,7 @@ impl InjectionManager {
         target_agent_id: &str,
         message: &str,
         submit: bool,
-    ) -> Result<(), InjectionError> {
+    ) -> Result<InjectionReceipt, InjectionError> {
         if !evaluator_id.ends_with("-evaluator") {
             return Err(InjectionError::NotAuthorized(
                 "Only the Evaluator can inject peer QA messages".to_string(),
@@ -150,7 +174,7 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Only persist watcher-visible state after PTY delivery succeeds.
-        self.write_to_agent(target_agent_id, message, submit)?;
+        let receipt = self.write_to_agent(target_agent_id, message, submit)?;
 
         if target_is_queen {
             self.write_session_peer_message(session_id, |state| {
@@ -166,7 +190,7 @@ impl InjectionManager {
             let _ = app_handle.emit("coordination-message", &coord_message);
         }
 
-        Ok(())
+        Ok(receipt)
     }
 
     /// Queen initiates a branch switch for all workers
@@ -192,7 +216,9 @@ impl InjectionManager {
 
         let mut results = Vec::new();
         for worker_id in worker_ids {
-            let result = self.write_to_agent(worker_id, &git_command, true);
+            let result = self
+                .write_to_agent(worker_id, &git_command, true)
+                .map(|_| ());
 
             let status = if result.is_ok() { "initiated" } else { "failed" };
             let log_msg = format!(
@@ -215,8 +241,10 @@ impl InjectionManager {
         agent_id: &str,
         message: &str,
         submit: bool,
-    ) -> Result<(), InjectionError> {
+    ) -> Result<InjectionReceipt, InjectionError> {
         let pty_manager = self.pty_manager.read();
+        let write_started_at = Utc::now();
+        let pty_output_before = pty_manager.recent_output(agent_id);
 
         // Strip any existing line endings first
         let clean_message = message.trim_end_matches(&['\r', '\n'][..]);
@@ -234,10 +262,36 @@ impl InjectionManager {
         };
         write_result
             .map_err(|e| InjectionError::PtyError(format!("Failed to write: {}", e)))?;
+        // This timestamp is deliberately after the successful submit/write call. Adapter submit
+        // gaps can be much longer than the stall threshold; a pre-write timestamp would make a
+        // just-finished injection look stale and could treat a heartbeat during the gap as recovery.
+        let submitted_at = Utc::now();
+        let pty_output_after_write = pty_manager.recent_output(agent_id);
+        let pty_output_bytes_before = pty_output_before.as_ref().map(String::len);
+        let pty_output_bytes_after_write = pty_output_after_write.as_ref().map(String::len);
+        let pty_activity_observed = match (&pty_output_before, &pty_output_after_write) {
+            (Some(before), Some(after)) => Some(before != after),
+            _ => None,
+        };
 
         tracing::info!("=== INJECTION COMPLETE ===");
 
-        Ok(())
+        Ok(InjectionReceipt {
+            write_started_at,
+            submitted_at,
+            observation_started_at: submitted_at,
+            payload_bytes_written: clean_message.len(),
+            submit_keystroke_issued: submit,
+            submit_bytes_written: if submit { 1 } else { 0 },
+            pty_output_before,
+            pty_output_after_write,
+            pty_activity_observed,
+            pty_output_bytes_before,
+            pty_output_bytes_after_write,
+            pty_output_bytes_after: pty_output_bytes_after_write,
+            observation_window_ms: 0,
+            observation_elapsed_ms: 0,
+        })
     }
 
     /// Direct injection from operator to any agent (bypasses Queen authorization)
@@ -247,7 +301,7 @@ impl InjectionManager {
         target_agent_id: &str,
         message: &str,
         submit: bool,
-    ) -> Result<(), InjectionError> {
+    ) -> Result<InjectionReceipt, InjectionError> {
         // Log to coordination.log
         let coord_message = CoordinationMessage::system(
             &format_agent_display(target_agent_id),
@@ -259,14 +313,14 @@ impl InjectionManager {
             .map_err(|e| InjectionError::StorageError(e.to_string()))?;
 
         // Write to agent's PTY stdin
-        self.write_to_agent(target_agent_id, message, submit)?;
+        let receipt = self.write_to_agent(target_agent_id, message, submit)?;
 
         // Emit event for UI
         if let Some(ref app_handle) = self.app_handle {
             let _ = app_handle.emit("coordination-message", &coord_message);
         }
 
-        Ok(())
+        Ok(receipt)
     }
 
     /// Notify Queen of new worker availability (logs only, no PTY injection)

--- a/src-tauri/src/http/handlers/conversations.rs
+++ b/src-tauri/src/http/handlers/conversations.rs
@@ -11,10 +11,21 @@ use std::sync::Arc;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use crate::storage::ConversationMessage;
-use super::{validate_agent_id, validate_session_id};
+use super::{canonical_agent_id, validate_agent_id, validate_session_id};
 
 const MAX_MESSAGE_CONTENT_LEN: usize = 1_048_576; // 1MB - allows large pastes
 const MAX_FROM_LEN: usize = 64;
+pub(crate) const SHARED_CONVERSATION_ID: &str = "shared";
+
+/// Resolve an agent conversation to the same full id used by the roster and UI.
+/// `shared` is a reserved session-wide broadcast channel, not an agent id.
+pub(crate) fn canonical_conversation_id(session_id: &str, agent_id: &str) -> String {
+    if agent_id == SHARED_CONVERSATION_ID {
+        SHARED_CONVERSATION_ID.to_string()
+    } else {
+        canonical_agent_id(session_id, agent_id)
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AppendMessageRequest {
@@ -70,6 +81,7 @@ pub async fn append_conversation(
 ) -> Result<(StatusCode, Json<Value>), ApiError> {
     validate_session_id(&session_id)?;
     validate_agent_id(&agent_id)?;
+    let agent_id = canonical_conversation_id(&session_id, &agent_id);
     let from = sanitize_text(&req.from, MAX_FROM_LEN, "from")?;
     validate_agent_id(&from)?;
     let content = sanitize_text(&req.content, MAX_MESSAGE_CONTENT_LEN, "content")?;
@@ -108,6 +120,7 @@ pub async fn read_conversation(
 ) -> Result<Json<ConversationResponse>, ApiError> {
     validate_session_id(&session_id)?;
     validate_agent_id(&agent_id)?;
+    let agent_id = canonical_conversation_id(&session_id, &agent_id);
     let since = parse_since(query.since)?;
 
     let messages = state

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -37,7 +37,7 @@ async fn observe_injection(
         return InjectionObservation {
             pty_observation_available: receipt.pty_output_after_write.is_some(),
             pty_output_bytes_after: receipt.pty_output_after_write.as_ref().map(String::len),
-            pty_activity_observed: Some(false),
+            pty_activity_observed: None,
             observation_window_ms: 0,
             observation_elapsed_ms: 0,
         };
@@ -526,7 +526,7 @@ mod tests {
         assert_eq!(response["submit_bytes_written"], 0);
         assert_eq!(response["observation_window_ms"], 0);
         assert_eq!(response["observation_elapsed_ms"], 0);
-        assert_eq!(response["pty_activity_observed"], false);
+        assert_eq!(response["pty_activity_observed"], Value::Null);
         assert_eq!(
             state
                 .pty_manager

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -5,14 +5,126 @@ use axum::{
 use serde::Deserialize;
 use serde_json::{json, Value};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use super::{validate_agent_id, validate_session_id};
-use crate::coordination::InjectionError;
+use crate::coordination::{InjectionError, InjectionReceipt};
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 
 fn default_submit() -> bool {
     true
+}
+
+const INJECTION_EVIDENCE_SCOPE: &str = "These facts prove only that bytes were written and the PTY output ring was observed for a bounded window; they do not prove that the agent took a turn.";
+const INJECTION_ACTIVITY_OBSERVATION_WINDOW: Duration = Duration::from_millis(250);
+const INJECTION_ACTIVITY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+struct InjectionObservation {
+    pty_observation_available: bool,
+    pty_output_bytes_after: Option<usize>,
+    pty_activity_observed: Option<bool>,
+    observation_window_ms: u64,
+    observation_elapsed_ms: u64,
+}
+
+async fn observe_injection(
+    state: &AppState,
+    agent_id: &str,
+    receipt: &InjectionReceipt,
+) -> InjectionObservation {
+    if !receipt.submit_keystroke_issued {
+        return InjectionObservation {
+            pty_observation_available: receipt.pty_output_after_write.is_some(),
+            pty_output_bytes_after: receipt.pty_output_after_write.as_ref().map(String::len),
+            pty_activity_observed: Some(false),
+            observation_window_ms: 0,
+            observation_elapsed_ms: 0,
+        };
+    }
+
+    let Some(baseline) = receipt.pty_output_after_write.as_ref() else {
+        return InjectionObservation {
+            pty_observation_available: false,
+            pty_output_bytes_after: None,
+            pty_activity_observed: None,
+            observation_window_ms: 0,
+            observation_elapsed_ms: 0,
+        };
+    };
+
+    let observation_started = Instant::now();
+    let deadline = observation_started + INJECTION_ACTIVITY_OBSERVATION_WINDOW;
+    let mut output_after = Some(baseline.clone());
+    let mut activity_observed = false;
+    while !activity_observed {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        tokio::time::sleep(INJECTION_ACTIVITY_POLL_INTERVAL.min(remaining)).await;
+        output_after = state.pty_manager.read().recent_output(agent_id);
+        let Some(current) = output_after.as_ref() else {
+            break;
+        };
+        activity_observed = current != baseline;
+    }
+
+    let observation_available = output_after.is_some();
+    InjectionObservation {
+        pty_observation_available: observation_available,
+        pty_output_bytes_after: output_after.as_ref().map(String::len),
+        pty_activity_observed: observation_available.then_some(activity_observed),
+        observation_window_ms: INJECTION_ACTIVITY_OBSERVATION_WINDOW.as_millis() as u64,
+        observation_elapsed_ms: observation_started.elapsed().as_millis() as u64,
+    }
+}
+
+fn record_injection_submission(
+    state: &AppState,
+    session_id: &str,
+    agent_id: &str,
+    receipt: &InjectionReceipt,
+) {
+    if let Err(error) = state
+        .session_controller
+        .read()
+        .record_injection_submission(
+            session_id,
+            agent_id,
+            receipt.submitted_at,
+            receipt.submit_keystroke_issued,
+        )
+    {
+        tracing::warn!(
+            "Injection succeeded but its awaiting-turn observation was not recorded for {session_id}/{agent_id}: {error}"
+        );
+    }
+}
+
+fn measured_response(
+    message: String,
+    receipt: &InjectionReceipt,
+    observation: &InjectionObservation,
+) -> Value {
+    json!({
+        "status": "success",
+        "message": message,
+        "write_started_at": receipt.write_started_at,
+        "submitted_at": receipt.submitted_at,
+        "payload_bytes_written": receipt.payload_bytes_written,
+        "submit_attempted": receipt.submit_keystroke_issued,
+        "submit_keystroke_issued": receipt.submit_keystroke_issued,
+        "submit_bytes_written": receipt.submit_bytes_written,
+        "pty_observation_available": observation.pty_observation_available,
+        "pty_output_bytes_before": receipt.pty_output_before.as_ref().map(String::len),
+        "pty_output_bytes_after_write": receipt.pty_output_after_write.as_ref().map(String::len),
+        "pty_output_bytes_after": observation.pty_output_bytes_after,
+        "pty_activity_observed": observation.pty_activity_observed,
+        "observation_window_ms": observation.observation_window_ms,
+        "observation_elapsed_ms": observation.observation_elapsed_ms,
+        "evidence_scope": INJECTION_EVIDENCE_SCOPE,
+    })
 }
 
 #[derive(Deserialize)]
@@ -49,24 +161,29 @@ pub async fn operator_inject(
     validate_session_id(&id)?;
     validate_agent_id(&payload.target_agent_id)?;
 
+    let target_agent_id = payload.target_agent_id.clone();
+    let injection_target_agent_id = target_agent_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
     let injection_result = tokio::task::spawn_blocking(move || {
         manager.read().operator_inject(
             &injection_session_id,
-            &payload.target_agent_id,
+            &injection_target_agent_id,
             &payload.message,
             payload.submit,
         )
     })
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
-    injection_result.map_err(|error| ApiError::internal(error.to_string()))?;
+    let receipt = injection_result.map_err(|error| ApiError::internal(error.to_string()))?;
+    let observation = observe_injection(&state, &target_agent_id, &receipt).await;
+    record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
-    Ok(Json(json!({
-        "status": "success",
-        "message": format!("Operator injection sent to session {}", id)
-    })))
+    Ok(Json(measured_response(
+        format!("Operator injection sent to session {}", id),
+        &receipt,
+        &observation,
+    )))
 }
 
 pub async fn queen_inject(
@@ -78,25 +195,30 @@ pub async fn queen_inject(
     validate_agent_id(&payload.queen_id)?;
     validate_agent_id(&payload.target_worker_id)?;
 
+    let target_worker_id = payload.target_worker_id.clone();
+    let injection_target_worker_id = target_worker_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
     let injection_result = tokio::task::spawn_blocking(move || {
         manager.read().queen_inject(
             &injection_session_id,
             &payload.queen_id,
-            &payload.target_worker_id,
+            &injection_target_worker_id,
             &payload.message,
             payload.submit,
         )
     })
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
-    injection_result.map_err(map_injection_error)?;
+    let receipt = injection_result.map_err(map_injection_error)?;
+    let observation = observe_injection(&state, &target_worker_id, &receipt).await;
+    record_injection_submission(&state, &id, &target_worker_id, &receipt);
 
-    Ok(Json(json!({
-        "status": "success",
-        "message": format!("Queen injection sent to session {}", id)
-    })))
+    Ok(Json(measured_response(
+        format!("Queen injection sent to session {}", id),
+        &receipt,
+        &observation,
+    )))
 }
 
 pub async fn evaluator_inject(
@@ -108,25 +230,30 @@ pub async fn evaluator_inject(
     validate_agent_id(&payload.evaluator_id)?;
     validate_agent_id(&payload.target_agent_id)?;
 
+    let target_agent_id = payload.target_agent_id.clone();
+    let injection_target_agent_id = target_agent_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
     let injection_result = tokio::task::spawn_blocking(move || {
         manager.read().evaluator_inject(
             &injection_session_id,
             &payload.evaluator_id,
-            &payload.target_agent_id,
+            &injection_target_agent_id,
             &payload.message,
             payload.submit,
         )
     })
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
-    injection_result.map_err(map_injection_error)?;
+    let receipt = injection_result.map_err(map_injection_error)?;
+    let observation = observe_injection(&state, &target_agent_id, &receipt).await;
+    record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
-    Ok(Json(json!({
-        "status": "success",
-        "message": format!("Evaluator injection sent to session {}", id)
-    })))
+    Ok(Json(measured_response(
+        format!("Evaluator injection sent to session {}", id),
+        &receipt,
+        &observation,
+    )))
 }
 
 fn map_injection_error(error: InjectionError) -> ApiError {
@@ -145,28 +272,95 @@ fn map_injection_error(error: InjectionError) -> ApiError {
 mod tests {
     use super::*;
     use crate::coordination::{InjectionManager, QueueManager};
+    use crate::domain::HiveExecutionPolicy;
     use crate::events::EventBus;
-    use crate::pty::{AgentRole, PtyManager};
-    use crate::session::SessionController;
+    use crate::pty::{AgentConfig, AgentRole, AgentStatus, PtyManager};
+    use crate::session::{
+        AgentInfo, AuthStrategy, Session, SessionController, SessionState, SessionType,
+    };
     use crate::storage::{ApplicationStateDb, QueueRepo, SessionStorage};
     use axum::{
-        body::Body,
+        body::{to_bytes, Body},
         http::{Request, StatusCode},
         routing::post,
         Router,
     };
+    use chrono::{Duration as ChronoDuration, Utc};
     use parking_lot::RwLock;
     use serde_json::{json, Value};
     use tempfile::TempDir;
     use tower::ServiceExt;
 
+    const SESSION_ID: &str = "inject-test";
     const AGENT_ID: &str = "inject-test-worker-1";
+    const QUEEN_ID: &str = "inject-test-queen";
+    const QA_WORKER_ID: &str = "inject-test-qa-worker-1";
+
+    fn agent(id: &str, role: AgentRole) -> AgentInfo {
+        AgentInfo {
+            id: id.to_string(),
+            role,
+            status: AgentStatus::Running,
+            config: AgentConfig::default(),
+            parent_id: None,
+            role_definition_id: None,
+            role_definition_version: None,
+            commit_sha: None,
+            base_commit_sha: None,
+        }
+    }
+
+    fn running_test_session(project_path: std::path::PathBuf) -> Session {
+        let now = Utc::now();
+        Session {
+            id: SESSION_ID.to_string(),
+            name: None,
+            color: None,
+            session_type: SessionType::Hive { worker_count: 1 },
+            project_path,
+            state: SessionState::Running,
+            created_at: now,
+            last_activity_at: now,
+            agents: vec![
+                agent(
+                    AGENT_ID,
+                    AgentRole::Worker {
+                        index: 1,
+                        parent: None,
+                    },
+                ),
+                agent(QUEEN_ID, AgentRole::Queen),
+                agent(
+                    QA_WORKER_ID,
+                    AgentRole::QaWorker {
+                        index: 1,
+                        parent: Some("inject-test-evaluator".to_string()),
+                    },
+                ),
+            ],
+            default_cli: "claude".to_string(),
+            default_model: None,
+            default_principal_cli: None,
+            default_principal_model: None,
+            default_principal_flags: Vec::new(),
+            execution_policy: HiveExecutionPolicy::default(),
+            qa_workers: Vec::new(),
+            max_qa_iterations: 3,
+            qa_timeout_secs: 300,
+            auth_strategy: AuthStrategy::default(),
+            worktree_path: None,
+            worktree_branch: None,
+            no_git: true,
+            resume_report: None,
+        }
+    }
 
     fn setup_test_app() -> (TempDir, Router, Arc<AppState>) {
         let temp_dir = TempDir::new().unwrap();
         let storage = Arc::new(
             SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap(),
         );
+        storage.create_session_dir(SESSION_ID).unwrap();
         let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
         let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
         pty_manager
@@ -184,10 +378,44 @@ mod tests {
                 24,
             )
             .unwrap();
+        pty_manager
+            .write()
+            .create_session(
+                QUEEN_ID.to_string(),
+                AgentRole::Queen,
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
+        pty_manager
+            .write()
+            .create_session(
+                QA_WORKER_ID.to_string(),
+                AgentRole::QaWorker {
+                    index: 1,
+                    parent: Some("inject-test-evaluator".to_string()),
+                },
+                "claude",
+                &[],
+                None,
+                80,
+                24,
+            )
+            .unwrap();
         let session_controller = Arc::new(RwLock::new(SessionController::new(
             pty_manager.clone(),
         )));
         session_controller.write().set_storage(storage.clone());
+        session_controller
+            .read()
+            .insert_test_session(running_test_session(temp_dir.path().to_path_buf()));
+        session_controller
+            .read()
+            .update_session_metadata(SESSION_ID, None, None)
+            .unwrap();
         let injection_manager = Arc::new(RwLock::new(InjectionManager::new(
             pty_manager.clone(),
             SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap(),
@@ -210,36 +438,62 @@ mod tests {
         ));
         let app = Router::new()
             .route("/api/sessions/{id}/inject", post(operator_inject))
+            .route("/api/sessions/{id}/inject/queen", post(queen_inject))
+            .route(
+                "/api/sessions/{id}/inject/evaluator",
+                post(evaluator_inject),
+            )
             .with_state(state.clone());
 
         (temp_dir, app, state)
     }
 
-    async fn post_operator_inject(app: Router, body: Value) -> StatusCode {
-        app.oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/sessions/inject-test/inject")
-                .header("content-type", "application/json")
-                .body(Body::from(body.to_string()))
-                .unwrap(),
-        )
-        .await
-        .unwrap()
-        .status()
+    async fn post_inject(app: Router, path: &str, body: Value) -> (StatusCode, Value) {
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(path)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+        (status, json)
     }
 
     #[tokio::test]
     async fn operator_inject_omitted_submit_defaults_to_true() {
         let (_temp_dir, app, state) = setup_test_app();
 
-        let status = post_operator_inject(
+        let (status, response) = post_inject(
             app,
+            "/api/sessions/inject-test/inject",
             json!({ "target_agent_id": AGENT_ID, "message": "hello\r\n" }),
         )
         .await;
 
         assert_eq!(status, StatusCode::OK);
+        assert_eq!(response["payload_bytes_written"], 5);
+        assert_eq!(response["submit_attempted"], true);
+        assert_eq!(response["submit_keystroke_issued"], true);
+        assert_eq!(response["submit_bytes_written"], 1);
+        assert_eq!(response["pty_observation_available"], true);
+        assert_eq!(response["pty_output_bytes_before"], 0);
+        assert_eq!(response["pty_output_bytes_after_write"], 6);
+        assert_eq!(response["pty_output_bytes_after"], 6);
+        assert_eq!(response["pty_activity_observed"], false);
+        assert_eq!(response["observation_window_ms"], 250);
+        assert!(response["write_started_at"].is_string());
+        assert!(response["submitted_at"].is_string());
+        assert!(response["evidence_scope"]
+            .as_str()
+            .unwrap()
+            .contains("do not prove that the agent took a turn"));
         assert_eq!(
             state
                 .pty_manager
@@ -254,8 +508,9 @@ mod tests {
     async fn operator_inject_submit_false_writes_payload_without_enter() {
         let (_temp_dir, app, state) = setup_test_app();
 
-        let status = post_operator_inject(
+        let (status, response) = post_inject(
             app,
+            "/api/sessions/inject-test/inject",
             json!({
                 "target_agent_id": AGENT_ID,
                 "message": "draft\r\n",
@@ -265,6 +520,13 @@ mod tests {
         .await;
 
         assert_eq!(status, StatusCode::OK);
+        assert_eq!(response["payload_bytes_written"], 5);
+        assert_eq!(response["submit_attempted"], false);
+        assert_eq!(response["submit_keystroke_issued"], false);
+        assert_eq!(response["submit_bytes_written"], 0);
+        assert_eq!(response["observation_window_ms"], 0);
+        assert_eq!(response["observation_elapsed_ms"], 0);
+        assert_eq!(response["pty_activity_observed"], false);
         assert_eq!(
             state
                 .pty_manager
@@ -279,8 +541,9 @@ mod tests {
     async fn operator_inject_multiline_preserves_newlines_and_submits_once() {
         let (_temp_dir, app, state) = setup_test_app();
 
-        let status = post_operator_inject(
+        let (status, _response) = post_inject(
             app,
+            "/api/sessions/inject-test/inject",
             json!({
                 "target_agent_id": AGENT_ID,
                 "message": "line one\nline two\r\n"
@@ -303,12 +566,106 @@ mod tests {
     async fn operator_inject_blocking_path_preserves_pty_error_status() {
         let (_temp_dir, app, _state) = setup_test_app();
 
-        let status = post_operator_inject(
+        let (status, _response) = post_inject(
             app,
+            "/api/sessions/inject-test/inject",
             json!({ "target_agent_id": "missing-agent", "message": "hello" }),
         )
         .await;
 
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[tokio::test]
+    async fn all_inject_routes_return_the_measured_sender_contract() {
+        let (_temp_dir, app, _state) = setup_test_app();
+        let cases = [
+            (
+                "/api/sessions/inject-test/inject",
+                json!({ "target_agent_id": AGENT_ID, "message": "operator" }),
+            ),
+            (
+                "/api/sessions/inject-test/inject/queen",
+                json!({
+                    "queen_id": QUEEN_ID,
+                    "target_worker_id": AGENT_ID,
+                    "message": "queen"
+                }),
+            ),
+            (
+                "/api/sessions/inject-test/inject/evaluator",
+                json!({
+                    "evaluator_id": "inject-test-evaluator",
+                    "target_agent_id": QUEEN_ID,
+                    "message": "evaluator"
+                }),
+            ),
+        ];
+
+        for (path, body) in cases {
+            let (status, response) = post_inject(app.clone(), path, body).await;
+            assert_eq!(status, StatusCode::OK, "{path}: {response}");
+            assert_eq!(response["submit_keystroke_issued"], true, "{path}");
+            assert_eq!(response["submit_bytes_written"], 1, "{path}");
+            assert_eq!(response["pty_observation_available"], true, "{path}");
+            assert!(response["pty_output_bytes_before"].is_number(), "{path}");
+            assert!(response["pty_output_bytes_after_write"].is_number(), "{path}");
+            assert_eq!(response["observation_window_ms"], 250, "{path}");
+            assert!(response["evidence_scope"]
+                .as_str()
+                .unwrap()
+                .contains("do not prove that the agent took a turn"));
+        }
+    }
+
+    #[test]
+    fn stall_report_distinguishes_awaiting_inject_from_crashed_and_idle() {
+        let (_temp_dir, _app, state) = setup_test_app();
+        let controller = state.session_controller.read();
+        controller
+            .update_heartbeat(SESSION_ID, AGENT_ID, "working", None)
+            .unwrap();
+        controller
+            .update_heartbeat(SESSION_ID, QUEEN_ID, "working", None)
+            .unwrap();
+        controller
+            .update_heartbeat(SESSION_ID, QA_WORKER_ID, "idle", None)
+            .unwrap();
+
+        let stale_at = Utc::now() - ChronoDuration::minutes(5);
+        for agent_id in [AGENT_ID, QUEEN_ID, QA_WORKER_ID] {
+            controller.set_heartbeat_last_activity_for_test(SESSION_ID, agent_id, stale_at);
+        }
+        controller
+            .record_injection_submission(
+                SESSION_ID,
+                AGENT_ID,
+                stale_at + ChronoDuration::seconds(1),
+                true,
+            )
+            .unwrap();
+        state.pty_manager.read().kill(QUEEN_ID).unwrap();
+
+        let reports = controller.get_stalled_agent_reports(
+            SESSION_ID,
+            std::time::Duration::from_secs(30),
+        );
+        let status_for = |agent_id: &str| {
+            reports
+                .iter()
+                .find(|(id, _, _)| id == agent_id)
+                .map(|(_, _, status)| status)
+                .unwrap()
+        };
+
+        assert_eq!(
+            status_for(AGENT_ID),
+            &AgentStatus::WaitingForInput("awaiting_injected_turn".to_string())
+        );
+        assert_eq!(
+            status_for(QUEEN_ID),
+            &AgentStatus::Error("process_not_alive".to_string())
+        );
+        assert_eq!(status_for(QA_WORKER_ID), &AgentStatus::Idle);
     }
 }

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -8,6 +8,8 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::path::Path as FsPath;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use super::{validate_cli, validate_session_id};
@@ -23,6 +25,91 @@ use crate::session::{AddWorkerError, AddWorkerRejectionReason, SessionController
 use crate::storage::queue::{
     QueueConflictAction, QueueConflictCoverage, QueueConflictRow, QueueResolutionUpdate, QueueStatus,
 };
+
+#[cfg(test)]
+struct StartupDeathCleanupHook {
+    reached: tokio::sync::oneshot::Sender<()>,
+    release: tokio::sync::oneshot::Receiver<()>,
+}
+
+#[cfg(test)]
+static STARTUP_DEATH_CLEANUP_HOOKS: OnceLock<
+    parking_lot::Mutex<HashMap<String, StartupDeathCleanupHook>>,
+> = OnceLock::new();
+
+#[cfg(test)]
+fn startup_death_cleanup_hooks(
+) -> &'static parking_lot::Mutex<HashMap<String, StartupDeathCleanupHook>> {
+    STARTUP_DEATH_CLEANUP_HOOKS.get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+}
+
+#[cfg(test)]
+pub(crate) struct StartupDeathCleanupTestControl {
+    worker_id: String,
+    reached: tokio::sync::oneshot::Receiver<()>,
+    release: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+#[cfg(test)]
+impl StartupDeathCleanupTestControl {
+    pub(crate) async fn wait_until_reached(
+        &mut self,
+    ) -> Result<(), tokio::sync::oneshot::error::RecvError> {
+        (&mut self.reached).await
+    }
+
+    pub(crate) fn release(mut self) {
+        if let Some(release) = self.release.take() {
+            let _ = release.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for StartupDeathCleanupTestControl {
+    fn drop(&mut self) {
+        startup_death_cleanup_hooks().lock().remove(&self.worker_id);
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn register_startup_death_cleanup_test_hook(
+    worker_id: &str,
+) -> StartupDeathCleanupTestControl {
+    use std::collections::hash_map::Entry;
+
+    let (reached_tx, reached_rx) = tokio::sync::oneshot::channel();
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+    match startup_death_cleanup_hooks()
+        .lock()
+        .entry(worker_id.to_string())
+    {
+        Entry::Vacant(entry) => {
+            entry.insert(StartupDeathCleanupHook {
+                reached: reached_tx,
+                release: release_rx,
+            });
+        }
+        Entry::Occupied(_) => {
+            panic!("startup-death cleanup hook already registered for {worker_id}")
+        }
+    }
+
+    StartupDeathCleanupTestControl {
+        worker_id: worker_id.to_string(),
+        reached: reached_rx,
+        release: Some(release_tx),
+    }
+}
+
+#[cfg(test)]
+async fn wait_for_startup_death_cleanup_test_hook(worker_id: &str) {
+    let hook = startup_death_cleanup_hooks().lock().remove(worker_id);
+    if let Some(hook) = hook {
+        let _ = hook.reached.send(());
+        let _ = hook.release.await;
+    }
+}
 
 struct QueueSchedulingFacts {
     prerequisite_task_ids: Vec<String>,
@@ -658,6 +745,9 @@ pub async fn add_worker(
         {
             let _ = state.pty_manager.read().kill(&agent_info.id);
         }
+
+        #[cfg(test)]
+        wait_for_startup_death_cleanup_test_hook(&agent_info.id).await;
 
         // Free the slot so a retry respawns worker-N in place instead of advancing the
         // index and orphaning the original branch/task-file paths.

--- a/src-tauri/src/http/handlers/workers.rs
+++ b/src-tauri/src/http/handlers/workers.rs
@@ -5,7 +5,8 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::Path as FsPath;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -17,10 +18,10 @@ use crate::domain::WorkspaceStrategy;
 use crate::http::error::ApiError;
 use crate::http::state::AppState;
 use crate::orchestrator::org_graph::definitions::role_prompt_template;
-use crate::pty::{AgentConfig, AgentRole, WorkerRole};
+use crate::pty::{AgentConfig, AgentRole, AgentStatus, WorkerRole};
 use crate::session::{AddWorkerError, AddWorkerRejectionReason, SessionController};
 use crate::storage::queue::{
-    QueueConflictAction, QueueConflictCoverage, QueueConflictRow, QueueResolutionUpdate,
+    QueueConflictAction, QueueConflictCoverage, QueueConflictRow, QueueResolutionUpdate, QueueStatus,
 };
 
 struct QueueSchedulingFacts {
@@ -29,6 +30,16 @@ struct QueueSchedulingFacts {
     conflicts: Vec<QueueConflictRow>,
     conflict_coverage: Option<QueueConflictCoverage>,
     reconcile_conflict_task_id: Option<String>,
+}
+
+fn plan_task_id_from_task_file(path: &FsPath) -> Option<String> {
+    let task_file = std::fs::read_to_string(path).ok()?;
+    let (_, after_heading) = task_file.split_once("## Plan Task ID")?;
+    let encoded = after_heading
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())?;
+    serde_json::from_str(encoded).ok()
 }
 
 fn queue_scheduling_facts(
@@ -97,10 +108,15 @@ fn queue_scheduling_facts(
                 },
             )
         } else {
-            // No graph, a complete edgeless graph, or a degraded empty graph retains legacy
-            // FIFO and any existing omission. It cannot truthfully clear an earlier resolution
-            // issue; only a later authoritative graph containing the task does that.
-            (Vec::new(), QueueResolutionUpdate::Preserve)
+            (
+                Vec::new(),
+                QueueResolutionUpdate::ResolutionIncomplete {
+                    task_id: task_id.to_string(),
+                    reason: format!(
+                        "explicit task {task_id} is absent from the authoritative work graph"
+                    ),
+                },
+            )
         }
     } else {
         (Vec::new(), QueueResolutionUpdate::Preserve)
@@ -963,34 +979,68 @@ pub async fn list_workers(
 ) -> Result<Json<Value>, ApiError> {
     validate_session_id(&session_id)?;
 
+    // The durable queue is authoritative for task-backed scheduling. A startup-death release
+    // can outlive failed roster cleanup, so project only the exact dead task-backed roster entry
+    // away once its row is durably queued under the canonical pending binding.
+    let queue = state
+        .queue_manager
+        .queue_snapshot(&session_id)
+        .map_err(|error| ApiError::internal(error.to_string()))?;
+    let released_pending_task_ids: HashSet<String> = queue
+        .rows
+        .iter()
+        .filter(|row| {
+            row.status == QueueStatus::Queued
+                && row.task_id.is_some()
+                && row.worker_id == format!("pending:{}", row.id)
+        })
+        .filter_map(|row| row.task_id.clone())
+        .collect();
+
     let controller = state.session_controller.read();
 
     let session = controller
         .get_session(&session_id)
         .ok_or_else(|| ApiError::not_found(format!("Session {} not found", session_id)))?;
+    drop(controller);
 
-    let workers: Vec<Value> = session
+    let mut workers = Vec::new();
+    for agent in session
         .agents
         .iter()
-        .filter(|a| matches!(a.role, AgentRole::Worker { .. }))
-        .map(|a| -> Result<Value, ApiError> {
-            let index = a.id.rsplit('-').next().unwrap_or("0");
-            let task_file = SessionController::task_file_path_for_session_worker(
-                &session,
-                index.parse::<usize>().unwrap_or(0),
-            )
-            .map_err(ApiError::internal)?
-            .to_string_lossy()
-            .to_string();
-            Ok(json!({
-                "id": a.id,
-                "role": a.config.role.as_ref().map(|r| &r.label).unwrap_or(&"Worker".to_string()),
-                "cli": a.config.cli,
-                "status": format!("{:?}", a.status),
-                "task_file": task_file
-            }))
-        })
-        .collect::<Result<_, _>>()?;
+        .filter(|agent| matches!(agent.role, AgentRole::Worker { .. }))
+    {
+        let index = agent.id.rsplit('-').next().unwrap_or("0");
+        let task_file = SessionController::task_file_path_for_session_worker(
+            &session,
+            index.parse::<usize>().unwrap_or(0),
+        )
+        .map_err(ApiError::internal)?;
+        let released_task_id = if matches!(&agent.status, AgentStatus::Running) {
+            plan_task_id_from_task_file(&task_file)
+                .filter(|task_id| released_pending_task_ids.contains(task_id))
+        } else {
+            None
+        };
+        if let Some(task_id) = released_task_id.filter(|_| {
+            !state.pty_manager.read().is_alive(&agent.id)
+        }) {
+            tracing::warn!(
+                session_id = %session_id,
+                worker_id = %agent.id,
+                task_id = %task_id,
+                "suppressed dead roster entry after its task-backed queue row was released"
+            );
+            continue;
+        }
+        workers.push(json!({
+            "id": agent.id,
+            "role": agent.config.role.as_ref().map(|role| &role.label).unwrap_or(&"Worker".to_string()),
+            "cli": agent.config.cli,
+            "status": format!("{:?}", agent.status),
+            "task_file": task_file.to_string_lossy().to_string()
+        }));
+    }
 
     Ok(Json(json!({
         "session_id": session_id,

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -5544,7 +5544,10 @@ async fn test_short_and_full_conversation_keys_share_canonical_history_and_live_
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
-    let event = events.recv().await.unwrap();
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), events.recv())
+        .await
+        .expect("timed out waiting for the short-key conversation event")
+        .expect("conversation event channel closed");
     assert_eq!(event.agent_id.as_deref(), Some(full_agent_id.as_str()));
     assert_eq!(event.payload["data"]["agent_id"], full_agent_id);
 
@@ -5589,7 +5592,10 @@ async fn test_short_and_full_conversation_keys_share_canonical_history_and_live_
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
-    let event = events.recv().await.unwrap();
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), events.recv())
+        .await
+        .expect("timed out waiting for the full-key conversation event")
+        .expect("conversation event channel closed");
     assert_eq!(event.payload["data"]["agent_id"], full_agent_id);
 
     let response = app
@@ -5642,7 +5648,10 @@ async fn test_short_and_full_conversation_keys_share_canonical_history_and_live_
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
-    let event = events.recv().await.unwrap();
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), events.recv())
+        .await
+        .expect("timed out waiting for the shared conversation event")
+        .expect("conversation event channel closed");
     assert_eq!(event.agent_id.as_deref(), Some("shared"));
     assert_eq!(event.payload["data"]["agent_id"], "shared");
     assert!(storage
@@ -9439,6 +9448,9 @@ async fn task_backed_startup_death_with_failed_discard_reconciles_worker_and_que
         ))
         .unwrap();
 
+    let mut cleanup_hook =
+        crate::http::handlers::workers::register_startup_death_cleanup_test_hook(&worker_id);
+
     let pending_request = {
         let app = app.clone();
         let session_id = session_id.clone();
@@ -9464,27 +9476,22 @@ async fn task_backed_startup_death_with_failed_discard_reconciles_worker_and_que
         })
     };
 
-    // The handler deliberately waits 150ms to drain final PTY output after observing death.
-    // Marking the now-rostered agent as having produced work makes discard_worker_slot refuse
-    // destructive cleanup, deterministically exercising slot_freed=false inside that window.
-    let mut forced_discard_failure = false;
-    for _ in 0..100 {
-        let rostered = controller
-            .read()
-            .get_session(&session_id)
-            .is_some_and(|session| session.agents.iter().any(|agent| agent.id == worker_id));
-        if rostered {
-            controller.read().sync_agent_commit_sha(
-                &session_id,
-                &worker_id,
-                Some("synthetic-completion-guard".to_string()),
-            );
-            forced_discard_failure = true;
-            break;
-        }
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
-    }
-    assert!(forced_discard_failure, "worker never reached the roster");
+    // Stop the handler immediately before guarded roster cleanup. This makes the fixture's
+    // completion marker an ordered prerequisite of discard_worker_slot rather than a race
+    // against the handler's PTY-output drain delay.
+    tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        cleanup_hook.wait_until_reached(),
+    )
+    .await
+    .expect("timed out waiting for startup-death cleanup barrier")
+    .expect("startup-death cleanup barrier closed before it was reached");
+    controller.read().sync_agent_commit_sha(
+        &session_id,
+        &worker_id,
+        Some("synthetic-completion-guard".to_string()),
+    );
+    cleanup_hook.release();
 
     let response = pending_request.await.unwrap();
     assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -4,6 +4,9 @@ use crate::domain::WorkspaceStrategy;
 use crate::events::EventBus;
 use crate::http::routes::create_router;
 use crate::http::state::AppState;
+use crate::orchestrator::work_graph::{
+    BindingRef, NodeContract, NodeKind, NodeStatus, TaskGraph, WorkNode,
+};
 use crate::pty::PtyManager;
 use crate::pty::{AgentConfig, AgentRole, AgentStatus};
 use crate::session::{
@@ -5508,22 +5511,24 @@ async fn test_select_winner_path_traversal() {
 // --- Conversations API tests ---
 
 #[tokio::test]
-async fn test_append_conversation_and_verify_file_content() {
-    let (app, controller) = setup_test_app_with_controller().await;
-    let storage = SessionStorage::new().unwrap();
+async fn test_short_and_full_conversation_keys_share_canonical_history_and_live_event() {
+    let storage_dir = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+    let (app, controller, storage, state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
     let session_id = format!("conv-append-{}", uuid::Uuid::new_v4());
-
-    let temp_dir = std::env::temp_dir().join(format!("hive-test-{}", session_id));
-    let _ = std::fs::create_dir_all(&temp_dir);
+    let full_agent_id = format!("{session_id}-worker-1");
     controller
         .read()
-        .insert_test_session(make_test_session(&session_id, temp_dir.to_str().unwrap()));
+        .insert_test_session(make_test_session(&session_id, project_dir.path().to_str().unwrap()));
+    let mut events = state.event_bus.subscribe_session(session_id.clone());
 
     let body = serde_json::json!({
         "from": "worker-1",
-        "content": "First conversation message"
+        "content": "Message sent through the short prompt-style key"
     });
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -5539,16 +5544,117 @@ async fn test_append_conversation_and_verify_file_content() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::CREATED);
 
+    let event = events.recv().await.unwrap();
+    assert_eq!(event.agent_id.as_deref(), Some(full_agent_id.as_str()));
+    assert_eq!(event.payload["data"]["agent_id"], full_agent_id);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/sessions/{}/conversations/{}",
+                    session_id, full_agent_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = read_json_body(response).await;
+    assert_eq!(response_json["messages"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        response_json["messages"][0]["content"],
+        "Message sent through the short prompt-style key"
+    );
+
+    let body = serde_json::json!({
+        "from": "worker-1",
+        "content": "Message sent through the full UI composer key"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/conversations/{}/append",
+                    session_id, full_agent_id
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let event = events.recv().await.unwrap();
+    assert_eq!(event.payload["data"]["agent_id"], full_agent_id);
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/sessions/{}/conversations/worker-1",
+                    session_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = read_json_body(response).await;
+    assert_eq!(response_json["messages"].as_array().unwrap().len(), 2);
+
     let conversation_file = storage
         .session_dir(&session_id)
         .join("conversations")
-        .join("worker-1.md");
+        .join(format!("{full_agent_id}.md"));
     let file_content = std::fs::read_to_string(conversation_file).unwrap();
     assert!(file_content.contains("from @worker-1"));
-    assert!(file_content.contains("First conversation message"));
+    assert!(file_content.contains("Message sent through the short prompt-style key"));
+    assert!(file_content.contains("Message sent through the full UI composer key"));
+    assert!(!storage
+        .session_dir(&session_id)
+        .join("conversations")
+        .join("worker-1.md")
+        .exists());
 
-    let _ = std::fs::remove_dir_all(storage.session_dir(&session_id));
-    let _ = std::fs::remove_dir_all(&temp_dir);
+    let shared_body = serde_json::json!({
+        "from": "worker-1",
+        "content": "Reserved broadcast"
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/conversations/shared/append",
+                    session_id
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&shared_body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let event = events.recv().await.unwrap();
+    assert_eq!(event.agent_id.as_deref(), Some("shared"));
+    assert_eq!(event.payload["data"]["agent_id"], "shared");
+    assert!(storage
+        .session_dir(&session_id)
+        .join("conversations")
+        .join("shared.md")
+        .exists());
+    assert!(!storage
+        .session_dir(&session_id)
+        .join("conversations")
+        .join(format!("{session_id}-shared.md"))
+        .exists());
 }
 
 #[tokio::test]
@@ -5639,6 +5745,68 @@ async fn test_read_conversation_since_filter() {
     let storage = SessionStorage::new().unwrap();
     let _ = std::fs::remove_dir_all(storage.session_dir(&session_id));
     let _ = std::fs::remove_dir_all(&temp_dir);
+}
+
+#[tokio::test]
+async fn test_read_conversation_preserves_legacy_bare_history_after_canonical_append() {
+    let storage_dir = TempDir::new().unwrap();
+    let project_dir = TempDir::new().unwrap();
+    let (app, controller, storage) =
+        setup_test_app_with_controller_at(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("conv-legacy-{}", uuid::Uuid::new_v4());
+    let full_queen_id = format!("{session_id}-queen");
+    controller
+        .read()
+        .insert_test_session(make_test_session(&session_id, project_dir.path().to_str().unwrap()));
+    storage.create_conversation_dir(&session_id).unwrap();
+    std::fs::write(
+        storage
+            .session_dir(&session_id)
+            .join("conversations")
+            .join("queen.md"),
+        "---\n[2026-04-08T23:30:00Z] from @worker-1\nLegacy queen history\n\n",
+    )
+    .unwrap();
+
+    let body = serde_json::json!({
+        "from": "worker-2",
+        "content": "Canonical queen history"
+    });
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/sessions/{}/conversations/{}/append",
+                    session_id, full_queen_id
+                ))
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/api/sessions/{}/conversations/queen",
+                    session_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let response_json = read_json_body(response).await;
+    let messages = response_json["messages"].as_array().unwrap();
+    assert_eq!(messages.len(), 2);
+    assert_eq!(messages[0]["content"], "Legacy queen history");
+    assert_eq!(messages[1]["content"], "Canonical queen history");
 }
 
 #[tokio::test]
@@ -9240,6 +9408,149 @@ async fn add_worker_that_dies_during_startup_is_failed_to_start_not_running() {
         format!("{}-worker-1", session_id),
         "recovery must respawn the original slot"
     );
+}
+
+/// #244 T4. A task-backed startup death can release the durable queue row after
+/// guarded roster cleanup fails. The queue is authoritative for durable scheduling,
+/// so GET /workers must not keep projecting that dead agent as Running.
+#[tokio::test]
+async fn task_backed_startup_death_with_failed_discard_reconciles_worker_and_queue_views() {
+    let storage_dir = TempDir::new().unwrap();
+    let (app, controller, storage, _state) =
+        setup_test_app_full(storage_dir.path().to_path_buf()).await;
+    let session_id = format!("task-doa-{}", uuid::Uuid::new_v4());
+    let worker_id = format!("{}-worker-1", session_id);
+    let temp_dir = TempDir::new().unwrap();
+    storage.create_session_dir(&session_id).unwrap();
+    let mut session = make_test_session(&session_id, temp_dir.path().to_str().unwrap());
+    session.no_git = true;
+    controller.read().insert_test_session(session);
+    StateManager::new(storage.session_dir(&session_id))
+        .write_work_graph(&TaskGraph::new(
+            vec![WorkNode::new(
+                "T4",
+                NodeKind::Task,
+                "T4",
+                NodeContract::default(),
+                BindingRef::Role("worker".to_string()),
+                NodeStatus::Ready,
+            )],
+            Vec::new(),
+        ))
+        .unwrap();
+
+    let pending_request = {
+        let app = app.clone();
+        let session_id = session_id.clone();
+        tokio::spawn(async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/sessions/{}/workers", session_id))
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::json!({
+                            "role_type": "researcher",
+                            "cli": "claude",
+                            "flags": ["--stub-die-on-start"],
+                            "task_id": "T4"
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        })
+    };
+
+    // The handler deliberately waits 150ms to drain final PTY output after observing death.
+    // Marking the now-rostered agent as having produced work makes discard_worker_slot refuse
+    // destructive cleanup, deterministically exercising slot_freed=false inside that window.
+    let mut forced_discard_failure = false;
+    for _ in 0..100 {
+        let rostered = controller
+            .read()
+            .get_session(&session_id)
+            .is_some_and(|session| session.agents.iter().any(|agent| agent.id == worker_id));
+        if rostered {
+            controller.read().sync_agent_commit_sha(
+                &session_id,
+                &worker_id,
+                Some("synthetic-completion-guard".to_string()),
+            );
+            forced_discard_failure = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    }
+    assert!(forced_discard_failure, "worker never reached the roster");
+
+    let response = pending_request.await.unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "failed_to_start");
+    assert_eq!(body["slot_freed"], false);
+    assert_eq!(
+        controller
+            .read()
+            .get_session(&session_id)
+            .unwrap()
+            .agents
+            .len(),
+        1,
+        "the fixture must prove guarded roster cleanup actually failed"
+    );
+
+    let queue_response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/sessions/{}/queue", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(queue_response.status(), StatusCode::OK);
+    let queue: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(queue_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(queue["running"], 0);
+    assert_eq!(queue["queued"], 1);
+    assert_eq!(queue["rows"][0]["task_id"], "T4");
+    assert!(queue["rows"][0]["worker_id"]
+        .as_str()
+        .is_some_and(|worker_id| worker_id.starts_with("pending:task:")));
+
+    let workers_response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/sessions/{}/workers", session_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(workers_response.status(), StatusCode::OK);
+    let workers: serde_json::Value = serde_json::from_slice(
+        &axum::body::to_bytes(workers_response.into_body(), usize::MAX)
+            .await
+            .unwrap(),
+    )
+    .unwrap();
+    assert_eq!(workers["count"], 0);
+    assert_eq!(workers["workers"], serde_json::json!([]));
 }
 
 /// #207 fix 4. A rostered worker with no live process is a dead slot; release must

--- a/src-tauri/src/http/tests_wg_plan.rs
+++ b/src-tauri/src/http/tests_wg_plan.rs
@@ -55,6 +55,18 @@ fn controller_with_plan(
     session_id: &str,
     plan_content: Option<&str>,
 ) -> (TempDir, SessionController, Arc<SessionStorage>) {
+    controller_with_plan_and_type(
+        session_id,
+        plan_content,
+        SessionType::Hive { worker_count: 0 },
+    )
+}
+
+fn controller_with_plan_and_type(
+    session_id: &str,
+    plan_content: Option<&str>,
+    session_type: SessionType,
+) -> (TempDir, SessionController, Arc<SessionStorage>) {
     let temp = tempfile::tempdir().expect("temporary plan fixture");
     let project_path = temp.path().join("project");
     let project_session_dir = project_path.join(".hive-manager").join(session_id);
@@ -73,7 +85,9 @@ fn controller_with_plan(
 
     let mut controller = SessionController::new(Arc::new(RwLock::new(PtyManager::new())));
     controller.set_storage(Arc::clone(&storage));
-    controller.insert_test_session(planning_session(session_id, &project_path));
+    let mut session = planning_session(session_id, &project_path);
+    session.session_type = session_type;
+    controller.insert_test_session(session);
     (temp, controller, storage)
 }
 
@@ -89,6 +103,116 @@ fn assert_session_state(
             .state,
         expected
     );
+}
+
+#[test]
+fn production_continue_builds_plan_graph_before_every_running_dispatch() {
+    let plan = r#"# Five-task production graph
+
+## Tasks
+- [ ] T1: Establish the root
+- [ ] T2: Build the first branch (deps: T1)
+- [ ] T3: Build the second branch (deps: T1)
+- [ ] T4: Join both branches (deps: T2, T3)
+- [ ] T5: Finish the workflow (deps: T4)
+"#;
+    let cases = [
+        (
+            "continue-hive",
+            SessionType::Hive { worker_count: 0 },
+            "Failed to read pending config",
+        ),
+        (
+            "continue-swarm",
+            SessionType::Swarm { planner_count: 1 },
+            "Failed to read pending swarm config",
+        ),
+        (
+            "continue-fusion",
+            SessionType::Fusion {
+                variants: vec!["Variant A".to_string()],
+            },
+            "Failed to read pending fusion config",
+        ),
+        (
+            "continue-debate",
+            SessionType::Debate {
+                variants: vec!["Debater A".to_string()],
+            },
+            "Failed to read pending debate config",
+        ),
+    ];
+
+    for (session_id, session_type, expected_dispatch_error) in cases {
+        let (_temp, controller, storage) =
+            controller_with_plan_and_type(session_id, Some(plan), session_type);
+
+        for attempt in 1..=2 {
+            let error = controller
+                .continue_after_planning(session_id)
+                .expect_err("missing launch config should stop inside the selected dispatch branch");
+            assert!(
+                error.contains(expected_dispatch_error),
+                "attempt {attempt} did not reach {session_id}'s dispatch branch: {error}"
+            );
+
+            let graph = StateManager::new(storage.session_dir(session_id))
+                .read_work_graph()
+                .expect("graph state is readable")
+                .expect("production continue persisted the plan graph");
+            assert_eq!(graph.nodes.len(), 5, "{session_id} node count");
+            assert_eq!(graph.edges.len(), 5, "{session_id} edge count");
+            assert!(graph.omissions.is_empty(), "{session_id} omissions");
+        }
+
+        assert_session_state(&controller, session_id, SessionState::PlanReady);
+    }
+}
+
+#[test]
+fn production_continue_replaces_empty_seed_with_typed_source_omissions() {
+    let malformed_plan = r#"# Malformed production graph
+
+## Tasks
+- [ ] T1: Keep launching despite malformed graph metadata (deps: T0
+"#;
+    let cases = [
+        (
+            "continue-malformed",
+            Some(malformed_plan),
+            WorkGraphOmissionReason::ResolutionIncomplete,
+            "unterminated",
+        ),
+        (
+            "continue-missing",
+            None,
+            WorkGraphOmissionReason::SourceUnreadable,
+            "plan.md",
+        ),
+    ];
+
+    for (session_id, plan, expected_reason, expected_example) in cases {
+        let (_temp, controller, storage) = controller_with_plan(session_id, plan);
+
+        let error = controller
+            .continue_after_planning(session_id)
+            .expect_err("missing launch config should fail after the non-blocking graph build");
+        assert!(
+            error.contains("Failed to read pending config"),
+            "plan source failure blocked before Hive dispatch: {error}"
+        );
+        assert_session_state(&controller, session_id, SessionState::PlanReady);
+
+        let graph = StateManager::new(storage.session_dir(session_id))
+            .read_work_graph()
+            .expect("graph state is readable")
+            .expect("production continue replaced the creation-time seed");
+        assert!(graph.nodes.is_empty());
+        assert!(graph.edges.is_empty());
+        assert_eq!(graph.omissions.len(), 1);
+        assert_eq!(graph.omissions[0].reason, expected_reason);
+        assert!(graph.omissions[0].examples[0].contains(expected_example));
+    }
 }
 
 #[test]

--- a/src-tauri/src/http/tests_wg_queue.rs
+++ b/src-tauri/src/http/tests_wg_queue.rs
@@ -2075,7 +2075,7 @@ async fn unresolved_running_task_keeps_conflict_coverage_partial() {
 }
 
 #[tokio::test]
-async fn complete_edgeless_graph_keeps_unknown_explicit_task_fifo() {
+async fn complete_edgeless_graph_rejects_unknown_explicit_task_without_spawning() {
     let temp = tempfile::tempdir().unwrap();
     let (app, state, controller) = dependency_http_fixture(&temp);
     let session_id = "http-dependency-session";
@@ -2092,14 +2092,48 @@ async fn complete_edgeless_graph_keeps_unknown_explicit_task_fifo() {
         ))
         .unwrap();
 
-    assert_eq!(post_task_worker(&app, "UNKNOWN").await.status(), StatusCode::CREATED);
+    let response = post_task_worker(&app, "UNKNOWN").await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "resolution_incomplete");
+    assert_eq!(body["task_id"], "UNKNOWN");
+    assert_eq!(controller.read().get_session(session_id).unwrap().agents.len(), 0);
     let snapshot = state.queue_manager.queue_snapshot(session_id).unwrap();
-    assert!(snapshot.resolution_incomplete.is_empty());
-    assert_eq!(snapshot.running, 1);
+    assert_eq!(snapshot.queued, 1);
+    assert_eq!(snapshot.running, 0);
+    assert_eq!(snapshot.resolution_incomplete.len(), 1);
 }
 
 #[tokio::test]
-async fn degraded_empty_graph_keeps_fifo_and_retains_its_omission() {
+async fn complete_edgeless_graph_admits_known_explicit_task() {
+    let temp = tempfile::tempdir().unwrap();
+    let (app, state, controller) = dependency_http_fixture(&temp);
+    let session_id = "http-dependency-session";
+    let project = temp.path().join("project");
+    std::fs::create_dir_all(&project).unwrap();
+    state.storage.create_session_dir(session_id).unwrap();
+    controller
+        .read()
+        .insert_test_session(quiet_hive_session(session_id, &project));
+    StateManager::new(state.storage.session_dir(session_id))
+        .write_work_graph(&TaskGraph::new(
+            vec![queue_test_node("KNOWN", NodeStatus::Ready)],
+            Vec::new(),
+        ))
+        .unwrap();
+
+    assert_eq!(post_task_worker(&app, "KNOWN").await.status(), StatusCode::CREATED);
+    let snapshot = state.queue_manager.queue_snapshot(session_id).unwrap();
+    assert!(snapshot.resolution_incomplete.is_empty());
+    assert_eq!(snapshot.running, 1);
+    assert_eq!(controller.read().get_session(session_id).unwrap().agents.len(), 1);
+}
+
+#[tokio::test]
+async fn degraded_empty_graph_rejects_unknown_and_retains_its_omission() {
     let temp = tempfile::tempdir().unwrap();
     let (app, state, controller) = dependency_http_fixture(&temp);
     let session_id = "http-dependency-session";
@@ -2120,10 +2154,18 @@ async fn degraded_empty_graph_keeps_fifo_and_retains_its_omission() {
     let state_manager = StateManager::new(state.storage.session_dir(session_id));
     state_manager.write_work_graph(&degraded).unwrap();
 
-    assert_eq!(post_task_worker(&app, "UNKNOWN").await.status(), StatusCode::CREATED);
+    let response = post_task_worker(&app, "UNKNOWN").await;
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+    let body: serde_json::Value = serde_json::from_slice(
+        &to_bytes(response.into_body(), usize::MAX).await.unwrap(),
+    )
+    .unwrap();
+    assert_eq!(body["reason"], "resolution_incomplete");
+    assert_eq!(body["task_id"], "UNKNOWN");
     assert_eq!(state_manager.read_work_graph().unwrap(), Some(degraded));
     let snapshot = state.queue_manager.queue_snapshot(session_id).unwrap();
-    assert!(snapshot.resolution_incomplete.is_empty());
+    assert_eq!(snapshot.resolution_incomplete.len(), 1);
+    assert_eq!(controller.read().get_session(session_id).unwrap().agents.len(), 0);
 }
 
 #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -180,12 +180,14 @@ pub fn run() {
             app_state.set_registry(Arc::clone(&action_registry));
             app.manage(Arc::clone(&app_state));
 
-            // Stall detection background task - runs every 60s, emits agent-stalled/agent-recovered
+            // Desktop-only stall detection: this Tauri setup task does not run in headless HTTP
+            // deployments. It emits typed agent-stalled reasons plus agent-recovered.
             let stall_controller = session_controller.clone();
             let stall_app_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 let stall_threshold = Duration::from_secs(180); // 3 minutes
-                let mut known_stalled: HashSet<(String, String)> = HashSet::new();
+                let mut known_stalled: std::collections::HashMap<(String, String), String> =
+                    std::collections::HashMap::new();
                 let mut interval = tokio::time::interval(Duration::from_secs(60));
                 loop {
                     interval.tick().await;
@@ -198,27 +200,44 @@ pub fn run() {
                         .collect();
                     drop(sessions);
 
-                    let mut currently_stalled: HashSet<(String, String)> = HashSet::new();
+                    let mut currently_stalled: std::collections::HashMap<
+                        (String, String),
+                        String,
+                    > = std::collections::HashMap::new();
                     for session_id in &running_session_ids {
-                        let stalled = controller.get_stalled_agents(session_id, stall_threshold);
-                        for (agent_id, _last_activity) in stalled {
-                            currently_stalled.insert((session_id.clone(), agent_id.clone()));
+                        let stalled =
+                            controller.get_stalled_agent_reports(session_id, stall_threshold);
+                        for (agent_id, _last_activity, status) in stalled {
+                            let reason = match status {
+                                crate::pty::AgentStatus::WaitingForInput(reason)
+                                    if reason == "awaiting_injected_turn" =>
+                                {
+                                    "awaiting_injected_turn"
+                                }
+                                crate::pty::AgentStatus::Idle => "idle",
+                                _ => "crashed",
+                            };
+                            currently_stalled.insert(
+                                (session_id.clone(), agent_id),
+                                reason.to_string(),
+                            );
                         }
                     }
                     drop(controller);
 
-                    // Emit agent-stalled for newly stalled
-                    for (sid, aid) in &currently_stalled {
-                        if !known_stalled.contains(&(sid.clone(), aid.clone())) {
+                    // Emit agent-stalled for a newly stalled agent or a changed reason.
+                    for ((sid, aid), reason) in &currently_stalled {
+                        if known_stalled.get(&(sid.clone(), aid.clone())) != Some(reason) {
                             let _ = stall_app_handle.emit("agent-stalled", serde_json::json!({
                                 "session_id": sid,
                                 "agent_id": aid,
+                                "reason": reason,
                             }));
                         }
                     }
                     // Emit agent-recovered for no longer stalled
-                    for (sid, aid) in known_stalled.iter() {
-                        if !currently_stalled.contains(&(sid.clone(), aid.clone())) {
+                    for (sid, aid) in known_stalled.keys() {
+                        if !currently_stalled.contains_key(&(sid.clone(), aid.clone())) {
                             let _ = stall_app_handle.emit("agent-recovered", serde_json::json!({
                                 "session_id": sid,
                                 "agent_id": aid,

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1715,25 +1715,100 @@ impl SessionController {
         Ok(())
     }
 
-    /// Get agents with no activity for longer than threshold.
+    const AWAITING_INJECTED_TURN_PREFIX: &'static str = "awaiting_injected_turn:";
+
+    fn awaiting_injected_turn_since(status: &AgentStatus) -> Option<DateTime<Utc>> {
+        let AgentStatus::WaitingForInput(reason) = status else {
+            return None;
+        };
+        let timestamp = reason.strip_prefix(Self::AWAITING_INJECTED_TURN_PREFIX)?;
+        DateTime::parse_from_rfc3339(timestamp)
+            .ok()
+            .map(|parsed| parsed.with_timezone(&Utc))
+    }
+
+    /// Record that a submit keystroke was delivered and a managed turn is now awaited.
     ///
-    /// A `completed` heartbeat retires only the assignment that produced it. The task file is
-    /// the standing channel for later assignments, so a newer task-file modification proves that
-    /// the same worker has been reassigned even if the wake-up injection never submits. Keeping
-    /// completed agents exempt until that proof exists makes the never-reassigned case silent.
+    /// The PTY `AgentStatus` enum is the canonical runtime vocabulary. Its existing
+    /// `WaitingForInput` variant carries this condition; domain-agent and cell statuses remain
+    /// projections. A later heartbeat clears this marker during the stall sweep.
+    pub fn record_injection_submission(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        submitted_at: DateTime<Utc>,
+        submit_keystroke_issued: bool,
+    ) -> Result<(), String> {
+        if !submit_keystroke_issued {
+            return Ok(());
+        }
+        if self
+            .agent_heartbeats
+            .read()
+            .get(session_id)
+            .and_then(|agents| agents.get(agent_id))
+            .is_some_and(|heartbeat| heartbeat.last_activity > submitted_at)
+        {
+            // The agent already produced managed recovery evidence while the HTTP route observed
+            // the post-submit PTY window. Do not overwrite that newer heartbeat with Waiting.
+            return Ok(());
+        }
+
+        {
+            let mut sessions = self.sessions.write();
+            let session = sessions
+                .get_mut(session_id)
+                .ok_or_else(|| format!("Session not found: {session_id}"))?;
+            let agent = session
+                .agents
+                .iter_mut()
+                .find(|agent| agent.id == agent_id)
+                .ok_or_else(|| format!("Agent {agent_id} not found in session {session_id}"))?;
+
+            // PTY-ring activity may be input echo or unrelated output. Only a later heartbeat
+            // proves the agent took another managed turn, so every successful submit starts in
+            // the awaiting state regardless of the observation result.
+            agent.status = AgentStatus::WaitingForInput(format!(
+                "{}{}",
+                Self::AWAITING_INJECTED_TURN_PREFIX,
+                submitted_at.to_rfc3339()
+            ));
+        }
+        self.emit_session_update(session_id);
+        Ok(())
+    }
+
+    /// Compatibility view for existing callers that only need identity and activity time.
     pub fn get_stalled_agents(
         &self,
         session_id: &str,
         threshold: Duration,
     ) -> Vec<(String, DateTime<Utc>)> {
+        self.get_stalled_agent_reports(session_id, threshold)
+            .into_iter()
+            .map(|(agent_id, last_activity, _status)| (agent_id, last_activity))
+            .collect()
+    }
+
+    /// Get stale agents with a canonical PTY status carrying the operator-visible reason.
+    ///
+    /// A `completed` heartbeat retires only the assignment that produced it. The task file is
+    /// the standing channel for later assignments, so a newer task-file modification proves that
+    /// the same worker has been reassigned even if the wake-up injection never submits. Keeping
+    /// completed agents exempt until that proof exists makes the never-reassigned case silent.
+    pub fn get_stalled_agent_reports(
+        &self,
+        session_id: &str,
+        threshold: Duration,
+    ) -> Vec<(String, DateTime<Utc>, AgentStatus)> {
         let now = Utc::now();
         let threshold_secs = threshold.as_secs() as i64;
-        let task_file_updates = {
+        let (task_file_updates, agent_statuses) = {
             let sessions = self.sessions.read();
             sessions
                 .get(session_id)
                 .map(|session| {
-                    session
+                    let task_updates = session
                         .agents
                         .iter()
                         .filter_map(|agent| {
@@ -1748,31 +1823,123 @@ impl SessionController {
                             let modified = std::fs::metadata(task_file).ok()?.modified().ok()?;
                             Some((agent.id.clone(), DateTime::<Utc>::from(modified)))
                         })
-                        .collect::<HashMap<_, _>>()
+                        .collect::<HashMap<_, _>>();
+                    let statuses = session
+                        .agents
+                        .iter()
+                        .map(|agent| (agent.id.clone(), agent.status.clone()))
+                        .collect::<HashMap<_, _>>();
+                    (task_updates, statuses)
                 })
                 .unwrap_or_default()
         };
         let heartbeats = self.agent_heartbeats.read();
-        let Some(agents) = heartbeats.get(session_id) else {
-            return vec![];
-        };
-        agents
-            .iter()
-            .filter_map(|(agent_id, info)| {
-                let elapsed = (now - info.last_activity).num_seconds();
+        let agents = heartbeats.get(session_id);
+        let mut recovered_after_injection = Vec::new();
+        let mut stalled = Vec::new();
+        if let Some(agents) = agents {
+            stalled.extend(agents.iter().filter_map(|(agent_id, info)| {
+                let mut awaiting_since = agent_statuses
+                    .get(agent_id)
+                    .and_then(Self::awaiting_injected_turn_since);
+                if awaiting_since.is_some_and(|started_at| info.last_activity > started_at) {
+                    awaiting_since = None;
+                    recovered_after_injection.push((agent_id.clone(), info.status.clone()));
+                }
+
+                // An inject is sender activity, not evidence that the managed agent ran. It can
+                // select the awaiting-injected-turn reason, but must not refresh an already-stale
+                // heartbeat clock. Agents without any heartbeat use the marker below as fallback.
+                let last_relevant_activity = info.last_activity;
+                let elapsed = (now - last_relevant_activity).num_seconds();
                 let reassigned_after_completion = info.status == "completed"
                     && task_file_updates
                         .get(agent_id)
                         .is_some_and(|modified| modified > &info.last_activity);
                 if elapsed > threshold_secs
-                    && (info.status != "completed" || reassigned_after_completion)
+                    && (awaiting_since.is_some()
+                        || info.status != "completed"
+                        || reassigned_after_completion)
                 {
-                    Some((agent_id.clone(), info.last_activity))
+                    let runtime_status = agent_statuses.get(agent_id);
+                    let process_dead = matches!(runtime_status, Some(AgentStatus::Error(_)))
+                        || !self.pty_manager.read().is_alive(agent_id);
+                    let status = if process_dead {
+                        AgentStatus::Error("process_not_alive".to_string())
+                    } else if awaiting_since.is_some() {
+                        AgentStatus::WaitingForInput("awaiting_injected_turn".to_string())
+                    } else if info.status == "idle" {
+                        AgentStatus::Idle
+                    } else {
+                        // A live process with a stale heartbeat is quiet/idle, not proven crashed.
+                        AgentStatus::Idle
+                    };
+                    Some((agent_id.clone(), last_relevant_activity, status))
                 } else {
                     None
                 }
-            })
-            .collect()
+            }));
+        }
+
+        // A submit can happen before an agent's first heartbeat. The in-memory canonical status
+        // still carries enough time information to surface that condition after the threshold.
+        for (agent_id, status) in &agent_statuses {
+            if agents.is_some_and(|agents| agents.contains_key(agent_id)) {
+                continue;
+            }
+            if let Some(awaiting_since) = Self::awaiting_injected_turn_since(status) {
+                if (now - awaiting_since).num_seconds() > threshold_secs {
+                    let status = if !self.pty_manager.read().is_alive(agent_id) {
+                        AgentStatus::Error("process_not_alive".to_string())
+                    } else {
+                        AgentStatus::WaitingForInput("awaiting_injected_turn".to_string())
+                    };
+                    stalled.push((
+                        agent_id.clone(),
+                        awaiting_since,
+                        status,
+                    ));
+                }
+            }
+        }
+        drop(heartbeats);
+
+        if !recovered_after_injection.is_empty() {
+            {
+                let mut sessions = self.sessions.write();
+                if let Some(session) = sessions.get_mut(session_id) {
+                    for (agent_id, heartbeat_status) in &recovered_after_injection {
+                        if let Some(agent) = session.agents.iter_mut().find(|a| &a.id == agent_id) {
+                            if Self::awaiting_injected_turn_since(&agent.status).is_some() {
+                                agent.status = if heartbeat_status == "idle" {
+                                    AgentStatus::Idle
+                                } else {
+                                    AgentStatus::Running
+                                };
+                            }
+                        }
+                    }
+                }
+            }
+            self.emit_session_update(session_id);
+        }
+
+        stalled
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_heartbeat_last_activity_for_test(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        last_activity: DateTime<Utc>,
+    ) {
+        self.agent_heartbeats
+            .write()
+            .get_mut(session_id)
+            .and_then(|agents| agents.get_mut(agent_id))
+            .expect("heartbeat fixture")
+            .last_activity = last_activity;
     }
 
     /// Get heartbeat info for a session (for active sessions endpoint).
@@ -5694,8 +5861,8 @@ Workers MUST use curl to exercise the conversation and heartbeat APIs.
    ```bash
    {smoke_worker_start_heartbeat}
    ```
-2. Post message to queen: `curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/queen/append" -H "Content-Type: application/json" -d '{{"from":"worker-1","content":"Worker 1 reporting in. Smoke test task started."}}'`
-3. Post to shared: `curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/shared/append" -H "Content-Type: application/json" -d '{{"from":"worker-1","content":"Worker 1 completed conversation smoke test."}}'`
+2. Post message to queen: `curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/{session_id}-queen/append" -H "Content-Type: application/json" -d '{{"from":"worker-1","content":"Worker 1 reporting in. Smoke test task started."}}'`
+3. Post to shared (reserved session-wide broadcast key): `curl -s -X POST "http://localhost:18800/api/sessions/{session_id}/conversations/shared/append" -H "Content-Type: application/json" -d '{{"from":"worker-1","content":"Worker 1 completed conversation smoke test."}}'`
 4. Send completed heartbeat:
    ```bash
    {smoke_worker_completed_heartbeat}
@@ -5703,8 +5870,8 @@ Workers MUST use curl to exercise the conversation and heartbeat APIs.
 
 ### Task 2 (Worker 2, if present):
 1. Send heartbeat with working status
-2. Read queen conversation: `curl -s "http://localhost:18800/api/sessions/{session_id}/conversations/queen"`
-3. Read shared conversation: `curl -s "http://localhost:18800/api/sessions/{session_id}/conversations/shared"`
+2. Read queen conversation: `curl -s "http://localhost:18800/api/sessions/{session_id}/conversations/{session_id}-queen"`
+3. Read shared conversation (reserved session-wide broadcast key): `curl -s "http://localhost:18800/api/sessions/{session_id}/conversations/shared"`
 4. Post message to queen confirming what was read
 5. Send completed heartbeat
 
@@ -6275,25 +6442,17 @@ Heartbeat while coordinating:
 
 `POST /api/sessions/{session_id}/inject` writes a message into a running agent's terminal.
 
-**Known defect on builds at or below v0.43.0 (issues #221, #226): the message does NOT submit.** The payload and its newline share one PTY write, so the text lands in the agent's composer and waits for a keypress that never comes.
-
-**Workaround: send a second, empty message.** It writes only the newline, with no payload, which is a standalone Enter delivered as its own discrete write. That submits whatever is buffered:
+With the default `"submit":true`, the sender performs two discrete PTY writes: the payload, then a bare carriage-return submit keystroke after the adapter's configured gap. Use `"submit":false` only when intentionally leaving text in the composer.
 
 ```bash
-# 1. the real message - lands in the composer, does NOT submit
 curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
   -H "Content-Type: application/json" \\
   -d '{{"target_agent_id":"{session_id}-worker-N","message":"your message here"}}'
-
-# 2. empty message == standalone Enter - THIS submits it
-curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
-  -H "Content-Type: application/json" \\
-  -d '{{"target_agent_id":"{session_id}-worker-N","message":""}}'
 ```
 
-Measured against a live codex agent, operator-confirmed with no keypress: step 1 alone did not submit after 60 seconds; step 2 submitted it. Drop step 2 once the fix ships.
+The response reports measured sender-side facts including `payload_bytes_written`, `submit_keystroke_issued`, `submit_bytes_written`, PTY-output byte counts, `pty_activity_observed`, and the bounded `observation_window_ms`.
 
-**Never verify an inject by watching whether the agent acts.** With an operator present at the terminal, that observable cannot distinguish an auto-submit from a human pressing Enter. Either have the operator confirm no keypress, or use the two-step form and treat submission as caused by step 2.
+**Evidence limit:** these facts prove only that bytes were written and the existing PTY-output ring was observed for a bounded window. They do **not** prove that the agent took a turn; output may be terminal echo or unrelated activity. Never infer success from receiver behaviour alone.
 
 **Task files remain the primary channel for assignments.** Inject is for nudges and mid-flight corrections; workers re-read their task file, so durable direction belongs there.
 
@@ -6656,7 +6815,7 @@ Use only the native tools exposed by the configured harness. The Capability Card
 - Queen channel: {queen_conversation}
 - Shared channel: {shared_conversation}
 - Read the shared channel before starting a new subtask.
-- Send progress, blockers, and completion evidence to POST /api/sessions/{session_id}/conversations/queen/append.
+- Send progress, blockers, and completion evidence to POST /api/sessions/{session_id}/conversations/{session_id}-queen/append. The reserved session-wide `shared` conversation key remains unprefixed.
 - If the API is unavailable, append the same message to {queen_conversation}.
 
 Heartbeat while active ({heartbeat_cadence} — REQUIRED). Long silent stretches (indexing, builds,
@@ -7259,6 +7418,11 @@ running, use `DELETE /api/sessions/{session_id}/agents/{{agent_id}}` instead.
 - Research/no-worktree Hive: the task file is under `.hive-manager/{session_id}/tasks/` in the operator project
 - Workers re-read the returned task file for new direction; durable queue readiness, not markdown polling, controls activation
 - Dynamic principals are supported by Hive/Research sessions. Fusion variants use their pre-created Fusion task files instead of this endpoint
+- Heartbeat status remains the closed `working` / `idle` / `completed` vocabulary. `awaiting_injected_turn` is server-authored because an inject-blocked receiver cannot take a turn to self-report it.
+- Worker-authored timeouts cannot run while that worker is inject-blocked. The sender's inject receipt measures writes and a bounded PTY-output observation only; it never proves a turn.
+- Automatic 60s sweeps with a 180s stall threshold and `agent-stalled` / `agent-recovered` events run only in the desktop Tauri `.setup()` task. Headless HTTP keeps the measured inject receipt but has no automatic stall sweep; in-memory awaiting markers also reset on process restart.
+- For task-backed scheduling, the durable `agent_run_queue` is authoritative for assignment, readiness, and lifecycle; `Session.agents` is the in-memory roster and metadata cache, while PTY liveness determines whether its process is live.
+- `GET /workers` suppresses a dead `Running` roster entry when its exact Plan Task ID maps to a durably queued `pending:` row. Spawn and release can still make the stores disagree transiently while work is in flight; this reconciliation eliminates the durable failed-cleanup case, not every transient window.
 - Use this to spawn workers sequentially as tasks complete
 "#,
             session_id = session_id,
@@ -12845,6 +13009,24 @@ The backend composed and persisted the following authoritative skeleton before l
             ));
         }
 
+        if matches!(&session.session_type, SessionType::Solo { .. }) {
+            return Err("Solo sessions do not support planning continuation".to_string());
+        }
+
+        // The production continue action is the authoritative exit from Planning.
+        // Build and persist the plan-derived graph before any session-type branch
+        // can transition to Running. A retry from PlanReady is intentionally a
+        // no-op here because the graph was already persisted by mark_plan_ready.
+        if session.state == SessionState::Planning {
+            self.mark_plan_ready(session_id)?;
+        }
+
+        let session = {
+            let sessions = self.sessions.read();
+            sessions.get(session_id).cloned()
+        }
+        .ok_or_else(|| format!("Session not found: {}", session_id))?;
+
         // Dispatch based on session type
         match &session.session_type {
             SessionType::Swarm { .. } => {
@@ -12856,9 +13038,7 @@ The backend composed and persisted the following authoritative skeleton before l
             SessionType::Debate { .. } => {
                 return self.continue_debate_after_planning(session_id, &session);
             }
-            SessionType::Solo { .. } => {
-                return Err("Solo sessions do not support planning continuation".to_string());
-            }
+            SessionType::Solo { .. } => unreachable!("Solo continuation rejected above"),
             _ => {} // Continue with Hive logic below
         }
 
@@ -16589,16 +16769,17 @@ mod tests {
         assert!(prompt.contains("supported; encouraged (authorized)"));
         assert!(prompt.contains("do not drop effort or reasoning settings"));
         assert!(prompt.contains("Shared Cell Integration"));
-        // Inject workaround section (issues #221/#226): assert it renders AND that the
-        // literal JSON braces survive format! as SINGLE braces. A brace-escaping slip
-        // compiles fine but emits a broken command, so assert the rendered text.
+        // Inject contract: the sender reports measured write/observation facts without
+        // claiming that output proves a managed turn.
         assert!(prompt.contains("## Messaging a Running Agent (inject)"));
-        assert!(prompt.contains("the message does NOT submit"));
-        assert!(prompt.contains(
-            r#"-d '{"target_agent_id":"session-modern-worker-N","message":""}'"#
-        ));
+        assert!(prompt.contains("two discrete PTY writes"));
+        assert!(prompt.contains("submit_keystroke_issued"));
+        assert!(prompt.contains("pty_activity_observed"));
+        assert!(prompt.contains("do **not** prove that the agent took a turn"));
+        assert!(!prompt.contains("payload and its newline share one PTY write"));
+        assert!(!prompt.contains("send a second, empty message"));
+        assert!(!prompt.contains("Measured against a live codex agent"));
         assert!(!prompt.contains("{{"));
-        assert!(prompt.contains("Never verify an inject by watching whether the agent acts"));
         assert!(prompt.contains("Principals do not commit"));
         assert!(prompt.contains("backend-created hive/session-modern/primary branch"));
         assert!(prompt.contains("Managed principals are visible Hive agents"));

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -1834,6 +1834,7 @@ impl SessionController {
                 .unwrap_or_default()
         };
         let heartbeats = self.agent_heartbeats.read();
+        let pty_manager = self.pty_manager.read();
         let agents = heartbeats.get(session_id);
         let mut recovered_after_injection = Vec::new();
         let mut stalled = Vec::new();
@@ -1863,7 +1864,7 @@ impl SessionController {
                 {
                     let runtime_status = agent_statuses.get(agent_id);
                     let process_dead = matches!(runtime_status, Some(AgentStatus::Error(_)))
-                        || !self.pty_manager.read().is_alive(agent_id);
+                        || !pty_manager.is_alive(agent_id);
                     let status = if process_dead {
                         AgentStatus::Error("process_not_alive".to_string())
                     } else if awaiting_since.is_some() {
@@ -1889,7 +1890,7 @@ impl SessionController {
             }
             if let Some(awaiting_since) = Self::awaiting_injected_turn_since(status) {
                 if (now - awaiting_since).num_seconds() > threshold_secs {
-                    let status = if !self.pty_manager.read().is_alive(agent_id) {
+                    let status = if !pty_manager.is_alive(agent_id) {
                         AgentStatus::Error("process_not_alive".to_string())
                     } else {
                         AgentStatus::WaitingForInput("awaiting_injected_turn".to_string())
@@ -1902,6 +1903,7 @@ impl SessionController {
                 }
             }
         }
+        drop(pty_manager);
         drop(heartbeats);
 
         if !recovered_after_injection.is_empty() {
@@ -13038,7 +13040,9 @@ The backend composed and persisted the following authoritative skeleton before l
             SessionType::Debate { .. } => {
                 return self.continue_debate_after_planning(session_id, &session);
             }
-            SessionType::Solo { .. } => unreachable!("Solo continuation rejected above"),
+            SessionType::Solo { .. } => {
+                return Err("Solo sessions do not support planning continuation".to_string());
+            }
             _ => {} // Continue with Hive logic below
         }
 

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -964,7 +964,7 @@ impl SessionStorage {
         Ok(message)
     }
 
-    /// Read conversation messages with optional since filter.
+    /// Read a canonical conversation plus any legacy bare-key history, with an optional since filter.
     pub async fn read_conversation(
         &self,
         session_id: &str,
@@ -972,13 +972,19 @@ impl SessionStorage {
         since: Option<DateTime<Utc>>,
     ) -> Result<Vec<ConversationMessage>, StorageError> {
         let path = self.conversation_file_path(session_id, agent_id);
+        let legacy_path = agent_id
+            .strip_prefix(&format!("{}-", session_id))
+            .map(|bare_id| self.conversation_file_path(session_id, bare_id));
 
         tokio::task::spawn_blocking(move || -> Result<Vec<ConversationMessage>, StorageError> {
-            if !path.exists() {
-                return Ok(Vec::new());
+            let mut messages = Vec::new();
+            for candidate in legacy_path.into_iter().chain(std::iter::once(path)) {
+                if candidate.exists() {
+                    let content = fs::read_to_string(candidate)?;
+                    messages.extend(parse_conversation_messages(&content));
+                }
             }
-            let content = fs::read_to_string(&path)?;
-            let mut messages = parse_conversation_messages(&content);
+            messages.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
             if let Some(since_ts) = since {
                 messages.retain(|m| m.timestamp > since_ts);
             }

--- a/src-tauri/src/storage/mod.rs
+++ b/src-tauri/src/storage/mod.rs
@@ -971,17 +971,15 @@ impl SessionStorage {
         agent_id: &str,
         since: Option<DateTime<Utc>>,
     ) -> Result<Vec<ConversationMessage>, StorageError> {
-        let path = self.conversation_file_path(session_id, agent_id);
-        let legacy_path = agent_id
-            .strip_prefix(&format!("{}-", session_id))
-            .map(|bare_id| self.conversation_file_path(session_id, bare_id));
+        let candidate_paths = self.conversation_file_candidates(session_id, agent_id);
 
         tokio::task::spawn_blocking(move || -> Result<Vec<ConversationMessage>, StorageError> {
             let mut messages = Vec::new();
-            for candidate in legacy_path.into_iter().chain(std::iter::once(path)) {
-                if candidate.exists() {
-                    let content = fs::read_to_string(candidate)?;
-                    messages.extend(parse_conversation_messages(&content));
+            for candidate in candidate_paths {
+                match fs::read_to_string(&candidate) {
+                    Ok(content) => messages.extend(parse_conversation_messages(&content)),
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(error) => return Err(StorageError::Io(error)),
                 }
             }
             messages.sort_by(|left, right| left.timestamp.cmp(&right.timestamp));
@@ -998,6 +996,18 @@ impl SessionStorage {
         self.session_dir(session_id)
             .join("conversations")
             .join(format!("{}.md", agent_id))
+    }
+
+    fn conversation_file_candidates(&self, session_id: &str, agent_id: &str) -> Vec<PathBuf> {
+        let canonical_path = self.conversation_file_path(session_id, agent_id);
+        let legacy_path = agent_id
+            .strip_prefix(&format!("{}-", session_id))
+            .map(|bare_id| self.conversation_file_path(session_id, bare_id));
+
+        legacy_path
+            .into_iter()
+            .chain(std::iter::once(canonical_path))
+            .collect()
     }
 
     fn artifact_dir(&self, session_id: &str) -> PathBuf {
@@ -1477,16 +1487,24 @@ impl SessionStorage {
         session_id: &str,
         agent_id: &str,
     ) -> Result<Option<String>, StorageError> {
-        let path = self.conversation_file_path(session_id, agent_id);
-        if !path.exists() {
-            return Ok(None);
+        for candidate in self
+            .conversation_file_candidates(session_id, agent_id)
+            .into_iter()
+            .rev()
+        {
+            match fs::read_to_string(&candidate) {
+                Ok(content) => {
+                    if let Some(message) = parse_conversation_messages(&content).into_iter().last()
+                    {
+                        return Ok(Some(message.content));
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => return Err(StorageError::Io(error)),
+            }
         }
 
-        let content = fs::read_to_string(path)?;
-        Ok(parse_conversation_messages(&content)
-            .into_iter()
-            .last()
-            .map(|message| message.content))
+        Ok(None)
     }
 
     fn atomic_write_json<T: Serialize>(&self, path: &Path, value: &T) -> Result<(), StorageError> {

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -1387,10 +1387,10 @@ curl "{{api_base_url}}/api/sessions/{{session_id}}/learnings"
 
 ## Inter-Agent Communication
 ### Check your inbox:
-curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?since=<last_check_ts>"
+curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-queen?since=<last_check_ts>"
 ### Send message to worker:
-curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
-### Broadcast to all:
+curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
+### Broadcast to all (reserved session-wide key `shared`):
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
 ### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
@@ -1528,10 +1528,10 @@ When you independently verify a researcher's findings are complete, immediately 
 
 ### Inter-Agent Communication
 #### Check your inbox:
-curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?since=<last_check_ts>"
+curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-queen?since=<last_check_ts>"
 #### Send message to worker:
-curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
-#### Broadcast to all:
+curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
+#### Broadcast to all (reserved session-wide key `shared`):
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
 #### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
@@ -1610,10 +1610,10 @@ curl "{{api_base_url}}/api/sessions/{{session_id}}/learnings"
 
 ## Inter-Agent Communication
 ### Check your inbox:
-curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/queen?since=<last_check_ts>"
+curl -fsS "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-queen?since=<last_check_ts>"
 ### Send message to worker:
-curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
-### Broadcast to all:
+curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/{{session_id}}-worker-N/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Your message"}'
+### Broadcast to all (reserved session-wide key `shared`):
 curl -fsS -X POST "{{api_base_url}}/api/sessions/{{session_id}}/conversations/shared/append" -H "Content-Type: application/json" -d '{"from":"queen","content":"Announcement"}'
 ### Heartbeat ({{heartbeat_cadence}}):
 {{queen_heartbeat_snippet}}
@@ -2351,6 +2351,35 @@ mod tests {
             DEFAULT_API_BASE_URL
         );
         assert_eq!(normalize_api_base_url(None), DEFAULT_API_BASE_URL);
+    }
+
+    #[test]
+    fn builtin_queen_prompts_use_full_conversation_ids_and_reserved_shared_key() {
+        let context = PromptContext {
+            session_id: "session-245".to_string(),
+            project_path: ".".to_string(),
+            task: None,
+            variables: HashMap::new(),
+        };
+
+        for template_name in ["queen-hive", "queen-research", "queen-fusion"] {
+            let prompt = TemplateEngine::default()
+                .render_template(template_name, &context)
+                .expect("render Queen prompt");
+
+            assert!(prompt.contains(
+                "/api/sessions/session-245/conversations/session-245-queen?since="
+            ));
+            assert!(prompt.contains(
+                "/api/sessions/session-245/conversations/session-245-worker-N/append"
+            ));
+            assert!(prompt.contains(
+                "/api/sessions/session-245/conversations/shared/append"
+            ));
+            assert!(prompt.contains("reserved session-wide key `shared`"));
+            assert!(!prompt.contains("/conversations/queen"));
+            assert!(!prompt.contains("/conversations/worker-N"));
+        }
     }
 
     #[test]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/lib/components/workgraph/WorkGraphView.svelte
+++ b/src/lib/components/workgraph/WorkGraphView.svelte
@@ -235,12 +235,8 @@
       </div>
     {:else if isEmpty}
       <div class="wg-msg">
-        <p class="wg-msg-title">No work graph for this session</p>
-        <p class="wg-msg-body">
-          The endpoint answered, so this is not a connection problem — the session simply has no
-          graph to project. A graph is built when a plan is parsed at <code>PlanReady</code>;
-          sessions started before the work graph shipped have none.
-        </p>
+        <p class="wg-msg-title">No tasks in this work graph</p>
+        <p class="wg-msg-body">The work graph endpoint returned no task nodes for this session.</p>
       </div>
     {:else if graph}
       <svg

--- a/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
+++ b/src/lib/components/workgraph/WorkGraphView.svelte.test.ts
@@ -153,7 +153,11 @@ describe('WorkGraphView', () => {
     const { container } = render(WorkGraphView);
     await settle();
 
-    expect(screen.getByText('No work graph for this session')).toBeTruthy();
+    expect(screen.getByText('No tasks in this work graph')).toBeTruthy();
+    expect(
+      screen.getByText('The work graph endpoint returned no task nodes for this session.')
+    ).toBeTruthy();
+    expect(container.textContent).not.toContain('started before the work graph shipped');
     expect(container.querySelector('.wg-svg')).toBeNull();
   });
 


### PR DESCRIPTION
Fixes five defects observed live in smoke-test session `257c130c` on build v0.44.1. Base `4364197`, no `origin/main` drift.

Closes #240
Closes #242
Closes #243
Closes #244
Closes #245

## #240 — Work graph never built from a plan that parses cleanly

The issue hypothesised the session "skipped `PlanReady`". True but incomplete. The real chain: the sole **plan-derived** graph writer `mark_plan_ready` was **unreachable in production**. The only production exit from planning is `PlanView.svelte` → `continue_after_planning`, which launched the hive directly and never built the graph; the frontend store method `markPlanReady` had **zero callers**.

This is the repo's own *"Correct + Tested != Reachable"* failure mode — `mark_plan_ready` had ~10 tests and no production call site. The enforced Rust reachability gate could not catch it, because the dead link was on the TypeScript side where the gate is advisory only.

- The build is hoisted into `continue_after_planning` **ahead of the session-type dispatch**, so all four branches that can reach `Running` (Hive, Swarm, Fusion, Debate) are covered *by construction* rather than by four separate patches. None waved off as unreachable.
- Guarded on `Planning`, so the `PlanReady` retry remains a deliberate no-op instead of erroring.
- **Correction to the issue text:** the empty file was a *creation-time seed*, not an absent write — `storage/mod.rs` writes `{"nodes":[],"edges":[],"omissions":[]}` at session creation. An unparseable/missing `plan.md` now records a typed `WorkGraphOmission` (`SourceUnreadable` / `ResolutionIncomplete`) so the seed is distinguishable from a clean build. **Launch is never blocked.**
- `WorkGraphView` no longer asserts "sessions started before the work graph shipped have none" — false for the session that produced this issue.

## #244 — Declared deps not gated; queue rows disagree with live agent status

**The gate was correct; it failed *open* on empty data.** The 409 machinery and `ClaimOutcome::ResolutionIncomplete` already existed. With an empty graph no dependency edges are ever seeded, so the correlated predicate inside `try_claim_for_worker`'s `UPDATE` found nothing blocking and the claim won.

§1 was therefore genuinely **downstream of #240** and is not "fixed" by rewriting the gate. The only new work was one `else` branch in `queue_scheduling_facts` returning `(Vec::new(), Preserve)` when the graph is absent or edgeless. That branch now fail-closes as `ResolutionIncomplete`, while a legitimately edgeless single-task plan is still admitted.

- **The readiness predicate is unchanged and stays inside the atomic `UPDATE`.** No gate was hoisted into a pre-read; check-then-act is not reintroduced.
- §2: `GET /workers` no longer projects a dead `Running` roster row whose task maps to a durably queued canonical `pending:` row.
- **Authority documented:** `agent_run_queue` is durable assignment/readiness/lifecycle truth; `Session.agents` is roster metadata; PTY is process truth.
- **Scope honesty:** the roster is set `Running` before the queue outcome is known, so the disagreement window is structural. This removes the **durable** failed-cleanup projection only; transient disagreement remains by design. No total invariant is claimed.

## #245 — Conversation keys not normalized

Short and full agent keys now resolve to one canonical record on read, append, **and the live-push event**. Normalization happens once at the handler entry point, so the emitted Tauri event id matches what the UI selects — a message sent while a tab is open renders without a reload. Fixing only read/append would have left live delivery broken while tests went green.

- `shared` is now an **explicit reserved unprefixed** broadcast key. Previously it survived only by string coincidence (frontend hardcodes the tab id, prompts hardcode the literal).
- Pre-existing bare-key history resolves **at read time** — no destructive migration on operator data.
- The Resolver's bare-`"queen"` consumer is preserved; canonicalizing blindly would have silently emptied `queen_summary`.
- `validate_agent_id` traversal defence still runs before any normalization.
- All 14 prompt literals corrected, with a negative-assertion test pinning them.
- **No frontend change was required** — the UI was already self-consistent. The mismatch was entirely prompts-vs-API.

## #242 / #243 — Inject observability

**Scope honesty, and it matters.** `git grep` for the ONE-CALL/TWO-CALL instruction and for the worker-side timeout instruction returns **zero hits across the tracked repo**. Neither exists here — both were session-authored operator/Queen text living in the smoke-test session's own `plan.md` and task files.

#243 is titled `fix(prompts)` and its suggestions 1–3 target receiver-side prompts. **There are no such prompts in this repository to fix.** No prompt edits were manufactured to make the issues look addressed. The durable deliverable is the measurement gap:

- All three inject routes now return **sender-side measured facts**: whether a submit keystroke was issued, byte counts, and a bounded post-submit PTY-activity observation built on the **existing** `pty-buffer` ring rather than a new instrument.
- The response **explicitly disclaims** that this proves a write plus an observation window — **not** that the agent took a turn. This is a hard requirement: presenting measured facts as proof-of-turn would recreate #243's exact failure, a confident verdict the evidence does not support.
- The **stale mechanism claim** in the Queen prompt ("the payload and its newline share one PTY write") is corrected — the code has performed two discrete writes separated by a gap for its whole tested history.
- "Awaiting an injected turn" is a typed condition on the **canonical `pty::AgentStatus`** enum. The `domain` and `CellStatus` enums remain projections — **no fourth status surface** was added to three already-drifting vocabularies.
- **An inject is sender activity, not agent liveness.** A fresh awaiting marker cannot rebase or mask an already-stale heartbeat; heartbeat-bearing agents age from `last_activity`, with the inject timestamp only a fallback for pre-first-heartbeat agents.
- The heartbeat vocabulary stays **closed** (`working`/`idle`/`completed`) — a blocked receiver cannot self-report, so a new value would be unusable.
- Documented plainly: **worker-authored timeouts are unenforceable for inject-blocked agents**, and the stall sweep is a Tauri `.setup()` task that **does not run headless**.

### #241 is out of scope and unfixed

The PTY submit path and the 50 ms `submit_gap` are **not modified**. No claim is made about current submit behaviour — `docs/pty-submit-sweep.md`'s evidence ledger remains `_unmeasured_` for this build, so nobody should assert the submit path is working or broken without running that procedure.

## Validation

| Gate | Result |
|---|---|
| `cargo test --lib` | **825 passed**, 0 failed, 1 ignored |
| `cargo clippy --all-targets` | clean |
| Rust reachability (**enforced**) | 146 modules, **0 findings** |
| `verify_vendor.py` | 3/3 OK |
| `npm run check` | **0 errors, 0 warnings** |
| WorkGraph vitest | **7/7** |

**Every lane proved its tests by mutation** — break the production line, watch the test go red, restore. Notable proofs: #240 went red at `left: 0, right: 5`; #244 went red **bidirectionally** (`201`/`409` and `409`/`201`), pinning both that unknown tasks are now rejected *and* that valid ones are still admitted; the inject no-turn disclaimer and the `Idle`-collapse discrimination were each pinned by their own mutation.

A regression caught during integration is worth noting: the typed-awaiting work initially broke a pre-existing stall-coverage test. It was fixed **in production logic, not by editing the assertion**, after deciding on the record that the old expectation remained authoritative.

### Known local-only red (not a gate failure)

The full `npm test` run cannot complete on this machine: an **unrelated** `StatusPanel` suite crashes the vitest worker pool with tinypool `Worker exited unexpectedly` on local **Node v22.22.2**. That file imports nothing from this diff. **CI pins Node 20** and is the authority. Flagging rather than papering over it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added measured injection results with submission status, timing, and output observations.
  * Improved agent stall reporting with statuses such as awaiting input, idle, or crashed.
  * Added safer task queue handling and clearer incomplete-resolution responses.
  * Improved conversation history across session-specific, shared, and legacy conversations.
  * Added reliable planning graphs across supported session types.
* **Bug Fixes**
  * Prevented stale worker entries when queued tasks cannot start.
  * Preserved legacy conversation history during migration.
* **UI**
  * Clarified the empty work graph message.
* **Release**
  * Updated the application to version 0.45.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->