### PR TITLE
fix(#258,#259): preserve partial work graphs and retry a swallowed submit (v0.46.2)

### DIFF
--- a/docs/pty-submit-sweep.md
+++ b/docs/pty-submit-sweep.md
@@ -70,9 +70,15 @@ The inject response reports measured facts, not request echoes:
 - `payload_bytes_written` counts the sanitized payload bytes actually written inside the
   envelope (embedded `ESC[201~` sequences are stripped before framing).
 - `submit_bytes_written` counts all discrete Enter bytes actually written;
-  `submit_keystroke_issued` is derived from the initial write. `submit_attempts` is `0` when
-  submit was not requested, `1` when the initial Enter was not confidently rejected, and `2`
-  when the one bounded retry ran.
+  `submit_keystroke_issued` is derived from the initial write. `submit_attempts` counts the Enter
+  writes that actually landed: `0` when submit was not requested, `1` when exactly one Enter was
+  written, and `2` when the one bounded retry also wrote. Note that `1` therefore covers two
+  distinct cases — the initial Enter was not confidently rejected so no retry was needed, **and**
+  the retry was attempted but its write failed. Read `submit_retry_failed` to tell them apart.
+- `submit_confirmation_window_ms` is **per attempt** (1,500 ms) while
+  `submit_confirmation_elapsed_ms` is **cumulative across attempts**. After a retry the elapsed
+  value can therefore approach 3,000 ms and legitimately exceed the reported window — do not
+  compute `elapsed / window` or assert `elapsed <= window`.
 - `submit_confirmed` is a tri-state delivery heuristic observed from the PTY output ring
   after an Enter write, over a bounded 1,500 ms window per attempt: `true` means sustained ring
   activity consistent with the composer accepting Enter and starting a turn, `false` means

--- a/docs/pty-submit-sweep.md
+++ b/docs/pty-submit-sweep.md
@@ -3,7 +3,10 @@
 This procedure measures whether a discrete bare carriage return submits input to each
 supported agent composer after a configurable delay. It deliberately does not infer success
 from a marker file, an agent reply, or any other downstream action: those signals are
-confounded when an operator is present and can press Enter.
+confounded when an operator is present and can press Enter. That constraint is asymmetric:
+operator interference invalidates a positive "submitted" observation, but text visibly
+remaining in the composer is admissible negative evidence because a keypress cannot
+manufacture the staged payload.
 
 The read-only instrument is:
 
@@ -35,7 +38,9 @@ keep `byte_count` directly comparable to the fixture byte length.
   for a window after a fast raw byte burst) from swallowing the follow-up `\r` as a
   literal newline inside the paste.
 - Enter is still a bare `\r` written as its own discrete PTY write; no `\n` is appended
-  and Enter is outside the bracketed-paste envelope.
+  and Enter is outside the bracketed-paste envelope. If the first observation returns the
+  confident negative `submit_confirmed: false`, the HTTP inject path writes exactly one more
+  bare `\r` and observes once more. Confirmed and ambiguous first observations do not retry.
 - An empty payload with `"submit": true` writes only the bare `\r` — this is the
   supported flush for content already staged in a composer.
 - A multi-line payload retains its internal newlines and receives one Enter after the whole
@@ -58,21 +63,35 @@ too short but do not support replacing it with another guessed constant. Note th
 observations predate the #256 bracketed envelope, which removes the dependency on the gap
 for paste-coalescing composers rather than tuning it.
 
-## Sender receipt and delivery signal (#256)
+## Sender receipt and delivery signal (#256, #259)
 
 The inject response reports measured facts, not request echoes:
 
 - `payload_bytes_written` counts the sanitized payload bytes actually written inside the
   envelope (embedded `ESC[201~` sequences are stripped before framing).
-- `submit_bytes_written` counts the discrete Enter write itself; `submit_keystroke_issued`
-  is derived from it.
+- `submit_bytes_written` counts all discrete Enter bytes actually written;
+  `submit_keystroke_issued` is derived from the initial write. `submit_attempts` is `0` when
+  submit was not requested, `1` when the initial Enter was not confidently rejected, and `2`
+  when the one bounded retry ran.
 - `submit_confirmed` is a tri-state delivery heuristic observed from the PTY output ring
-  after the Enter write, over a bounded 1,500 ms window: `true` means sustained ring
+  after an Enter write, over a bounded 1,500 ms window per attempt: `true` means sustained ring
   activity consistent with the composer accepting Enter and starting a turn, `false` means
   the Enter produced no observable ring reaction at all, and `null` means unknown,
   unobservable, or `"submit": false`. An agent that was already streaming output can
   produce a false positive; the field never upgrades an ambiguous buffer observation to a
   sweep PASS.
+- The retry is keyed strictly on the first `false` verdict and is capped at one extra CR.
+  Its observation baseline is captured after that CR so local echo cannot become false
+  receiver evidence. The response reports the retry observation as the final verdict; two
+  quiet windows therefore remain `false`. A false negative can double-execute a turn on a
+  non-idempotent composer, so the matrix measurement must settle that risk before any widening.
+- Issue #260 tracks the opposite live failure: during this session, four injects to three
+  busy codex principals returned `submit_confirmed: true` with
+  `sustained-post-submit-activity` even though each payload remained visibly staged and needed
+  a later bare-Enter flush. Busy receiver output can therefore create a false positive that
+  bypasses this strictly `Some(false)`-keyed retry. The classifier and retry key remain
+  unchanged for #259; the sweep must treat `true` as sender-side evidence, never as a PASS
+  without controlled receiver-buffer confirmation.
 
 ## Two-call workaround
 
@@ -88,6 +107,8 @@ curl -X POST .../inject -d '{"target_agent_id":"...","message":"","submit":true}
 ```
 
 ## Evidence status before this sweep
+
+Issue #241 owns this sweep matrix and the single-call receiver-side assertion.
 
 No cell has been measured against the current per-adapter policy and T6 instrument. Each cell
 below must be measured in two controlled states: **idle at the prompt** and **mid-generation**.
@@ -108,8 +129,10 @@ matrix cells because their adapter, payload class, and busy state were not all c
 2. Start a fresh backend for each gap candidate with
    `HIVE_PTY_SUBMIT_GAP_MS=<milliseconds>` set before launch.
 3. Start a fresh real session for the selected adapter and record its session and agent IDs.
-4. The operator must not focus the target terminal or touch the keyboard from immediately
-   before injection until after the buffer observation is recorded.
+4. For a positive PASS, the operator must not focus the target terminal or touch the keyboard
+   from immediately before injection until after the buffer observation is recorded. A
+   visibly staged payload remains admissible FAIL evidence even if the operator was present,
+   because operator input can confound submission but cannot manufacture that negative state.
 5. Record the build SHA, OS/ConPTY version, adapter CLI version, model, session/agent IDs,
    candidate gap, payload class, attempt number, and whether the agent was visibly busy.
 
@@ -158,22 +181,25 @@ gap:
 
 4. Without touching the target terminal, repeat the PTY-buffer `GET` at 250 ms, 1 second,
    5 seconds, and 10 seconds after the configured gap. Save every raw status and response;
-   do not rely on a transient UI repaint. Note that since #256 the inject POST itself can
-   stay pending up to ~1,500 ms after the Enter write while the `submit_confirmed`
-   observation runs, so issue the POST from a separate shell (or background it) rather
-   than waiting for its response — otherwise the 250 ms and 1 second samples are missed
-   before the POST returns.
+   do not rely on a transient UI repaint. Note that the inject POST itself can stay pending
+   up to ~1,500 ms after one Enter write, or ~3,000 ms when a confident negative triggers
+   the single retry and second observation. Issue the POST from a separate shell (or
+   background it) rather than waiting for its response — otherwise the 250 ms and 1 second
+   samples are missed before the POST returns.
 5. Score the current terminal state reconstructed from the PTY output:
 
    - **PASS**: the unique payload is no longer sitting in the composer and the buffer shows
      the composer accepted the discrete Enter.
    - **FAIL**: the unique payload remains in the composer, including the literal-newline or
      shift-Enter shape documented by issue #226.
-   - **INVALID**: the operator touched the keyboard, the 8 KB tail evicted the observation,
-     the process exited, or output is insufficient to distinguish submitted from staged.
+   - **INVALID**: for a claimed PASS, the operator touched the keyboard; or, for either result,
+     the 8 KB tail evicted the observation, the process exited, or output is insufficient to
+     distinguish submitted from staged.
 
    A marker file, response text, or other downstream agent action is supporting context only;
-   it never upgrades an ambiguous buffer observation to PASS.
+   it never upgrades an ambiguous buffer observation to PASS. Operator interference likewise
+   cannot establish a PASS, but a payload visibly resident in the composer is always admissible
+   FAIL evidence.
 6. Repeat until there are three valid attempts for that adapter/payload/state/gap cell. Record
    every invalid attempt
    and its cause, but exclude it from the pass denominator.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive-manager",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "Multi-agent orchestration and monitoring for Claude Code workflows",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1683,7 +1683,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive-manager"
-version = "0.46.1"
+version = "0.46.2"
 dependencies = [
  "async-trait",
  "axum",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive-manager"
-version = "0.46.1"
+version = "0.46.2"
 description = "Multi-agent orchestration and monitoring for Claude Code workflows"
 authors = ["RDuff"]
 edition = "2021"

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -730,7 +730,9 @@ pub(crate) fn parse_plan_markdown_checked(
     }
 }
 
-fn parse_plan_markdown_with_diagnostics(content: &str) -> (SessionPlan, Vec<String>) {
+pub(crate) fn parse_plan_markdown_with_diagnostics(
+    content: &str,
+) -> (SessionPlan, Vec<String>) {
     let mut title = String::new();
     let mut summary = String::new();
     let mut tasks: Vec<PlanTask> = Vec::new();
@@ -780,16 +782,14 @@ fn parse_plan_markdown_with_diagnostics(content: &str) -> (SessionPlan, Vec<Stri
     if title.is_empty() {
         title = "Plan in Progress...".to_string();
     }
-    if tasks.iter().any(|task| task.explicit_id) {
-        for task in tasks
-            .iter()
-            .filter(|task| task.checkbox_source && !task.explicit_id)
-        {
-            diagnostics.push(format!(
-                "schedulable checkbox task is missing a stable T<number>: id: {}",
-                task.title
-            ));
-        }
+    for task in tasks
+        .iter()
+        .filter(|task| task.checkbox_source && !task.explicit_id)
+    {
+        diagnostics.push(format!(
+            "schedulable checkbox task is missing a stable T<number>: id: {}",
+            task.title
+        ));
     }
 
     (
@@ -893,6 +893,11 @@ fn extract_explicit_task_id(text: &str) -> (String, Option<TaskId>) {
     let Some((candidate, remainder)) = text.split_once(':') else {
         return (text.to_string(), None);
     };
+    let candidate = candidate.trim();
+    let candidate = candidate
+        .strip_prefix('[')
+        .and_then(|candidate| candidate.split_once(']'))
+        .map_or(candidate, |(_, candidate)| candidate.trim_start());
     let mut chars = candidate.chars();
     let is_explicit_id = matches!(chars.next(), Some('T' | 't'))
         && chars.clone().next().is_some()
@@ -1014,6 +1019,55 @@ mod tests {
 
         assert_eq!(title, "Fix launch regression");
         assert_eq!(priority.as_deref(), Some("high"));
+    }
+
+    #[test]
+    fn task_line_resolves_explicit_id_with_optional_bracket_label_and_spacing() {
+        let cases = [
+            ("P4", "- [ ] [P4] T4: title", "T4"),
+            ("P18", "- [ ] [P18] T18: title", "T18"),
+            ("Queen", "- [ ] [Queen] T5: title", "T5"),
+            ("Operator", "- [ ] [Operator] T6: title", "T6"),
+            ("bare-T", "- [ ] T7: title", "T7"),
+            ("spaced-colon", "- [ ] T8 : title", "T8"),
+        ];
+
+        for (case, line, expected_id) in cases {
+            let mut counter = 0;
+            let task = parse_task_line(line, &mut counter)
+                .unwrap_or_else(|| panic!("{case}: expected a parsed task"));
+
+            assert_eq!(task.id, expected_id, "{case}");
+            assert!(task.explicit_id, "{case}");
+            assert_eq!(task.title, "title", "{case}");
+        }
+    }
+
+    #[test]
+    fn task_line_keeps_recognized_priority_tokens() {
+        let cases = [
+            ("HIGH", "high"),
+            ("MEDIUM", "medium"),
+            ("LOW", "low"),
+            ("P1", "high"),
+            ("P2", "medium"),
+            ("P3", "low"),
+        ];
+
+        for (marker, expected_priority) in cases {
+            let mut counter = 0;
+            let line = format!("- [ ] [{marker}] T1: title");
+            let task = parse_task_line(&line, &mut counter)
+                .unwrap_or_else(|| panic!("{marker}: expected a parsed task"));
+
+            assert_eq!(task.id, "T1", "{marker}");
+            assert_eq!(task.title, "title", "{marker}");
+            assert_eq!(
+                task.priority.as_deref(),
+                Some(expected_priority),
+                "{marker}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/actions/coordination.rs
+++ b/src-tauri/src/actions/coordination.rs
@@ -782,14 +782,16 @@ pub(crate) fn parse_plan_markdown_with_diagnostics(
     if title.is_empty() {
         title = "Plan in Progress...".to_string();
     }
-    for task in tasks
-        .iter()
-        .filter(|task| task.checkbox_source && !task.explicit_id)
-    {
-        diagnostics.push(format!(
-            "schedulable checkbox task is missing a stable T<number>: id: {}",
-            task.title
-        ));
+    if tasks.iter().any(|task| task.explicit_id) {
+        for task in tasks
+            .iter()
+            .filter(|task| task.checkbox_source && !task.explicit_id)
+        {
+            diagnostics.push(format!(
+                "schedulable checkbox task is missing a stable T<number>: id: {}",
+                task.title
+            ));
+        }
     }
 
     (
@@ -997,7 +999,8 @@ fn extract_assignee(text: &str) -> (String, Option<String>) {
 #[cfg(test)]
 mod tests {
     use super::{
-        extract_assignee, extract_priority, parse_task_line, run_blocking_injection,
+        extract_assignee, extract_priority, parse_plan_markdown_with_diagnostics, parse_task_line,
+        run_blocking_injection,
     };
     use crate::coordination::InjectionError;
 
@@ -1108,6 +1111,17 @@ mod tests {
             extract_assignee("Title -> worker-1 -> trailing"),
             ("Title ".to_string(), Some("worker-1 -> trailing".to_string()))
         );
+    }
+
+    #[test]
+    fn legacy_checkbox_plan_has_no_missing_stable_id_diagnostics() {
+        let (plan, diagnostics) = parse_plan_markdown_with_diagnostics(
+            "# Legacy\n\n## Tasks\n- [ ] First positional task\n- [ ] Second positional task\n",
+        );
+
+        assert_eq!(plan.tasks.len(), 2);
+        assert!(plan.tasks.iter().all(|task| !task.explicit_id));
+        assert!(diagnostics.is_empty());
     }
 }
 

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -4,7 +4,8 @@ use axum::{
 };
 use serde::Deserialize;
 use serde_json::{json, Value};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use super::{validate_agent_id, validate_session_id};
@@ -42,6 +43,64 @@ struct InjectionMeasurement {
     observation: InjectionObservation,
     submit_attempts: usize,
     submit_bytes_written: usize,
+    submit_retry_failure: Option<String>,
+}
+
+type InjectionTransactionMutex = tokio::sync::Mutex<()>;
+type InjectionTransactionLockMap = HashMap<(usize, String), Weak<InjectionTransactionMutex>>;
+
+/// Serialize the complete write -> observe -> optional retry transaction per runtime/agent.
+///
+/// The map holds only weak references, so completed transactions do not retain one mutex per
+/// historical agent. Including the AppState identity keeps independent runtimes (and tests) from
+/// blocking each other when they happen to use the same agent id.
+fn injection_transaction_lock(state: &AppState, agent_id: &str) -> Arc<InjectionTransactionMutex> {
+    static LOCKS: OnceLock<parking_lot::Mutex<InjectionTransactionLockMap>> = OnceLock::new();
+
+    let key = (state as *const AppState as usize, agent_id.to_string());
+    let mut locks = LOCKS
+        .get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+        .lock();
+    locks.retain(|_, lock| lock.strong_count() > 0);
+    if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+        return lock;
+    }
+
+    let lock = Arc::new(InjectionTransactionMutex::new(()));
+    locks.insert(key, Arc::downgrade(&lock));
+    lock
+}
+
+#[cfg(all(test, windows))]
+type BeforeSubmitRetryHook =
+    std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + 'static>>;
+
+#[cfg(all(test, windows))]
+fn before_submit_retry_hooks() -> &'static parking_lot::Mutex<HashMap<usize, BeforeSubmitRetryHook>>
+{
+    static HOOKS: OnceLock<parking_lot::Mutex<HashMap<usize, BeforeSubmitRetryHook>>> =
+        OnceLock::new();
+    HOOKS.get_or_init(|| parking_lot::Mutex::new(HashMap::new()))
+}
+
+#[cfg(all(test, windows))]
+fn install_before_submit_retry_hook<F>(state: &AppState, hook: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    before_submit_retry_hooks()
+        .lock()
+        .insert(state as *const AppState as usize, Box::pin(hook));
+}
+
+#[cfg(all(test, windows))]
+async fn run_before_submit_retry_hook(state: &AppState) {
+    let hook = before_submit_retry_hooks()
+        .lock()
+        .remove(&(state as *const AppState as usize));
+    if let Some(hook) = hook {
+        hook.await;
+    }
 }
 
 impl InjectionObservation {
@@ -75,9 +134,7 @@ impl InjectionObservation {
 fn classify_submit_confirmation(change_offsets: &[Duration]) -> (Option<bool>, &'static str) {
     match change_offsets {
         [] => (Some(false), "no-post-submit-activity"),
-        [first, .., last]
-            if last.saturating_sub(*first) >= SUBMIT_CONFIRMATION_MIN_SPAN =>
-        {
+        [first, .., last] if last.saturating_sub(*first) >= SUBMIT_CONFIRMATION_MIN_SPAN => {
             (Some(true), "sustained-post-submit-activity")
         }
         _ => (None, "ambiguous-post-submit-activity"),
@@ -169,7 +226,7 @@ async fn observe_injection_with_retry(
     state: &AppState,
     agent_id: &str,
     receipt: &InjectionReceipt,
-) -> Result<InjectionMeasurement, ApiError> {
+) -> InjectionMeasurement {
     let mut observation = observe_submit(
         state,
         agent_id,
@@ -179,32 +236,53 @@ async fn observe_injection_with_retry(
     .await;
     let mut submit_attempts = usize::from(receipt.submit_keystroke_issued);
     let mut submit_bytes_written = receipt.submit_bytes_written;
+    let mut submit_retry_failure = None;
 
     if observation.submit_confirmed == Some(false) {
+        let first_confirmation_elapsed_ms = observation.submit_confirmation_elapsed_ms;
+        #[cfg(all(test, windows))]
+        run_before_submit_retry_hook(state).await;
+
         let pty_manager = Arc::clone(&state.pty_manager);
         let retry_agent_id = agent_id.to_string();
         let retry_result = tokio::task::spawn_blocking(move || {
             pty_manager.read().write(&retry_agent_id, SUBMIT_KEYSTROKE)
         })
-        .await
-        .map_err(|error| ApiError::internal(format!("Submit retry task failed: {error}")))?;
-        retry_result
-            .map_err(|error| ApiError::internal(format!("Submit retry failed: {error}")))?;
-        submit_attempts += 1;
-        submit_bytes_written += SUBMIT_KEYSTROKE.len();
+        .await;
+        let retry_result = retry_result
+            .map_err(|error| format!("Submit retry task failed: {error}"))
+            .and_then(|result| result.map_err(|error| format!("Submit retry failed: {error}")));
 
-        // Capture the new baseline after the retry write. PTYs with local echo (including
-        // the Windows test stub) mirror the CR into the ring; observing from the old
-        // baseline would misclassify that self-echo as receiver activity.
-        let retry_baseline = state.pty_manager.read().recent_output(agent_id);
-        observation = observe_submit(state, agent_id, true, retry_baseline.as_deref()).await;
+        match retry_result {
+            Ok(()) => {
+                submit_attempts += 1;
+                submit_bytes_written += SUBMIT_KEYSTROKE.len();
+
+                // Capture the new baseline after the retry write. PTYs with local echo
+                // (including the Windows test stub) mirror the CR into the ring; observing
+                // from the old baseline would misclassify that self-echo as receiver activity.
+                let retry_baseline = state.pty_manager.read().recent_output(agent_id);
+                let mut retry_observation =
+                    observe_submit(state, agent_id, true, retry_baseline.as_deref()).await;
+                retry_observation.submit_confirmation_elapsed_ms = first_confirmation_elapsed_ms
+                    .saturating_add(retry_observation.submit_confirmation_elapsed_ms);
+                observation = retry_observation;
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Initial injection succeeded but its bounded submit retry failed for {agent_id}: {error}"
+                );
+                submit_retry_failure = Some(error);
+            }
+        }
     }
 
-    Ok(InjectionMeasurement {
+    InjectionMeasurement {
         observation,
         submit_attempts,
         submit_bytes_written,
-    })
+        submit_retry_failure,
+    }
 }
 
 fn record_injection_submission(
@@ -213,16 +291,12 @@ fn record_injection_submission(
     agent_id: &str,
     receipt: &InjectionReceipt,
 ) {
-    if let Err(error) = state
-        .session_controller
-        .read()
-        .record_injection_submission(
-            session_id,
-            agent_id,
-            receipt.submitted_at,
-            receipt.submit_keystroke_issued,
-        )
-    {
+    if let Err(error) = state.session_controller.read().record_injection_submission(
+        session_id,
+        agent_id,
+        receipt.submitted_at,
+        receipt.submit_keystroke_issued,
+    ) {
         tracing::warn!(
             "Injection succeeded but its awaiting-turn observation was not recorded for {session_id}/{agent_id}: {error}"
         );
@@ -245,6 +319,8 @@ fn measured_response(
         "submit_keystroke_issued": receipt.submit_keystroke_issued,
         "submit_bytes_written": measurement.submit_bytes_written,
         "submit_attempts": measurement.submit_attempts,
+        "submit_retry_failed": measurement.submit_retry_failure.is_some(),
+        "submit_retry_failure": measurement.submit_retry_failure,
         "pty_observation_available": observation.pty_observation_available,
         "pty_output_bytes_before": receipt.pty_output_before.as_ref().map(String::len),
         "pty_output_bytes_after_write": receipt.pty_output_after_write.as_ref().map(String::len),
@@ -295,6 +371,8 @@ pub async fn operator_inject(
     validate_agent_id(&payload.target_agent_id)?;
 
     let target_agent_id = payload.target_agent_id.clone();
+    let transaction_lock = injection_transaction_lock(&state, &target_agent_id);
+    let _transaction_guard = transaction_lock.lock().await;
     let injection_target_agent_id = target_agent_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
@@ -309,7 +387,7 @@ pub async fn operator_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(|error| ApiError::internal(error.to_string()))?;
-    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await?;
+    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await;
     record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
     Ok(Json(measured_response(
@@ -329,6 +407,8 @@ pub async fn queen_inject(
     validate_agent_id(&payload.target_worker_id)?;
 
     let target_worker_id = payload.target_worker_id.clone();
+    let transaction_lock = injection_transaction_lock(&state, &target_worker_id);
+    let _transaction_guard = transaction_lock.lock().await;
     let injection_target_worker_id = target_worker_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
@@ -344,7 +424,7 @@ pub async fn queen_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(map_injection_error)?;
-    let measurement = observe_injection_with_retry(&state, &target_worker_id, &receipt).await?;
+    let measurement = observe_injection_with_retry(&state, &target_worker_id, &receipt).await;
     record_injection_submission(&state, &id, &target_worker_id, &receipt);
 
     Ok(Json(measured_response(
@@ -364,6 +444,8 @@ pub async fn evaluator_inject(
     validate_agent_id(&payload.target_agent_id)?;
 
     let target_agent_id = payload.target_agent_id.clone();
+    let transaction_lock = injection_transaction_lock(&state, &target_agent_id);
+    let _transaction_guard = transaction_lock.lock().await;
     let injection_target_agent_id = target_agent_id.clone();
     let manager = Arc::clone(&state.injection_manager);
     let injection_session_id = id.clone();
@@ -379,7 +461,7 @@ pub async fn evaluator_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(map_injection_error)?;
-    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await?;
+    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await;
     record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
     Ok(Json(measured_response(
@@ -490,9 +572,8 @@ mod tests {
 
     fn setup_test_app() -> (TempDir, Router, Arc<AppState>) {
         let temp_dir = TempDir::new().unwrap();
-        let storage = Arc::new(
-            SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap(),
-        );
+        let storage =
+            Arc::new(SessionStorage::new_with_base(temp_dir.path().to_path_buf()).unwrap());
         storage.create_session_dir(SESSION_ID).unwrap();
         let config = Arc::new(tokio::sync::RwLock::new(storage.load_config().unwrap()));
         let pty_manager = Arc::new(RwLock::new(PtyManager::new()));
@@ -538,9 +619,7 @@ mod tests {
                 24,
             )
             .unwrap();
-        let session_controller = Arc::new(RwLock::new(SessionController::new(
-            pty_manager.clone(),
-        )));
+        let session_controller = Arc::new(RwLock::new(SessionController::new(pty_manager.clone())));
         session_controller.write().set_storage(storage.clone());
         session_controller
             .read()
@@ -616,6 +695,8 @@ mod tests {
         assert_eq!(response["submit_keystroke_issued"], true);
         assert_eq!(response["submit_bytes_written"], 2);
         assert_eq!(response["submit_attempts"], 2);
+        assert_eq!(response["submit_retry_failed"], false);
+        assert_eq!(response["submit_retry_failure"], Value::Null);
         assert_eq!(response["pty_observation_available"], true);
         assert_eq!(response["pty_output_bytes_before"], 0);
         // The stub mirrors stdin into the ring: 6-byte start marker + 5-byte payload
@@ -632,6 +713,10 @@ mod tests {
             "no-post-submit-activity"
         );
         assert_eq!(response["submit_confirmation_window_ms"], 1500);
+        assert!(
+            response["submit_confirmation_elapsed_ms"].as_u64().unwrap() >= 2800,
+            "two quiet confirmation windows must report cumulative elapsed time: {response}"
+        );
         assert!(response["write_started_at"].is_string());
         assert!(response["submitted_at"].is_string());
         assert!(response["evidence_scope"]
@@ -675,6 +760,8 @@ mod tests {
         assert_eq!(response["submit_keystroke_issued"], false);
         assert_eq!(response["submit_bytes_written"], 0);
         assert_eq!(response["submit_attempts"], 0);
+        assert_eq!(response["submit_retry_failed"], false);
+        assert_eq!(response["submit_retry_failure"], Value::Null);
         assert_eq!(response["observation_window_ms"], 0);
         assert_eq!(response["observation_elapsed_ms"], 0);
         assert_eq!(response["pty_activity_observed"], Value::Null);
@@ -723,7 +810,13 @@ mod tests {
                 b"\r".to_vec()
             ]
         );
-        assert_eq!(writes.iter().filter(|write| write.as_slice() == b"\r").count(), 2);
+        assert_eq!(
+            writes
+                .iter()
+                .filter(|write| write.as_slice() == b"\r")
+                .count(),
+            2
+        );
         assert!(!writes.last().unwrap().contains(&b'\n'));
     }
 
@@ -773,16 +866,18 @@ mod tests {
             assert_eq!(response["submit_keystroke_issued"], true, "{path}");
             assert_eq!(response["submit_bytes_written"], 2, "{path}");
             assert_eq!(response["submit_attempts"], 2, "{path}");
+            assert_eq!(response["submit_retry_failed"], false, "{path}");
+            assert_eq!(response["submit_retry_failure"], Value::Null, "{path}");
             assert_eq!(response["pty_observation_available"], true, "{path}");
             assert!(response["pty_output_bytes_before"].is_number(), "{path}");
-            assert!(response["pty_output_bytes_after_write"].is_number(), "{path}");
+            assert!(
+                response["pty_output_bytes_after_write"].is_number(),
+                "{path}"
+            );
             assert_eq!(response["observation_window_ms"], 250, "{path}");
             assert_eq!(response["submit_confirmed"], false, "{path}");
             assert_eq!(response["submit_confirmation_window_ms"], 1500, "{path}");
-            assert!(
-                response["submit_confirmation_basis"].is_string(),
-                "{path}"
-            );
+            assert!(response["submit_confirmation_basis"].is_string(), "{path}");
             assert!(response["evidence_scope"]
                 .as_str()
                 .unwrap()
@@ -923,6 +1018,113 @@ mod tests {
         );
     }
 
+    /// Review finding 3: the staging request begins only after the submitting request has
+    /// completed its first quiet observation. Without the per-agent transaction lock, the
+    /// test hook gives the staged payload time to land before the delayed bare-Enter retry.
+    #[tokio::test]
+    async fn concurrent_injects_to_same_agent_do_not_cross_submit_staged_text() {
+        let (_temp_dir, app, state) = setup_test_app();
+        let (retry_ready_tx, retry_ready_rx) = tokio::sync::oneshot::channel();
+        install_before_submit_retry_hook(&state, async move {
+            let _ = retry_ready_tx.send(());
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        });
+
+        let submitting_app = app.clone();
+        let submitting = tokio::spawn(async move {
+            post_inject(
+                submitting_app,
+                "/api/sessions/inject-test/inject",
+                json!({ "target_agent_id": AGENT_ID, "message": "first" }),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(2), retry_ready_rx)
+            .await
+            .expect("initial quiet confirmation window")
+            .expect("retry hook signal");
+
+        let staged = tokio::spawn(async move {
+            post_inject(
+                app,
+                "/api/sessions/inject-test/inject",
+                json!({
+                    "target_agent_id": AGENT_ID,
+                    "message": "draft",
+                    "submit": false
+                }),
+            )
+            .await
+        });
+        let (submitting, staged) = tokio::join!(submitting, staged);
+        let (submit_status, submit_response) = submitting.unwrap();
+        let (stage_status, stage_response) = staged.unwrap();
+
+        assert_eq!(submit_status, StatusCode::OK, "{submit_response}");
+        assert_eq!(stage_status, StatusCode::OK, "{stage_response}");
+        assert_eq!(submit_response["submit_attempts"], 2);
+        assert_eq!(stage_response["submit_attempts"], 0);
+        assert_eq!(
+            state
+                .pty_manager
+                .read()
+                .write_records_for_test(AGENT_ID)
+                .unwrap(),
+            vec![
+                b"\x1b[200~".to_vec(),
+                b"first".to_vec(),
+                b"\x1b[201~".to_vec(),
+                b"\r".to_vec(),
+                b"\r".to_vec(),
+                b"draft".to_vec(),
+            ],
+            "staged text must be written only after the submitting transaction finishes"
+        );
+    }
+
+    /// Review finding 4: once the initial payload and Enter succeeded, losing the PTY before
+    /// the bounded retry is a receipt caveat, not an HTTP failure or reason to skip recording.
+    #[tokio::test]
+    async fn failed_submit_retry_returns_success_and_records_initial_submission() {
+        let (_temp_dir, app, state) = setup_test_app();
+        let pty_manager = Arc::clone(&state.pty_manager);
+        install_before_submit_retry_hook(&state, async move {
+            pty_manager.read().kill(AGENT_ID).unwrap();
+        });
+
+        let (status, response) = post_inject(
+            app,
+            "/api/sessions/inject-test/inject",
+            json!({ "target_agent_id": AGENT_ID, "message": "go" }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{response}");
+        assert_eq!(response["status"], "success");
+        assert_eq!(response["submit_attempts"], 1);
+        assert_eq!(response["submit_bytes_written"], 1);
+        assert_eq!(response["submit_retry_failed"], true);
+        assert!(response["submit_retry_failure"]
+            .as_str()
+            .unwrap()
+            .contains("Submit retry failed"));
+        assert_eq!(response["submit_confirmed"], false);
+        assert!(matches!(
+            state
+                .session_controller
+                .read()
+                .get_session(SESSION_ID)
+                .unwrap()
+                .agents
+                .into_iter()
+                .find(|agent| agent.id == AGENT_ID)
+                .unwrap()
+                .status,
+            AgentStatus::WaitingForInput(reason)
+                if reason.starts_with("awaiting_injected_turn:")
+        ));
+    }
+
     /// #256: sustained post-submit ring activity flips submit_confirmed to true. A
     /// background task plays the role of the child TUI repainting after it accepted
     /// the Enter.
@@ -985,10 +1187,7 @@ mod tests {
             "a single repaint also matches a swallowed Enter"
         );
         assert_eq!(
-            classify_submit_confirmation(&[
-                Duration::from_millis(40),
-                Duration::from_millis(120)
-            ]),
+            classify_submit_confirmation(&[Duration::from_millis(40), Duration::from_millis(120)]),
             (None, "ambiguous-post-submit-activity"),
             "a short burst is not sustained activity"
         );
@@ -1030,10 +1229,8 @@ mod tests {
             .unwrap();
         state.pty_manager.read().kill(QUEEN_ID).unwrap();
 
-        let reports = controller.get_stalled_agent_reports(
-            SESSION_ID,
-            std::time::Duration::from_secs(30),
-        );
+        let reports =
+            controller.get_stalled_agent_reports(SESSION_ID, std::time::Duration::from_secs(30));
         let status_for = |agent_id: &str| {
             reports
                 .iter()

--- a/src-tauri/src/http/handlers/inject.rs
+++ b/src-tauri/src/http/handlers/inject.rs
@@ -19,6 +19,7 @@ fn default_submit() -> bool {
 const INJECTION_EVIDENCE_SCOPE: &str = "These facts prove only that bytes were written and the PTY output ring was observed for a bounded window; they do not prove that the agent took a turn. submit_confirmed is heuristic: true means sustained post-submit ring activity consistent with the composer accepting Enter, false means Enter produced no observable reaction within the confirmation window, null means unknown or not applicable. An agent that was already streaming output can produce a false positive.";
 const INJECTION_ACTIVITY_OBSERVATION_WINDOW: Duration = Duration::from_millis(250);
 const INJECTION_ACTIVITY_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const SUBMIT_KEYSTROKE: &[u8] = b"\r";
 /// How long the sender watches the ring for delivery evidence after the Enter write (#256).
 const SUBMIT_CONFIRMATION_WINDOW: Duration = Duration::from_millis(1500);
 /// Minimum spread between the first and last observed ring change for the activity to
@@ -35,6 +36,12 @@ struct InjectionObservation {
     submit_confirmation_basis: &'static str,
     submit_confirmation_window_ms: u64,
     submit_confirmation_elapsed_ms: u64,
+}
+
+struct InjectionMeasurement {
+    observation: InjectionObservation,
+    submit_attempts: usize,
+    submit_bytes_written: usize,
 }
 
 impl InjectionObservation {
@@ -77,27 +84,28 @@ fn classify_submit_confirmation(change_offsets: &[Duration]) -> (Option<bool>, &
     }
 }
 
-async fn observe_injection(
+async fn observe_submit(
     state: &AppState,
     agent_id: &str,
-    receipt: &InjectionReceipt,
+    submit_keystroke_issued: bool,
+    pty_output_after_write: Option<&str>,
 ) -> InjectionObservation {
-    if !receipt.submit_keystroke_issued {
+    if !submit_keystroke_issued {
         return InjectionObservation::unobserved(
-            receipt.pty_output_after_write.is_some(),
-            receipt.pty_output_after_write.as_ref().map(String::len),
+            pty_output_after_write.is_some(),
+            pty_output_after_write.map(str::len),
             "not-submitted",
         );
     }
 
-    let Some(baseline) = receipt.pty_output_after_write.as_ref() else {
+    let Some(baseline) = pty_output_after_write else {
         return InjectionObservation::unobserved(false, None, "pty-unobservable");
     };
 
     let observation_started = Instant::now();
     let confirmation_deadline = observation_started + SUBMIT_CONFIRMATION_WINDOW;
-    let mut previous = baseline.clone();
-    let mut output_after = Some(baseline.clone());
+    let mut previous = baseline.to_owned();
+    let mut output_after = Some(baseline.to_owned());
     let mut first_activity_elapsed: Option<Duration> = None;
     let mut change_offsets: Vec<Duration> = Vec::new();
     let mut ring_lost = false;
@@ -157,6 +165,48 @@ async fn observe_injection(
     }
 }
 
+async fn observe_injection_with_retry(
+    state: &AppState,
+    agent_id: &str,
+    receipt: &InjectionReceipt,
+) -> Result<InjectionMeasurement, ApiError> {
+    let mut observation = observe_submit(
+        state,
+        agent_id,
+        receipt.submit_keystroke_issued,
+        receipt.pty_output_after_write.as_deref(),
+    )
+    .await;
+    let mut submit_attempts = usize::from(receipt.submit_keystroke_issued);
+    let mut submit_bytes_written = receipt.submit_bytes_written;
+
+    if observation.submit_confirmed == Some(false) {
+        let pty_manager = Arc::clone(&state.pty_manager);
+        let retry_agent_id = agent_id.to_string();
+        let retry_result = tokio::task::spawn_blocking(move || {
+            pty_manager.read().write(&retry_agent_id, SUBMIT_KEYSTROKE)
+        })
+        .await
+        .map_err(|error| ApiError::internal(format!("Submit retry task failed: {error}")))?;
+        retry_result
+            .map_err(|error| ApiError::internal(format!("Submit retry failed: {error}")))?;
+        submit_attempts += 1;
+        submit_bytes_written += SUBMIT_KEYSTROKE.len();
+
+        // Capture the new baseline after the retry write. PTYs with local echo (including
+        // the Windows test stub) mirror the CR into the ring; observing from the old
+        // baseline would misclassify that self-echo as receiver activity.
+        let retry_baseline = state.pty_manager.read().recent_output(agent_id);
+        observation = observe_submit(state, agent_id, true, retry_baseline.as_deref()).await;
+    }
+
+    Ok(InjectionMeasurement {
+        observation,
+        submit_attempts,
+        submit_bytes_written,
+    })
+}
+
 fn record_injection_submission(
     state: &AppState,
     session_id: &str,
@@ -182,8 +232,9 @@ fn record_injection_submission(
 fn measured_response(
     message: String,
     receipt: &InjectionReceipt,
-    observation: &InjectionObservation,
+    measurement: &InjectionMeasurement,
 ) -> Value {
+    let observation = &measurement.observation;
     json!({
         "status": "success",
         "message": message,
@@ -192,7 +243,8 @@ fn measured_response(
         "payload_bytes_written": receipt.payload_bytes_written,
         "submit_attempted": receipt.submit_keystroke_issued,
         "submit_keystroke_issued": receipt.submit_keystroke_issued,
-        "submit_bytes_written": receipt.submit_bytes_written,
+        "submit_bytes_written": measurement.submit_bytes_written,
+        "submit_attempts": measurement.submit_attempts,
         "pty_observation_available": observation.pty_observation_available,
         "pty_output_bytes_before": receipt.pty_output_before.as_ref().map(String::len),
         "pty_output_bytes_after_write": receipt.pty_output_after_write.as_ref().map(String::len),
@@ -257,13 +309,13 @@ pub async fn operator_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(|error| ApiError::internal(error.to_string()))?;
-    let observation = observe_injection(&state, &target_agent_id, &receipt).await;
+    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await?;
     record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
     Ok(Json(measured_response(
         format!("Operator injection sent to session {}", id),
         &receipt,
-        &observation,
+        &measurement,
     )))
 }
 
@@ -292,13 +344,13 @@ pub async fn queen_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(map_injection_error)?;
-    let observation = observe_injection(&state, &target_worker_id, &receipt).await;
+    let measurement = observe_injection_with_retry(&state, &target_worker_id, &receipt).await?;
     record_injection_submission(&state, &id, &target_worker_id, &receipt);
 
     Ok(Json(measured_response(
         format!("Queen injection sent to session {}", id),
         &receipt,
-        &observation,
+        &measurement,
     )))
 }
 
@@ -327,13 +379,13 @@ pub async fn evaluator_inject(
     .await
     .map_err(|error| ApiError::internal(format!("Injection task failed: {error}")))?;
     let receipt = injection_result.map_err(map_injection_error)?;
-    let observation = observe_injection(&state, &target_agent_id, &receipt).await;
+    let measurement = observe_injection_with_retry(&state, &target_agent_id, &receipt).await?;
     record_injection_submission(&state, &id, &target_agent_id, &receipt);
 
     Ok(Json(measured_response(
         format!("Evaluator injection sent to session {}", id),
         &receipt,
-        &observation,
+        &measurement,
     )))
 }
 
@@ -562,15 +614,18 @@ mod tests {
         assert_eq!(response["payload_bytes_written"], 5);
         assert_eq!(response["submit_attempted"], true);
         assert_eq!(response["submit_keystroke_issued"], true);
-        assert_eq!(response["submit_bytes_written"], 1);
+        assert_eq!(response["submit_bytes_written"], 2);
+        assert_eq!(response["submit_attempts"], 2);
         assert_eq!(response["pty_observation_available"], true);
         assert_eq!(response["pty_output_bytes_before"], 0);
         // The stub mirrors stdin into the ring: 6-byte start marker + 5-byte payload
-        // + 6-byte end marker + 1-byte Enter.
+        // + 6-byte end marker + the initial Enter. The retry adds one more byte.
         assert_eq!(response["pty_output_bytes_after_write"], 18);
-        assert_eq!(response["pty_output_bytes_after"], 18);
+        assert_eq!(response["pty_output_bytes_after"], 19);
         assert_eq!(response["pty_activity_observed"], false);
         assert_eq!(response["observation_window_ms"], 250);
+        // Neither bounded observation saw receiver activity. Capturing the retry baseline
+        // after its self-echo preserves the second confident negative as false.
         assert_eq!(response["submit_confirmed"], false);
         assert_eq!(
             response["submit_confirmation_basis"],
@@ -593,6 +648,7 @@ mod tests {
                 b"\x1b[200~".to_vec(),
                 b"hello".to_vec(),
                 b"\x1b[201~".to_vec(),
+                b"\r".to_vec(),
                 b"\r".to_vec()
             ]
         );
@@ -618,6 +674,7 @@ mod tests {
         assert_eq!(response["submit_attempted"], false);
         assert_eq!(response["submit_keystroke_issued"], false);
         assert_eq!(response["submit_bytes_written"], 0);
+        assert_eq!(response["submit_attempts"], 0);
         assert_eq!(response["observation_window_ms"], 0);
         assert_eq!(response["observation_elapsed_ms"], 0);
         assert_eq!(response["pty_activity_observed"], Value::Null);
@@ -635,10 +692,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn operator_inject_multiline_preserves_newlines_and_submits_once() {
+    async fn operator_inject_multiline_preserves_newlines_and_retries_one_confident_negative() {
         let (_temp_dir, app, state) = setup_test_app();
 
-        let (status, _response) = post_inject(
+        let (status, response) = post_inject(
             app,
             "/api/sessions/inject-test/inject",
             json!({
@@ -649,6 +706,8 @@ mod tests {
         .await;
 
         assert_eq!(status, StatusCode::OK);
+        assert_eq!(response["submit_attempts"], 2);
+        assert_eq!(response["submit_bytes_written"], 2);
         let writes = state
             .pty_manager
             .read()
@@ -660,10 +719,11 @@ mod tests {
                 b"\x1b[200~".to_vec(),
                 b"line one\nline two".to_vec(),
                 b"\x1b[201~".to_vec(),
+                b"\r".to_vec(),
                 b"\r".to_vec()
             ]
         );
-        assert_eq!(writes.iter().filter(|write| write.as_slice() == b"\r").count(), 1);
+        assert_eq!(writes.iter().filter(|write| write.as_slice() == b"\r").count(), 2);
         assert!(!writes.last().unwrap().contains(&b'\n'));
     }
 
@@ -711,7 +771,8 @@ mod tests {
             let (status, response) = post_inject(app.clone(), path, body).await;
             assert_eq!(status, StatusCode::OK, "{path}: {response}");
             assert_eq!(response["submit_keystroke_issued"], true, "{path}");
-            assert_eq!(response["submit_bytes_written"], 1, "{path}");
+            assert_eq!(response["submit_bytes_written"], 2, "{path}");
+            assert_eq!(response["submit_attempts"], 2, "{path}");
             assert_eq!(response["pty_observation_available"], true, "{path}");
             assert!(response["pty_output_bytes_before"].is_number(), "{path}");
             assert!(response["pty_output_bytes_after_write"].is_number(), "{path}");
@@ -730,10 +791,9 @@ mod tests {
     }
 
     /// #256 acceptance: a payload well over 1 KB travels through the full HTTP stack in
-    /// one bracketed envelope with exactly one Enter, and the receipt reports the real
-    /// payload byte count.
+    /// one bracketed envelope, and a confident negative adds only one bare-Enter retry.
     #[tokio::test]
-    async fn operator_inject_large_payload_brackets_once_and_submits_once() {
+    async fn operator_inject_large_payload_brackets_once_and_retries_once() {
         let (_temp_dir, app, state) = setup_test_app();
         let payload = "p".repeat(1287);
 
@@ -746,7 +806,8 @@ mod tests {
 
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response["payload_bytes_written"], 1287);
-        assert_eq!(response["submit_bytes_written"], 1);
+        assert_eq!(response["submit_bytes_written"], 2);
+        assert_eq!(response["submit_attempts"], 2);
         let writes = state
             .pty_manager
             .read()
@@ -758,6 +819,7 @@ mod tests {
                 b"\x1b[200~".to_vec(),
                 payload.as_bytes().to_vec(),
                 b"\x1b[201~".to_vec(),
+                b"\r".to_vec(),
                 b"\r".to_vec()
             ]
         );
@@ -787,7 +849,8 @@ mod tests {
     }
 
     /// #256: the documented two-call workaround — an empty message with submit:true —
-    /// stays a bare-Enter flush with no paste envelope.
+    /// stays a bare-Enter flush with no paste envelope; the stub's confident negative
+    /// produces the one bounded bare-Enter retry.
     #[tokio::test]
     async fn operator_inject_empty_message_flushes_with_a_bare_enter() {
         let (_temp_dir, app, state) = setup_test_app();
@@ -802,14 +865,61 @@ mod tests {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(response["payload_bytes_written"], 0);
         assert_eq!(response["submit_keystroke_issued"], true);
-        assert_eq!(response["submit_bytes_written"], 1);
+        assert_eq!(response["submit_bytes_written"], 2);
+        assert_eq!(response["submit_attempts"], 2);
         assert_eq!(
             state
                 .pty_manager
                 .read()
                 .write_records_for_test(AGENT_ID)
                 .unwrap(),
-            vec![b"\r".to_vec()]
+            vec![b"\r".to_vec(), b"\r".to_vec()]
+        );
+    }
+
+    /// #259: one isolated repaint is ambiguous, so the tri-state contract must suppress
+    /// the retry and leave exactly one Enter in the stub writer.
+    #[tokio::test]
+    async fn operator_inject_does_not_retry_ambiguous_submit_observation() {
+        let (_temp_dir, app, state) = setup_test_app();
+
+        let pty_manager = Arc::clone(&state.pty_manager);
+        let repainter = tokio::spawn(async move {
+            // The initial submit holds a 50 ms adapter gap before capturing its receipt
+            // baseline. Wait well past that gap so this is post-submit receiver activity.
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            pty_manager
+                .read()
+                .record_output_for_test(AGENT_ID, b"one-frame;");
+        });
+
+        let (status, response) = post_inject(
+            app,
+            "/api/sessions/inject-test/inject",
+            json!({ "target_agent_id": AGENT_ID, "message": "go" }),
+        )
+        .await;
+        repainter.await.unwrap();
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(response["submit_confirmed"], Value::Null);
+        assert_eq!(
+            response["submit_confirmation_basis"],
+            "ambiguous-post-submit-activity"
+        );
+        assert_eq!(response["submit_attempts"], 1);
+        assert_eq!(response["submit_bytes_written"], 1);
+        let writes = state
+            .pty_manager
+            .read()
+            .write_records_for_test(AGENT_ID)
+            .unwrap();
+        assert_eq!(
+            writes
+                .iter()
+                .filter(|write| write.as_slice() == b"\r")
+                .count(),
+            1
         );
     }
 
@@ -844,7 +954,21 @@ mod tests {
             response["submit_confirmation_basis"],
             "sustained-post-submit-activity"
         );
+        assert_eq!(response["submit_attempts"], 1);
+        assert_eq!(response["submit_bytes_written"], 1);
         assert!(response["submit_confirmation_elapsed_ms"].as_u64().unwrap() <= 1500);
+        let writes = state
+            .pty_manager
+            .read()
+            .write_records_for_test(AGENT_ID)
+            .unwrap();
+        assert_eq!(
+            writes
+                .iter()
+                .filter(|write| write.as_slice() == b"\r")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src-tauri/src/http/tests.rs
+++ b/src-tauri/src/http/tests.rs
@@ -4349,6 +4349,61 @@ fn test_persisted_session_legacy_json_defaults_to_claude() {
 
 // --- Fusion mode smoke tests ---
 
+#[test]
+fn planner_task_line_prompts_emit_safe_examples_and_priority_tokens() {
+    let [fusion, debate, hive, swarm, hive_smoke, swarm_smoke] =
+        SessionController::planner_task_line_prompts_for_test();
+    let allowed_brackets =
+        "Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.";
+    let correlated_t1 = format!("- [ ] [P{}] T{}:", 1, 1);
+    let correlated_t2 = format!("- [ ] [P{}] T{}:", 2, 2);
+
+    for (name, prompt) in [
+        ("fusion", &fusion),
+        ("debate", &debate),
+        ("hive", &hive),
+        ("swarm", &swarm),
+    ] {
+        let normalized_prompt = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+        assert!(
+            prompt.contains("- [ ] T1:"),
+            "{name} prompt must emit a bracket-free T1 exemplar"
+        );
+        assert!(
+            prompt.contains("- [ ] T2:"),
+            "{name} prompt must emit a bracket-free T2 exemplar"
+        );
+        assert!(
+            normalized_prompt.contains(allowed_brackets),
+            "{name} prompt must state the leading-bracket allowlist"
+        );
+        assert!(
+            !prompt.contains(&correlated_t1) && !prompt.contains(&correlated_t2),
+            "{name} prompt must not correlate bracket and task indices"
+        );
+    }
+
+    fn emitted_priorities(prompt: &str) -> Vec<&str> {
+        prompt
+            .lines()
+            .filter_map(|line| {
+                line.strip_prefix("- [ ] [")
+                    .and_then(|rest| rest.split_once("] T"))
+                    .map(|(priority, _)| priority)
+            })
+            .collect()
+    }
+
+    assert_eq!(
+        emitted_priorities(&hive_smoke),
+        ["HIGH", "MEDIUM", "LOW", "LOW"]
+    );
+    assert_eq!(
+        emitted_priorities(&swarm_smoke),
+        ["HIGH", "MEDIUM", "LOW", "LOW"]
+    );
+}
+
 #[tokio::test]
 async fn test_launch_fusion_success() {
     let app = setup_test_app().await;

--- a/src-tauri/src/http/tests_wg_plan.rs
+++ b/src-tauri/src/http/tests_wg_plan.rs
@@ -705,13 +705,7 @@ Keep the existing parser behavior.
         .unwrap();
     assert_eq!(graph.nodes.len(), 2);
     assert!(graph.edges.is_empty());
-    assert_eq!(graph.omissions.len(), 1);
-    assert_eq!(
-        graph.omissions[0].reason,
-        WorkGraphOmissionReason::ResolutionIncomplete
-    );
-    assert_eq!(graph.omissions[0].count, 1);
-    assert!(graph.omissions[0].examples[0].contains("Fix launch regression"));
+    assert!(graph.omissions.is_empty());
     assert!(
         StateManager::new(storage.session_dir("legacy-plan"))
             .read_graph_composition_state()
@@ -851,7 +845,7 @@ fn partially_parsed_twenty_two_line_plan_preserves_eighteen_nodes_and_four_omiss
 }
 
 #[test]
-fn all_legacy_checkbox_tasks_are_preserved_but_reported_without_stable_ids() {
+fn all_legacy_checkbox_tasks_are_preserved_without_omissions() {
     let plan = r#"# Positional-only plan
 
 ## Tasks
@@ -875,16 +869,7 @@ fn all_legacy_checkbox_tasks_are_preserved_but_reported_without_stable_ids() {
             .collect::<Vec<_>>(),
         vec!["task-1", "task-2"]
     );
-    assert_eq!(graph.omissions.len(), 1);
-    assert_eq!(graph.omissions[0].count, 2);
-    assert!(graph.omissions[0]
-        .examples
-        .iter()
-        .any(|example| example.contains("First positional")));
-    assert!(graph.omissions[0]
-        .examples
-        .iter()
-        .any(|example| example.contains("Second positional")));
+    assert!(graph.omissions.is_empty());
 }
 
 #[test]
@@ -952,6 +937,61 @@ fn duplicate_explicit_ids_are_reported_without_blocking_readable_plan() {
         .iter()
         .flat_map(|omission| omission.examples.iter())
         .any(|example| example.contains("duplicate") && example.contains("T1")));
+}
+
+#[test]
+fn duplicate_dependency_metadata_is_omitted_without_manufacturing_a_cycle() {
+    let plan = r#"# Duplicate dependency metadata
+
+## Tasks
+- [ ] T1: Root
+- [ ] T2: Second (deps: T1)
+- [ ] T1: Duplicate declaration (deps: T2)
+"#;
+    let (_temp, controller, storage) =
+        controller_with_plan("duplicate-dependency-plan", Some(plan));
+
+    let result = controller.mark_plan_ready("duplicate-dependency-plan");
+    assert!(
+        result.is_ok(),
+        "a duplicate declaration must not manufacture a cycle: {result:?}"
+    );
+    assert_session_state(
+        &controller,
+        "duplicate-dependency-plan",
+        SessionState::PlanReady,
+    );
+
+    let graph = StateManager::new(storage.session_dir("duplicate-dependency-plan"))
+        .read_work_graph()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        graph
+            .nodes
+            .iter()
+            .map(|node| (node.id.as_str(), node.title.as_str()))
+            .collect::<Vec<_>>(),
+        vec![("T1", "Root"), ("T2", "Second")]
+    );
+    assert_eq!(graph.edges.len(), 1);
+    assert_eq!(graph.edges[0].source, "T1");
+    assert_eq!(graph.edges[0].target, "T2");
+    assert!(
+        graph
+            .edges
+            .iter()
+            .all(|edge| !(edge.source == "T2" && edge.target == "T1")),
+        "T1 must not inherit the duplicate declaration's dependency"
+    );
+    validate_plan_ready(&graph).expect("the persisted graph must not contain a cycle");
+    assert!(graph.omissions.iter().any(|omission| {
+        omission.reason == WorkGraphOmissionReason::ResolutionIncomplete
+            && omission
+                .examples
+                .iter()
+                .any(|example| example.contains("duplicate") && example.contains("T1"))
+    }));
 }
 
 #[test]

--- a/src-tauri/src/http/tests_wg_plan.rs
+++ b/src-tauri/src/http/tests_wg_plan.rs
@@ -11,11 +11,14 @@ use tempfile::TempDir;
 use crate::actions::coordination::{parse_plan_markdown, parse_plan_markdown_checked};
 use crate::coordination::StateManager;
 use crate::domain::HiveExecutionPolicy;
+use crate::orchestrator::work_graph::review::{
+    MULTI_LENS_REVIEW_TEMPLATE, VERIFICATION_DUTY_PARAMETER,
+};
 use crate::orchestrator::work_graph::validate::{
     validate_plan_ready, PlanReadyWarning,
 };
 use crate::orchestrator::work_graph::{
-    EdgeKind, EdgeProvenance, NodeStatus, WorkGraphOmissionReason,
+    EdgeKind, EdgeProvenance, NodeKind, NodeStatus, WorkGraphOmissionReason,
 };
 use crate::pty::PtyManager;
 use crate::session::{
@@ -180,18 +183,20 @@ fn production_continue_replaces_empty_seed_with_typed_source_omissions() {
         (
             "continue-malformed",
             Some(malformed_plan),
+            1,
             WorkGraphOmissionReason::ResolutionIncomplete,
             "unterminated",
         ),
         (
             "continue-missing",
             None,
+            0,
             WorkGraphOmissionReason::SourceUnreadable,
             "plan.md",
         ),
     ];
 
-    for (session_id, plan, expected_reason, expected_example) in cases {
+    for (session_id, plan, expected_nodes, expected_reason, expected_example) in cases {
         let (_temp, controller, storage) = controller_with_plan(session_id, plan);
 
         let error = controller
@@ -207,7 +212,7 @@ fn production_continue_replaces_empty_seed_with_typed_source_omissions() {
             .read_work_graph()
             .expect("graph state is readable")
             .expect("production continue replaced the creation-time seed");
-        assert!(graph.nodes.is_empty());
+        assert_eq!(graph.nodes.len(), expected_nodes);
         assert!(graph.edges.is_empty());
         assert_eq!(graph.omissions.len(), 1);
         assert_eq!(graph.omissions[0].reason, expected_reason);
@@ -227,28 +232,104 @@ fn mark_plan_ready_rejects_cycle_and_leaves_session_planning() {
 
     let error = controller
         .mark_plan_ready("cycle-plan")
-        .expect_err("cycle must fail the real PlanReady transition");
+        .expect_err("a dependency cycle must block the PlanReady transition");
     assert!(error.contains("T1"), "cycle error omitted T1: {error}");
     assert!(error.contains("T2"), "cycle error omitted T2: {error}");
     assert_session_state(&controller, "cycle-plan", SessionState::Planning);
 }
 
 #[test]
-fn mark_plan_ready_rejects_dangling_dependency_and_names_both_ids() {
+fn mark_plan_ready_rejects_missing_review_signal_and_leaves_session_planning() {
+    let plan = "# Review authority plan\n\n## Tasks\n- [ ] T1: Planner extension (deps: design)\n";
+    let (_temp, controller, storage) = controller_with_plan("review-authority", Some(plan));
+    let project_path = controller
+        .get_session("review-authority")
+        .unwrap()
+        .project_path;
+    controller
+        .prepare_initial_work_graph(
+            &project_path,
+            "review-authority",
+            Some("feature-build"),
+            &BTreeMap::from([("component".to_string(), "billing".to_string())]),
+        )
+        .expect("review skeleton composes")
+        .expect("feature-build provides a review skeleton");
+
+    let state_manager = StateManager::new(storage.session_dir("review-authority"));
+    let mut composition = state_manager
+        .read_graph_composition_state()
+        .unwrap()
+        .unwrap();
+    let review = composition
+        .graph
+        .nodes
+        .iter_mut()
+        .find(|node| {
+            node.kind == NodeKind::Join
+                && node
+                    .expansion
+                    .as_ref()
+                    .is_some_and(|expansion| expansion.template == MULTI_LENS_REVIEW_TEMPLATE)
+        })
+        .expect("feature-build includes a multi-lens review gate");
+    let review_id = review.id.clone();
+    review
+        .expansion
+        .as_mut()
+        .expect("review expansion exists")
+        .parameters
+        .remove(VERIFICATION_DUTY_PARAMETER);
+    state_manager
+        .write_graph_composition_state(&composition)
+        .unwrap();
+
+    let error = controller
+        .mark_plan_ready("review-authority")
+        .expect_err("a review gate without a verification signal must block PlanReady");
+    assert!(
+        error.contains(&review_id),
+        "review-authority error omitted the review id: {error}"
+    );
+    assert!(
+        error.contains("no named verification signal"),
+        "unexpected review-authority error: {error}"
+    );
+    assert_session_state(&controller, "review-authority", SessionState::Planning);
+}
+
+#[test]
+fn mark_plan_ready_is_always_ok_and_quarantines_dangling_dependency() {
     let plan = r#"# Dangling plan
 
 ## Tasks
 - [ ] T1: Root task
 - [ ] T2: Dependent task (deps: MISSING)
 "#;
-    let (_temp, controller, _storage) = controller_with_plan("dangling-plan", Some(plan));
+    let (_temp, controller, storage) = controller_with_plan("dangling-plan", Some(plan));
 
-    let error = controller
+    controller
         .mark_plan_ready("dangling-plan")
-        .expect_err("dangling dependency must fail PlanReady");
-    assert!(error.contains("T2"), "error omitted dependent id: {error}");
-    assert!(error.contains("MISSING"), "error omitted unknown id: {error}");
-    assert_session_state(&controller, "dangling-plan", SessionState::Planning);
+        .expect("a readable dangling plan must not block PlanReady");
+    assert_session_state(&controller, "dangling-plan", SessionState::PlanReady);
+
+    let graph = StateManager::new(storage.session_dir("dangling-plan"))
+        .read_work_graph()
+        .unwrap()
+        .unwrap();
+    assert_eq!(graph.nodes.len(), 2);
+    validate_plan_ready(&graph).expect("the persisted graph must be valid after edge quarantine");
+    assert!(
+        graph.edges.is_empty(),
+        "unresolved dependencies must not survive quarantine"
+    );
+    let diagnostic = graph
+        .omissions
+        .iter()
+        .flat_map(|omission| omission.examples.iter())
+        .find(|example| example.contains("MISSING"))
+        .expect("the quarantined dependency must remain operator-visible");
+    assert!(diagnostic.contains("T2"));
 }
 
 #[test]
@@ -459,7 +540,7 @@ fn phase_b_reconciliation_is_idempotent_after_a_persisted_retry() {
 
 #[test]
 fn mark_plan_ready_persists_one_authoritative_reconciled_graph() {
-    let plan = "# Reconciled plan\n\n## Tasks\n- [ ] T1: Planner extension (deps: design) (acceptance: reconciled)\n";
+    let plan = "# Reconciled plan\n\n## Tasks\n- [ ] T1: Planner extension (deps: design, MISSING) (acceptance: reconciled)\n";
     let (_temp, controller, storage) =
         controller_with_plan("composed-plan-ready", Some(plan));
     let project_path = controller
@@ -488,6 +569,21 @@ fn mark_plan_ready_persists_one_authoritative_reconciled_graph() {
     assert_eq!(authoritative, composition.graph);
     assert!(authoritative.nodes.iter().any(|node| node.id == "design"));
     assert!(authoritative.nodes.iter().any(|node| node.id == "T1"));
+    assert!(authoritative.edges.iter().any(|edge| {
+        edge.source == "design" && edge.target == "T1" && edge.kind == EdgeKind::DependsOn
+    }));
+    assert!(
+        authoritative
+            .edges
+            .iter()
+            .all(|edge| edge.source != "MISSING" && edge.target != "MISSING"),
+        "quarantine runs after reconciliation so skeleton references survive and unknown ones do not"
+    );
+    assert!(authoritative
+        .omissions
+        .iter()
+        .flat_map(|omission| omission.examples.iter())
+        .any(|example| example.contains("T1") && example.contains("MISSING")));
     assert!(composition.lineage.is_some());
     assert!(
         !composition.graph.omissions.is_empty(),
@@ -609,7 +705,13 @@ Keep the existing parser behavior.
         .unwrap();
     assert_eq!(graph.nodes.len(), 2);
     assert!(graph.edges.is_empty());
-    assert!(graph.omissions.is_empty());
+    assert_eq!(graph.omissions.len(), 1);
+    assert_eq!(
+        graph.omissions[0].reason,
+        WorkGraphOmissionReason::ResolutionIncomplete
+    );
+    assert_eq!(graph.omissions[0].count, 1);
+    assert!(graph.omissions[0].examples[0].contains("Fix launch regression"));
     assert!(
         StateManager::new(storage.session_dir("legacy-plan"))
             .read_graph_composition_state()
@@ -620,7 +722,7 @@ Keep the existing parser behavior.
 }
 
 #[test]
-fn malformed_graph_metadata_degrades_to_edgeless_graph_with_omission() {
+fn malformed_graph_metadata_preserves_task_and_degrades_to_edgeless_graph() {
     let plan = r#"# Legacy-compatible malformed graph metadata
 
 ## Tasks
@@ -637,7 +739,8 @@ fn malformed_graph_metadata_degrades_to_edgeless_graph_with_omission() {
         .read_work_graph()
         .unwrap()
         .unwrap();
-    assert!(graph.nodes.is_empty());
+    assert_eq!(graph.nodes.len(), 1);
+    assert_eq!(graph.nodes[0].id, "T1");
     assert!(graph.edges.is_empty());
     assert_eq!(graph.omissions.len(), 1);
     assert_eq!(
@@ -648,12 +751,13 @@ fn malformed_graph_metadata_degrades_to_edgeless_graph_with_omission() {
 }
 
 #[test]
-fn explicit_graph_with_unidentified_checkbox_degrades_and_reports_it() {
+fn explicit_graph_preserves_resolved_tasks_and_reports_every_lost_reference() {
     let plan = r#"# Mixed malformed graph
 
 ## Tasks
 - [ ] T1: Stable root task
 - [ ] Crucial workstream missing its stable id
+- [ ] T2: Stable dependent task (deps: T3)
 "#;
     let error = parse_plan_markdown_checked(plan)
         .expect_err("an explicit graph cannot silently discard a schedulable checkbox");
@@ -665,18 +769,122 @@ fn explicit_graph_with_unidentified_checkbox_degrades_and_reports_it() {
     let (_temp, controller, storage) = controller_with_plan("mixed-malformed", Some(plan));
     controller
         .mark_plan_ready("mixed-malformed")
-        .expect("malformed graph syntax follows the degrade-and-report guardrail");
+        .expect("partial graph syntax must preserve usable work without blocking PlanReady");
+    assert_session_state(&controller, "mixed-malformed", SessionState::PlanReady);
     let graph = StateManager::new(storage.session_dir("mixed-malformed"))
         .read_work_graph()
         .unwrap()
         .unwrap();
-    assert!(graph.nodes.is_empty());
-    assert!(graph.edges.is_empty());
     assert_eq!(
-        graph.omissions[0].reason,
+        graph
+            .nodes
+            .iter()
+            .map(|node| node.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["T1", "T2"],
+        "every successfully identified task must be preserved"
+    );
+    assert!(
+        graph.edges.is_empty(),
+        "the dependency on the unresolved T3 endpoint must be quarantined"
+    );
+    assert!(graph
+        .omissions
+        .iter()
+        .all(|omission| omission.reason == WorkGraphOmissionReason::ResolutionIncomplete));
+    let examples = graph
+        .omissions
+        .iter()
+        .flat_map(|omission| omission.examples.iter())
+        .collect::<Vec<_>>();
+    assert!(
+        examples
+            .iter()
+            .any(|example| example.contains("Crucial workstream")),
+        "the unidentified schedulable line must not disappear silently"
+    );
+    assert!(
+        examples
+            .iter()
+            .any(|example| example.contains("T2") && example.contains("T3")),
+        "the quarantined dependency must name both endpoints"
+    );
+}
+
+#[test]
+fn partially_parsed_twenty_two_line_plan_preserves_eighteen_nodes_and_four_omissions() {
+    let mut plan = String::from("# Partially parsed plan\n\n## Tasks\n");
+    for id in 1..=18 {
+        plan.push_str(&format!("- [ ] T{id}: Stable task {id}\n"));
+    }
+    for id in 19..=22 {
+        plan.push_str(&format!("- [ ] Unidentified task {id}\n"));
+    }
+
+    let (_temp, controller, storage) = controller_with_plan("partial-18-of-22", Some(&plan));
+    controller
+        .mark_plan_ready("partial-18-of-22")
+        .expect("a readable partially parsed plan must not block PlanReady");
+    assert_session_state(&controller, "partial-18-of-22", SessionState::PlanReady);
+
+    let graph = StateManager::new(storage.session_dir("partial-18-of-22"))
+        .read_work_graph()
+        .unwrap()
+        .unwrap();
+    assert_eq!(graph.nodes.len(), 18);
+    let parser_omission = graph
+        .omissions
+        .iter()
+        .find(|omission| omission.count == 4)
+        .expect("the four unresolved lines must be counted as omissions");
+    assert_eq!(
+        parser_omission.reason,
         WorkGraphOmissionReason::ResolutionIncomplete
     );
-    assert!(graph.omissions[0].examples[0].contains("Crucial workstream"));
+    assert_eq!(parser_omission.examples.len(), 4);
+    for id in 19..=22 {
+        assert!(parser_omission
+            .examples
+            .iter()
+            .any(|example| example.contains(&format!("Unidentified task {id}"))));
+    }
+}
+
+#[test]
+fn all_legacy_checkbox_tasks_are_preserved_but_reported_without_stable_ids() {
+    let plan = r#"# Positional-only plan
+
+## Tasks
+- [ ] First positional task
+- [ ] Second positional task
+"#;
+    let (_temp, controller, storage) = controller_with_plan("all-positional", Some(plan));
+
+    controller
+        .mark_plan_ready("all-positional")
+        .expect("positional compatibility must not block PlanReady");
+    let graph = StateManager::new(storage.session_dir("all-positional"))
+        .read_work_graph()
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        graph
+            .nodes
+            .iter()
+            .map(|node| node.id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["task-1", "task-2"]
+    );
+    assert_eq!(graph.omissions.len(), 1);
+    assert_eq!(graph.omissions[0].count, 2);
+    assert!(graph.omissions[0]
+        .examples
+        .iter()
+        .any(|example| example.contains("First positional")));
+    assert!(graph.omissions[0]
+        .examples
+        .iter()
+        .any(|example| example.contains("Second positional")));
 }
 
 #[test]
@@ -720,19 +928,30 @@ fn unreadable_plan_degrades_and_persists_source_omission() {
 }
 
 #[test]
-fn duplicate_explicit_ids_fail_the_real_gate_without_state_change() {
+fn duplicate_explicit_ids_are_reported_without_blocking_readable_plan() {
     let plan = r#"# Duplicate ids
 
 ## Tasks
 - [ ] T1: First declaration
 - [ ] T1: Second declaration
 "#;
-    let (_temp, controller, _storage) = controller_with_plan("duplicate-plan", Some(plan));
-    let error = controller
+    let (_temp, controller, storage) = controller_with_plan("duplicate-plan", Some(plan));
+    controller
         .mark_plan_ready("duplicate-plan")
-        .expect_err("duplicate task ids must fail PlanReady");
-    assert!(error.contains("T1"), "duplicate error omitted task id: {error}");
-    assert_session_state(&controller, "duplicate-plan", SessionState::Planning);
+        .expect("duplicate ids in a readable plan must not block PlanReady");
+    assert_session_state(&controller, "duplicate-plan", SessionState::PlanReady);
+
+    let graph = StateManager::new(storage.session_dir("duplicate-plan"))
+        .read_work_graph()
+        .unwrap()
+        .unwrap();
+    assert_eq!(graph.nodes.len(), 1);
+    validate_plan_ready(&graph).expect("the persisted graph must retain one unambiguous T1 node");
+    assert!(graph
+        .omissions
+        .iter()
+        .flat_map(|omission| omission.examples.iter())
+        .any(|example| example.contains("duplicate") && example.contains("T1")));
 }
 
 #[test]

--- a/src-tauri/src/orchestrator/work_graph/plan_parse.rs
+++ b/src-tauri/src/orchestrator/work_graph/plan_parse.rs
@@ -4,7 +4,7 @@ use crate::actions::coordination::SessionPlan;
 
 use super::schema::{
     BindingRef, EdgeKind, EdgeProvenance, NodeContract, NodeKind, NodeStatus, TaskGraph, TaskId,
-    WorkEdge, WorkNode,
+    WorkEdge, WorkGraphOmission, WorkGraphOmissionReason, WorkNode,
 };
 use super::review::JUDGE_PRINCE_REMEDIATION_TEMPLATE;
 
@@ -18,15 +18,23 @@ pub fn task_graph_from_plan(plan: &SessionPlan) -> TaskGraph {
     // parser are descriptive rather than schedulable. Plans with no explicit IDs
     // retain positional `task-N` nodes for backward compatibility.
     let has_explicit_graph = plan.tasks.iter().any(|task| task.explicit_id);
+    let mut seen_task_ids = std::collections::BTreeSet::new();
+    let mut duplicate_task_ids = Vec::new();
     let graph_tasks = plan
         .tasks
         .iter()
         .filter(|task| !has_explicit_graph || task.explicit_id)
+        .filter(|task| {
+            if seen_task_ids.insert(task.id.clone()) {
+                true
+            } else {
+                duplicate_task_ids.push(task.id.clone());
+                false
+            }
+        })
         .collect::<Vec<_>>();
-    let nodes = plan
-        .tasks
+    let nodes = graph_tasks
         .iter()
-        .filter(|task| !has_explicit_graph || task.explicit_id)
         .map(|task| {
             let status = if task.status == "completed" {
                 NodeStatus::Completed
@@ -53,7 +61,7 @@ pub fn task_graph_from_plan(plan: &SessionPlan) -> TaskGraph {
         .collect();
 
     let edges = graph_tasks
-        .into_iter()
+        .iter()
         .flat_map(|task| {
             task.depends_on.iter().map(move |dependency| {
                 WorkEdge::new(
@@ -66,7 +74,22 @@ pub fn task_graph_from_plan(plan: &SessionPlan) -> TaskGraph {
         })
         .collect();
 
-    TaskGraph::new(nodes, edges)
+    let mut graph = TaskGraph::new(nodes, edges);
+    if !duplicate_task_ids.is_empty() {
+        duplicate_task_ids.sort();
+        let examples = duplicate_task_ids
+            .iter()
+            .map(|task_id| {
+                format!("duplicate task {task_id} was omitted after its first declaration")
+            })
+            .collect();
+        graph.omissions.push(WorkGraphOmission::new(
+            WorkGraphOmissionReason::ResolutionIncomplete,
+            duplicate_task_ids.len(),
+            examples,
+        ));
+    }
+    graph
 }
 
 /// Promote only the initial plan-time frontier after every structural stage

--- a/src-tauri/src/orchestrator/work_graph/validate.rs
+++ b/src-tauri/src/orchestrator/work_graph/validate.rs
@@ -140,6 +140,54 @@ impl fmt::Display for PlanReadyError {
 
 impl Error for PlanReadyError {}
 
+/// Retain the first declaration of each task id and quarantine later ones.
+pub fn quarantine_duplicate_nodes(graph: &mut TaskGraph) -> Vec<TaskId> {
+    let mut seen = BTreeSet::new();
+    let mut quarantined = Vec::new();
+
+    graph.nodes.retain(|node| {
+        if seen.insert(node.id.clone()) {
+            true
+        } else {
+            quarantined.push(node.id.clone());
+            false
+        }
+    });
+
+    quarantined.sort();
+    quarantined
+}
+
+/// Remove dependency edges whose source or target is absent from the graph.
+/// The returned references preserve the operator-facing detail that would
+/// otherwise be lost when the invalid edges are quarantined.
+pub fn quarantine_dangling_dependencies(graph: &mut TaskGraph) -> Vec<DanglingDependency> {
+    let node_ids = graph
+        .nodes
+        .iter()
+        .map(|node| node.id.clone())
+        .collect::<BTreeSet<_>>();
+    let mut quarantined = Vec::new();
+
+    graph.edges.retain(|edge| {
+        let dangling = edge.kind == EdgeKind::DependsOn
+            && (!node_ids.contains(&edge.source) || !node_ids.contains(&edge.target));
+        if dangling {
+            quarantined.push(DanglingDependency {
+                dependent: edge.target.clone(),
+                dependency: edge.source.clone(),
+            });
+        }
+        !dangling
+    });
+
+    quarantined.sort_by(|left, right| {
+        (&left.dependent, &left.dependency).cmp(&(&right.dependent, &right.dependency))
+    });
+    quarantined.dedup();
+    quarantined
+}
+
 pub fn validate_plan_ready(graph: &TaskGraph) -> Result<PlanReadyValidation, PlanReadyError> {
     let mut counts = BTreeMap::<&str, usize>::new();
     for node in &graph.nodes {

--- a/src-tauri/src/pty/session.rs
+++ b/src-tauri/src/pty/session.rs
@@ -451,11 +451,24 @@ impl PtySession {
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
         tracing::debug!("PTY write: {} bytes: {:?}", data.len(), String::from_utf8_lossy(data));
         let mut writer = self.writer.lock();
-        Self::write_locked(&mut writer, data)?;
+        if data == Self::SUBMIT_KEYSTROKE {
+            Self::write_submit_keystroke_locked(&mut writer)?;
+        } else {
+            Self::write_locked(&mut writer, data)?;
+        }
 
         tracing::debug!("PTY write complete");
         Ok(())
     }
+
+    // BEGIN SHARED SUBMIT KEYSTROKE PRIMITIVE
+    const SUBMIT_KEYSTROKE: &'static [u8] = b"\r";
+
+    fn write_submit_keystroke_locked(writer: &mut SendWriter) -> Result<usize, PtyError> {
+        Self::write_locked(writer, Self::SUBMIT_KEYSTROKE)?;
+        Ok(Self::SUBMIT_KEYSTROKE.len())
+    }
+    // END SHARED SUBMIT KEYSTROKE PRIMITIVE
 
     /// Deliver a payload inside a bracketed-paste envelope, then Enter as a discrete
     /// bare carriage return outside the envelope.
@@ -476,10 +489,10 @@ impl PtySession {
         // Keep the per-session writer locked so no concurrent write can be
         // interleaved and accidentally submitted by this Enter.
         std::thread::sleep(submit_gap(self.submit_policy));
-        Self::write_locked(&mut writer, b"\r")?;
+        let submit_bytes_written = Self::write_submit_keystroke_locked(&mut writer)?;
         Ok(PtySubmitResult {
             payload_bytes_written,
-            submit_bytes_written: 1,
+            submit_bytes_written,
         })
     }
 

--- a/src-tauri/src/pty/session_stub.rs
+++ b/src-tauri/src/pty/session_stub.rs
@@ -451,8 +451,22 @@ impl PtySession {
 
     pub fn write(&self, data: &[u8]) -> Result<(), PtyError> {
         let mut writer = self.writer.lock();
-        Self::write_locked(&mut writer, data)
+        if data == Self::SUBMIT_KEYSTROKE {
+            Self::write_submit_keystroke_locked(&mut writer)?;
+            Ok(())
+        } else {
+            Self::write_locked(&mut writer, data)
+        }
     }
+
+    // BEGIN SHARED SUBMIT KEYSTROKE PRIMITIVE
+    const SUBMIT_KEYSTROKE: &'static [u8] = b"\r";
+
+    fn write_submit_keystroke_locked(writer: &mut SendWriter) -> Result<usize, PtyError> {
+        Self::write_locked(writer, Self::SUBMIT_KEYSTROKE)?;
+        Ok(Self::SUBMIT_KEYSTROKE.len())
+    }
+    // END SHARED SUBMIT KEYSTROKE PRIMITIVE
 
     pub fn submit(&self, data: &[u8]) -> Result<PtySubmitResult, PtyError> {
         let mut writer = self.writer.lock();
@@ -463,10 +477,10 @@ impl PtySession {
         };
         self.pause_submit_after_payload_if_requested();
         std::thread::sleep(submit_gap(self.submit_policy));
-        Self::write_locked(&mut writer, b"\r")?;
+        let submit_bytes_written = Self::write_submit_keystroke_locked(&mut writer)?;
         Ok(PtySubmitResult {
             payload_bytes_written,
-            submit_bytes_written: 1,
+            submit_bytes_written,
         })
     }
 
@@ -692,6 +706,27 @@ mod tests {
         let production = policy_block(include_str!("session.rs"));
         let test_stub = policy_block(include_str!("session_stub.rs"));
         assert_eq!(production, test_stub, "the Windows shim must not drift");
+    }
+
+    #[test]
+    fn submit_keystroke_primitive_matches_the_production_session() {
+        fn primitive_block(source: &str) -> String {
+            source
+                .split_once("// BEGIN SHARED SUBMIT KEYSTROKE PRIMITIVE")
+                .expect("submit keystroke primitive start marker")
+                .1
+                .split_once("// END SHARED SUBMIT KEYSTROKE PRIMITIVE")
+                .expect("submit keystroke primitive end marker")
+                .0
+                .replace("\r\n", "\n")
+        }
+
+        let production = primitive_block(include_str!("session.rs"));
+        let test_stub = primitive_block(include_str!("session_stub.rs"));
+        assert_eq!(
+            production, test_stub,
+            "the production and Windows-shim submit retry primitives must not drift"
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -4927,6 +4927,8 @@ Task syntax is load-bearing: use a unique stable `T<number>:` prefix, put comma-
 prerequisites in `(deps: T1, T2)`, and keep `(inputs: ...)`, `(outputs: ...)`, and
 `(acceptance: ...)` on the same checkbox line. Omit `deps:` for roots. Dependency metadata,
 not prose phases, is the executable ordering source.
+Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`,
+`[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 ## IMPORTANT
 - Write the plan to `.hive-manager/{session_id}/plan.md` and then STOP
@@ -5018,6 +5020,8 @@ Write a concise debate plan to `.hive-manager/{session_id}/plan.md`:
 Task syntax is load-bearing: every task has a unique stable `T<number>:` prefix; prerequisites
 use `(deps: T1, T2)`; contracts use `(inputs: ...)`, `(outputs: ...)`, and
 `(acceptance: ...)` on that same checkbox line. Omit `deps:` for roots.
+Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`,
+`[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 Do not run the debate. Stop after writing the plan.
 "#,
@@ -5394,9 +5398,10 @@ This roster is available implementation capacity, not a required task count. Des
 - Evidence and repository findings
 - Coherent workstreams with owned paths and authoritative inputs
 - A `## Tasks` graph. Every schedulable task is exactly one checkbox line using this syntax:
-  `- [ ] [P1] T1: Stable root task (inputs: input) (outputs: output) (acceptance: observable criterion) -> P1`
-  `- [ ] [P2] T2: Stable dependent task (deps: T1) (inputs: T1 output) (outputs: result) (acceptance: observable criterion) -> P2`
+  `- [ ] T1: Stable root task (inputs: input) (outputs: output) (acceptance: observable criterion) -> P1`
+  `- [ ] T2: Stable dependent task (deps: T1) (inputs: T1 output) (outputs: result) (acceptance: observable criterion) -> P2`
   Use unique stable `T<number>:` ids. Omit `(deps: ...)` for roots; otherwise list comma-separated prerequisite ids. `source` prerequisites run before the task. Keep inputs, outputs, and acceptance on the same line. The `deps:` declarations are the executable dependency source.
+  Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 - Ownership matrix and serialized hotspots
 - Integration order and wave narrative consistent with the task graph
 - Validation gates with commands/evidence
@@ -5623,12 +5628,12 @@ Write to `.hive-manager/{session_id}/plan.md`:
 ## Domain Tasks (for Planners)
 
 ### Domain 1: [Domain Name]
-- [ ] [P1] T1: Task description (inputs: required context) (outputs: domain result) (acceptance: observable completion criterion) -> Planner 1
+- [ ] T1: Task description (inputs: required context) (outputs: domain result) (acceptance: observable completion criterion) -> Planner 1
 Files: [list of files in this domain]
 Workers: {workers_per} available
 
 ### Domain 2: [Domain Name]
-- [ ] [P2] T2: Task description (deps: T1) (inputs: T1 output) (outputs: domain result) (acceptance: observable completion criterion) -> Planner 2
+- [ ] T2: Task description (deps: T1) (inputs: T1 output) (outputs: domain result) (acceptance: observable completion criterion) -> Planner 2
 Files: [list of files in this domain]
 Workers: {workers_per} available
 
@@ -5648,6 +5653,8 @@ Workers: {workers_per} available
 Task syntax is load-bearing: use unique stable `T<number>:` ids, comma-separated prerequisite
 ids in `(deps: ...)`, and same-line `(inputs: ...)`, `(outputs: ...)`, and `(acceptance: ...)`.
 Omit `deps:` for roots. The graph metadata, not PHASE prose, controls execution order.
+Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`,
+`[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 ---
 
@@ -5666,6 +5673,36 @@ Omit `deps:` for roots. The graph metadata, not PHASE prose, controls execution 
             planner_table = planner_table.trim_end(),
             worker_info = worker_info.trim_end()
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn planner_task_line_prompts_for_test() -> [String; 6] {
+        let planner = AgentConfig::default();
+        let policy = HiveExecutionPolicy::default();
+        let smoke_workers = vec![AgentConfig::default(); 4];
+
+        [
+            Self::build_fusion_master_planner_prompt("test-fusion", "test objective", &[]),
+            Self::build_debate_master_planner_prompt("test-debate", "test topic", &[], 2),
+            Self::build_master_planner_prompt(
+                "test-hive",
+                "test objective",
+                &planner,
+                &[],
+                &policy,
+                Path::new("/repo"),
+                Path::new("/repo/.hive-manager/worktrees/test-hive/primary"),
+            ),
+            Self::build_swarm_master_planner_prompt("test-swarm", "test objective", 2, &[]),
+            Self::build_smoke_test_prompt("test-hive-smoke", &smoke_workers, false, None),
+            Self::build_swarm_smoke_test_prompt(
+                "test-swarm-smoke",
+                4,
+                &[],
+                false,
+                None,
+            ),
+        ]
     }
 
     /// Build a minimal smoke test prompt that creates a simple plan without real investigation
@@ -5852,6 +5889,8 @@ Testing {worker_count} workers as configured by the user.
 The `T<number>:` ids and `(deps: ...)` declarations above are the executable work graph.
 Keep every task's `(inputs: ...)`, `(outputs: ...)`, and `(acceptance: ...)` metadata on its
 checkbox line; prose in the Dependencies section is explanatory only.
+Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`,
+`[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 ## Task Details
 
@@ -6107,6 +6146,8 @@ Testing {planner_count} planners, each with {workers_per} workers ({total_worker
 The stable `T<number>:` ids and task-line `(deps: ...)` declarations are the executable graph.
 Inputs, outputs, and acceptance stay on the same checkbox line; the prose dependency section is
 only a readable explanation of those edges.
+Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`,
+`[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 ## Planner → Worker Breakdown
 
@@ -6452,9 +6493,9 @@ curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
   -d '{{"target_agent_id":"{session_id}-worker-N","message":"your message here"}}'
 ```
 
-The response reports measured sender-side facts: `payload_bytes_written` and `submit_bytes_written` count the bytes actually written (the sanitized payload and the discrete Enter write), `submit_keystroke_issued` reflects the real Enter write, plus PTY-output byte counts, `pty_activity_observed`, the bounded `observation_window_ms`, and the tri-state `submit_confirmed` (`true` = sustained post-submit PTY activity consistent with the composer accepting Enter, `false` = the Enter produced no observable reaction, `null` = unknown or not requested). A `"submit":true` response may stay pending up to ~1500 ms while that confirmation window runs (it returns earlier once activity is confirmed); `submit_confirmation_elapsed_ms` reports the actual wait. Do not treat the held response as a stalled agent.
+The response reports measured sender-side facts: `payload_bytes_written` counts the sanitized payload bytes, `submit_bytes_written` is the aggregate number of Enter bytes written across all attempts, and `submit_attempts` reports `0` when no Enter was requested, `1` when one Enter was written, or `2` when the bounded automatic retry fired. `submit_keystroke_issued` reflects whether any Enter was written. The receipt also includes PTY-output byte counts, `pty_activity_observed`, the bounded `observation_window_ms`, and the tri-state `submit_confirmed` (`true` = sustained post-submit PTY activity consistent with the composer accepting Enter, `false` = the initial Enter and its one automatic retry both produced no observable reaction, `null` = unknown or not requested). When `submit_confirmed` is `false`, the sender has already retried once automatically; flush the target with `{{"message":"","submit":true}}`, then re-check its state. Remediate one target at a time. A `"submit":true` response may stay pending up to ~1500 ms while that confirmation window runs (it returns earlier once activity is confirmed); `submit_confirmation_elapsed_ms` reports the actual wait. Do not treat the held response as a stalled agent.
 
-**Evidence limit:** these facts prove only that bytes were written and the existing PTY-output ring was observed for a bounded window. They do **not** prove that the agent took a turn; output may be terminal echo or unrelated activity, and `submit_confirmed` is heuristic. Never infer success from receiver behaviour alone.
+**Evidence limit:** these facts prove only that bytes were written and the existing PTY-output ring was observed for a bounded window. They do **not** prove that the agent took a turn; output may be terminal echo or unrelated activity, and `submit_confirmed` is heuristic. `submit_confirmed: true` is not proof that a busy receiver accepted Enter: unrelated output from a target that was already streaming can create a false positive and bypass the false-only retry. When the target was busy, inspect its actual state rather than treating `true` as confirmation. Never infer success from receiver behaviour alone.
 
 **Task files remain the primary channel for assignments.** Inject is a nudge; task files are the contract. Workers re-read their task file, so durable direction belongs there. `HIVE_PTY_SUBMIT_GAP_MS` (ceiling 300000 ms) overrides the submit gap, but the value is cached on first use and requires an app restart to change.
 
@@ -9943,6 +9984,7 @@ The backend composed and persisted the following authoritative skeleton before l
 - The listed node contracts and dependency edges already exist and will be reconciled with your plan rather than replaced by it.
 - Add only genuinely plan-specific `T<number>` tasks. Their `(deps: ...)` values may reference the exact skeleton IDs below.
 - Do not emit a checkbox line that attempts to redefine a non-`T<number>` skeleton node. Describe any rationale in prose and preserve the stable ID in dependency metadata.
+- Leading bracket tokens are optional and restricted to `[CRITICAL]`, `[HIGH]`, `[MEDIUM]`, `[MED]`, `[LOW]`, `[P1]`, `[P2]`, and `[P3]`; put free-form labels after `->`.
 
 ```json
 {payload}
@@ -13304,26 +13346,24 @@ The backend composed and persisted the following authoritative skeleton before l
 
         let mut graph = match std::fs::read_to_string(&plan_path) {
             Ok(content) => {
-                match crate::actions::coordination::parse_plan_markdown_checked(&content) {
-                    Ok(plan) => {
-                        crate::orchestrator::work_graph::plan_parse::task_graph_from_plan(&plan)
-                    }
-                    Err(error) => {
-                        tracing::warn!(
-                            session_id,
-                            plan_path = %plan_path.display(),
-                            error = %error,
-                            "Plan graph metadata could not be parsed; degrading to an edgeless graph"
-                        );
-                        let mut graph = TaskGraph::default();
-                        graph.omissions.push(WorkGraphOmission::new(
-                            WorkGraphOmissionReason::ResolutionIncomplete,
-                            error.messages.len(),
-                            error.messages,
-                        ));
-                        graph
-                    }
+                let (plan, messages) =
+                    crate::actions::coordination::parse_plan_markdown_with_diagnostics(&content);
+                let mut graph =
+                    crate::orchestrator::work_graph::plan_parse::task_graph_from_plan(&plan);
+                if !messages.is_empty() {
+                    tracing::warn!(
+                        session_id,
+                        plan_path = %plan_path.display(),
+                        diagnostics = messages.len(),
+                        "Plan graph metadata was only partially parsed; preserving resolved nodes"
+                    );
+                    graph.omissions.push(WorkGraphOmission::new(
+                        WorkGraphOmissionReason::ResolutionIncomplete,
+                        messages.len(),
+                        messages,
+                    ));
                 }
+                graph
             }
             Err(error) => {
                 tracing::warn!(
@@ -13342,10 +13382,33 @@ The backend composed and persisted the following authoritative skeleton before l
             }
         };
 
+        let duplicate_nodes =
+            crate::orchestrator::work_graph::validate::quarantine_duplicate_nodes(&mut graph);
+        if !duplicate_nodes.is_empty() {
+            let examples = duplicate_nodes
+                .iter()
+                .map(|task_id| {
+                    format!(
+                        "duplicate task {task_id} was omitted after its first declaration"
+                    )
+                })
+                .collect::<Vec<_>>();
+            tracing::warn!(
+                session_id,
+                duplicates = duplicate_nodes.len(),
+                "Duplicate plan task declarations were quarantined"
+            );
+            graph.omissions.push(WorkGraphOmission::new(
+                WorkGraphOmissionReason::ResolutionIncomplete,
+                duplicate_nodes.len(),
+                examples,
+            ));
+        }
+
         // Phase B is opt-in by persisted state rather than by a live launch
         // config. That makes a crash/retry deterministic and lets resumed
         // planning sessions finish without reconstructing departed agents.
-        let reconciled_composition = if let Some(storage) = self.storage.as_ref() {
+        let mut reconciled_composition = if let Some(storage) = self.storage.as_ref() {
             let state_manager = StateManager::new(storage.session_dir(session_id));
             Self::reconcile_planner_graph_with_persisted_skeleton(&state_manager, &graph)?
         } else {
@@ -13355,10 +13418,62 @@ The backend composed and persisted the following authoritative skeleton before l
             graph = composition.graph.clone();
         }
 
-        let validation = crate::orchestrator::work_graph::validate::validate_plan_ready(&graph)
-            .map_err(|error| error.to_string())?;
-        for warning in validation.warnings {
-            tracing::warn!(session_id, warning = %warning, "PlanReady validation warning");
+        let quarantined =
+            crate::orchestrator::work_graph::validate::quarantine_dangling_dependencies(
+                &mut graph,
+            );
+        if !quarantined.is_empty() {
+            let examples = quarantined
+                .iter()
+                .map(|reference| {
+                    format!(
+                        "{} depends on unknown {}",
+                        reference.dependent, reference.dependency
+                    )
+                })
+                .collect::<Vec<_>>();
+            tracing::warn!(
+                session_id,
+                dependencies = quarantined.len(),
+                "Dangling plan dependencies were quarantined"
+            );
+            graph.omissions.push(WorkGraphOmission::new(
+                WorkGraphOmissionReason::ResolutionIncomplete,
+                quarantined.len(),
+                examples,
+            ));
+        }
+
+        use crate::orchestrator::work_graph::validate::PlanReadyError;
+        match crate::orchestrator::work_graph::validate::validate_plan_ready(&graph) {
+            Ok(validation) => {
+                for warning in validation.warnings {
+                    tracing::warn!(session_id, warning = %warning, "PlanReady validation warning");
+                }
+            }
+            Err(error @ (PlanReadyError::DuplicateTaskIds { .. }
+            | PlanReadyError::DanglingDependencies { .. })) => {
+                let message = error.to_string();
+                tracing::warn!(
+                    session_id,
+                    error = %message,
+                    "Plan topology validation was incomplete; allowing the readable plan to proceed"
+                );
+                graph.omissions.push(WorkGraphOmission::new(
+                    WorkGraphOmissionReason::ResolutionIncomplete,
+                    1,
+                    vec![message],
+                ));
+            }
+            Err(error @ (PlanReadyError::Cycle { .. }
+            | PlanReadyError::MissingVerificationSignal { .. }
+            | PlanReadyError::MissingVerificationSignalClass { .. }
+            | PlanReadyError::InsufficientVerificationIsolation { .. }
+            | PlanReadyError::InvalidReviewAuthorityMetadata { .. }
+            | PlanReadyError::MissingAdjudicator { .. }
+            | PlanReadyError::AdjudicatorLacksAuthority { .. })) => {
+                return Err(error.to_string());
+            }
         }
 
         if self.storage.is_none() {
@@ -13370,6 +13485,10 @@ The backend composed and persisted the following authoritative skeleton before l
                 vec![message.to_string()],
             ));
             tracing::warn!(session_id, omission = message);
+        }
+
+        if let Some(composition) = reconciled_composition.as_mut() {
+            composition.graph = graph.clone();
         }
 
         let changes = {
@@ -16781,9 +16900,24 @@ mod tests {
         assert!(prompt.contains(r#"{"message":"","submit":true}"#));
         assert!(prompt.contains("submit_keystroke_issued"));
         assert!(prompt.contains("submit_confirmed"));
+        assert!(prompt.contains("`submit_bytes_written` is the aggregate number"));
+        assert!(prompt.contains("`submit_attempts` reports `0` when no Enter was requested"));
+        let remediation_passage = prompt
+            .split("\n\n")
+            .find(|passage| passage.contains("the tri-state `submit_confirmed`"))
+            .expect("inject receipt and remediation passage");
+        assert!(
+            remediation_passage.contains(
+                "`false` = the initial Enter and its one automatic retry both produced no observable reaction"
+            ) && remediation_passage.contains(
+                r#"When `submit_confirmed` is `false`, the sender has already retried once automatically; flush the target with `{"message":"","submit":true}`, then re-check its state. Remediate one target at a time."#
+            ),
+            "the false verdict and its measured remediation must stay in one emitted passage"
+        );
         assert!(prompt.contains("may stay pending up to ~1500 ms"));
         assert!(prompt.contains("pty_activity_observed"));
         assert!(prompt.contains("do **not** prove that the agent took a turn"));
+        assert!(prompt.contains("`submit_confirmed: true` is not proof that a busy receiver accepted Enter"));
         assert!(!prompt.contains("payload and its newline share one PTY write"));
         assert!(!prompt.contains("send a second, empty message"));
         assert!(!prompt.contains("Measured against a live codex agent"));

--- a/src-tauri/src/session/controller.rs
+++ b/src-tauri/src/session/controller.rs
@@ -6493,7 +6493,7 @@ curl -sS -X POST "http://localhost:18800/api/sessions/{session_id}/inject" \\
   -d '{{"target_agent_id":"{session_id}-worker-N","message":"your message here"}}'
 ```
 
-The response reports measured sender-side facts: `payload_bytes_written` counts the sanitized payload bytes, `submit_bytes_written` is the aggregate number of Enter bytes written across all attempts, and `submit_attempts` reports `0` when no Enter was requested, `1` when one Enter was written, or `2` when the bounded automatic retry fired. `submit_keystroke_issued` reflects whether any Enter was written. The receipt also includes PTY-output byte counts, `pty_activity_observed`, the bounded `observation_window_ms`, and the tri-state `submit_confirmed` (`true` = sustained post-submit PTY activity consistent with the composer accepting Enter, `false` = the initial Enter and its one automatic retry both produced no observable reaction, `null` = unknown or not requested). When `submit_confirmed` is `false`, the sender has already retried once automatically; flush the target with `{{"message":"","submit":true}}`, then re-check its state. Remediate one target at a time. A `"submit":true` response may stay pending up to ~1500 ms while that confirmation window runs (it returns earlier once activity is confirmed); `submit_confirmation_elapsed_ms` reports the actual wait. Do not treat the held response as a stalled agent.
+The response reports measured sender-side facts: `payload_bytes_written` counts the sanitized payload bytes, `submit_bytes_written` is the aggregate number of Enter bytes written across all attempts, and `submit_attempts` reports `0` when no Enter was requested, `1` when one Enter was written, or `2` when the bounded automatic retry was written. `submit_keystroke_issued` reflects whether the initial Enter was written. The receipt also includes PTY-output byte counts, `pty_activity_observed`, the bounded per-attempt `observation_window_ms`, and the tri-state `submit_confirmed` (`true` = sustained post-submit PTY activity consistent with the composer accepting Enter, `false` = no observable reaction in the last completed confirmation window, `null` = unknown or not requested). Normally, `false` means the initial Enter and its one automatic retry both produced no observable reaction. If the retry write itself fails, the response remains successful because the initial injection already happened: `submit_retry_failed` is `true`, `submit_retry_failure` gives the caveat, `submit_attempts`/`submit_bytes_written` count only successful Enter writes, and `submit_confirmed` retains the honest pre-retry verdict. When `submit_confirmed` is `false` and `submit_retry_failed` is `false`, the sender has already retried once automatically; flush the target with `{{"message":"","submit":true}}`, then re-check its state. Remediate one target at a time. A `"submit":true` response may stay pending up to ~3000 ms across two confirmation windows (it returns earlier once activity is confirmed); `submit_confirmation_elapsed_ms` reports cumulative time spent in every completed confirmation window. Do not treat the held response as a stalled agent.
 
 **Evidence limit:** these facts prove only that bytes were written and the existing PTY-output ring was observed for a bounded window. They do **not** prove that the agent took a turn; output may be terminal echo or unrelated activity, and `submit_confirmed` is heuristic. `submit_confirmed: true` is not proof that a busy receiver accepted Enter: unrelated output from a target that was already streaming can create a false positive and bypass the false-only retry. When the target was busy, inspect its actual state rather than treating `true` as confirmation. Never infer success from receiver behaviour alone.
 
@@ -16908,13 +16908,15 @@ mod tests {
             .expect("inject receipt and remediation passage");
         assert!(
             remediation_passage.contains(
-                "`false` = the initial Enter and its one automatic retry both produced no observable reaction"
+                "Normally, `false` means the initial Enter and its one automatic retry both produced no observable reaction"
             ) && remediation_passage.contains(
-                r#"When `submit_confirmed` is `false`, the sender has already retried once automatically; flush the target with `{"message":"","submit":true}`, then re-check its state. Remediate one target at a time."#
+                r#"When `submit_confirmed` is `false` and `submit_retry_failed` is `false`, the sender has already retried once automatically; flush the target with `{"message":"","submit":true}`, then re-check its state. Remediate one target at a time."#
             ),
             "the false verdict and its measured remediation must stay in one emitted passage"
         );
-        assert!(prompt.contains("may stay pending up to ~1500 ms"));
+        assert!(prompt.contains("`submit_retry_failed` is `true`"));
+        assert!(prompt.contains("`submit_confirmation_elapsed_ms` reports cumulative time"));
+        assert!(prompt.contains("may stay pending up to ~3000 ms across two confirmation windows"));
         assert!(prompt.contains("pty_activity_observed"));
         assert!(prompt.contains("do **not** prove that the agent took a turn"));
         assert!(prompt.contains("`submit_confirmed: true` is not proof that a busy receiver accepted Enter"));

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Hive Manager",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "identifier": "com.rduff.hive-manager",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Three defect fixes plus one measurement hand-off, from a 3-principal Hive session.

- **#258** — a single unrecognized bracket label in `plan.md` discarded the *entire* work graph.
- **#259** — inject detected a swallowed Enter (`submit_confirmed: false`) and never acted on it.
- **#241** — re-scoped rather than closed; it now owns the post-#256 receiver-side measurement that
  neither #257 nor #259 delivers.

Version: **0.46.1 -> 0.46.2** (defect repair, per the `x.x.Z` scheme).

## #258 — bracket labels no longer discard the graph

Three defects, and one landmine the issue did not mention.

**(a) Parse tolerance.** `extract_explicit_task_id` split on the first colon and required the whole
candidate to be `T`+digits. `[P1] T1:` parsed *only because* `extract_priority` happened to strip
the token first; `[P4]`, `[Queen]`, `[Operator]` survived into the candidate and failed. The
candidate was also never trimmed, so `T4 :` failed too. Both are fixed, and the recognized
`HIGH`/`MEDIUM`/`LOW`/`P1`-`P3` tokens still strip to a priority exactly as before.

**(b) Partial graphs are preserved.** `parse_plan_markdown_checked` was discarding an
already-parsed plan whenever any diagnostic existed. `mark_plan_ready` now keeps every parsed node
and reports the failed lines as per-line omissions.

**(c) The exemplars taught the failing pattern — in six places, not the two the issue cited.** A
full sweep found four prompt builders plus two runtime generators, none sharing a constant. Two of
the four builders *already* omitted the bracket, so the other two were brought in line with that
existing precedent rather than inventing a convention. The two runtime generators were **not**
changed: their bracket comes from a `HIGH`/`MEDIUM`/`LOW` ladder that parses correctly today, so
they were verified and pinned with a test instead.

**(d) The landmine.** Fixing (b) alone converts a silent empty graph into a **wedged session**:
dropped tasks leave dangling edges, `validate_plan_ready` returns `DanglingDependencies`, and
`continue_session` propagates that as the authoritative exit from Planning — so the session cannot
leave Planning at all. Dangling edges are now quarantined into omissions before validation, holding
the invariant that **`mark_plan_ready` returns `Ok` for any readable `plan.md`**.

Note that this **deliberately reverses a prior policy judgement.** The existing test
`explicit_graph_with_unidentified_checkbox_degrades_and_reports_it` asserted an empty graph on
purpose, so that "an explicit graph cannot silently discard a schedulable checkbox". That concern is
still honoured — nothing disappears silently — but now by preserving the node and reporting the
omission rather than by discarding everything. The test's intent was rewritten, not just its numbers.

## #259 — one bounded submit retry

`classify_submit_confirmation` already produced a confident negative and nothing consumed it. Now a
`submit_confirmed == Some(false)` triggers **exactly one** additional bare carriage return, and the
receipt reports `submit_attempts`.

Deliberately narrow:

- Keyed **strictly** on `Some(false)`. `None` (ambiguous) never retries — the tri-state exists so an
  ambiguous buffer is never upgraded, and the same restraint applies to acting on it.
- Capped at one. On a composer where Enter is not idempotent, a false negative would otherwise
  **double-run the agent's turn** — materially worse than the "harmless blank line" framing in the
  issue. That risk is why the retry is bounded and why measurement precedes any widening.
- The re-observation baseline is captured **after** the retry write, so the retry's own local echo
  cannot be misread as receiver activity.

## #241 — re-scoped, intentionally left open

The v0.44.1 framing is stale: suggested fix 1 landed in #257 (the CR is now a discrete write outside
the envelope) and suggested fix 3 is documented. What remains undelivered is **suggested fix 2** —
a test that injects once and asserts the receiver takes a turn without a second call — plus the
sweep matrix, which still reads `UNMEASURED` in all six cells. #241 now owns both.

#259 does **not** supersede it: a compensating retry changes the sender, not the measurement.

## New defect found during this session — #260

While coordinating, the Queen's own injects reported `submit_confirmed: true` on four consecutive
calls while every payload sat **unsubmitted** in the target composers. The receivers were codex
processes mid-indexing, so the PTY ring was churning for unrelated reasons and the classifier read
that noise as confirmation.

This composes badly with the retry above: it keys on `false`, so a false `true` **bypasses it
entirely** — and a busy receiver is the *common* case, because inject exists to interrupt working
agents. Filed as #260 and documented for agents; the classifier itself is deliberately unchanged
here to keep this PR scoped.

It also established an **evidence asymmetry** now written into the sweep methodology: the
"an operator at the terminal cannot verify an inject" rule constrains *positive* observations only.
No keypress can manufacture a *non*-submit, so "the text is still sitting there" is admissible
evidence even uncontrolled.

## Validation

All five code tasks were verified by the Queen independently of the implementing principal, each
with a mutation check on a **different** line than the worker's own — a worker mutating the branch
it just wrote and reporting red is close to circular.

| Check | Result |
|---|---|
| `cargo check --tests` | pass |
| `cargo test` | pass |
| `cargo clippy` | pass |
| codegraph `rs` gate | no certain finding |

Mutations run by the Queen, all red-then-green:

- removed the id-extractor `trim()` -> the spaced-colon case failed
- reverted a planner exemplar to `[P1] T1` -> the emitted-prompt assertion failed
- moved the retry observation baseline back before the retry write -> two inject tests failed
- **added a second CR to `pty/session.rs` — a file `cargo test` never compiles on Windows — and the
  source-parity guard caught it.** That module is swapped for `session_stub.rs` under
  `cfg(all(test, windows))`, so a change made only in `session.rs` is invisible to the suite with CI
  fully green. The parity assertion is what makes that surface testable at all.

Closes #258
Closes #259

Refs #241, #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added bounded automatic Enter retries when submission activity is not detected.
  - Submission results now show attempts, bytes sent, failures, and confirmation timing.
  - Planner prompts support optional priority markers and flexible task labels.

- **Bug Fixes**
  - Improved handling of partially parsed plans, duplicate tasks, and invalid dependency references while preserving valid work.
  - Enhanced compatibility with legacy task plans and varied task ID formatting.

- **Documentation**
  - Expanded guidance for submission retries, diagnostics, validation, and remediation.

- **Release**
  - Updated the application version to 0.46.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->